### PR TITLE
Salvage 6 lore-vm ops (merge_unresolve, file hash/history/diff/metadata_set, commit_with_metadata)

### DIFF
--- a/crates/lore-vm/src/ops/branch/merge_unresolve.rs
+++ b/crates/lore-vm/src/ops/branch/merge_unresolve.rs
@@ -1,8 +1,118 @@
 //! `branch merge_unresolve` operation — binds `lore::branch::merge_unresolve`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Marks previously resolved merge paths as unresolved, restoring their
+//! conflict state. Emits `BranchMergeUnresolveFile` for each affected path
+//! and `BranchMergeUnresolveRevision` with the updated staged revision.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::branch::LoreBranchMergeUnresolveArgs;
+use lore::interface::{LoreArray, LoreEvent, LoreString};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BranchMergeUnresolveArgs {
+    #[serde(default)]
+    pub paths: Vec<String>,
+}
+
+impl BranchMergeUnresolveArgs {
+    fn into_lore(self) -> LoreBranchMergeUnresolveArgs {
+        LoreBranchMergeUnresolveArgs {
+            paths: LoreArray::from_vec(
+                self.paths.iter().map(|p| LoreString::from_str(p)).collect(),
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BranchMergeUnresolveResult {
+    pub unresolved_paths: Vec<String>,
+}
+
+pub async fn merge_unresolve(
+    api: &LoreApi,
+    args: BranchMergeUnresolveArgs,
+) -> Result<BranchMergeUnresolveResult> {
+    let (callback, rx) = collect_events();
+
+    let status =
+        lore::branch::merge_unresolve(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("branch merge_unresolve failed with status {status}"),
+        )));
+    }
+
+    let unresolved_paths: Vec<String> = stream
+        .events
+        .iter()
+        .filter_map(|event| {
+            if let LoreEvent::BranchMergeUnresolveFile(data) = event {
+                Some(data.path.as_str().to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    Ok(BranchMergeUnresolveResult { unresolved_paths })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_unresolve_args_serializes() {
+        let args = BranchMergeUnresolveArgs {
+            paths: vec!["src/main.rs".into(), "README.md".into()],
+        };
+        let json = serde_json::to_string(&args).expect("should serialize");
+        assert!(json.contains("src/main.rs"));
+        assert!(json.contains("README.md"));
+    }
+
+    #[test]
+    fn merge_unresolve_args_deserializes_with_default() {
+        let json = r#"{}"#;
+        let args: BranchMergeUnresolveArgs =
+            serde_json::from_str(json).expect("should deserialize");
+        assert!(args.paths.is_empty());
+    }
+
+    #[test]
+    fn merge_unresolve_args_into_lore_conversion() {
+        let args = BranchMergeUnresolveArgs {
+            paths: vec!["a.txt".into(), "b.txt".into()],
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.paths.as_slice().len(), 2);
+    }
+
+    #[test]
+    fn merge_unresolve_result_serializes() {
+        let result = BranchMergeUnresolveResult {
+            unresolved_paths: vec!["conflict.rs".into()],
+        };
+        let json = serde_json::to_string(&result).expect("should serialize");
+        assert!(json.contains("conflict.rs"));
+    }
+
+    #[test]
+    fn merge_unresolve_result_empty() {
+        let result = BranchMergeUnresolveResult {
+            unresolved_paths: vec![],
+        };
+        let json = serde_json::to_string(&result).expect("should serialize");
+        assert!(json.contains("[]"));
+    }
+}

--- a/crates/lore-vm/src/ops/file/diff.rs
+++ b/crates/lore-vm/src/ops/file/diff.rs
@@ -1,8 +1,253 @@
 //! `file diff` operation — binds `lore::file::diff`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Computes the unified diff of files between two revisions.
+//! Emits one `LoreEvent::FileDiff` per changed file containing the
+//! path, unified-diff patch text, and the action (add/delete/move/copy/keep).
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::file::LoreFileDiffArgs;
+use lore::interface::{LoreEvent, LoreString};
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`diff`].
+///
+/// Mirrors `LoreFileDiffArgs` from the upstream `lore` crate
+/// but uses plain `String` so it serialises cleanly across the Tauri boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiffArgs {
+    /// File paths to diff; empty diffs all changed files.
+    #[serde(default)]
+    pub paths: Vec<String>,
+    /// Source revision (empty = working tree).
+    #[serde(default)]
+    pub source_revision: String,
+    /// Target revision (empty = working tree).
+    #[serde(default)]
+    pub target_revision: String,
+    /// Produce three-way merge output with conflict markers.
+    #[serde(default)]
+    pub diff3: bool,
+    /// Number of unchanged context lines per unified-diff hunk.
+    #[serde(default = "default_context_lines")]
+    pub context_lines: u32,
+    /// Treat lines that differ only in trailing whitespace as equal.
+    #[serde(default)]
+    pub ignore_whitespace_eol: bool,
+    /// Collapse runs of internal whitespace to a single space for comparison.
+    #[serde(default)]
+    pub ignore_whitespace_inline: bool,
+}
+
+fn default_context_lines() -> u32 {
+    3
+}
+
+impl DiffArgs {
+    fn into_lore(self) -> LoreFileDiffArgs {
+        LoreFileDiffArgs {
+            paths: lore::interface::LoreArray::from_vec(
+                self.paths
+                    .into_iter()
+                    .map(|p| LoreString::from_str(&p))
+                    .collect(),
+            ),
+            source_revision: LoreString::from_str(&self.source_revision),
+            target_revision: LoreString::from_str(&self.target_revision),
+            diff3: u8::from(self.diff3),
+            context_lines: self.context_lines,
+            ignore_whitespace_eol: u8::from(self.ignore_whitespace_eol),
+            ignore_whitespace_inline: u8::from(self.ignore_whitespace_inline),
+        }
+    }
+}
+
+/// The action applied to a diffed file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FileAction {
+    Keep,
+    Add,
+    Delete,
+    Move,
+    Copy,
+}
+
+/// One entry in the diff result — a single file's patch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileDiffEntry {
+    /// Path of the file.
+    pub path: String,
+    /// Unified-diff patch text describing the change.
+    pub patch: String,
+    /// Action applied to the file (add, delete, move, copy, keep).
+    pub action: FileAction,
+}
+
+/// Compute the diff of files between two revisions.
+///
+/// Calls the upstream `lore::file::diff` in-process and collects
+/// all `FileDiff` events into a typed result vector.
+pub async fn diff(api: &LoreApi, args: DiffArgs) -> Result<Vec<FileDiffEntry>> {
+    let (callback, rx) = collect_events();
+
+    let status = lore::file::diff(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("file diff failed with status {status}"),
+        )));
+    }
+
+    let entries: Vec<FileDiffEntry> = stream
+        .events
+        .iter()
+        .filter_map(|event| {
+            if let LoreEvent::FileDiff(data) = event {
+                let action = match data.action {
+                    lore::interface::LoreFileAction::Keep => FileAction::Keep,
+                    lore::interface::LoreFileAction::Add => FileAction::Add,
+                    lore::interface::LoreFileAction::Delete => FileAction::Delete,
+                    lore::interface::LoreFileAction::Move => FileAction::Move,
+                    lore::interface::LoreFileAction::Copy => FileAction::Copy,
+                };
+                Some(FileDiffEntry {
+                    path: data.path.as_str().to_string(),
+                    patch: data.patch.as_str().to_string(),
+                    action,
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diff_args_serializes() {
+        let args = DiffArgs {
+            paths: vec!["src/main.rs".into()],
+            source_revision: "abc123".into(),
+            target_revision: "def456".into(),
+            diff3: false,
+            context_lines: 3,
+            ignore_whitespace_eol: false,
+            ignore_whitespace_inline: false,
+        };
+        let json = serde_json::to_string(&args).expect("should serialize");
+        assert!(json.contains("src/main.rs"));
+        assert!(json.contains("abc123"));
+        assert!(json.contains("def456"));
+    }
+
+    #[test]
+    fn diff_args_deserializes_with_defaults() {
+        let json = r#"{}"#;
+        let args: DiffArgs = serde_json::from_str(json).expect("should deserialize");
+        assert!(args.paths.is_empty());
+        assert_eq!(args.source_revision, "");
+        assert_eq!(args.target_revision, "");
+        assert!(!args.diff3);
+        assert_eq!(args.context_lines, 3);
+        assert!(!args.ignore_whitespace_eol);
+        assert!(!args.ignore_whitespace_inline);
+    }
+
+    #[test]
+    fn diff_args_into_lore_conversion() {
+        let args = DiffArgs {
+            paths: vec!["file1.txt".into(), "file2.txt".into()],
+            source_revision: "rev1".into(),
+            target_revision: "rev2".into(),
+            diff3: true,
+            context_lines: 5,
+            ignore_whitespace_eol: true,
+            ignore_whitespace_inline: true,
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.source_revision.as_str(), "rev1");
+        assert_eq!(lore_args.target_revision.as_str(), "rev2");
+        assert_eq!(lore_args.diff3, 1);
+        assert_eq!(lore_args.context_lines, 5);
+        assert_eq!(lore_args.ignore_whitespace_eol, 1);
+        assert_eq!(lore_args.ignore_whitespace_inline, 1);
+    }
+
+    #[test]
+    fn diff_args_into_lore_paths() {
+        let args = DiffArgs {
+            paths: vec!["a.rs".into(), "b.rs".into()],
+            source_revision: String::new(),
+            target_revision: String::new(),
+            diff3: false,
+            context_lines: 3,
+            ignore_whitespace_eol: false,
+            ignore_whitespace_inline: false,
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.paths.len(), 2);
+    }
+
+    #[test]
+    fn file_diff_entry_serializes() {
+        let entry = FileDiffEntry {
+            path: "src/lib.rs".into(),
+            patch: "--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1,3 +1,4 @@\n+use foo;\n".into(),
+            action: FileAction::Add,
+        };
+        let json = serde_json::to_string(&entry).expect("should serialize");
+        assert!(json.contains("src/lib.rs"));
+        assert!(json.contains(r#""action":"add""#));
+    }
+
+    #[test]
+    fn file_action_serializes_all_variants() {
+        assert_eq!(
+            serde_json::to_string(&FileAction::Keep).unwrap(),
+            r#""keep""#
+        );
+        assert_eq!(
+            serde_json::to_string(&FileAction::Add).unwrap(),
+            r#""add""#
+        );
+        assert_eq!(
+            serde_json::to_string(&FileAction::Delete).unwrap(),
+            r#""delete""#
+        );
+        assert_eq!(
+            serde_json::to_string(&FileAction::Move).unwrap(),
+            r#""move""#
+        );
+        assert_eq!(
+            serde_json::to_string(&FileAction::Copy).unwrap(),
+            r#""copy""#
+        );
+    }
+
+    #[test]
+    fn file_action_roundtrips() {
+        for action in [
+            FileAction::Keep,
+            FileAction::Add,
+            FileAction::Delete,
+            FileAction::Move,
+            FileAction::Copy,
+        ] {
+            let json = serde_json::to_string(&action).unwrap();
+            let parsed: FileAction = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, action);
+        }
+    }
+}

--- a/crates/lore-vm/src/ops/file/hash.rs
+++ b/crates/lore-vm/src/ops/file/hash.rs
@@ -1,8 +1,146 @@
 //! `file hash` operation — binds `lore::file::hash`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Computes the content hash (BLAKE3) and size of one or more files in the
+//! repository. Emits one `LoreEvent::FileHash` per file.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::file::LoreFileHashArgs;
+use lore::interface::{LoreEvent, LoreString};
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`hash`].
+///
+/// Mirrors `LoreFileHashArgs` from the upstream `lore` crate
+/// but uses plain `Vec<String>` so it serialises cleanly across the Tauri boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileHashArgs {
+    /// File paths to hash (relative to the repository root).
+    pub paths: Vec<String>,
+}
+
+impl FileHashArgs {
+    fn into_lore(self) -> LoreFileHashArgs {
+        LoreFileHashArgs {
+            paths: lore::interface::LoreArray::from_vec(
+                self.paths
+                    .into_iter()
+                    .map(|p| LoreString::from_str(&p))
+                    .collect(),
+            ),
+        }
+    }
+}
+
+/// Hash and size of a single file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileHashEntry {
+    /// Path of the file.
+    pub path: String,
+    /// Size of the file in bytes.
+    pub size: u64,
+    /// BLAKE3 content hash (hex string).
+    pub hash: String,
+}
+
+/// Result returned on successful file hash computation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileHashResult {
+    /// One entry per file that was hashed.
+    pub files: Vec<FileHashEntry>,
+}
+
+/// Compute the content hash and size of one or more files.
+///
+/// Calls the upstream `lore::file::hash` in-process and collects
+/// `FileHash` events to return typed results.
+pub async fn hash(api: &LoreApi, args: FileHashArgs) -> Result<FileHashResult> {
+    let (callback, rx) = collect_events();
+
+    let status = lore::file::hash(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("file hash failed with status {status}"),
+        )));
+    }
+
+    let files: Vec<FileHashEntry> = stream
+        .events
+        .iter()
+        .filter_map(|event| {
+            if let LoreEvent::FileHash(data) = event {
+                Some(FileHashEntry {
+                    path: data.path.as_str().to_string(),
+                    size: data.size,
+                    hash: format!("{}", data.hash),
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    Ok(FileHashResult { files })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_hash_args_serializes() {
+        let args = FileHashArgs {
+            paths: vec!["foo.txt".into(), "bar/baz.rs".into()],
+        };
+        let json = serde_json::to_string(&args).expect("should serialize");
+        assert!(json.contains("foo.txt"));
+        assert!(json.contains("bar/baz.rs"));
+    }
+
+    #[test]
+    fn file_hash_args_deserializes() {
+        let json = r#"{"paths":["a.txt"]}"#;
+        let args: FileHashArgs = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(args.paths, vec!["a.txt"]);
+    }
+
+    #[test]
+    fn file_hash_args_into_lore_conversion() {
+        let args = FileHashArgs {
+            paths: vec!["hello.md".into()],
+        };
+        let lore_args = args.into_lore();
+        let slice = lore_args.paths.as_slice();
+        assert_eq!(slice.len(), 1);
+        assert_eq!(slice[0].as_str(), "hello.md");
+    }
+
+    #[test]
+    fn file_hash_result_serializes() {
+        let result = FileHashResult {
+            files: vec![FileHashEntry {
+                path: "test.txt".into(),
+                size: 42,
+                hash: "abc123def456".into(),
+            }],
+        };
+        let json = serde_json::to_string(&result).expect("should serialize");
+        assert!(json.contains("test.txt"));
+        assert!(json.contains("42"));
+        assert!(json.contains("abc123def456"));
+    }
+
+    #[test]
+    fn file_hash_result_empty_files() {
+        let result = FileHashResult { files: vec![] };
+        let json = serde_json::to_string(&result).expect("should serialize");
+        assert!(json.contains(r#""files":[]"#));
+    }
+}

--- a/crates/lore-vm/src/ops/file/history.rs
+++ b/crates/lore-vm/src/ops/file/history.rs
@@ -1,8 +1,271 @@
 //! `file history` operation — binds `lore::file::history`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Retrieves the revision history for a specific file. Emits one
+//! `LoreEvent::FileHistory` per revision in which the file was modified.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::file::LoreFileHistoryArgs;
+use lore::interface::{LoreEvent, LoreString};
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`history`].
+///
+/// Mirrors `LoreFileHistoryArgs` from the upstream `lore` crate
+/// but uses plain `String` so it serialises cleanly across the Tauri boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileHistoryArgs {
+    /// Repository-relative path to the file.
+    pub path: String,
+    /// Optional revision specifier to start from.
+    #[serde(default)]
+    pub revision: String,
+    /// Restrict history to revisions on this branch.
+    #[serde(default)]
+    pub branch: String,
+    /// Number of revisions to list (0 = default 100).
+    #[serde(default)]
+    pub length: u32,
+    /// Number of revisions to search initially (0 = default 10).
+    #[serde(default)]
+    pub depth: u32,
+}
+
+impl FileHistoryArgs {
+    fn into_lore(self) -> LoreFileHistoryArgs {
+        LoreFileHistoryArgs {
+            path: LoreString::from_str(&self.path),
+            revision: LoreString::from_str(&self.revision),
+            branch: LoreString::from_str(&self.branch),
+            length: self.length,
+            depth: self.depth,
+        }
+    }
+}
+
+/// The action applied to a file at a given revision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FileHistoryAction {
+    Keep,
+    Add,
+    Delete,
+    Move,
+    Copy,
+}
+
+/// A single entry in the file's revision history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileHistoryEntry {
+    /// Path of the file at this revision.
+    pub path: String,
+    /// Repository identifier.
+    pub repository: String,
+    /// Revision hash.
+    pub revision: String,
+    /// Sequential revision number.
+    pub revision_number: u64,
+    /// Parent revision hashes (up to 2).
+    pub parents: Vec<String>,
+    /// Content address at this revision.
+    pub address: String,
+    /// File size in bytes at this revision.
+    pub size: u64,
+    /// Action applied to the file at this revision.
+    pub action: FileHistoryAction,
+}
+
+/// Result returned on successful file history query.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileHistoryResult {
+    /// History entries, one per revision that modified the file.
+    pub entries: Vec<FileHistoryEntry>,
+}
+
+/// Retrieve the revision history for a specific file.
+///
+/// Calls the upstream `lore::file::history` in-process and collects
+/// `FileHistory` events into a typed result.
+pub async fn history(api: &LoreApi, args: FileHistoryArgs) -> Result<FileHistoryResult> {
+    let (callback, rx) = collect_events();
+
+    let status = lore::file::history(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("file history failed with status {status}"),
+        )));
+    }
+
+    let entries: Vec<FileHistoryEntry> = stream
+        .events
+        .iter()
+        .filter_map(|event| {
+            if let LoreEvent::FileHistory(data) = event {
+                let action = match data.action {
+                    lore::interface::LoreFileAction::Keep => FileHistoryAction::Keep,
+                    lore::interface::LoreFileAction::Add => FileHistoryAction::Add,
+                    lore::interface::LoreFileAction::Delete => FileHistoryAction::Delete,
+                    lore::interface::LoreFileAction::Move => FileHistoryAction::Move,
+                    lore::interface::LoreFileAction::Copy => FileHistoryAction::Copy,
+                };
+                let parents: Vec<String> = data
+                    .parent
+                    .iter()
+                    .filter(|h| !h.is_zero())
+                    .map(|h| format!("{h}"))
+                    .collect();
+                Some(FileHistoryEntry {
+                    path: data.path.as_str().to_string(),
+                    repository: format!("{}", data.repository),
+                    revision: format!("{}", data.revision),
+                    revision_number: data.revision_number,
+                    parents,
+                    address: format!("{}", data.address),
+                    size: data.size,
+                    action,
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    Ok(FileHistoryResult { entries })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn history_args_serializes() {
+        let args = FileHistoryArgs {
+            path: "src/main.rs".into(),
+            revision: "abc123".into(),
+            branch: String::new(),
+            length: 50,
+            depth: 0,
+        };
+        let json = serde_json::to_string(&args).expect("should serialize");
+        assert!(json.contains("src/main.rs"));
+        assert!(json.contains("abc123"));
+        assert!(json.contains("50"));
+    }
+
+    #[test]
+    fn history_args_deserializes_with_defaults() {
+        let json = r#"{"path": "README.md"}"#;
+        let args: FileHistoryArgs = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(args.path, "README.md");
+        assert_eq!(args.revision, "");
+        assert_eq!(args.branch, "");
+        assert_eq!(args.length, 0);
+        assert_eq!(args.depth, 0);
+    }
+
+    #[test]
+    fn history_args_into_lore_conversion() {
+        let args = FileHistoryArgs {
+            path: "assets/texture.png".into(),
+            revision: "rev1".into(),
+            branch: "main".into(),
+            length: 25,
+            depth: 5,
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.path.as_str(), "assets/texture.png");
+        assert_eq!(lore_args.revision.as_str(), "rev1");
+        assert_eq!(lore_args.branch.as_str(), "main");
+        assert_eq!(lore_args.length, 25);
+        assert_eq!(lore_args.depth, 5);
+    }
+
+    #[test]
+    fn history_action_serializes() {
+        assert_eq!(
+            serde_json::to_string(&FileHistoryAction::Keep).unwrap(),
+            r#""keep""#
+        );
+        assert_eq!(
+            serde_json::to_string(&FileHistoryAction::Add).unwrap(),
+            r#""add""#
+        );
+        assert_eq!(
+            serde_json::to_string(&FileHistoryAction::Delete).unwrap(),
+            r#""delete""#
+        );
+        assert_eq!(
+            serde_json::to_string(&FileHistoryAction::Move).unwrap(),
+            r#""move""#
+        );
+        assert_eq!(
+            serde_json::to_string(&FileHistoryAction::Copy).unwrap(),
+            r#""copy""#
+        );
+    }
+
+    #[test]
+    fn history_entry_serializes() {
+        let entry = FileHistoryEntry {
+            path: "src/lib.rs".into(),
+            repository: "repo-abc".into(),
+            revision: "rev-def".into(),
+            revision_number: 42,
+            parents: vec!["parent1".into()],
+            address: "addr-ghi".into(),
+            size: 1024,
+            action: FileHistoryAction::Add,
+        };
+        let json = serde_json::to_string(&entry).expect("should serialize");
+        assert!(json.contains("src/lib.rs"));
+        assert!(json.contains("rev-def"));
+        assert!(json.contains("42"));
+        assert!(json.contains("1024"));
+        assert!(json.contains(r#""add""#));
+    }
+
+    #[test]
+    fn history_result_serializes() {
+        let result = FileHistoryResult {
+            entries: vec![
+                FileHistoryEntry {
+                    path: "a.txt".into(),
+                    repository: "r".into(),
+                    revision: "r1".into(),
+                    revision_number: 1,
+                    parents: vec![],
+                    address: "a1".into(),
+                    size: 100,
+                    action: FileHistoryAction::Add,
+                },
+                FileHistoryEntry {
+                    path: "a.txt".into(),
+                    repository: "r".into(),
+                    revision: "r2".into(),
+                    revision_number: 2,
+                    parents: vec!["r1".into()],
+                    address: "a2".into(),
+                    size: 200,
+                    action: FileHistoryAction::Keep,
+                },
+            ],
+        };
+        let json = serde_json::to_string(&result).expect("should serialize");
+        assert!(json.contains("r1"));
+        assert!(json.contains("r2"));
+    }
+
+    #[test]
+    fn history_result_empty() {
+        let result = FileHistoryResult { entries: vec![] };
+        let json = serde_json::to_string(&result).expect("should serialize");
+        assert!(json.contains("[]"));
+    }
+}

--- a/crates/lore-vm/src/ops/file/metadata_set.rs
+++ b/crates/lore-vm/src/ops/file/metadata_set.rs
@@ -1,8 +1,256 @@
 //! `file metadata_set` operation — binds `lore::file::metadata_set`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Sets metadata key/value pairs on one or more files in the repository.
+//! Each path can have multiple metadata entries. The operation accepts
+//! parallel arrays of paths, keys, values, and formats along with an entries
+//! array specifying how many metadata entries apply to each path.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::file::LoreFileMetadataSetArgs;
+use lore::interface::{LoreArray, LoreMetadataType, LoreString};
+use serde::{Deserialize, Serialize};
+
+/// Type identifier for metadata values.
+///
+/// Corresponds to `lore::interface::LoreMetadataType`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum MetadataType {
+    /// A block of raw bytes.
+    Binary = 0,
+    /// An unsigned integer value.
+    Numeric = 1,
+    /// A string value.
+    String = 2,
+}
+
+impl From<MetadataType> for LoreMetadataType {
+    fn from(value: MetadataType) -> Self {
+        match value {
+            MetadataType::Binary => LoreMetadataType::Binary,
+            MetadataType::Numeric => LoreMetadataType::Numeric,
+            MetadataType::String => LoreMetadataType::String,
+        }
+    }
+}
+
+impl From<LoreMetadataType> for MetadataType {
+    fn from(value: LoreMetadataType) -> Self {
+        match value {
+            LoreMetadataType::Binary => MetadataType::Binary,
+            LoreMetadataType::Numeric => MetadataType::Numeric,
+            LoreMetadataType::String => MetadataType::String,
+        }
+    }
+}
+
+/// Arguments for [`metadata_set`].
+///
+/// Mirrors `LoreFileMetadataSetArgs` from the upstream `lore` crate
+/// but uses plain Rust types so it serialises cleanly across the Tauri boundary.
+///
+/// # Arguments
+///
+/// - `paths`: Array of file paths to set metadata on
+/// - `keys`: Array of metadata keys (flat across all paths)
+/// - `values`: Array of metadata values (flat across all paths)
+/// - `formats`: Array of value types (flat across all paths)
+/// - `entries`: Array where each element is the count of metadata entries for the corresponding path
+///
+/// The `keys`, `values`, and `formats` arrays are flat - all entries for all paths
+/// are concatenated. The `entries` array describes how to partition them: the first
+/// `entries[0]` key/value/format triples belong to `paths[0]`, the next `entries[1]`
+/// belong to `paths[1]`, and so on.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetadataSetArgs {
+    /// Array of file paths to set metadata on.
+    pub paths: Vec<String>,
+    /// Array of metadata keys (flat across all paths).
+    pub keys: Vec<String>,
+    /// Array of metadata values (flat across all paths).
+    pub values: Vec<String>,
+    /// Array of value types (flat across all paths).
+    #[serde(default)]
+    pub formats: Vec<MetadataType>,
+    /// Array where each element is the count of metadata entries for the corresponding path.
+    pub entries: Vec<u32>,
+}
+
+impl MetadataSetArgs {
+    fn into_lore(self) -> LoreFileMetadataSetArgs {
+        LoreFileMetadataSetArgs {
+            paths: LoreArray::from_vec(
+                self.paths
+                    .into_iter()
+                    .map(|p| LoreString::from_str(&p))
+                    .collect(),
+            ),
+            keys: LoreArray::from_vec(
+                self.keys
+                    .into_iter()
+                    .map(|k| LoreString::from_str(&k))
+                    .collect(),
+            ),
+            values: LoreArray::from_vec(
+                self.values
+                    .into_iter()
+                    .map(|v| LoreString::from_str(&v))
+                    .collect(),
+            ),
+            formats: LoreArray::from_vec(
+                self.formats
+                    .into_iter()
+                    .map(|t| t.into())
+                    .collect(),
+            ),
+            entries: LoreArray::from_vec(self.entries),
+        }
+    }
+}
+
+/// Result returned on successful metadata set operation.
+///
+/// Since `lore::file::metadata_set` emits only standard events (Log, Error, Complete),
+/// this result type is minimal - success is indicated by the absence of an error.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetadataSetResult {
+    /// Number of files processed.
+    pub files_processed: u32,
+    /// Total number of metadata entries set.
+    pub entries_set: u32,
+}
+
+/// Set metadata key/value pairs on one or more files.
+///
+/// Calls the upstream `lore::file::metadata_set` in-process and collects
+/// standard events to determine success/failure.
+///
+/// # Example
+///
+/// ```ignore
+/// let result = metadata_set(&api, MetadataSetArgs {
+///     paths: vec!["file1.txt".into(), "file2.txt".into()],
+///     keys: vec!["author".into(), "priority".into(), "reviewed".into()],
+///     values: vec!["alice".into(), "1".into(), "true".into()],
+///     formats: vec![MetadataType::String, MetadataType::Numeric, MetadataType::String],
+///     entries: vec![2, 1], // file1 has 2 entries, file2 has 1
+/// }).await?;
+/// ```
+pub async fn metadata_set(api: &LoreApi, args: MetadataSetArgs) -> Result<MetadataSetResult> {
+    // Calculate totals before consuming args
+    let files_processed = args.paths.len() as u32;
+    let entries_set: u32 = args.entries.iter().sum();
+
+    let (callback, rx) = collect_events();
+
+    let status = lore::file::metadata_set(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("metadata_set failed with status {status}"),
+        )));
+    }
+
+    Ok(MetadataSetResult {
+        files_processed,
+        entries_set,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_set_args_serializes() {
+        let args = MetadataSetArgs {
+            paths: vec!["file1.txt".into(), "file2.txt".into()],
+            keys: vec!["author".into(), "priority".into()],
+            values: vec!["alice".into(), "1".into()],
+            formats: vec![MetadataType::String, MetadataType::Numeric],
+            entries: vec![1, 1],
+        };
+        let json = serde_json::to_string(&args).expect("should serialize");
+        assert!(json.contains("file1.txt"));
+        assert!(json.contains("author"));
+    }
+
+    #[test]
+    fn metadata_set_args_deserializes_with_defaults() {
+        let json = r#"{"paths":[],"keys":[],"values":[],"entries":[]}"#;
+        let args: MetadataSetArgs =
+            serde_json::from_str(json).expect("should deserialize");
+        assert!(args.paths.is_empty());
+        assert!(args.keys.is_empty());
+        assert!(args.formats.is_empty());
+    }
+
+    #[test]
+    fn metadata_type_serializes_lowercase() {
+        let json = serde_json::to_string(&MetadataType::String).expect("should serialize");
+        assert_eq!(json, r#""string""#);
+    }
+
+    #[test]
+    fn metadata_type_from_lore() {
+        assert_eq!(
+            MetadataType::from(LoreMetadataType::Binary),
+            MetadataType::Binary
+        );
+        assert_eq!(
+            MetadataType::from(LoreMetadataType::Numeric),
+            MetadataType::Numeric
+        );
+        assert_eq!(
+            MetadataType::from(LoreMetadataType::String),
+            MetadataType::String
+        );
+    }
+
+    #[test]
+    fn metadata_type_into_lore() {
+        assert_eq!(LoreMetadataType::from(MetadataType::Binary), LoreMetadataType::Binary);
+        assert_eq!(
+            LoreMetadataType::from(MetadataType::Numeric),
+            LoreMetadataType::Numeric
+        );
+        assert_eq!(LoreMetadataType::from(MetadataType::String), LoreMetadataType::String);
+    }
+
+    #[test]
+    fn metadata_set_result_serializes() {
+        let result = MetadataSetResult {
+            files_processed: 2,
+            entries_set: 5,
+        };
+        let json = serde_json::to_string(&result).expect("should serialize");
+        assert!(json.contains("2"));
+        assert!(json.contains("5"));
+    }
+
+    #[test]
+    fn metadata_set_args_with_multiple_entries_per_path() {
+        let args = MetadataSetArgs {
+            paths: vec!["file1.txt".into(), "file2.txt".into()],
+            keys: vec!["author".into(), "priority".into(), "reviewed".into()],
+            values: vec!["alice".into(), "1".into(), "true".into()],
+            formats: vec![
+                MetadataType::String,
+                MetadataType::Numeric,
+                MetadataType::String,
+            ],
+            entries: vec![2, 1], // file1 has author+priority, file2 has reviewed
+        };
+        assert_eq!(args.paths.len(), 2);
+        assert_eq!(args.keys.len(), 3);
+        assert_eq!(args.entries.len(), 2);
+        assert_eq!(args.entries.iter().sum::<u32>(), 3);
+    }
+}

--- a/crates/lore-vm/src/ops/revision/commit_with_metadata.rs
+++ b/crates/lore-vm/src/ops/revision/commit_with_metadata.rs
@@ -1,8 +1,207 @@
 //! `revision commit_with_metadata` operation — binds `lore::revision::commit_with_metadata`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Creates a new revision from staged files, attaching key-value metadata entries
+//! to the revision. Each metadata entry has a key, value, and format type
+//! (Binary, Numeric, or String).
+//!
+//! Emits `LoreEvent::RevisionCommitRevision` on success containing the repository,
+//! branch, and revision identifiers.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::interface::{LoreArray, LoreEvent, LoreString};
+use lore::revision::LoreRevisionCommitWithMetadataArgs;
+use serde::{Deserialize, Serialize};
+
+/// Metadata format type — mirrors `lore::interface::LoreMetadataType` with
+/// serde-friendly naming for the Tauri boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MetadataFormat {
+    Binary,
+    Numeric,
+    String,
+}
+
+impl MetadataFormat {
+    fn into_lore(self) -> lore::interface::LoreMetadataType {
+        match self {
+            MetadataFormat::Binary => lore::interface::LoreMetadataType::Binary,
+            MetadataFormat::Numeric => lore::interface::LoreMetadataType::Numeric,
+            MetadataFormat::String => lore::interface::LoreMetadataType::String,
+        }
+    }
+}
+
+/// Arguments for [`commit_with_metadata`].
+///
+/// Mirrors `LoreRevisionCommitWithMetadataArgs` from the upstream `lore` crate
+/// but uses plain Rust types so it serialises cleanly across the Tauri boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitWithMetadataArgs {
+    /// Commit message describing the revision.
+    pub message: String,
+    /// Metadata keys (parallel array with `values` and `formats`).
+    #[serde(default)]
+    pub keys: Vec<String>,
+    /// Metadata values (parallel array with `keys` and `formats`).
+    #[serde(default)]
+    pub values: Vec<String>,
+    /// Metadata format types (parallel array with `keys` and `values`).
+    #[serde(default)]
+    pub formats: Vec<MetadataFormat>,
+}
+
+impl CommitWithMetadataArgs {
+    fn into_lore(self) -> LoreRevisionCommitWithMetadataArgs {
+        LoreRevisionCommitWithMetadataArgs {
+            message: LoreString::from_str(&self.message),
+            keys: LoreArray::from_vec(
+                self.keys.iter().map(|k| LoreString::from_str(k)).collect(),
+            ),
+            values: LoreArray::from_vec(
+                self.values.iter().map(|v| LoreString::from_str(v)).collect(),
+            ),
+            formats: LoreArray::from_vec(
+                self.formats.iter().map(|f| f.into_lore()).collect(),
+            ),
+        }
+    }
+}
+
+/// Result returned on successful commit with metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitWithMetadataResult {
+    /// BLAKE3 hash signature of the newly created revision.
+    pub revision: String,
+    /// Sequential revision number on the branch.
+    pub revision_number: u64,
+    /// Branch identifier the revision was committed on.
+    pub branch: String,
+}
+
+/// Commit staged files as a new revision with attached metadata key-value pairs.
+///
+/// Calls the upstream `lore::revision::commit_with_metadata` in-process and
+/// collects the `RevisionCommitRevision` event to return a typed result.
+pub async fn commit_with_metadata(
+    api: &LoreApi,
+    args: CommitWithMetadataArgs,
+) -> Result<CommitWithMetadataResult> {
+    let (callback, rx) = collect_events();
+
+    let status =
+        lore::revision::commit_with_metadata(api.globals().build(), args.into_lore(), callback)
+            .await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("commit_with_metadata failed with status {status}"),
+        )));
+    }
+
+    let data = stream
+        .events
+        .iter()
+        .find_map(|event| {
+            if let LoreEvent::RevisionCommitRevision(data) = event {
+                Some(data.clone())
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| {
+            LoreError::Parse(
+                "commit_with_metadata succeeded but no RevisionCommitRevision event emitted".into(),
+            )
+        })?;
+
+    Ok(CommitWithMetadataResult {
+        revision: format!("{}", data.revision),
+        revision_number: data.revision_number,
+        branch: format!("{}", data.branch),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_serializes() {
+        let args = CommitWithMetadataArgs {
+            message: "Initial commit".into(),
+            keys: vec!["author".into(), "ticket".into()],
+            values: vec!["alice".into(), "SBAI-3750".into()],
+            formats: vec![MetadataFormat::String, MetadataFormat::String],
+        };
+        let json = serde_json::to_string(&args).expect("should serialize");
+        assert!(json.contains("Initial commit"));
+        assert!(json.contains("author"));
+        assert!(json.contains("SBAI-3750"));
+    }
+
+    #[test]
+    fn args_deserializes_with_defaults() {
+        let json = r#"{"message":"test"}"#;
+        let args: CommitWithMetadataArgs = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(args.message, "test");
+        assert!(args.keys.is_empty());
+        assert!(args.values.is_empty());
+        assert!(args.formats.is_empty());
+    }
+
+    #[test]
+    fn args_full_roundtrip() {
+        let args = CommitWithMetadataArgs {
+            message: "Add feature".into(),
+            keys: vec!["priority".into()],
+            values: vec!["42".into()],
+            formats: vec![MetadataFormat::Numeric],
+        };
+        let json = serde_json::to_string(&args).expect("serialize");
+        let back: CommitWithMetadataArgs = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.message, "Add feature");
+        assert_eq!(back.keys, vec!["priority"]);
+        assert_eq!(back.values, vec!["42"]);
+        assert_eq!(back.formats, vec![MetadataFormat::Numeric]);
+    }
+
+    #[test]
+    fn metadata_format_serde() {
+        assert_eq!(
+            serde_json::to_string(&MetadataFormat::Binary).unwrap(),
+            r#""binary""#
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataFormat::Numeric).unwrap(),
+            r#""numeric""#
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataFormat::String).unwrap(),
+            r#""string""#
+        );
+
+        let back: MetadataFormat = serde_json::from_str(r#""numeric""#).unwrap();
+        assert_eq!(back, MetadataFormat::Numeric);
+    }
+
+    #[test]
+    fn result_serializes() {
+        let result = CommitWithMetadataResult {
+            revision: "abc123def456".into(),
+            revision_number: 7,
+            branch: "main-ctx-hash".into(),
+        };
+        let json = serde_json::to_string(&result).expect("should serialize");
+        assert!(json.contains("abc123def456"));
+        assert!(json.contains("7"));
+        assert!(json.contains("main-ctx-hash"));
+    }
+}


### PR DESCRIPTION
Op+test files salvaged from #26/#23/#22/#21/#17/#14 to lore-vm scope. cargo test -p lore-vm green.