### PR TITLE
SBAI-3841: LoreGUI onboarding mode selector (Connect client vs Host server)

### DIFF
--- a/frontend/src/onboarding/ModeSelect.tsx
+++ b/frontend/src/onboarding/ModeSelect.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+
+export type OnboardingMode = "client" | "host";
+
+interface ModeSelectProps {
+  /** Optional callback when a mode is selected. The onboarding shell can wire this. */
+  onModeSelect?: (mode: OnboardingMode) => void;
+}
+
+export default function ModeSelect({ onModeSelect }: ModeSelectProps) {
+  const [selectedMode, setSelectedMode] = useState<OnboardingMode | null>(null);
+
+  const handleSelect = (mode: OnboardingMode) => {
+    setSelectedMode(mode);
+    onModeSelect?.(mode);
+  };
+
+  const handleContinue = () => {
+    if (selectedMode) {
+      onModeSelect?.(selectedMode);
+    }
+  };
+
+  return (
+    <div className="onboarding-mode-select">
+      <h2 className="onboarding-title">Choose Your Setup Mode</h2>
+      <p className="onboarding-description">
+        Select how you want to use LoreGUI. You can connect to an existing server
+        or set up your own.
+      </p>
+
+      <div className="onboarding-mode-cards">
+        {/* Client Mode Card */}
+        <div
+          className={`onboarding-mode-card ${
+            selectedMode === "client" ? "onboarding-mode-card--selected" : ""
+          }`}
+          onClick={() => handleSelect("client")}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              handleSelect("client");
+            }
+          }}
+          aria-selected={selectedMode === "client"}
+        >
+          <div className="onboarding-mode-icon">
+            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path d="M20 17.58A5 5 0 0 0 18 8h-1.26A8 8 0 1 0 4 16.25" />
+              <line x1="8" y1="16" x2="8.01" y2="16" />
+              <line x1="8" y1="20" x2="8.01" y2="20" />
+              <line x1="12" y1="18" x2="12.01" y2="18" />
+              <line x1="12" y1="22" x2="12.01" y2="22" />
+              <line x1="16" y1="16" x2="16.01" y2="16" />
+              <line x1="16" y1="20" x2="16.01" y2="20" />
+            </svg>
+          </div>
+          <h3 className="onboarding-mode-title">Connect to a Lore Server</h3>
+          <p className="onboarding-mode-description">
+            Connect to an existing Lore server to collaborate with a team or access
+            shared repositories.
+          </p>
+          <div className="onboarding-mode-features">
+            <span>• Remote repository access</span>
+            <span>• Team collaboration</span>
+            <span>• Real-time sync</span>
+          </div>
+        </div>
+
+        {/* Host Mode Card */}
+        <div
+          className={`onboarding-mode-card ${
+            selectedMode === "host" ? "onboarding-mode-card--selected" : ""
+          }`}
+          onClick={() => handleSelect("host")}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              handleSelect("host");
+            }
+          }}
+          aria-selected={selectedMode === "host"}
+        >
+          <div className="onboarding-mode-icon">
+            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <rect x="2" y="2" width="20" height="8" rx="2" ry="2" />
+              <rect x="2" y="14" width="20" height="8" rx="2" ry="2" />
+              <line x1="6" y1="6" x2="6.01" y2="6" />
+              <line x1="6" y1="18" x2="6.01" y2="18" />
+            </svg>
+          </div>
+          <h3 className="onboarding-mode-title">Set Up / Host a Server</h3>
+          <p className="onboarding-mode-description">
+            Create and host your own Lore server. Set up storage, repositories,
+            and manage access for your team.
+          </p>
+          <div className="onboarding-mode-features">
+            <span>• Full server control</span>
+            <span>• Local storage options</span>
+            <span>• Self-hosted privacy</span>
+          </div>
+        </div>
+      </div>
+
+      {selectedMode && (
+        <div className="onboarding-mode-actions">
+          <button
+            className="onboarding-button onboarding-button--primary"
+            onClick={handleContinue}
+          >
+            Continue with {selectedMode === "client" ? "Client" : "Host"} Mode
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -101,3 +101,61 @@ h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; color: v
 .file-info-dl .badge.modified { background: rgba(210,153,34,0.15); color: var(--amber); font-size: 10px; padding: 1px 6px; border-radius: 4px; margin-right: 4px; }
 .file-info-dl .badge.added { background: rgba(63,185,80,0.15); color: var(--green); font-size: 10px; padding: 1px 6px; border-radius: 4px; margin-right: 4px; }
 .file-info-dl .badge.deleted { background: rgba(248,81,73,0.15); color: var(--red); font-size: 10px; padding: 1px 6px; border-radius: 4px; margin-right: 4px; }
+
+/* --- onboarding components --- */
+.onboarding-title { font-size: 20px; font-weight: 600; margin: 0 0 8px; color: var(--text); }
+.onboarding-description { color: var(--muted); font-size: 14px; margin: 0 0 24px; line-height: 1.5; max-width: 500px; }
+.onboarding-card { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 24px; }
+.onboarding-checkbox { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text); margin-bottom: 16px; cursor: pointer; }
+.onboarding-checkbox input { margin: 0; }
+.onboarding-button { background: var(--panel2); color: var(--text); border: 1px solid var(--border); border-radius: 6px; padding: 10px 20px; cursor: pointer; font-size: 14px; font-weight: 500; }
+.onboarding-button:hover:not(:disabled) { border-color: var(--accent); background: var(--panel); }
+.onboarding-button:disabled { opacity: 0.5; cursor: not-allowed; }
+.onboarding-button--primary { background: var(--accent); border-color: var(--accent); color: white; }
+.onboarding-button--primary:hover:not(:disabled) { background: var(--accent2); border-color: var(--accent2); }
+.onboarding-success { display: flex; align-items: center; gap: 12px; color: var(--green); font-size: 14px; margin-top: 16px; }
+.success-icon { font-size: 18px; }
+
+/* --- mode select --- */
+.onboarding-mode-select { padding: 20px; max-width: 700px; margin: 0 auto; }
+.onboarding-mode-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; margin: 24px 0; }
+.onboarding-mode-card {
+  background: var(--panel);
+  border: 2px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.onboarding-mode-card:hover { border-color: var(--accent); background: var(--panel2); }
+.onboarding-mode-card--selected { border-color: var(--accent); background: rgba(59,130,246,0.08); }
+.onboarding-mode-card:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.onboarding-mode-icon { color: var(--accent); display: flex; align-items: center; justify-content: center; width: 56px; height: 56px; background: rgba(59,130,246,0.1); border-radius: 12px; }
+.onboarding-mode-title { font-size: 16px; font-weight: 600; margin: 0; color: var(--text); }
+.onboarding-mode-description { font-size: 13px; color: var(--muted); margin: 0; line-height: 1.5; }
+.onboarding-mode-features { display: flex; flex-direction: column; gap: 4px; margin-top: 8px; font-size: 12px; color: var(--muted); }
+.onboarding-mode-actions { margin-top: 24px; display: flex; justify-content: center; }
+
+/* --- init store --- */
+.onboarding-init-store { max-width: 500px; margin: 0 auto; padding: 20px; }
+.onboarding-init-store h2 { font-size: 18px; margin: 0 0 8px; }
+.onboarding-init-store .subtitle { color: var(--muted); font-size: 13px; margin: 0 0 24px; }
+.onboarding-init-store .step { margin: 24px 0; }
+.onboarding-init-store .step h3 { font-size: 14px; margin: 0 0 16px; color: var(--text); }
+.onboarding-init-store .step.done h3 { color: var(--green); }
+.onboarding-init-store .field { margin-bottom: 16px; }
+.onboarding-init-store .field label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 6px; }
+.onboarding-init-store .field input {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--panel);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 13px;
+}
+.onboarding-init-store .field input:focus { outline: none; border-color: var(--accent); }
+.onboarding-init-store .success { color: var(--green); font-size: 13px; margin-bottom: 16px; }


### PR DESCRIPTION
Resolves SBAI-3841

## Summary
Created a self-contained React component `ModeSelect.tsx` that allows users to choose between two onboarding modes:
- **Connect to a Lore server** (client mode) — for connecting to an existing server
- **Set up / host a server** (host mode) — for creating and hosting a new server

The component follows the existing onboarding component patterns (ServiceSetup.tsx, InitStore.tsx) and integrates with the onboarding shell via an optional `onModeSelect` callback.

## Files Changed
- **frontend/src/onboarding/ModeSelect.tsx** (new) — Mode selection component with two clickable cards, keyboard support, and optional callback
- **frontend/src/styles.css** — Added onboarding CSS classes (onboarding-card, onboarding-button, mode-select-specific styles)

## Testing
- `npm --prefix frontend run build` passes (tsc strict + vite build)
- Component follows existing patterns from ServiceSetup.tsx and InitStore.tsx
- Includes keyboard accessibility (Enter/Space to select cards)
- Uses consistent CSS classes and theming

## How to Verify
1. Build frontend: `npm --prefix frontend run build`
2. Component exports `default function ModeSelect` with optional `onModeSelect: (mode: 'client' | 'host') => void` prop
3. Two mode cards are rendered with icons, titles, descriptions, and feature lists
4. Selected card gets visual highlight (border accent color, background tint)
5. Continue button appears when a mode is selected