### PR TITLE
SBAI-3790: wire file info Tauri command + frontend GUI

### DIFF
--- a/crates/lore-vm/src/ops/link/list.rs
+++ b/crates/lore-vm/src/ops/link/list.rs
@@ -42,19 +42,16 @@ pub async fn list(api: &LoreApi) -> Result<LinkListResult> {
     let args = LoreLinkListArgs {};
     let (callback, rx) = collect_events();
 
-    let status =
-        lore::link::list(api.globals().build(), args, callback).await;
+    let status = lore::link::list(api.globals().build(), args, callback).await;
 
     let stream = rx
         .await
         .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
 
     if !stream.is_ok() {
-        return Err(LoreError::CommandFailed(
-            stream
-                .error
-                .unwrap_or_else(|| format!("link list failed with status {status}")),
-        ));
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("link list failed with status {status}"),
+        )));
     }
 
     let mut links = Vec::new();

--- a/crates/lore-vm/src/ops/notification/unsubscribe.rs
+++ b/crates/lore-vm/src/ops/notification/unsubscribe.rs
@@ -21,19 +21,21 @@ pub struct UnsubscribeResult {}
 pub async fn unsubscribe(api: &LoreApi) -> Result<UnsubscribeResult> {
     let (callback, rx) = collect_events();
 
-    let status =
-        lore::notification::unsubscribe(api.globals().build(), LoreNotificationUnsubscribeArgs {}, callback).await;
+    let status = lore::notification::unsubscribe(
+        api.globals().build(),
+        LoreNotificationUnsubscribeArgs {},
+        callback,
+    )
+    .await;
 
     let stream = rx
         .await
         .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
 
     if !stream.is_ok() {
-        return Err(LoreError::CommandFailed(
-            stream
-                .error
-                .unwrap_or_else(|| format!("unsubscribe failed with status {status}")),
-        ));
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("unsubscribe failed with status {status}"),
+        )));
     }
 
     Ok(UnsubscribeResult::default())

--- a/crates/lore-vm/tests/notification_unsubscribe.rs
+++ b/crates/lore-vm/tests/notification_unsubscribe.rs
@@ -8,8 +8,7 @@ use lore_vm::ops::notification::unsubscribe::UnsubscribeResult;
 fn test_unsubscribe_result_serializes() {
     let result = UnsubscribeResult::default();
     let json = serde_json::to_string(&result).expect("should serialize");
-    let deserialized: UnsubscribeResult =
-        serde_json::from_str(&json).expect("should deserialize");
+    let deserialized: UnsubscribeResult = serde_json::from_str(&json).expect("should deserialize");
     let _ = deserialized;
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,11 +6,13 @@ import {
   branchMergeIntoApi,
   branchMergeUnresolveApi,
   branchProtectApi,
+  fileInfoApi,
   fileObliterateApi,
   revisionDiffApi,
   type Branch,
   type BranchInfoResult,
   type FileChange,
+  type FileInfoEntry,
   type RepoStatus,
   type Revision,
   type RevisionDiffResult,
@@ -40,6 +42,11 @@ export default function App() {
   // --- branch info state ---
   const [branchInfoData, setBranchInfoData] = useState<BranchInfoResult | null>(null);
   const [branchInfoLoading, setBranchInfoLoading] = useState(false);
+
+  // --- file info state ---
+  const [fileInfoData, setFileInfoData] = useState<FileInfoEntry | null>(null);
+  const [fileInfoPath, setFileInfoPath] = useState<string | null>(null);
+  const [fileInfoLoading, setFileInfoLoading] = useState(false);
 
   // --- revision diff state ---
   const [diffData, setDiffData] = useState<RevisionDiffResult | null>(null);
@@ -79,6 +86,27 @@ export default function App() {
       }
     },
     [branchInfoData],
+  );
+
+  const fetchFileInfo = useCallback(
+    async (path: string) => {
+      if (fileInfoPath === path) {
+        setFileInfoData(null);
+        setFileInfoPath(null);
+        return;
+      }
+      setFileInfoLoading(true);
+      setFileInfoPath(path);
+      try {
+        const result = await fileInfoApi.info([path], "", true, false);
+        setFileInfoData(result.entries[0] ?? null);
+      } catch {
+        setFileInfoData(null);
+      } finally {
+        setFileInfoLoading(false);
+      }
+    },
+    [fileInfoPath],
   );
 
   const fetchRevisionDiff = useCallback(
@@ -249,6 +277,7 @@ export default function App() {
             items={staged}
             action="unstage"
             onAction={(paths) => void run(async () => { await api.unstage(paths); await refresh(); })}
+            onFileInfo={(path) => void fetchFileInfo(path)}
             extraAction={{
               label: "unresolve",
               onAction: (paths) =>
@@ -263,6 +292,7 @@ export default function App() {
             items={unstaged}
             action="stage"
             onAction={(paths) => void run(async () => { await api.stage(paths); await refresh(); })}
+            onFileInfo={(path) => void fetchFileInfo(path)}
             extraAction={{
               label: "obliterate",
               onAction: (paths) =>
@@ -274,6 +304,41 @@ export default function App() {
                 }),
             }}
           />
+          {fileInfoLoading && <p className="file-info-loading">Loading file info...</p>}
+          {fileInfoData && !fileInfoLoading && (
+            <div className="file-info-panel">
+              <h3>
+                File: {fileInfoPath}
+                <button className="meta-close" onClick={() => { setFileInfoData(null); setFileInfoPath(null); }}>x</button>
+              </h3>
+              <dl className="file-info-dl">
+                <dt>Type</dt>
+                <dd>{fileInfoData.is_file ? "file" : fileInfoData.is_dir ? "directory" : "other"}</dd>
+                <dt>Hash</dt>
+                <dd><code>{fileInfoData.hash.slice(0, 12) || "---"}</code></dd>
+                <dt>Context</dt>
+                <dd><code>{fileInfoData.context.slice(0, 12) || "---"}</code></dd>
+                <dt>Size</dt>
+                <dd>{fileInfoData.size}</dd>
+                <dt>Local size</dt>
+                <dd>{fileInfoData.local_size}</dd>
+                <dt>Filter size</dt>
+                <dd>{fileInfoData.filter_size}</dd>
+                <dt>Mode</dt>
+                <dd>{fileInfoData.mode}</dd>
+                <dt>Local hash</dt>
+                <dd><code>{fileInfoData.local_hash.slice(0, 12) || "---"}</code></dd>
+                <dt>Status</dt>
+                <dd>
+                  {fileInfoData.flag_conflict && <span className="badge conflict">conflict</span>}
+                  {fileInfoData.flag_modified && <span className="badge modified">modified</span>}
+                  {fileInfoData.flag_added && <span className="badge added">added</span>}
+                  {fileInfoData.flag_deleted && <span className="badge deleted">deleted</span>}
+                  {!fileInfoData.flag_conflict && !fileInfoData.flag_modified && !fileInfoData.flag_added && !fileInfoData.flag_deleted && <span>clean</span>}
+                </dd>
+              </dl>
+            </div>
+          )}
           <div className="commit">
             <textarea
               placeholder="Commit message"
@@ -343,12 +408,14 @@ function Section({
   items,
   action,
   onAction,
+  onFileInfo,
   extraAction,
 }: {
   title: string;
   items: FileChange[];
   action: string;
   onAction: (paths: string[]) => void;
+  onFileInfo?: (path: string) => void;
   extraAction?: { label: string; onAction: (paths: string[]) => void };
 }) {
   return (
@@ -366,6 +433,9 @@ function Section({
           <li key={c.path}>
             <span className={`kind ${c.kind}`}>{c.kind[0].toUpperCase()}</span>
             <span className="path">{c.path}</span>
+            {onFileInfo && (
+              <button className="info-btn" onClick={() => onFileInfo(c.path)}>info</button>
+            )}
             <button onClick={() => onAction([c.path])}>{action}</button>
             {extraAction && (
               <button onClick={() => extraAction.onAction([c.path])}>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -190,6 +190,44 @@ export const fileObliterateApi = {
     invoke<FileObliterateResult>("file_obliterate", { path, address }),
 };
 
+// --- file info ---
+
+export interface FileInfoEntry {
+  path: string;
+  context: string;
+  hash: string;
+  is_file: boolean;
+  is_dir: boolean;
+  flag_modified: boolean;
+  flag_deleted: boolean;
+  flag_added: boolean;
+  flag_conflict: boolean;
+  mode: number;
+  size: number;
+  local_size: number;
+  local_hash: string;
+  filter_size: number;
+}
+
+export interface FileInfoResult {
+  entries: FileInfoEntry[];
+}
+
+export const fileInfoApi = {
+  info: (
+    paths: string[],
+    revision: string = "",
+    local: boolean = false,
+    filtered: boolean = false,
+  ) =>
+    invoke<FileInfoResult>("file_info", {
+      paths,
+      revision,
+      local,
+      filtered,
+    }),
+};
+
 // --- revision diff ---
 
 export type DiffFileAction = "keep" | "add" | "delete" | "move" | "copy";

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -87,3 +87,17 @@ h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; color: v
 .branch-info-dl dt { color: var(--muted); }
 .branch-info-dl dd { margin: 0; }
 .branch-info-dl code { color: var(--accent); font-family: ui-monospace, monospace; font-size: 11px; }
+
+/* file info */
+.file-info-loading { color: var(--muted); font-size: 12px; padding: 8px; }
+.file-info-panel { background: var(--panel2); border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; margin-top: 8px; }
+.file-info-panel h3 { margin: 0 0 8px; font-size: 13px; display: flex; align-items: center; gap: 6px; }
+.file-info-panel .meta-close { margin-left: auto; font-size: 11px; padding: 1px 6px; }
+.file-info-dl { display: grid; grid-template-columns: auto 1fr; gap: 2px 10px; margin: 0; font-size: 12px; }
+.file-info-dl dt { color: var(--muted); }
+.file-info-dl dd { margin: 0; }
+.file-info-dl code { color: var(--accent); font-family: ui-monospace, monospace; font-size: 11px; }
+.file-info-dl .badge.conflict { background: rgba(248,81,73,0.15); color: var(--red); font-size: 10px; padding: 1px 6px; border-radius: 4px; margin-right: 4px; }
+.file-info-dl .badge.modified { background: rgba(210,153,34,0.15); color: var(--amber); font-size: 10px; padding: 1px 6px; border-radius: 4px; margin-right: 4px; }
+.file-info-dl .badge.added { background: rgba(63,185,80,0.15); color: var(--green); font-size: 10px; padding: 1px 6px; border-radius: 4px; margin-right: 4px; }
+.file-info-dl .badge.deleted { background: rgba(248,81,73,0.15); color: var(--red); font-size: 10px; padding: 1px 6px; border-radius: 4px; margin-right: 4px; }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -188,6 +188,31 @@ pub async fn branch_merge_unresolve(
     op_branch_merge_unresolve(&api, BranchMergeUnresolveArgs { paths }).await
 }
 
+// --- file info ---
+
+use lore_vm::ops::file::info::{info as op_file_info, FileInfoArgs, FileInfoResult};
+
+#[tauri::command]
+pub async fn file_info(
+    state: State<'_, AppState>,
+    paths: Vec<String>,
+    revision: String,
+    local: bool,
+    filtered: bool,
+) -> Result<FileInfoResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_file_info(
+        &api,
+        FileInfoArgs {
+            paths,
+            revision,
+            local,
+            filtered,
+        },
+    )
+    .await
+}
+
 // --- file obliterate ---
 
 use lore_vm::ops::file::obliterate::{

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,6 +46,7 @@ pub fn run() {
             commands::branch_archive,
             commands::branch_merge_unresolve,
             commands::branch_merge_into,
+            commands::file_info,
             commands::file_obliterate,
             commands::revision_diff,
             subscribe_notifications,


### PR DESCRIPTION
## Summary
- Adds Tauri `#[tauri::command] file_info` wrapper binding to `lore_vm::ops::file::info`
- Adds TypeScript `FileInfoEntry`/`FileInfoResult` types and `fileInfoApi` to frontend API
- Adds "info" button per file in Staged/Changes sections with a metadata panel (hash, size, status flags, context, mode)
- Fixes `cargo fmt` issues in batch4 merge files (link/list, notification/unsubscribe)

Layer 1 (lore-vm binding + tests) was merged via PR #34. This PR wires it through Layer 2 (Tauri command) and Layer 3 (frontend GUI).

## Test plan
- [x] `cargo check -p loregui` passes
- [x] `cargo fmt --all --check` passes
- [x] TypeScript `tsc --noEmit` passes
- [ ] CI green (cargo check + clippy + test + windows build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)