### PR TITLE
SBAI-3749: revision commit

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -571,6 +571,19 @@ export const revisionAmendApi = {
     invoke<AmendResult>("revision_amend", { message }),
 };
 
+// --- revision commit (ops-layer) ---
+
+export interface RevisionCommitResult {
+  revision: string;
+  revision_number: number;
+  branch: string;
+}
+
+export const revisionCommitApi = {
+  commit: (message: string) =>
+    invoke<RevisionCommitResult>("revision_commit", { message }),
+};
+
 // --- revision revert_local ---
 
 export interface RevertConflictFile {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -728,6 +728,21 @@ pub async fn revision_amend(
     op_revision_amend(&api, AmendArgs { message }).await
 }
 
+// --- revision commit (ops-layer) ---
+
+use lore_vm::ops::revision::commit::{
+    commit as op_revision_commit, CommitArgs as OpsCommitArgs, CommitResult,
+};
+
+#[tauri::command]
+pub async fn revision_commit(
+    state: State<'_, AppState>,
+    message: String,
+) -> Result<CommitResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_revision_commit(&api, OpsCommitArgs { message }).await
+}
+
 // --- lock file_query ---
 
 use lore_vm::ops::lock::file_query::{

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,6 +67,7 @@ pub fn run() {
             commands::revision_history,
             commands::revision_info,
             commands::revision_amend,
+            commands::revision_commit,
             commands::revision_revert_resolve,
             commands::auth_local_user_info,
             commands::lock_file_release,


### PR DESCRIPTION
## Summary
- Binds `lore::revision::commit` across the Tauri command and frontend API layers
- VM ops layer (`crates/lore-vm/src/ops/revision/commit.rs`) was already implemented and tested
- Adds `#[tauri::command] revision_commit` wrapper using `LoreApi` + ops pattern
- Adds `revisionCommitApi` typed invoke wrapper in `frontend/src/api.ts`
- Registers command in `generate_handler![]`

## Test plan
- [x] `cargo check -p loregui` — compiles clean
- [x] `cargo fmt --all --check` — passes
- [x] `cargo clippy -p lore-vm -- -D warnings` — passes
- [x] `cargo test -p lore-vm` — all tests pass (includes 3 commit-specific unit tests)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)