### PR TITLE
SBAI-3812: layer layer_list

### DIFF
--- a/crates/lore-vm/src/ops/layer/layer_list.rs
+++ b/crates/lore-vm/src/ops/layer/layer_list.rs
@@ -1,8 +1,117 @@
 //! `layer layer_list` operation — binds `lore::layer::layer_list`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Lists all layers configured in the repository, emitting a `LayerEntry` event
+//! per layer with the target path, source repository, source path, metadata key,
+//! and current revision.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::layer::LoreLayerListArgs;
+use lore::interface::LoreEvent;
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`layer_list`].
+///
+/// Mirrors `LoreLayerListArgs` from the upstream `lore` crate (empty struct).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LayerListArgs;
+
+impl LayerListArgs {
+    fn into_lore(self) -> LoreLayerListArgs {
+        LoreLayerListArgs {}
+    }
+}
+
+/// One layer entry returned by `layer_list`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LayerEntry {
+    /// Path in the outer repository where the layer is placed.
+    pub target_path: String,
+    /// Identifier of the source repository.
+    pub source_repository: String,
+    /// Path inside the source repository where the layer starts.
+    pub source_path: String,
+    /// Metadata key used to match revisions between repositories.
+    pub metadata: String,
+    /// Current revision of the source repository layer.
+    pub revision: String,
+}
+
+/// Result returned on successful layer list.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LayerListResult {
+    /// One entry per layer configured in the repository.
+    pub layers: Vec<LayerEntry>,
+}
+
+/// List all layers configured in the repository.
+///
+/// Calls the upstream `lore::layer::layer_list` in-process and collects the
+/// `LayerEntry` events into a typed result.
+pub async fn layer_list(api: &LoreApi, args: LayerListArgs) -> Result<LayerListResult> {
+    let (callback, rx) = collect_events();
+
+    let status =
+        lore::layer::layer_list(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("layer_list failed with status {status}"),
+        )));
+    }
+
+    let mut result = LayerListResult::default();
+
+    for event in &stream.events {
+        if let LoreEvent::LayerEntry(data) = event {
+            result.layers.push(LayerEntry {
+                target_path: data.target_path.as_str().to_string(),
+                source_repository: format!("{}", data.source_repository),
+                source_path: data.source_path.as_str().to_string(),
+                metadata: data.metadata.as_str().to_string(),
+                revision: format!("{}", data.revision),
+            });
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layer_list_args_defaults() {
+        let args = LayerListArgs;
+        let lore_args = args.into_lore();
+        // Just verify it compiles - LoreLayerListArgs is an empty struct
+        let _ = lore_args;
+    }
+
+    #[test]
+    fn layer_entry_serializes() {
+        let entry = LayerEntry {
+            target_path: "/layers/assets".to_string(),
+            source_repository: "repo-id".to_string(),
+            source_path: "/".to_string(),
+            metadata: "branch".to_string(),
+            revision: "abc123".to_string(),
+        };
+        let json = serde_json::to_string(&entry).expect("should serialize");
+        assert!(json.contains("/layers/assets"));
+        assert!(json.contains("repo-id"));
+    }
+
+    #[test]
+    fn layer_list_result_default_is_empty() {
+        let result = LayerListResult::default();
+        assert!(result.layers.is_empty());
+    }
+}


### PR DESCRIPTION
Resolves SBAI-3812

## Summary
Implements the `layer_list` operation binding to `lore::layer::layer_list`.

## What Changed
- **File**: `crates/lore-vm/src/ops/layer/layer_list.rs`
  - Replaced stub with full implementation
  - Added `LayerListArgs` struct (empty, matches `LoreLayerListArgs`)
  - Added `LayerEntry` struct for layer data (target_path, source_repository, source_path, metadata, revision)
  - Added `LayerListResult` wrapper for Vec<LayerEntry>
  - Implemented `layer_list()` function following reference pattern (auth/login_with_token.rs)
  - Added unit tests for args serialization, entry serialization, and default result

## Testing
- `cargo check -p lore-vm` ✅ (green)
- `cargo test -p lore-vm` ✅ (all tests passed)
- Tests verify:
  - Args construction
  - LayerEntry serialization
  - Default empty result

## Implementation Pattern
Follows the standard binding pattern from IMPLEMENTATION-PLAN.md §4:
1. Build args via `crate::global::LoreGlobal` (via `api.globals().build()`)
2. Collect events via `crate::collect::collect_events`
3. Map `LoreEvent::LayerEntry` events to typed `LayerEntry` structs
4. Return `LayerListResult` with Vec<LayerEntry>

## Events
- Listens to `LoreEvent::LayerEntry` events emitted by `lore::layer::layer_list`
- Each event contains: target_path, source_repository, source_path, metadata, revision

## Notes
- Single file change (no registry edits — integration manager handles those)
- Ready for integration manager to wire Tauri command + GUI affordance