### PR TITLE
SBAI-3780: file stage

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -270,6 +270,31 @@ export const branchMergeIntoApi = {
     }),
 };
 
+// --- file stage ---
+
+export type FileStageAction = "keep" | "add" | "delete" | "move" | "copy";
+export type CaseChange = "error" | "keep" | "rename";
+
+export interface FileStageEntry {
+  path: string;
+  from_path: string;
+  action: FileStageAction;
+}
+
+export interface FileStageResult {
+  files: FileStageEntry[];
+  revision: string;
+}
+
+export const fileStageApi = {
+  stage: (
+    paths: string[],
+    caseChange?: CaseChange,
+    scan?: boolean,
+  ) =>
+    invoke<FileStageResult>("file_stage", { paths, caseChange, scan }),
+};
+
 // --- file dirty ---
 
 export interface FileDirtyResult {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -557,6 +557,31 @@ pub async fn file_write(
     .await
 }
 
+// --- file stage ---
+
+use lore_vm::ops::file::stage::{
+    stage as op_file_stage, CaseChange, FileStageArgs, FileStageResult,
+};
+
+#[tauri::command]
+pub async fn file_stage(
+    state: State<'_, AppState>,
+    paths: Vec<String>,
+    case_change: Option<CaseChange>,
+    scan: Option<bool>,
+) -> Result<FileStageResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_file_stage(
+        &api,
+        FileStageArgs {
+            paths,
+            case_change: case_change.unwrap_or_default(),
+            scan: scan.unwrap_or(false),
+        },
+    )
+    .await
+}
+
 // --- file dirty ---
 
 use lore_vm::ops::file::dirty::{dirty as op_file_dirty, FileDirtyArgs, FileDirtyResult};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,6 +48,7 @@ pub fn run() {
             commands::branch_merge_into,
             commands::file_info,
             commands::file_write,
+            commands::file_stage,
             commands::file_dirty,
             commands::file_dirty_copy,
             commands::file_obliterate,


### PR DESCRIPTION
## Summary
- Wire up the existing `lore-vm::ops::file::stage` binding to the Tauri command layer and frontend API
- Add `file_stage` `#[tauri::command]` with `CaseChange` and `scan` options (via `LoreApi` pattern)
- Register command in `generate_handler![]`
- Add typed `fileStageApi` in `frontend/src/api.ts` with `FileStageResult`, `FileStageEntry`, `CaseChange` types

The VM op was already fully implemented (PR #51). Workers incorrectly identified the ticket as complete without wiring up the Tauri + frontend layers.

## Test plan
- [x] `cargo check -p loregui` — compiles clean (no new warnings)
- [x] `npm run build` in frontend/ — builds clean
- [ ] Manual verification against a real lore repo (deferred to integration test phase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)