### PR TITLE
SBAI-3753: revision history

### DIFF
--- a/crates/lore-vm/tests/revision_history.rs
+++ b/crates/lore-vm/tests/revision_history.rs
@@ -1,0 +1,101 @@
+//! Integration test for revision history operation.
+//!
+//! Tests the `lore_vm::ops::revision::history` binding's type surface and
+//! serialization round-trips. A full end-to-end test (create repo, commit,
+//! query history) requires shared-store infrastructure; here we validate
+//! construction and serde so CI stays green.
+
+use lore_vm::api::LoreApi;
+use lore_vm::ops::revision::history::{
+    RevisionHistoryArgs, RevisionHistoryEntry, RevisionHistoryResult,
+};
+use tempfile::TempDir;
+
+#[test]
+fn api_and_args_construct() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let repo_path = temp_dir.path().join("test_repo");
+
+    let api = LoreApi::new(repo_path.clone());
+    assert_eq!(api.global().repository_path, repo_path);
+
+    let args = RevisionHistoryArgs {
+        revision: "rev1".into(),
+        branch: "main".into(),
+        date: 0,
+        length: 50,
+        only_branch: true,
+    };
+    assert_eq!(args.revision, "rev1");
+    assert_eq!(args.branch, "main");
+    assert_eq!(args.length, 50);
+    assert!(args.only_branch);
+}
+
+#[test]
+fn args_defaults_from_json() {
+    let json = r#"{}"#;
+    let args: RevisionHistoryArgs = serde_json::from_str(json).expect("should deserialize");
+    assert_eq!(args.revision, "");
+    assert_eq!(args.branch, "");
+    assert_eq!(args.date, 0);
+    assert_eq!(args.length, 0);
+    assert!(!args.only_branch);
+}
+
+#[test]
+fn args_round_trips_through_json() {
+    let args = RevisionHistoryArgs {
+        revision: "abc123".into(),
+        branch: "feature".into(),
+        date: 1700000000,
+        length: 100,
+        only_branch: true,
+    };
+    let json = serde_json::to_string(&args).expect("serialise");
+    let back: RevisionHistoryArgs = serde_json::from_str(&json).expect("deserialise");
+    assert_eq!(back.revision, args.revision);
+    assert_eq!(back.branch, args.branch);
+    assert_eq!(back.date, args.date);
+    assert_eq!(back.length, args.length);
+    assert_eq!(back.only_branch, args.only_branch);
+}
+
+#[test]
+fn result_round_trips_through_json() {
+    let result = RevisionHistoryResult {
+        entries: vec![
+            RevisionHistoryEntry {
+                revision: "r3".into(),
+                revision_number: 3,
+                parents: vec!["r2".into()],
+            },
+            RevisionHistoryEntry {
+                revision: "r2".into(),
+                revision_number: 2,
+                parents: vec!["r1".into()],
+            },
+            RevisionHistoryEntry {
+                revision: "r1".into(),
+                revision_number: 1,
+                parents: vec![],
+            },
+        ],
+    };
+    let json = serde_json::to_string(&result).expect("serialise");
+    let back: RevisionHistoryResult = serde_json::from_str(&json).expect("deserialise");
+    assert_eq!(back.entries.len(), 3);
+    assert_eq!(back.entries[0].revision, "r3");
+    assert_eq!(back.entries[0].revision_number, 3);
+    assert_eq!(back.entries[0].parents, vec!["r2"]);
+    assert_eq!(back.entries[2].parents.len(), 0);
+}
+
+#[test]
+fn empty_result_serializes() {
+    let result = RevisionHistoryResult { entries: vec![] };
+    let json = serde_json::to_string(&result).expect("serialise");
+    assert!(json.contains("[]"));
+    let back: RevisionHistoryResult = serde_json::from_str(&json).expect("deserialise");
+    assert!(back.entries.is_empty());
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -487,6 +487,35 @@ export const revisionFindLocalApi = {
     }),
 };
 
+// --- revision history ---
+
+export interface RevisionHistoryEntry {
+  revision: string;
+  revision_number: number;
+  parents: string[];
+}
+
+export interface RevisionHistoryResult {
+  entries: RevisionHistoryEntry[];
+}
+
+export const revisionHistoryApi = {
+  history: (
+    revision: string = "",
+    branch: string = "",
+    date: number = 0,
+    length: number = 0,
+    onlyBranch: boolean = false,
+  ) =>
+    invoke<RevisionHistoryResult>("revision_history", {
+      revision,
+      branch,
+      date,
+      length,
+      onlyBranch,
+    }),
+};
+
 // --- revision revert_local ---
 
 export interface RevertConflictFile {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -661,6 +661,35 @@ pub async fn revision_sync(
     .await
 }
 
+// --- revision history ---
+
+use lore_vm::ops::revision::history::{
+    history as op_revision_history, RevisionHistoryArgs, RevisionHistoryResult,
+};
+
+#[tauri::command]
+pub async fn revision_history(
+    state: State<'_, AppState>,
+    revision: String,
+    branch: String,
+    date: u64,
+    length: u32,
+    only_branch: bool,
+) -> Result<RevisionHistoryResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_revision_history(
+        &api,
+        RevisionHistoryArgs {
+            revision,
+            branch,
+            date,
+            length,
+            only_branch,
+        },
+    )
+    .await
+}
+
 // --- lock file_query ---
 
 use lore_vm::ops::lock::file_query::{

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,6 +64,7 @@ pub fn run() {
             commands::revision_find_local,
             commands::revision_revert_local,
             commands::revision_sync,
+            commands::revision_history,
             commands::revision_revert_resolve,
             commands::auth_local_user_info,
             commands::lock_file_release,


### PR DESCRIPTION
## Summary
- Adds `#[tauri::command] revision_history` wrapper in `src-tauri/src/commands.rs` forwarding to the existing `lore-vm::ops::revision::history` op
- Registers the command in `src-tauri/src/lib.rs` `generate_handler!`
- Adds typed frontend API binding (`revisionHistoryApi`) in `frontend/src/api.ts`
- Adds integration test (`crates/lore-vm/tests/revision_history.rs`) with 5 tests covering arg construction, defaults, serde round-trips, and empty results

## Test plan
- [x] `cargo test -p lore-vm --test revision_history` — 5/5 pass
- [x] `cargo check -p loregui` — compiles clean (only pre-existing warnings)
- [ ] CI gates: `cargo fmt --check`, `cargo clippy`, `cargo test`, `cargo check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)