### PR TITLE
SBAI-3769: revision cherry_pick_resolve

### DIFF
--- a/crates/lore-vm/src/ops/revision/cherry_pick_resolve.rs
+++ b/crates/lore-vm/src/ops/revision/cherry_pick_resolve.rs
@@ -1,8 +1,132 @@
 //! `revision cherry_pick_resolve` operation — binds `lore::revision::cherry_pick_resolve`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Marks the specified conflicted paths as resolved during an in-progress
+//! cherry-pick, indicating the user has manually resolved the conflicts.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::interface::LoreString;
+use lore::revision::LoreRevisionCherryPickResolveArgs;
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`cherry_pick_resolve`].
+///
+/// Mirrors `LoreRevisionCherryPickResolveArgs` from the upstream `lore` crate
+/// but uses plain `Vec<String>` so it serialises cleanly across the Tauri boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CherryPickResolveArgs {
+    /// Repository-relative paths to mark as resolved.
+    pub paths: Vec<String>,
+}
+
+impl CherryPickResolveArgs {
+    fn into_lore(self) -> LoreRevisionCherryPickResolveArgs {
+        LoreRevisionCherryPickResolveArgs {
+            paths: lore::interface::LoreArray::from_vec(
+                self.paths
+                    .into_iter()
+                    .map(|p| LoreString::from_str(&p))
+                    .collect(),
+            ),
+        }
+    }
+}
+
+/// Result returned on successful cherry-pick resolve.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CherryPickResolveResult {
+    /// The paths that were marked as resolved.
+    pub paths: Vec<String>,
+}
+
+/// Mark cherry-pick conflicts on the given paths as resolved.
+///
+/// Calls the upstream `lore::revision::cherry_pick_resolve` in-process and
+/// returns a typed result echoing the paths that were resolved.
+pub async fn cherry_pick_resolve(
+    api: &LoreApi,
+    args: CherryPickResolveArgs,
+) -> Result<CherryPickResolveResult> {
+    let paths = args.paths.clone();
+
+    let (callback, rx) = collect_events();
+
+    let status = lore::revision::cherry_pick_resolve(
+        api.globals().build(),
+        args.into_lore(),
+        callback,
+    )
+    .await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("cherry_pick_resolve failed with status {status}"),
+        )));
+    }
+
+    Ok(CherryPickResolveResult { paths })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_serialises() {
+        let args = CherryPickResolveArgs {
+            paths: vec!["src/main.rs".into(), "README.md".into()],
+        };
+        let json = serde_json::to_string(&args).expect("should serialise");
+        assert!(json.contains("src/main.rs"));
+        assert!(json.contains("README.md"));
+    }
+
+    #[test]
+    fn args_deserialises() {
+        let json = r#"{"paths":["a.txt","b.txt"]}"#;
+        let args: CherryPickResolveArgs =
+            serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(args.paths, vec!["a.txt", "b.txt"]);
+    }
+
+    #[test]
+    fn result_serialises() {
+        let result = CherryPickResolveResult {
+            paths: vec!["file.txt".into()],
+        };
+        let json = serde_json::to_string(&result).expect("should serialise");
+        assert!(json.contains("file.txt"));
+    }
+
+    #[test]
+    fn result_deserialises() {
+        let json = r#"{"paths":["x.rs"]}"#;
+        let result: CherryPickResolveResult =
+            serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(result.paths, vec!["x.rs"]);
+    }
+
+    #[test]
+    fn args_empty_paths() {
+        let args = CherryPickResolveArgs { paths: vec![] };
+        let json = serde_json::to_string(&args).expect("should serialise");
+        let round: CherryPickResolveArgs =
+            serde_json::from_str(&json).expect("should deserialise");
+        assert!(round.paths.is_empty());
+    }
+
+    #[test]
+    fn into_lore_converts() {
+        let args = CherryPickResolveArgs {
+            paths: vec!["a.txt".into()],
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.paths.len(), 1);
+    }
+}

--- a/crates/lore-vm/src/ops/revision/cherry_pick_resolve.rs
+++ b/crates/lore-vm/src/ops/revision/cherry_pick_resolve.rs
@@ -53,12 +53,9 @@ pub async fn cherry_pick_resolve(
 
     let (callback, rx) = collect_events();
 
-    let status = lore::revision::cherry_pick_resolve(
-        api.globals().build(),
-        args.into_lore(),
-        callback,
-    )
-    .await;
+    let status =
+        lore::revision::cherry_pick_resolve(api.globals().build(), args.into_lore(), callback)
+            .await;
 
     let stream = rx
         .await
@@ -90,8 +87,7 @@ mod tests {
     #[test]
     fn args_deserialises() {
         let json = r#"{"paths":["a.txt","b.txt"]}"#;
-        let args: CherryPickResolveArgs =
-            serde_json::from_str(json).expect("should deserialise");
+        let args: CherryPickResolveArgs = serde_json::from_str(json).expect("should deserialise");
         assert_eq!(args.paths, vec!["a.txt", "b.txt"]);
     }
 
@@ -116,8 +112,7 @@ mod tests {
     fn args_empty_paths() {
         let args = CherryPickResolveArgs { paths: vec![] };
         let json = serde_json::to_string(&args).expect("should serialise");
-        let round: CherryPickResolveArgs =
-            serde_json::from_str(&json).expect("should deserialise");
+        let round: CherryPickResolveArgs = serde_json::from_str(&json).expect("should deserialise");
         assert!(round.paths.is_empty());
     }
 


### PR DESCRIPTION
## Summary
- Implement `lore-vm::ops::revision::cherry_pick_resolve` binding per IMPLEMENTATION-PLAN.md §4 pattern
- Binds upstream `lore::revision::cherry_pick_resolve` in-process (no CLI shelling)
- Includes typed `CherryPickResolveArgs`/`CherryPickResolveResult` structs with serde serialization
- 6 unit tests: serde round-trips, empty paths edge case, `into_lore` conversion

## Test plan
- [x] `cargo check -p lore-vm` — compiles clean
- [x] `cargo check -p loregui` — Tauri app compiles clean
- [x] `cargo test -p lore-vm` — all 466 tests pass (6 new for this op)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)