### PR TITLE
SBAI-3779: revision revert_resolve_theirs

### DIFF
--- a/crates/lore-vm/src/ops/revision/revert_resolve_theirs.rs
+++ b/crates/lore-vm/src/ops/revision/revert_resolve_theirs.rs
@@ -1,8 +1,128 @@
 //! `revision revert_resolve_theirs` operation — binds `lore::revision::revert_resolve_theirs`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Resolves the specified conflicted paths during an in-progress revert by
+//! keeping the "theirs" (reverted/incoming) version of each file.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::interface::LoreString;
+use lore::revision::LoreRevisionRevertResolveTheirsArgs;
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`revert_resolve_theirs`].
+///
+/// Mirrors `LoreRevisionRevertResolveTheirsArgs` from the upstream `lore` crate
+/// but uses plain `Vec<String>` so it serialises cleanly across the Tauri boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevertResolveTheirsArgs {
+    /// Repository-relative paths to resolve in favor of "theirs" (incoming).
+    pub paths: Vec<String>,
+}
+
+impl RevertResolveTheirsArgs {
+    fn into_lore(self) -> LoreRevisionRevertResolveTheirsArgs {
+        LoreRevisionRevertResolveTheirsArgs {
+            paths: lore::interface::LoreArray::from_vec(
+                self.paths
+                    .into_iter()
+                    .map(|p| LoreString::from_str(&p))
+                    .collect(),
+            ),
+        }
+    }
+}
+
+/// Result returned on successful revert resolve-theirs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevertResolveTheirsResult {
+    /// The paths that were resolved in favor of "theirs".
+    pub paths: Vec<String>,
+}
+
+/// Resolve revert conflicts on the given paths by keeping the "theirs" version.
+///
+/// Calls the upstream `lore::revision::revert_resolve_theirs` in-process and
+/// returns a typed result echoing the paths that were resolved.
+pub async fn revert_resolve_theirs(
+    api: &LoreApi,
+    args: RevertResolveTheirsArgs,
+) -> Result<RevertResolveTheirsResult> {
+    let paths = args.paths.clone();
+
+    let (callback, rx) = collect_events();
+
+    let status =
+        lore::revision::revert_resolve_theirs(api.globals().build(), args.into_lore(), callback)
+            .await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("revert_resolve_theirs failed with status {status}"),
+        )));
+    }
+
+    Ok(RevertResolveTheirsResult { paths })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_serialises() {
+        let args = RevertResolveTheirsArgs {
+            paths: vec!["src/main.rs".into(), "README.md".into()],
+        };
+        let json = serde_json::to_string(&args).expect("should serialise");
+        assert!(json.contains("src/main.rs"));
+        assert!(json.contains("README.md"));
+    }
+
+    #[test]
+    fn args_deserialises() {
+        let json = r#"{"paths":["a.txt","b.txt"]}"#;
+        let args: RevertResolveTheirsArgs = serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(args.paths, vec!["a.txt", "b.txt"]);
+    }
+
+    #[test]
+    fn result_serialises() {
+        let result = RevertResolveTheirsResult {
+            paths: vec!["file.txt".into()],
+        };
+        let json = serde_json::to_string(&result).expect("should serialise");
+        assert!(json.contains("file.txt"));
+    }
+
+    #[test]
+    fn result_deserialises() {
+        let json = r#"{"paths":["x.rs"]}"#;
+        let result: RevertResolveTheirsResult =
+            serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(result.paths, vec!["x.rs"]);
+    }
+
+    #[test]
+    fn args_empty_paths() {
+        let args = RevertResolveTheirsArgs { paths: vec![] };
+        let json = serde_json::to_string(&args).expect("should serialise");
+        let round: RevertResolveTheirsArgs =
+            serde_json::from_str(&json).expect("should deserialise");
+        assert!(round.paths.is_empty());
+    }
+
+    #[test]
+    fn into_lore_converts() {
+        let args = RevertResolveTheirsArgs {
+            paths: vec!["a.txt".into()],
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.paths.len(), 1);
+    }
+}


### PR DESCRIPTION
Resolves SBAI-3779

## Summary
- Replaced the doc-stub in `crates/lore-vm/src/ops/revision/revert_resolve_theirs.rs` with the full lore-vm binding implementation
- Calls `lore::revision::revert_resolve_theirs` in-process (no CLI shelling)
- Takes a `Vec<String>` of repository-relative paths and resolves revert conflicts by keeping the "theirs" (incoming) version
- Follows the established pattern from `cherry_pick_resolve_mine.rs`

## Files Changed
- `crates/lore-vm/src/ops/revision/revert_resolve_theirs.rs` — replaced stub with full implementation + unit tests

## Testing
- `cargo check -p lore-vm` ✅
- `cargo test -p lore-vm` ✅ (all tests pass, including 6 new unit tests for serde round-trips and into_lore conversion)