### PR TITLE
style: rustfmt drift cleanup (unblocks ci.yml fmt gate)

### DIFF
--- a/crates/lore-vm/src/ops/auth/clear.rs
+++ b/crates/lore-vm/src/ops/auth/clear.rs
@@ -33,9 +33,11 @@ pub async fn clear(api: &LoreApi, _args: ClearArgs) -> Result<()> {
         .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
 
     if !stream.is_ok() {
-        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
-            || format!("clear failed with status {status}"),
-        )));
+        return Err(LoreError::CommandFailed(
+            stream
+                .error
+                .unwrap_or_else(|| format!("clear failed with status {status}")),
+        ));
     }
 
     Ok(())

--- a/crates/lore-vm/src/ops/file/metadata_clear.rs
+++ b/crates/lore-vm/src/ops/file/metadata_clear.rs
@@ -103,8 +103,7 @@ mod tests {
     #[test]
     fn metadata_clear_result_deserializes() {
         let json = r#"{"path":"file.txt"}"#;
-        let result: MetadataClearResult =
-            serde_json::from_str(json).expect("should deserialize");
+        let result: MetadataClearResult = serde_json::from_str(json).expect("should deserialize");
         assert_eq!(result.path, "file.txt");
     }
 }

--- a/crates/lore-vm/src/ops/file/metadata_list.rs
+++ b/crates/lore-vm/src/ops/file/metadata_list.rs
@@ -98,14 +98,10 @@ pub struct MetadataListResult {
 ///     println!("{}: {} ({:?})", entry.key, entry.value, entry.entry_type);
 /// }
 /// ```
-pub async fn metadata_list(
-    api: &LoreApi,
-    args: MetadataListArgs,
-) -> Result<MetadataListResult> {
+pub async fn metadata_list(api: &LoreApi, args: MetadataListArgs) -> Result<MetadataListResult> {
     let (callback, rx) = collect_events();
 
-    let status =
-        lore::file::metadata_list(api.globals().build(), args.into_lore(), callback).await;
+    let status = lore::file::metadata_list(api.globals().build(), args.into_lore(), callback).await;
 
     let stream = rx
         .await
@@ -138,7 +134,9 @@ pub async fn metadata_list(
 ///
 /// This extracts the actual value from the FFI wrapper types and determines
 /// the appropriate type tag for the entry.
-fn convert_lore_metadata(value: &lore::interface::LoreMetadata) -> Result<(String, MetadataEntryType)> {
+fn convert_lore_metadata(
+    value: &lore::interface::LoreMetadata,
+) -> Result<(String, MetadataEntryType)> {
     use lore::interface::LoreMetadata;
     match value {
         LoreMetadata::Address(addr) => {

--- a/crates/lore-vm/src/ops/link/add.rs
+++ b/crates/lore-vm/src/ops/link/add.rs
@@ -64,8 +64,7 @@ pub async fn add(api: &LoreApi, args: AddArgs) -> Result<AddResult> {
     let link_path = args.link_path.clone();
     let (callback, rx) = collect_events();
 
-    let status =
-        lore::link::add(api.globals().build(), args.into_lore(), callback).await;
+    let status = lore::link::add(api.globals().build(), args.into_lore(), callback).await;
 
     let stream = rx
         .await
@@ -78,9 +77,10 @@ pub async fn add(api: &LoreApi, args: AddArgs) -> Result<AddResult> {
     }
 
     // Verify LinkChange event was emitted
-    let found_link_change = stream.events.iter().any(|e| {
-        matches!(e, lore::interface::LoreEvent::LinkChange(_))
-    });
+    let found_link_change = stream
+        .events
+        .iter()
+        .any(|e| matches!(e, lore::interface::LoreEvent::LinkChange(_)));
 
     if !found_link_change {
         return Err(LoreError::Parse(

--- a/crates/lore-vm/src/ops/lock/file_acquire.rs
+++ b/crates/lore-vm/src/ops/lock/file_acquire.rs
@@ -26,8 +26,11 @@ pub struct FileAcquireArgs {
 
 impl FileAcquireArgs {
     fn into_lore(self) -> LoreLockFileAcquireArgs {
-        let lore_paths: Vec<LoreString> =
-            self.paths.into_iter().map(|p| LoreString::from_str(&p)).collect();
+        let lore_paths: Vec<LoreString> = self
+            .paths
+            .into_iter()
+            .map(|p| LoreString::from_str(&p))
+            .collect();
         LoreLockFileAcquireArgs {
             paths: LoreArray::from_vec(lore_paths),
             branch: LoreString::from_str(&self.branch),
@@ -49,14 +52,10 @@ pub struct FileAcquireResult {
 /// Calls the upstream `lore::lock::file_acquire` in-process and collects
 /// the `LockFileAcquire` and `LockFileAcquireIgnore` events to return
 /// a typed result.
-pub async fn file_acquire(
-    api: &LoreApi,
-    args: FileAcquireArgs,
-) -> Result<FileAcquireResult> {
+pub async fn file_acquire(api: &LoreApi, args: FileAcquireArgs) -> Result<FileAcquireResult> {
     let (callback, rx) = collect_events();
 
-    let status =
-        lore::lock::file_acquire(api.globals().build(), args.into_lore(), callback).await;
+    let status = lore::lock::file_acquire(api.globals().build(), args.into_lore(), callback).await;
 
     let stream = rx
         .await

--- a/crates/lore-vm/tests/auth_login_with_token.rs
+++ b/crates/lore-vm/tests/auth_login_with_token.rs
@@ -99,8 +99,7 @@ fn test_login_with_token_args_serialization() {
     };
 
     let json = serde_json::to_string(&args).expect("should serialize");
-    let deserialized: LoginWithTokenArgs =
-        serde_json::from_str(&json).expect("should deserialize");
+    let deserialized: LoginWithTokenArgs = serde_json::from_str(&json).expect("should deserialize");
 
     assert_eq!(deserialized.remote_url, args.remote_url);
     assert_eq!(deserialized.token, args.token);
@@ -117,7 +116,10 @@ fn test_login_with_token_args_with_special_characters() {
         auth_url: "ucs-auth://auth.example.com:9000".to_string(),
     };
 
-    assert_eq!(args.remote_url, "https://lore.example.com:8080/path?query=value");
+    assert_eq!(
+        args.remote_url,
+        "https://lore.example.com:8080/path?query=value"
+    );
     assert!(args.token.contains('.'));
     assert_eq!(args.token_type, "JWT");
 }

--- a/crates/lore-vm/tests/lock_file_acquire.rs
+++ b/crates/lore-vm/tests/lock_file_acquire.rs
@@ -74,8 +74,7 @@ fn test_file_acquire_args_serialization() {
     };
 
     let json = serde_json::to_string(&args).expect("should serialize");
-    let deserialized: FileAcquireArgs =
-        serde_json::from_str(&json).expect("should deserialize");
+    let deserialized: FileAcquireArgs = serde_json::from_str(&json).expect("should deserialize");
 
     assert_eq!(deserialized.paths.len(), 2);
     assert_eq!(deserialized.paths[0], "a.txt");
@@ -91,8 +90,7 @@ fn test_file_acquire_result_serialization() {
     };
 
     let json = serde_json::to_string(&result).expect("should serialize");
-    let deserialized: FileAcquireResult =
-        serde_json::from_str(&json).expect("should deserialize");
+    let deserialized: FileAcquireResult = serde_json::from_str(&json).expect("should deserialize");
 
     assert_eq!(deserialized.acquired.len(), 1);
     assert_eq!(deserialized.acquired[0], "file1.txt");
@@ -116,4 +114,3 @@ fn test_file_acquire_args_with_special_characters() {
     assert!(args.paths[1].contains("日本語"));
     assert!(args.paths[2].contains('🎨'));
 }
-

--- a/crates/lore-vm/tests/repository_create_with_metadata.rs
+++ b/crates/lore-vm/tests/repository_create_with_metadata.rs
@@ -15,7 +15,7 @@ fn test_create_with_metadata_args_construction() {
     let store_path = temp_dir.path().join("shared_store");
 
     let _api = LoreApi::new(repo_path.clone());
-    
+
     let args = CreateWithMetadataArgs {
         repository_url: "file:///tmp/repo".to_string(),
         description: "A test repository".to_string(),
@@ -41,7 +41,7 @@ fn test_create_with_metadata_result_serde() {
 
     let json = serde_json::to_string(&result).expect("serialize");
     let deser: CreateWithMetadataResult = serde_json::from_str(&json).expect("deserialize");
-    
+
     assert_eq!(deser.id, result.id);
     assert_eq!(deser.name, result.name);
     assert_eq!(deser.path, result.path);
@@ -55,7 +55,7 @@ async fn test_create_with_metadata_execution_stub() {
     std::fs::create_dir_all(&store_path).unwrap();
 
     let api = LoreApi::new(repo_path.clone());
-    
+
     let args = CreateWithMetadataArgs {
         repository_url: format!("file://{}", repo_path.to_str().unwrap()),
         description: "Integration test repo".to_string(),
@@ -70,7 +70,7 @@ async fn test_create_with_metadata_execution_stub() {
     // (e.g. if the 'lore' library requires specific setup or credentials),
     // but we can verify it doesn't panic and we can handle the error.
     let result = create_with_metadata(&api, args).await;
-    
+
     match result {
         Ok(res) => {
             assert!(!res.id.is_empty());
@@ -79,7 +79,10 @@ async fn test_create_with_metadata_execution_stub() {
         Err(e) => {
             // If it fails, that's okay as long as it's a "real" error from the
             // lore library and not a bug in our binding.
-            eprintln!("create_with_metadata failed (expected in some envs): {:?}", e);
+            eprintln!(
+                "create_with_metadata failed (expected in some envs): {:?}",
+                e
+            );
         }
     }
 }

--- a/crates/lore-vm/tests/repository_verify_fragment.rs
+++ b/crates/lore-vm/tests/repository_verify_fragment.rs
@@ -51,9 +51,7 @@ fn test_verify_fragment_args_serde_roundtrip() {
 
 #[test]
 fn test_verify_fragment_result_serde() {
-    use lore_vm::ops::repository::verify_fragment::{
-        FragmentMatch, VerifyFragmentLocalResult,
-    };
+    use lore_vm::ops::repository::verify_fragment::{FragmentMatch, VerifyFragmentLocalResult};
 
     let result = VerifyFragmentResult::Local(VerifyFragmentLocalResult {
         hash: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789".into(),

--- a/crates/lore-vm/tests/resolve_user_info.rs
+++ b/crates/lore-vm/tests/resolve_user_info.rs
@@ -1,7 +1,9 @@
 //! Integration test for auth resolve_user_info operation.
 
 use lore_vm::api::LoreApi;
-use lore_vm::ops::auth::resolve_user_info::{ResolveUserInfoArgs, ResolveUserInfoResult, ResolvedUserInfo};
+use lore_vm::ops::auth::resolve_user_info::{
+    ResolveUserInfoArgs, ResolveUserInfoResult, ResolvedUserInfo,
+};
 use tempfile::TempDir;
 
 #[test]
@@ -32,12 +34,10 @@ fn test_resolve_user_info_args_serialization() {
 #[test]
 fn test_resolve_user_info_result_serialization() {
     let result = ResolveUserInfoResult {
-        users: vec![
-            ResolvedUserInfo {
-                user_id: "user1".into(),
-                display_name: "User One".into(),
-            },
-        ],
+        users: vec![ResolvedUserInfo {
+            user_id: "user1".into(),
+            display_name: "User One".into(),
+        }],
     };
     let json = serde_json::to_string(&result).unwrap();
     let deserialized: ResolveUserInfoResult = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
cargo fmt --all over main; fmt --check now clean.