### PR TITLE
test(lore-vm): runtime integration harness against a real in-process lore engine

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,28 @@
+name: integration
+
+# Heavy runtime integration harness for lore-vm: drives the REAL in-process
+# `lore` engine through the public lore-vm op bindings (create → stage → commit
+# → status → branch → history) against a temp repo in in-memory mode. Kept
+# SEPARATE from the fast `ci.yml` so it never blocks normal op PRs — `ci.yml`
+# runs only the fast unit tests (`cargo test -p lore-vm`, no feature), this job
+# runs the gated `integration-tests` feature.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "crates/lore-vm/**"
+      - ".github/workflows/integration.yml"
+  workflow_dispatch:
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: System deps for lore build
+        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config
+      - name: Integration roundtrip against a real in-process lore instance
+        run: cargo test -p lore-vm --features integration-tests --test integration_roundtrip

--- a/crates/lore-vm/Cargo.toml
+++ b/crates/lore-vm/Cargo.toml
@@ -25,6 +25,10 @@ cli-backend = []
 # end-goal per the architecture: this is what StudioBrain will use. Stubbed until
 # the lore-client API is pinned — see src/client_backend.rs.
 client-backend = []
+# Enable the heavy runtime integration-test harness (tests/integration_roundtrip.rs)
+# that drives the REAL in-process lore engine against a temp dir. Off by default so
+# the normal fast unit-test job (`cargo test -p lore-vm`) never runs it.
+integration-tests = []
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lore-vm/src/api.rs
+++ b/crates/lore-vm/src/api.rs
@@ -19,6 +19,15 @@ impl LoreApi {
         }
     }
 
+    /// Construct an API from a fully configured [`LoreGlobal`].
+    ///
+    /// Useful when non-default global flags are required (identity, offline,
+    /// in-memory stores, …) — e.g. the integration-test harness drives the
+    /// engine headlessly via `LoreGlobal::new(dir).in_memory(true).offline(true)`.
+    pub fn from_global(global: LoreGlobal) -> Self {
+        Self { global }
+    }
+
     /// Access the mutable global-args builder.
     pub fn global(&self) -> &LoreGlobal {
         &self.global

--- a/crates/lore-vm/src/global.rs
+++ b/crates/lore-vm/src/global.rs
@@ -15,6 +15,11 @@ pub struct LoreGlobal {
     pub offline: bool,
     pub force: bool,
     pub max_connections: u32,
+    /// Run with in-process, in-memory immutable/mutable stores (no on-disk
+    /// `.urc` store and no server). Used by the integration-test harness to
+    /// drive the real lore engine headlessly. Mirrors
+    /// [`LoreGlobalArgs::in_memory`].
+    pub in_memory: bool,
 }
 
 impl LoreGlobal {
@@ -25,6 +30,7 @@ impl LoreGlobal {
             offline: false,
             force: false,
             max_connections: 8,
+            in_memory: false,
         }
     }
 
@@ -48,6 +54,11 @@ impl LoreGlobal {
         self
     }
 
+    pub fn in_memory(mut self, v: bool) -> Self {
+        self.in_memory = v;
+        self
+    }
+
     /// Build the [`LoreGlobalArgs`] expected by the lore crate's async fns.
     pub fn build(&self) -> LoreGlobalArgs {
         LoreGlobalArgs {
@@ -64,7 +75,7 @@ impl LoreGlobal {
             search_limit: 100,
             search_nearest: 0,
             gc: 0,
-            in_memory: 0,
+            in_memory: u8::from(self.in_memory),
             // Remaining fields (file_count_limit, file_size_limit, compress_task_limit,
             // store_keep_alive*, sync_data, cache) take their upstream defaults.
             ..Default::default()

--- a/crates/lore-vm/src/ops/branch/create.rs
+++ b/crates/lore-vm/src/ops/branch/create.rs
@@ -1,8 +1,146 @@
 //! `branch create` operation — binds `lore::branch::create`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Creates a new branch with the given name and category. Emits
+//! `LoreEvent::BranchCreate` carrying the new branch name and latest revision.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::branch::LoreBranchCreateArgs;
+use lore::interface::{LoreEvent, LoreString};
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`create`].
+///
+/// Mirrors `LoreBranchCreateArgs` from the upstream `lore` crate but uses plain
+/// `String` so it serialises cleanly across the Tauri boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BranchCreateArgs {
+    /// Name of the branch to create.
+    pub branch: String,
+    /// Category of the branch.
+    #[serde(default)]
+    pub category: String,
+    /// Optional explicit branch ID (hex-encoded 16-byte context).
+    #[serde(default)]
+    pub id: String,
+}
+
+impl BranchCreateArgs {
+    fn into_lore(self) -> LoreBranchCreateArgs {
+        LoreBranchCreateArgs {
+            branch: LoreString::from_str(&self.branch),
+            category: LoreString::from_str(&self.category),
+            id: LoreString::from_str(&self.id),
+        }
+    }
+}
+
+/// Result returned on a successful branch creation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BranchCreateResult {
+    /// Name of the created branch.
+    pub name: String,
+    /// Latest revision the new branch points at (empty when unset).
+    pub latest: String,
+    /// True when creating the branch also produced a new commit.
+    pub is_commit: bool,
+}
+
+/// Create a new branch.
+///
+/// Calls the upstream `lore::branch::create` in-process and collects the
+/// `BranchCreate` event to return a typed result.
+pub async fn create(api: &LoreApi, args: BranchCreateArgs) -> Result<BranchCreateResult> {
+    let (callback, rx) = collect_events();
+
+    let status = lore::branch::create(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("branch create failed with status {status}"),
+        )));
+    }
+
+    let data = stream
+        .events
+        .iter()
+        .find_map(|event| {
+            if let LoreEvent::BranchCreate(data) = event {
+                Some(data.clone())
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| {
+            LoreError::Parse("branch created successfully but no BranchCreate event emitted".into())
+        })?;
+
+    let latest = if data.latest.is_zero() {
+        String::new()
+    } else {
+        format!("{}", data.latest)
+    };
+
+    Ok(BranchCreateResult {
+        name: data.name.as_str().to_string(),
+        latest,
+        is_commit: data.is_commit != 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_args_serializes() {
+        let args = BranchCreateArgs {
+            branch: "feature/x".into(),
+            category: "feature".into(),
+            id: String::new(),
+        };
+        let json = serde_json::to_string(&args).expect("should serialize");
+        assert!(json.contains("feature/x"));
+        assert!(json.contains("feature"));
+    }
+
+    #[test]
+    fn create_args_deserializes_with_defaults() {
+        let json = r#"{"branch":"dev"}"#;
+        let args: BranchCreateArgs = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(args.branch, "dev");
+        assert_eq!(args.category, "");
+        assert_eq!(args.id, "");
+    }
+
+    #[test]
+    fn create_args_into_lore_conversion() {
+        let args = BranchCreateArgs {
+            branch: "main".into(),
+            category: "trunk".into(),
+            id: "deadbeef".into(),
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.branch.as_str(), "main");
+        assert_eq!(lore_args.category.as_str(), "trunk");
+        assert_eq!(lore_args.id.as_str(), "deadbeef");
+    }
+
+    #[test]
+    fn create_result_serializes() {
+        let result = BranchCreateResult {
+            name: "feature/x".into(),
+            latest: "abc123".into(),
+            is_commit: false,
+        };
+        let json = serde_json::to_string(&result).expect("should serialize");
+        assert!(json.contains("feature/x"));
+        assert!(json.contains("abc123"));
+    }
+}

--- a/crates/lore-vm/src/ops/file/stage.rs
+++ b/crates/lore-vm/src/ops/file/stage.rs
@@ -1,8 +1,223 @@
 //! `file stage` operation — binds `lore::file::stage`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Stages one or more files for inclusion in the next commit. Each path is
+//! classified as a file or directory by the upstream engine; directory paths
+//! honour the `scan` flag for a recursive filesystem walk.
+//!
+//! Emits `FileStageFile` per file and `FileStageRevision` with the resulting
+//! staged-revision identifier.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::file::LoreFileStageArgs;
+use lore::interface::{LoreArray, LoreEvent, LoreString};
+use serde::{Deserialize, Serialize};
+
+/// Case-change handling for staged paths — mirrors the upstream `case_change`
+/// integer with serde-friendly naming for the Tauri boundary.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CaseChange {
+    /// Error on a case-only change (0).
+    #[default]
+    Error,
+    /// Update the filesystem to match the repository (1).
+    Keep,
+    /// Update the repository to match the filesystem (2).
+    Rename,
+}
+
+impl CaseChange {
+    fn as_u32(self) -> u32 {
+        match self {
+            CaseChange::Error => 0,
+            CaseChange::Keep => 1,
+            CaseChange::Rename => 2,
+        }
+    }
+}
+
+/// Arguments for [`stage`].
+///
+/// Mirrors `LoreFileStageArgs` from the upstream `lore` crate but uses plain
+/// `Vec<String>` so it serialises cleanly across the Tauri boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileStageArgs {
+    /// Paths to stage. Individual files are always reconciled against the
+    /// filesystem; directory paths honour [`scan`](FileStageArgs::scan).
+    #[serde(default)]
+    pub paths: Vec<String>,
+    /// How to handle case-only path changes.
+    #[serde(default)]
+    pub case_change: CaseChange,
+    /// Force a recursive filesystem scan of directory paths.
+    #[serde(default)]
+    pub scan: bool,
+}
+
+impl FileStageArgs {
+    fn into_lore(self) -> LoreFileStageArgs {
+        let lore_paths: Vec<LoreString> =
+            self.paths.iter().map(|p| LoreString::from_str(p)).collect();
+        LoreFileStageArgs {
+            paths: LoreArray::from_vec(lore_paths),
+            case_change: self.case_change.as_u32(),
+            scan: u8::from(self.scan),
+        }
+    }
+}
+
+/// The action applied to a file when it was staged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FileStageAction {
+    Keep,
+    Add,
+    Delete,
+    Move,
+    Copy,
+}
+
+fn map_action(action: &lore::interface::LoreFileAction) -> FileStageAction {
+    match action {
+        lore::interface::LoreFileAction::Keep => FileStageAction::Keep,
+        lore::interface::LoreFileAction::Add => FileStageAction::Add,
+        lore::interface::LoreFileAction::Delete => FileStageAction::Delete,
+        lore::interface::LoreFileAction::Move => FileStageAction::Move,
+        lore::interface::LoreFileAction::Copy => FileStageAction::Copy,
+    }
+}
+
+/// One file affected by the stage operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileStageEntry {
+    /// Repository-relative path that was staged.
+    pub path: String,
+    /// Previous path, when the file was moved. Empty otherwise.
+    pub from_path: String,
+    /// Action applied to the file.
+    pub action: FileStageAction,
+}
+
+/// Result returned on a successful stage.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileStageResult {
+    /// One entry per file affected.
+    pub files: Vec<FileStageEntry>,
+    /// Resulting staged-revision identifier (empty when none was reported).
+    pub revision: String,
+}
+
+/// Stage one or more files for the next commit.
+///
+/// Calls the upstream `lore::file::stage` in-process and collects
+/// `FileStageFile` / `FileStageRevision` events into a typed result.
+pub async fn stage(api: &LoreApi, args: FileStageArgs) -> Result<FileStageResult> {
+    let (callback, rx) = collect_events();
+
+    let status = lore::file::stage(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("file stage failed with status {status}"),
+        )));
+    }
+
+    let mut files = Vec::new();
+    let mut revision = String::new();
+
+    for event in &stream.events {
+        match event {
+            LoreEvent::FileStageFile(data) => {
+                files.push(FileStageEntry {
+                    path: data.path.as_str().to_string(),
+                    from_path: data.from_path.as_str().to_string(),
+                    action: map_action(&data.action),
+                });
+            }
+            LoreEvent::FileStageRevision(data) => {
+                revision = format!("{}", data.revision);
+            }
+            _ => {}
+        }
+    }
+
+    Ok(FileStageResult { files, revision })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stage_args_serializes() {
+        let args = FileStageArgs {
+            paths: vec!["src/main.rs".into(), "README.md".into()],
+            case_change: CaseChange::Error,
+            scan: true,
+        };
+        let json = serde_json::to_string(&args).expect("should serialize");
+        assert!(json.contains("src/main.rs"));
+        assert!(json.contains("README.md"));
+    }
+
+    #[test]
+    fn stage_args_deserializes_with_defaults() {
+        let json = r#"{}"#;
+        let args: FileStageArgs = serde_json::from_str(json).expect("should deserialize");
+        assert!(args.paths.is_empty());
+        assert_eq!(args.case_change, CaseChange::Error);
+        assert!(!args.scan);
+    }
+
+    #[test]
+    fn stage_args_into_lore_conversion() {
+        let args = FileStageArgs {
+            paths: vec!["a.txt".into(), "b.txt".into()],
+            case_change: CaseChange::Rename,
+            scan: true,
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.paths.len(), 2);
+        assert_eq!(lore_args.case_change, 2);
+        assert_eq!(lore_args.scan, 1);
+    }
+
+    #[test]
+    fn case_change_serde() {
+        assert_eq!(
+            serde_json::to_string(&CaseChange::Error).unwrap(),
+            r#""error""#
+        );
+        assert_eq!(
+            serde_json::to_string(&CaseChange::Keep).unwrap(),
+            r#""keep""#
+        );
+        assert_eq!(
+            serde_json::to_string(&CaseChange::Rename).unwrap(),
+            r#""rename""#
+        );
+    }
+
+    #[test]
+    fn stage_result_serializes() {
+        let result = FileStageResult {
+            files: vec![FileStageEntry {
+                path: "a.txt".into(),
+                from_path: String::new(),
+                action: FileStageAction::Add,
+            }],
+            revision: "abc123".into(),
+        };
+        let json = serde_json::to_string(&result).expect("should serialize");
+        assert!(json.contains("a.txt"));
+        assert!(json.contains("abc123"));
+        assert!(json.contains(r#""add""#));
+    }
+}

--- a/crates/lore-vm/src/ops/repository/create.rs
+++ b/crates/lore-vm/src/ops/repository/create.rs
@@ -1,8 +1,145 @@
 //! `repository create` operation — binds `lore::repository::create`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Creates a new repository at the configured working directory. Emits
+//! `LoreEvent::RepositoryCreate` carrying the new repository id, name, and path.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::interface::{LoreEvent, LoreString};
+use lore::repository::LoreRepositoryCreateArgs;
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`create`].
+///
+/// Mirrors `LoreRepositoryCreateArgs` from the upstream `lore` crate but uses
+/// plain Rust types so it serialises cleanly across the Tauri boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateArgs {
+    /// URL to the repository (e.g. `lore://localhost/<name>`).
+    pub repository_url: String,
+    /// Optional repository description.
+    #[serde(default)]
+    pub description: String,
+    /// Optional repository ID (UUID); empty string generates a new one.
+    #[serde(default)]
+    pub id: String,
+    /// Use the shared store instead of a local immutable store.
+    #[serde(default)]
+    pub use_shared_store: bool,
+    /// Optional path for the shared store.
+    #[serde(default)]
+    pub shared_store_path: String,
+}
+
+impl CreateArgs {
+    fn into_lore(self) -> LoreRepositoryCreateArgs {
+        LoreRepositoryCreateArgs {
+            repository_url: LoreString::from_str(&self.repository_url),
+            description: LoreString::from_str(&self.description),
+            id: LoreString::from_str(&self.id),
+            use_shared_store: u8::from(self.use_shared_store),
+            shared_store_path: LoreString::from_str(&self.shared_store_path),
+        }
+    }
+}
+
+/// Result of a successful `create` call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateResult {
+    /// Identifier of the created repository.
+    pub id: String,
+    /// Name of the created repository.
+    pub name: String,
+    /// Local path of the created repository.
+    pub path: String,
+}
+
+/// Create a new repository.
+///
+/// Calls the upstream `lore::repository::create` in-process and collects the
+/// `RepositoryCreate` event to return a typed result.
+pub async fn create(api: &LoreApi, args: CreateArgs) -> Result<CreateResult> {
+    let (callback, rx) = collect_events();
+
+    let status = lore::repository::create(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("repository create failed with status {status}"),
+        )));
+    }
+
+    for event in &stream.events {
+        if let LoreEvent::RepositoryCreate(data) = event {
+            return Ok(CreateResult {
+                id: format!("{}", data.id),
+                name: data.name.as_str().to_string(),
+                path: data.path.as_str().to_string(),
+            });
+        }
+    }
+
+    Err(LoreError::Parse(
+        "repository created successfully but no RepositoryCreate event emitted".into(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_args_serializes() {
+        let args = CreateArgs {
+            repository_url: "lore://localhost/demo".into(),
+            description: "demo repo".into(),
+            id: String::new(),
+            use_shared_store: false,
+            shared_store_path: String::new(),
+        };
+        let json = serde_json::to_string(&args).expect("should serialize");
+        assert!(json.contains("lore://localhost/demo"));
+    }
+
+    #[test]
+    fn create_args_deserializes_with_defaults() {
+        let json = r#"{"repository_url":"lore://localhost/x"}"#;
+        let args: CreateArgs = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(args.repository_url, "lore://localhost/x");
+        assert_eq!(args.description, "");
+        assert!(!args.use_shared_store);
+    }
+
+    #[test]
+    fn create_args_into_lore_conversion() {
+        let args = CreateArgs {
+            repository_url: "lore://localhost/y".into(),
+            description: "d".into(),
+            id: "id1".into(),
+            use_shared_store: true,
+            shared_store_path: "/tmp/store".into(),
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.repository_url.as_str(), "lore://localhost/y");
+        assert_eq!(lore_args.use_shared_store, 1);
+        assert_eq!(lore_args.shared_store_path.as_str(), "/tmp/store");
+    }
+
+    #[test]
+    fn create_result_serializes() {
+        let result = CreateResult {
+            id: "repo-1".into(),
+            name: "demo".into(),
+            path: "/tmp/demo".into(),
+        };
+        let json = serde_json::to_string(&result).expect("should serialize");
+        assert!(json.contains("repo-1"));
+        assert!(json.contains("demo"));
+    }
+}

--- a/crates/lore-vm/src/ops/repository/status.rs
+++ b/crates/lore-vm/src/ops/repository/status.rs
@@ -1,8 +1,285 @@
 //! `repository status` operation — binds `lore::repository::status`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Reports the working-directory status: the current/staged revision plus the
+//! set of files with pending changes. Emits `RepositoryStatusRevision` (branch
+//! and revision context), `RepositoryStatusFile` per changed file, and an
+//! optional `RepositoryStatusCount` summary when `count` is set.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::interface::{LoreArray, LoreEvent, LoreString};
+use lore::repository::LoreRepositoryStatusArgs;
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`status`].
+///
+/// Mirrors `LoreRepositoryStatusArgs` from the upstream `lore` crate but uses
+/// plain Rust types so it serialises cleanly across the Tauri boundary.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RepositoryStatusArgs {
+    /// Include staged state in the report.
+    #[serde(default)]
+    pub staged: bool,
+    /// Reconcile against the filesystem and refresh dirty tracking.
+    #[serde(default)]
+    pub scan: bool,
+    /// Verify dirty flags against the filesystem without a full scan.
+    #[serde(default)]
+    pub check_dirty: bool,
+    /// Reset the tracked state before computing status.
+    #[serde(default)]
+    pub reset: bool,
+    /// Include the sync point in the report.
+    #[serde(default)]
+    pub sync_point: bool,
+    /// Only emit revision info, skipping all diffs.
+    #[serde(default)]
+    pub revision_only: bool,
+    /// Count directories and files in the staged state / current revision.
+    #[serde(default)]
+    pub count: bool,
+    /// Repository-relative paths to limit the status to; empty checks all.
+    #[serde(default)]
+    pub paths: Vec<String>,
+}
+
+impl RepositoryStatusArgs {
+    fn into_lore(self) -> LoreRepositoryStatusArgs {
+        let lore_paths: Vec<LoreString> =
+            self.paths.iter().map(|p| LoreString::from_str(p)).collect();
+        LoreRepositoryStatusArgs {
+            staged: u8::from(self.staged),
+            scan: u8::from(self.scan),
+            check_dirty: u8::from(self.check_dirty),
+            reset: u8::from(self.reset),
+            sync_point: u8::from(self.sync_point),
+            revision_only: u8::from(self.revision_only),
+            count: u8::from(self.count),
+            paths: LoreArray::from_vec(lore_paths),
+        }
+    }
+}
+
+/// The action applied to a file reported by status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StatusFileAction {
+    Keep,
+    Add,
+    Delete,
+    Move,
+    Copy,
+}
+
+/// The kind of node reported by status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StatusNodeType {
+    Directory,
+    File,
+    Link,
+}
+
+/// One file reported by status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatusFile {
+    /// Repository-relative path.
+    pub path: String,
+    /// Size of the file in bytes.
+    pub size: u64,
+    /// Change applied to the file.
+    pub action: StatusFileAction,
+    /// Node kind.
+    pub node_type: StatusNodeType,
+    /// True when the change is staged.
+    pub staged: bool,
+    /// True when the file is in conflict.
+    pub conflict: bool,
+    /// True when the file differs from the recorded state.
+    pub dirty: bool,
+    /// Previous path when moved/copied; empty otherwise.
+    pub from_path: String,
+}
+
+/// Revision/branch context reported by status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatusRevision {
+    /// Repository identifier.
+    pub repository: String,
+    /// Current branch identifier.
+    pub branch: String,
+    /// Current branch name.
+    pub branch_name: String,
+    /// Current revision identifier.
+    pub revision: String,
+    /// Current revision number.
+    pub revision_number: u64,
+    /// Staged revision identifier (empty when nothing is staged).
+    pub revision_staged: String,
+}
+
+/// Count summary reported by status when `count` is set.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StatusCount {
+    pub directories: u64,
+    pub files: u64,
+}
+
+/// Result returned on a successful status query.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RepositoryStatusResult {
+    /// Revision/branch context, when reported.
+    pub revision: Option<StatusRevision>,
+    /// One entry per file with pending changes.
+    pub files: Vec<StatusFile>,
+    /// Count summary, when `count` was requested.
+    pub count: Option<StatusCount>,
+}
+
+fn map_action(action: &lore::interface::LoreFileAction) -> StatusFileAction {
+    match action {
+        lore::interface::LoreFileAction::Keep => StatusFileAction::Keep,
+        lore::interface::LoreFileAction::Add => StatusFileAction::Add,
+        lore::interface::LoreFileAction::Delete => StatusFileAction::Delete,
+        lore::interface::LoreFileAction::Move => StatusFileAction::Move,
+        lore::interface::LoreFileAction::Copy => StatusFileAction::Copy,
+    }
+}
+
+fn map_node_type(node_type: &lore::interface::LoreNodeType) -> StatusNodeType {
+    match node_type {
+        lore::interface::LoreNodeType::Directory => StatusNodeType::Directory,
+        lore::interface::LoreNodeType::File => StatusNodeType::File,
+        lore::interface::LoreNodeType::Link => StatusNodeType::Link,
+    }
+}
+
+/// Hash signatures format to all-zero hex when unset; treat that as "empty".
+fn hash_or_empty(hash: &lore::interface::Hash) -> String {
+    if hash.is_zero() {
+        String::new()
+    } else {
+        format!("{hash}")
+    }
+}
+
+/// Report the working-directory status.
+///
+/// Calls the upstream `lore::repository::status` in-process and collects the
+/// `RepositoryStatusRevision`, `RepositoryStatusFile`, and `RepositoryStatusCount`
+/// events into a typed result.
+pub async fn status(api: &LoreApi, args: RepositoryStatusArgs) -> Result<RepositoryStatusResult> {
+    let (callback, rx) = collect_events();
+
+    let status = lore::repository::status(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("repository status failed with status {status}"),
+        )));
+    }
+
+    let mut result = RepositoryStatusResult::default();
+
+    for event in &stream.events {
+        match event {
+            LoreEvent::RepositoryStatusRevision(data) => {
+                result.revision = Some(StatusRevision {
+                    repository: format!("{}", data.repository),
+                    branch: format!("{}", data.branch),
+                    branch_name: data.branch_name.as_str().to_string(),
+                    revision: hash_or_empty(&data.revision),
+                    revision_number: data.revision_number,
+                    revision_staged: hash_or_empty(&data.revision_staged),
+                });
+            }
+            LoreEvent::RepositoryStatusFile(data) => {
+                result.files.push(StatusFile {
+                    path: data.path.as_str().to_string(),
+                    size: data.size,
+                    action: map_action(&data.action),
+                    node_type: map_node_type(&data.r#type),
+                    staged: data.flag_staged != 0,
+                    conflict: data.flag_conflict != 0,
+                    dirty: data.flag_dirty != 0,
+                    from_path: data.from_path.as_str().to_string(),
+                });
+            }
+            LoreEvent::RepositoryStatusCount(data) => {
+                result.count = Some(StatusCount {
+                    directories: data.directories,
+                    files: data.files,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_args_defaults() {
+        let json = r#"{}"#;
+        let args: RepositoryStatusArgs = serde_json::from_str(json).expect("should deserialize");
+        assert!(!args.staged);
+        assert!(!args.scan);
+        assert!(args.paths.is_empty());
+    }
+
+    #[test]
+    fn status_args_into_lore_conversion() {
+        let args = RepositoryStatusArgs {
+            staged: true,
+            count: true,
+            paths: vec!["a.txt".into()],
+            ..Default::default()
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.staged, 1);
+        assert_eq!(lore_args.count, 1);
+        assert_eq!(lore_args.paths.len(), 1);
+    }
+
+    #[test]
+    fn status_result_serializes() {
+        let result = RepositoryStatusResult {
+            revision: Some(StatusRevision {
+                repository: "repo".into(),
+                branch: "br".into(),
+                branch_name: "main".into(),
+                revision: "rev1".into(),
+                revision_number: 1,
+                revision_staged: String::new(),
+            }),
+            files: vec![StatusFile {
+                path: "a.txt".into(),
+                size: 11,
+                action: StatusFileAction::Add,
+                node_type: StatusNodeType::File,
+                staged: true,
+                conflict: false,
+                dirty: false,
+                from_path: String::new(),
+            }],
+            count: Some(StatusCount {
+                directories: 0,
+                files: 1,
+            }),
+        };
+        let json = serde_json::to_string(&result).expect("should serialize");
+        assert!(json.contains("a.txt"));
+        assert!(json.contains("main"));
+        assert!(json.contains(r#""add""#));
+    }
+}

--- a/crates/lore-vm/src/ops/revision/commit.rs
+++ b/crates/lore-vm/src/ops/revision/commit.rs
@@ -1,8 +1,118 @@
 //! `revision commit` operation — binds `lore::revision::commit`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Commits all staged changes to the current branch as a new revision. Emits
+//! `LoreEvent::RevisionCommitRevision` carrying the new revision identifier,
+//! number, and branch.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::interface::{LoreEvent, LoreString};
+use lore::revision::LoreRevisionCommitArgs;
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`commit`].
+///
+/// Mirrors the happy-path subset of `LoreRevisionCommitArgs` from the upstream
+/// `lore` crate. Link- and layer-specific fields take their upstream defaults.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitArgs {
+    /// Commit message describing the revision.
+    pub message: String,
+}
+
+impl CommitArgs {
+    fn into_lore(self) -> LoreRevisionCommitArgs {
+        LoreRevisionCommitArgs {
+            message: LoreString::from_str(&self.message),
+            ..Default::default()
+        }
+    }
+}
+
+/// Result returned on a successful commit.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitResult {
+    /// BLAKE3 hash signature of the newly created revision.
+    pub revision: String,
+    /// Sequential revision number on the branch.
+    pub revision_number: u64,
+    /// Branch identifier the revision was committed on.
+    pub branch: String,
+}
+
+/// Commit staged changes as a new revision.
+///
+/// Calls the upstream `lore::revision::commit` in-process and collects the
+/// `RevisionCommitRevision` event to return a typed result.
+pub async fn commit(api: &LoreApi, args: CommitArgs) -> Result<CommitResult> {
+    let (callback, rx) = collect_events();
+
+    let status = lore::revision::commit(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("revision commit failed with status {status}"),
+        )));
+    }
+
+    let data = stream
+        .events
+        .iter()
+        .find_map(|event| {
+            if let LoreEvent::RevisionCommitRevision(data) = event {
+                Some(data.clone())
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| {
+            LoreError::Parse("commit succeeded but no RevisionCommitRevision event emitted".into())
+        })?;
+
+    Ok(CommitResult {
+        revision: format!("{}", data.revision),
+        revision_number: data.revision_number,
+        branch: format!("{}", data.branch),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn commit_args_serializes() {
+        let args = CommitArgs {
+            message: "Initial commit".into(),
+        };
+        let json = serde_json::to_string(&args).expect("should serialize");
+        assert!(json.contains("Initial commit"));
+    }
+
+    #[test]
+    fn commit_args_into_lore_conversion() {
+        let args = CommitArgs {
+            message: "Add feature".into(),
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.message.as_str(), "Add feature");
+    }
+
+    #[test]
+    fn commit_result_serializes() {
+        let result = CommitResult {
+            revision: "abc123".into(),
+            revision_number: 1,
+            branch: "main".into(),
+        };
+        let json = serde_json::to_string(&result).expect("should serialize");
+        assert!(json.contains("abc123"));
+        assert!(json.contains("main"));
+    }
+}

--- a/crates/lore-vm/src/ops/revision/history.rs
+++ b/crates/lore-vm/src/ops/revision/history.rs
@@ -1,8 +1,161 @@
 //! `revision history` operation — binds `lore::revision::history`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Retrieves the revision history for the current branch or a specified
+//! revision. Emits one `LoreEvent::RevisionHistoryEntry` per revision.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::interface::{LoreEvent, LoreString};
+use lore::revision::LoreRevisionHistoryArgs;
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`history`].
+///
+/// Mirrors `LoreRevisionHistoryArgs` from the upstream `lore` crate but uses
+/// plain Rust types so it serialises cleanly across the Tauri boundary.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RevisionHistoryArgs {
+    /// Start from this revision; empty for current.
+    #[serde(default)]
+    pub revision: String,
+    /// Restrict to this branch; empty for current.
+    #[serde(default)]
+    pub branch: String,
+    /// Stop at revisions created before this date (Unix timestamp; 0 disables).
+    #[serde(default)]
+    pub date: u64,
+    /// Maximum number of revisions to return; 0 for unlimited.
+    #[serde(default)]
+    pub length: u32,
+    /// Stop when reaching a different branch.
+    #[serde(default)]
+    pub only_branch: bool,
+}
+
+impl RevisionHistoryArgs {
+    fn into_lore(self) -> LoreRevisionHistoryArgs {
+        LoreRevisionHistoryArgs {
+            revision: LoreString::from_str(&self.revision),
+            branch: LoreString::from_str(&self.branch),
+            date: self.date,
+            length: self.length,
+            only_branch: u8::from(self.only_branch),
+        }
+    }
+}
+
+/// A single entry in the revision history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevisionHistoryEntry {
+    /// Revision hash signature.
+    pub revision: String,
+    /// Sequential revision number.
+    pub revision_number: u64,
+    /// Parent revision hashes (zero hashes are omitted).
+    pub parents: Vec<String>,
+}
+
+/// Result returned on a successful history query.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RevisionHistoryResult {
+    /// History entries, newest first.
+    pub entries: Vec<RevisionHistoryEntry>,
+}
+
+/// Retrieve the revision history for the current branch or a specified revision.
+///
+/// Calls the upstream `lore::revision::history` in-process and collects
+/// `RevisionHistoryEntry` events into a typed result.
+pub async fn history(api: &LoreApi, args: RevisionHistoryArgs) -> Result<RevisionHistoryResult> {
+    let (callback, rx) = collect_events();
+
+    let status = lore::revision::history(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("revision history failed with status {status}"),
+        )));
+    }
+
+    let entries: Vec<RevisionHistoryEntry> = stream
+        .events
+        .iter()
+        .filter_map(|event| {
+            if let LoreEvent::RevisionHistoryEntry(data) = event {
+                let parents: Vec<String> = data
+                    .parent
+                    .iter()
+                    .filter(|h| !h.is_zero())
+                    .map(|h| format!("{h}"))
+                    .collect();
+                Some(RevisionHistoryEntry {
+                    revision: format!("{}", data.revision),
+                    revision_number: data.revision_number,
+                    parents,
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    Ok(RevisionHistoryResult { entries })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn history_args_defaults() {
+        let json = r#"{}"#;
+        let args: RevisionHistoryArgs = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(args.revision, "");
+        assert_eq!(args.branch, "");
+        assert_eq!(args.length, 0);
+        assert!(!args.only_branch);
+    }
+
+    #[test]
+    fn history_args_into_lore_conversion() {
+        let args = RevisionHistoryArgs {
+            revision: "rev1".into(),
+            branch: "main".into(),
+            date: 0,
+            length: 10,
+            only_branch: true,
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.revision.as_str(), "rev1");
+        assert_eq!(lore_args.branch.as_str(), "main");
+        assert_eq!(lore_args.length, 10);
+        assert_eq!(lore_args.only_branch, 1);
+    }
+
+    #[test]
+    fn history_result_serializes() {
+        let result = RevisionHistoryResult {
+            entries: vec![
+                RevisionHistoryEntry {
+                    revision: "r2".into(),
+                    revision_number: 2,
+                    parents: vec!["r1".into()],
+                },
+                RevisionHistoryEntry {
+                    revision: "r1".into(),
+                    revision_number: 1,
+                    parents: vec![],
+                },
+            ],
+        };
+        let json = serde_json::to_string(&result).expect("should serialize");
+        assert!(json.contains("r1"));
+        assert!(json.contains("r2"));
+    }
+}

--- a/crates/lore-vm/tests/integration_roundtrip.rs
+++ b/crates/lore-vm/tests/integration_roundtrip.rs
@@ -1,0 +1,185 @@
+//! Runtime integration-test harness for `lore-vm`'s op bindings.
+//!
+//! Unlike the per-op unit tests (which only check arg/result *serialisation*),
+//! this harness drives the REAL in-process `lore` engine through the public
+//! `lore-vm` API and asserts on the typed results it returns. It is the only
+//! place that proves the op bindings are wired correctly at runtime — that the
+//! right upstream fn is called, the right events are collected, and the right
+//! fields are mapped.
+//!
+//! It runs the lore engine in **in-memory mode** (`in_memory = 1`,
+//! `offline = 1`): the immutable/mutable stores live in a process-wide cache
+//! instead of on disk, and crucially persist across sequential library calls,
+//! so a create → stage → commit → status → branch → history round trip works
+//! entirely headlessly with no server and no `.urc` store on disk. This mirrors
+//! upstream lore's own `lore/tests/in_memory.rs`.
+//!
+//! Gated behind the `integration-tests` cargo feature so the normal fast
+//! `cargo test -p lore-vm` never builds or runs it. Run with:
+//!
+//! ```sh
+//! cargo test -p lore-vm --features integration-tests
+//! ```
+#![cfg(feature = "integration-tests")]
+
+use std::io::Write;
+use std::path::Path;
+
+use lore_vm::api::LoreApi;
+use lore_vm::global::LoreGlobal;
+use lore_vm::ops;
+
+/// Build a `LoreApi` pointed at `dir`, configured for headless in-memory
+/// operation (no server, no on-disk store).
+fn in_memory_api(dir: &Path) -> LoreApi {
+    let global = LoreGlobal::new(dir.to_path_buf())
+        .in_memory(true)
+        .offline(true)
+        .identity("integration-test");
+    LoreApi::from_global(global)
+}
+
+/// Write `contents` to `path`, creating parent directories as needed.
+fn write_file(path: &Path, contents: &[u8]) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dirs");
+    }
+    let mut f = std::fs::File::options()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(path)
+        .expect("create file");
+    f.write_all(contents).expect("write file");
+}
+
+/// Full create → stage → commit → status → branch → history round trip,
+/// asserting on the REAL typed results returned by each op binding.
+#[tokio::test]
+async fn full_roundtrip_against_real_lore() {
+    let tempdir = tempfile::tempdir().expect("create temp dir");
+    let repo_path = tempdir.path().to_path_buf();
+    let api = in_memory_api(&repo_path);
+
+    // ---- 1. create the repository -------------------------------------------
+    let name = format!("itest-{}", std::process::id());
+    let create = ops::repository::create::create(
+        &api,
+        ops::repository::create::CreateArgs {
+            repository_url: format!("lore://localhost/{name}"),
+            description: "lore-vm integration test repo".into(),
+            id: String::new(),
+            use_shared_store: false,
+            shared_store_path: String::new(),
+        },
+    )
+    .await
+    .expect("repository::create should succeed against the real engine");
+    assert!(
+        !create.id.is_empty(),
+        "create returned an empty repository id: {create:?}"
+    );
+
+    // ---- 2. write a file in the working tree and stage it -------------------
+    let file_path = repo_path.join("hello.txt");
+    write_file(&file_path, b"hello lore-vm");
+
+    let stage = ops::file::stage::stage(
+        &api,
+        ops::file::stage::FileStageArgs {
+            // Stage absolute filesystem paths, matching upstream's in-memory test.
+            paths: vec![file_path.to_string_lossy().into_owned()],
+            case_change: ops::file::stage::CaseChange::Error,
+            scan: true,
+        },
+    )
+    .await
+    .expect("file::stage should succeed");
+    assert!(
+        stage.files.iter().any(|f| f.path.ends_with("hello.txt")),
+        "stage did not report hello.txt: {stage:?}"
+    );
+
+    // ---- 3. commit the staged file ------------------------------------------
+    let commit = ops::revision::commit::commit(
+        &api,
+        ops::revision::commit::CommitArgs {
+            message: "initial commit".into(),
+        },
+    )
+    .await
+    .expect("revision::commit should succeed");
+    assert!(
+        !commit.revision.is_empty(),
+        "commit returned an empty revision hash: {commit:?}"
+    );
+    let committed_revision = commit.revision.clone();
+
+    // ---- 4. status should report the committed file -------------------------
+    let status = ops::repository::status::status(
+        &api,
+        ops::repository::status::RepositoryStatusArgs {
+            staged: true,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("repository::status should succeed");
+    // After commit the file is part of the current revision; assert the status
+    // call returns coherent revision context for the branch it was committed on.
+    let rev = status
+        .revision
+        .as_ref()
+        .expect("status should report revision context");
+    assert!(
+        !rev.branch_name.is_empty(),
+        "status reported an empty branch name: {status:?}"
+    );
+
+    // ---- 5. create a branch and switch to it --------------------------------
+    let branch = ops::branch::create::create(
+        &api,
+        ops::branch::create::BranchCreateArgs {
+            branch: "feature/itest".into(),
+            category: String::new(),
+            id: String::new(),
+        },
+    )
+    .await
+    .expect("branch::create should succeed");
+    assert_eq!(
+        branch.name, "feature/itest",
+        "branch::create returned an unexpected name: {branch:?}"
+    );
+
+    let switched = ops::branch::switch::switch(
+        &api,
+        ops::branch::switch::BranchSwitchArgs {
+            branch: "feature/itest".into(),
+            revision: String::new(),
+            reset: false,
+            bare: false,
+        },
+    )
+    .await
+    .expect("branch::switch should succeed");
+    assert_eq!(
+        switched.branch, "feature/itest",
+        "branch::switch returned an unexpected branch: {switched:?}"
+    );
+
+    // ---- 6. history should contain the commit we made -----------------------
+    let history = ops::revision::history::history(
+        &api,
+        ops::revision::history::RevisionHistoryArgs::default(),
+    )
+    .await
+    .expect("revision::history should succeed");
+    assert!(
+        history
+            .entries
+            .iter()
+            .any(|e| e.revision == committed_revision),
+        "history did not contain the committed revision {committed_revision}: {history:?}"
+    );
+}


### PR DESCRIPTION
## What

Adds a **runtime** integration-test harness for `lore-vm` so its op bindings are verified against a **real in-process Lore engine**, not just compiled.

Until now, every per-op test only checked arg/result *serialisation*. Nothing proved that a binding calls the right upstream fn, collects the right events, and maps the right fields at runtime. This PR closes that gap.

## The harness

`crates/lore-vm/tests/integration_roundtrip.rs` drives a full round trip through the **public lore-vm API** against a `tempfile` temp dir, asserting on the **real typed results**:

```
repository::create → file::stage → revision::commit →
repository::status → branch::create → branch::switch → revision::history
```

It runs the engine in **in-memory mode** (`in_memory = 1`, `offline = 1`): the immutable/mutable stores live in a process-wide cache that persists across sequential library calls, so the whole round trip works **headlessly with no server and no on-disk `.urc` store**. This mirrors upstream lore's own `lore/tests/in_memory.rs`.

Local result: **all steps pass** against the real engine.

```
running 1 test
test full_roundtrip_against_real_lore ... ok
test result: ok. 1 passed; 0 failed
```

## Gating (keeps the fast path fast)

- New `integration-tests` cargo feature gates the harness (`#![cfg(feature = "integration-tests")]`). The normal `cargo test -p lore-vm` (no feature) compiles the test binary but runs **0 tests** — the heavy round trip never executes by default.
- New **separate** workflow `.github/workflows/integration.yml` (ubuntu-latest) runs `cargo test -p lore-vm --features integration-tests --test integration_roundtrip`, kept apart from the fast `ci.yml` so it never blocks normal op PRs.

## Supporting changes

- **global**: add `in_memory` field + builder on `LoreGlobal`, wired into `LoreGlobalArgs` (was hard-coded to `0`, so headless in-process operation was impossible).
- **api**: add `LoreApi::from_global` to build an API from a pre-configured global.
- **ops**: implement the previously-**stubbed** happy-path bindings the round trip needs — `repository::create`, `file::stage`, `revision::commit`, `repository::status`, `branch::create`, `revision::history` — each following the established `collect_events` + typed-result pattern, with serde unit tests. (`branch::switch` was already implemented.)

## Verification

- `cargo test -p lore-vm` (default, fast) — passes; integration round trip not executed (0 tests).
- `cargo test -p lore-vm --features integration-tests` — executes against a real temp repo and **passes**.
- `cargo clippy -p lore-vm --all-targets -D warnings` and the same with `--features integration-tests` — clean.

## Notes for reviewer

- The 6 op files implemented here were `TODO` stubs on `main`; the round trip would have nothing real to exercise otherwise. They are minimal happy-path bindings, not full surface coverage.
- Pre-existing: `cargo fmt --all --check` already fails on `main` (unrelated formatting drift in a few `auth`/test files). This PR deliberately does **not** touch those files to stay focused, so the existing `ci.yml` fmt step is unaffected by this change either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dg4LRevPWAS4dAZ5gNqtbM
