### PR TITLE
SBAI-3846: onboarding server connectivity validation (storage round-trip)

### DIFF
--- a/frontend/src/onboarding/server/ValidateConnectivity.tsx
+++ b/frontend/src/onboarding/server/ValidateConnectivity.tsx
@@ -1,0 +1,116 @@
+import { useCallback, useState } from "react";
+import { api, type StorageBackendConfig } from "../../api";
+
+type Step = "idle" | "testing" | "pass" | "fail";
+
+interface ValidateConnectivityProps {
+  /** Storage backend config provided by the onboarding shell. */
+  config: StorageBackendConfig;
+}
+
+export default function ValidateConnectivity({
+  config,
+}: ValidateConnectivityProps) {
+  const [step, setStep] = useState<Step>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const TEST_KEY = "__lore_connectivity_check__";
+  const TEST_DATA = [79, 75]; // "OK" as bytes
+
+  const handleTest = useCallback(async () => {
+    try {
+      setStep("testing");
+      setError(null);
+
+      // Open the configured storage backend
+      await api.storageOpen(config);
+
+      // Put a test key
+      await api.storagePut(TEST_KEY, TEST_DATA);
+
+      // Get it back and verify round-trip
+      const got = await api.storageGet(TEST_KEY);
+      const ok =
+        got.length === TEST_DATA.length &&
+        got.every((b, i) => b === TEST_DATA[i]);
+
+      if (!ok) {
+        throw new Error(
+          `Round-trip mismatch: wrote [${TEST_DATA}], got [${got}]`,
+        );
+      }
+
+      // Clean up the test key
+      await api.storageObliterate(TEST_KEY);
+
+      setStep("pass");
+    } catch (e) {
+      // Best-effort cleanup if put succeeded but get/obliterate failed
+      try {
+        await api.storageObliterate(TEST_KEY);
+      } catch {
+        // ignore — the key may not exist or storage may be unreachable
+      }
+      const msg = typeof e === "string" ? e : JSON.stringify(e);
+      setError(msg);
+      setStep("fail");
+    }
+  }, [config]);
+
+  const handleRetry = useCallback(() => {
+    setStep("idle");
+    setError(null);
+  }, []);
+
+  return (
+    <div className="onboarding-card">
+      <h2>Validate Backend Connectivity</h2>
+      <p className="onboarding-description">
+        Run a storage round-trip test (Put → Get → Obliterate) to verify the
+        configured backend is reachable and functioning correctly.
+      </p>
+
+      {error && <div className="error">{error}</div>}
+
+      {step === "idle" && (
+        <button
+          className="onboarding-button onboarding-button--primary"
+          onClick={() => void handleTest()}
+        >
+          Run Connectivity Test
+        </button>
+      )}
+
+      {step === "testing" && (
+        <button className="onboarding-button onboarding-button--primary" disabled>
+          Testing&hellip;
+        </button>
+      )}
+
+      {step === "pass" && (
+        <div className="onboarding-success">
+          <span className="success-icon">&#10003;</span>
+          <span>Storage round-trip passed — backend is reachable.</span>
+          <button className="onboarding-button" onClick={handleRetry}>
+            Test Again
+          </button>
+        </div>
+      )}
+
+      {step === "fail" && (
+        <div>
+          <div className="onboarding-fail">
+            <span className="fail-icon">&#10007;</span>
+            <span>Connectivity test failed.</span>
+          </div>
+          <button
+            className="onboarding-button onboarding-button--primary"
+            onClick={() => void handleTest()}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Resolves SBAI-3846

## Summary
Added ValidateConnectivity component that validates the configured storage backend via a round-trip test (Put → Get → Obliterate). Shows pass/fail status to the user.

## Files Changed
- `frontend/src/onboarding/server/ValidateConnectivity.tsx` — new component

## Component Details
- Accepts `StorageBackendConfig` as a prop (wired by onboarding shell)
- Uses existing api surface: `storageOpen`, `storagePut`, `storageGet`, `storageObliterate`
- Verifies byte-for-byte round-trip correctness
- Best-effort cleanup on failure (obliterates test key if it was written)
- Follows existing onboarding component patterns (CSS classes, state machine)

## Testing
- `npm --prefix frontend run build` — green (tsc strict + vite, zero errors)
- No new errors introduced (pre-existing build was clean after `npm install`)