### PR TITLE
feat(palette): Phase 0 command-palette infra (Ctrl-K, manifest-driven)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import OnboardingFlow from "./onboarding/OnboardingFlow";
 import ThemeEditor from "./theme/ThemeEditor";
+import CommandPalette, { OPEN_PALETTE_EVENT } from "./palette/CommandPalette";
 import {
   api,
   branchArchiveApi,
@@ -306,6 +307,12 @@ export default function App() {
         </div>
         <div className="repo">{repo || "no repository open"}</div>
         <div className="actions">
+          <button
+            onClick={() => window.dispatchEvent(new Event(OPEN_PALETTE_EVENT))}
+            title="Command palette (Ctrl/Cmd-K)"
+          >
+            ⌘K
+          </button>
           <button onClick={() => setThemeOpen(true)} title="Customize theme">
             Theme
           </button>
@@ -904,6 +911,8 @@ export default function App() {
           </div>
         </div>
       )}
+
+      <CommandPalette />
     </div>
   );
 }

--- a/frontend/src/palette/CommandPalette.tsx
+++ b/frontend/src/palette/CommandPalette.tsx
@@ -1,0 +1,306 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { CSSProperties } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { OP_MANIFEST } from "./manifest";
+import type { OpManifest } from "./types";
+import OpForm from "./form";
+import OpResult from "./result";
+
+/** Window event the topbar launcher dispatches to open the palette. */
+export const OPEN_PALETTE_EVENT = "loregui:open-palette";
+
+function matches(m: OpManifest, q: string): boolean {
+  if (!q) return true;
+  const hay = `${m.id} ${m.label} ${m.description ?? ""} ${(m.keywords ?? []).join(" ")}`.toLowerCase();
+  return q
+    .toLowerCase()
+    .split(/\s+/)
+    .every((term) => hay.includes(term));
+}
+
+const overlayStyle: CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(0,0,0,0.5)",
+  display: "flex",
+  alignItems: "flex-start",
+  justifyContent: "center",
+  padding: "10vh 16px 16px",
+  zIndex: 1100,
+};
+const panelStyle: CSSProperties = {
+  width: "100%",
+  maxWidth: 640,
+  maxHeight: "75vh",
+  display: "flex",
+  flexDirection: "column",
+  background: "var(--surface-overlay-bg)",
+  color: "var(--surface-base-text)",
+  border: "1px solid var(--surface-overlay-border)",
+  borderRadius: 8,
+  boxShadow: "var(--shadow-lg)",
+  overflow: "hidden",
+};
+const searchStyle: CSSProperties = {
+  width: "100%",
+  boxSizing: "border-box",
+  padding: "12px 14px",
+  background: "transparent",
+  color: "var(--surface-base-text)",
+  border: "none",
+  borderBottom: "1px solid var(--surface-overlay-border)",
+  fontSize: 15,
+  outline: "none",
+};
+
+export default function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<OpManifest | null>(null);
+  const [highlight, setHighlight] = useState(0);
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<{ value: unknown } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const reset = useCallback(() => {
+    setQuery("");
+    setSelected(null);
+    setHighlight(0);
+    setResult(null);
+    setError(null);
+    setRunning(false);
+  }, []);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    reset();
+  }, [reset]);
+
+  const filtered = useMemo(
+    () =>
+      OP_MANIFEST.filter((m) => matches(m, query)).sort((a, b) =>
+        a.label.localeCompare(b.label),
+      ),
+    [query],
+  );
+
+  // Global open shortcut (Ctrl/Cmd-K) + launcher event.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((o) => !o);
+      }
+    };
+    const onOpen = () => setOpen(true);
+    window.addEventListener("keydown", onKey);
+    window.addEventListener(OPEN_PALETTE_EVENT, onOpen);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener(OPEN_PALETTE_EVENT, onOpen);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (open && !selected) searchRef.current?.focus();
+  }, [open, selected]);
+
+  useEffect(() => {
+    if (highlight >= filtered.length) setHighlight(Math.max(0, filtered.length - 1));
+  }, [filtered, highlight]);
+
+  const pick = useCallback((m: OpManifest) => {
+    setSelected(m);
+    setResult(null);
+    setError(null);
+  }, []);
+
+  const run = useCallback(
+    async (args: Record<string, unknown>) => {
+      if (!selected) return;
+      setRunning(true);
+      setError(null);
+      setResult(null);
+      try {
+        const value = await invoke(selected.command, args);
+        setResult({ value });
+      } catch (e) {
+        setError(typeof e === "string" ? e : JSON.stringify(e));
+      } finally {
+        setRunning(false);
+      }
+    },
+    [selected],
+  );
+
+  if (!open) return null;
+
+  const onListKey = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlight((h) => Math.min(h + 1, filtered.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight((h) => Math.max(h - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const m = filtered[highlight];
+      if (m) pick(m);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      close();
+    }
+  };
+
+  return (
+    <div style={overlayStyle} onClick={close}>
+      <div
+        style={panelStyle}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+      >
+        {!selected ? (
+          <>
+            <input
+              ref={searchRef}
+              style={searchStyle}
+              placeholder="Run a command…  (type to search all ops)"
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setHighlight(0);
+              }}
+              onKeyDown={onListKey}
+            />
+            <div style={{ overflowY: "auto" }}>
+              {filtered.length === 0 && (
+                <div
+                  style={{
+                    padding: 16,
+                    color: "var(--surface-base-text-secondary)",
+                    fontSize: 13,
+                  }}
+                >
+                  No commands match “{query}”.
+                </div>
+              )}
+              {filtered.map((m, i) => (
+                <button
+                  key={m.id}
+                  onClick={() => pick(m)}
+                  onMouseEnter={() => setHighlight(i)}
+                  style={{
+                    display: "block",
+                    width: "100%",
+                    textAlign: "left",
+                    padding: "9px 14px",
+                    border: "none",
+                    cursor: "pointer",
+                    background:
+                      i === highlight
+                        ? "var(--surface-primary-bg)"
+                        : "transparent",
+                    color:
+                      i === highlight
+                        ? "var(--surface-primary-text)"
+                        : "var(--surface-base-text)",
+                  }}
+                >
+                  <div style={{ fontSize: 13, fontWeight: 600 }}>{m.label}</div>
+                  {m.description && (
+                    <div
+                      style={{
+                        fontSize: 11,
+                        opacity: 0.8,
+                        color: "inherit",
+                      }}
+                    >
+                      {m.description}
+                    </div>
+                  )}
+                </button>
+              ))}
+            </div>
+            <div
+              style={{
+                padding: "6px 14px",
+                fontSize: 11,
+                color: "var(--surface-base-text-secondary)",
+                borderTop: "1px solid var(--surface-overlay-border)",
+              }}
+            >
+              {filtered.length} command{filtered.length === 1 ? "" : "s"} · ↑↓ to
+              navigate · Enter to select · Esc to close
+            </div>
+          </>
+        ) : (
+          <div style={{ padding: 16, overflowY: "auto" }}>
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                marginBottom: 12,
+              }}
+            >
+              <div>
+                <div style={{ fontSize: 14, fontWeight: 700 }}>
+                  {selected.label}
+                </div>
+                <code
+                  style={{
+                    fontSize: 11,
+                    color: "var(--surface-base-text-secondary)",
+                  }}
+                >
+                  {selected.command}
+                </code>
+              </div>
+              <button
+                onClick={() => {
+                  setSelected(null);
+                  setResult(null);
+                  setError(null);
+                }}
+              >
+                ← Back
+              </button>
+            </div>
+            {selected.description && (
+              <p
+                style={{
+                  fontSize: 12,
+                  color: "var(--surface-base-text-secondary)",
+                  margin: "0 0 14px",
+                }}
+              >
+                {selected.description}
+              </p>
+            )}
+            <OpForm manifest={selected} running={running} onRun={run} />
+            {error && (
+              <div
+                style={{
+                  marginTop: 12,
+                  padding: "10px 12px",
+                  background: "var(--surface-error-bg)",
+                  color: "var(--surface-error-text)",
+                  border: "1px solid var(--surface-error-border)",
+                  borderRadius: 4,
+                  fontSize: 12,
+                  whiteSpace: "pre-wrap",
+                }}
+              >
+                {error}
+              </div>
+            )}
+            {result && <OpResult value={result.value} kind={selected.resultKind} />}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/palette/README.md
+++ b/frontend/src/palette/README.md
@@ -1,0 +1,56 @@
+# Command Palette
+
+A single Ctrl/Cmd-K palette that can invoke any lore-vm op via a manifest-driven
+generated form. This is the host for **full GUI parity**: one manifest entry per
+op makes that op reachable, searchable, and runnable.
+
+## Architecture
+
+| File | Role |
+|---|---|
+| `types.ts` | `FieldSpec` + `OpManifest` model (the per-op contract). |
+| `form.tsx` | Renders a generated form from `OpManifest.args` and runs it. |
+| `result.tsx` | Renders the command result per `resultKind` (`void`/`text`/`json`). |
+| `CommandPalette.tsx` | The Ctrl-K overlay: fuzzy search → form → `invoke`. |
+| `manifest/index.ts` | The registry. **Append-only** — the only shared file. |
+| `manifest/<domain>/<op>.ts` | One entry per op. The unit of parity work. |
+
+## Adding an op (the fan-out unit)
+
+1. Create `manifest/<domain>/<op>.ts` exporting a default `OpManifest`:
+
+   ```ts
+   import type { OpManifest } from "../../types";
+
+   const manifest: OpManifest = {
+     id: "branch.create",
+     domain: "branch",
+     op: "create",
+     label: "Branch: Create",
+     description: "Create a new branch.",
+     command: "create_branch",        // the registered Tauri command name
+     args: [
+       { name: "name", kind: "text", label: "Branch name", required: true },
+     ],
+     resultKind: "json",
+     keywords: ["branch", "new"],
+   };
+
+   export default manifest;
+   ```
+
+   - `command` must be a registered `#[tauri::command]` (add the wrapper + an
+     `api.ts` binding if the op lacks one).
+   - `FieldSpec.name` is the **camelCase** arg key the command expects (Tauri v2
+     maps camelCase → snake_case), matching the `api.ts` call site.
+   - `kind`: `text | number | boolean | enum | string-list`. `enum` needs
+     `options`. `string-list` collects one value per line.
+
+2. Append one `import` + one array element (sorted by `id`) to
+   `manifest/index.ts`. **Do not** edit any other op's file.
+
+3. Acceptance: the op appears in Ctrl-K, its generated form invokes the command,
+   and the result renders.
+
+See the three Phase 0 reference entries: `repository/status` (no args, JSON),
+`file/stage` (string-list, void), `revision/commit` (required text, text result).

--- a/frontend/src/palette/form.tsx
+++ b/frontend/src/palette/form.tsx
@@ -1,0 +1,211 @@
+import { useMemo, useState } from "react";
+import type { CSSProperties } from "react";
+import type { FieldSpec, OpManifest } from "./types";
+
+/** Editable representation of a field value while the form is open. */
+type EditValue = string | boolean;
+
+function initialValues(manifest: OpManifest): Record<string, EditValue> {
+  const out: Record<string, EditValue> = {};
+  for (const f of manifest.args) {
+    if (f.kind === "boolean") {
+      out[f.name] = typeof f.default === "boolean" ? f.default : false;
+    } else if (f.kind === "string-list") {
+      out[f.name] = Array.isArray(f.default) ? f.default.join("\n") : "";
+    } else if (f.default !== undefined) {
+      out[f.name] = String(f.default);
+    } else {
+      out[f.name] = "";
+    }
+  }
+  return out;
+}
+
+function fieldFilled(f: FieldSpec, v: EditValue): boolean {
+  if (f.kind === "boolean") return true;
+  if (f.kind === "string-list") {
+    return String(v)
+      .split("\n")
+      .some((line) => line.trim().length > 0);
+  }
+  return String(v).trim().length > 0;
+}
+
+/** Convert the edit-time values into the typed args object for `invoke`. */
+function buildArgs(
+  manifest: OpManifest,
+  values: Record<string, EditValue>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const f of manifest.args) {
+    const v = values[f.name];
+    const filled = fieldFilled(f, v);
+    switch (f.kind) {
+      case "boolean":
+        out[f.name] = Boolean(v);
+        break;
+      case "number":
+        if (filled) out[f.name] = Number(v);
+        else if (f.required) out[f.name] = Number(v);
+        break;
+      case "string-list":
+        out[f.name] = String(v)
+          .split("\n")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0);
+        break;
+      default: // text | enum
+        if (filled || f.required) out[f.name] = String(v);
+        break;
+    }
+  }
+  return out;
+}
+
+const labelStyle: CSSProperties = {
+  display: "block",
+  fontSize: 12,
+  fontWeight: 600,
+  marginBottom: 4,
+  color: "var(--surface-base-text)",
+};
+const descStyle: CSSProperties = {
+  fontSize: 11,
+  color: "var(--surface-base-text-secondary)",
+  marginTop: 2,
+};
+const inputStyle: CSSProperties = {
+  width: "100%",
+  boxSizing: "border-box",
+  padding: "6px 8px",
+  background: "var(--surface-input-bg)",
+  color: "var(--surface-input-text)",
+  border: "1px solid var(--surface-input-border)",
+  borderRadius: 4,
+  fontSize: 13,
+};
+
+interface OpFormProps {
+  manifest: OpManifest;
+  running: boolean;
+  onRun: (args: Record<string, unknown>) => void;
+}
+
+/** Renders a generated form from an op's {@link FieldSpec}s and runs it. */
+export default function OpForm({ manifest, running, onRun }: OpFormProps) {
+  const [values, setValues] = useState<Record<string, EditValue>>(() =>
+    initialValues(manifest),
+  );
+
+  const valid = useMemo(
+    () =>
+      manifest.args
+        .filter((f) => f.required)
+        .every((f) => fieldFilled(f, values[f.name])),
+    [manifest, values],
+  );
+
+  const set = (name: string, v: EditValue) =>
+    setValues((prev) => ({ ...prev, [name]: v }));
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (valid && !running) onRun(buildArgs(manifest, values));
+      }}
+    >
+      {manifest.args.length === 0 && (
+        <p style={{ ...descStyle, marginBottom: 12 }}>
+          This command takes no arguments.
+        </p>
+      )}
+
+      {manifest.args.map((f) => (
+        <div key={f.name} style={{ marginBottom: 12 }}>
+          {f.kind === "boolean" ? (
+            <label
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                cursor: "pointer",
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={Boolean(values[f.name])}
+                onChange={(e) => set(f.name, e.target.checked)}
+                disabled={running}
+              />
+              <span style={{ ...labelStyle, marginBottom: 0 }}>
+                {f.label}
+                {f.required ? " *" : ""}
+              </span>
+            </label>
+          ) : (
+            <>
+              <label style={labelStyle} htmlFor={`pf-${f.name}`}>
+                {f.label}
+                {f.required ? " *" : ""}
+              </label>
+              {f.kind === "enum" ? (
+                <select
+                  id={`pf-${f.name}`}
+                  style={inputStyle}
+                  value={String(values[f.name])}
+                  onChange={(e) => set(f.name, e.target.value)}
+                  disabled={running}
+                >
+                  <option value="">—</option>
+                  {(f.options ?? []).map((o) => (
+                    <option key={o.value} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+              ) : f.kind === "string-list" ? (
+                <textarea
+                  id={`pf-${f.name}`}
+                  style={{ ...inputStyle, minHeight: 64, fontFamily: "inherit" }}
+                  placeholder={f.placeholder ?? "one value per line"}
+                  value={String(values[f.name])}
+                  onChange={(e) => set(f.name, e.target.value)}
+                  disabled={running}
+                />
+              ) : (
+                <input
+                  id={`pf-${f.name}`}
+                  type={f.kind === "number" ? "number" : "text"}
+                  style={inputStyle}
+                  placeholder={f.placeholder}
+                  value={String(values[f.name])}
+                  onChange={(e) => set(f.name, e.target.value)}
+                  disabled={running}
+                />
+              )}
+            </>
+          )}
+          {f.description && <div style={descStyle}>{f.description}</div>}
+        </div>
+      ))}
+
+      <button
+        type="submit"
+        disabled={!valid || running}
+        style={{
+          padding: "7px 14px",
+          background: "var(--surface-primary-bg)",
+          color: "var(--surface-primary-text)",
+          border: "1px solid var(--surface-primary-border)",
+          borderRadius: 4,
+          fontWeight: 600,
+          cursor: valid && !running ? "pointer" : "not-allowed",
+          opacity: valid && !running ? 1 : 0.5,
+        }}
+      >
+        {running ? "Running…" : "Run"}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/palette/manifest/file/stage.ts
+++ b/frontend/src/palette/manifest/file/stage.ts
@@ -1,0 +1,28 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Reference manifest entry (Phase 0). Exercises the `string-list` field and a
+ * `void` result.
+ */
+const manifest: OpManifest = {
+  id: "file.stage",
+  domain: "file",
+  op: "stage",
+  label: "File: Stage",
+  description: "Stage one or more paths for the next commit.",
+  command: "stage",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths",
+      description: "One path per line.",
+      required: true,
+      placeholder: "src/foo.txt\nsrc/bar.txt",
+    },
+  ],
+  resultKind: "void",
+  keywords: ["add", "stage", "index"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/index.ts
+++ b/frontend/src/palette/manifest/index.ts
@@ -1,0 +1,22 @@
+import type { OpManifest } from "../types";
+import repositoryStatus from "./repository/status";
+import fileStage from "./file/stage";
+import revisionCommit from "./revision/commit";
+
+/**
+ * The command-palette op registry.
+ *
+ * Phase 0 ships three reference entries. The per-op parity fan-out appends one
+ * `import` + one array element per op (append-only — the only shared file, the
+ * integration manager merges these in order). Keep the array sorted by `id`.
+ */
+export const OP_MANIFEST: OpManifest[] = [
+  fileStage,
+  repositoryStatus,
+  revisionCommit,
+];
+
+/** Lookup by `"<domain>.<op>"` id. */
+export const OP_BY_ID: Record<string, OpManifest> = Object.fromEntries(
+  OP_MANIFEST.map((m) => [m.id, m]),
+);

--- a/frontend/src/palette/manifest/repository/status.ts
+++ b/frontend/src/palette/manifest/repository/status.ts
@@ -1,0 +1,20 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Reference manifest entry (Phase 0). A no-arg op whose result is a typed
+ * object — exercises the empty-form + JSON-result path of the palette.
+ */
+const manifest: OpManifest = {
+  id: "repository.status",
+  domain: "repository",
+  op: "status",
+  label: "Repository: Status",
+  description:
+    "Show working-tree status — branch, revision, changes, ahead/behind.",
+  command: "status",
+  args: [],
+  resultKind: "json",
+  keywords: ["status", "changes", "dirty", "state"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/revision/commit.ts
+++ b/frontend/src/palette/manifest/revision/commit.ts
@@ -1,0 +1,27 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Reference manifest entry (Phase 0). Exercises a required `text` field and a
+ * `text` result (the new revision hash).
+ */
+const manifest: OpManifest = {
+  id: "revision.commit",
+  domain: "revision",
+  op: "commit",
+  label: "Revision: Commit",
+  description: "Commit the staged changes with a message.",
+  command: "commit",
+  args: [
+    {
+      name: "message",
+      kind: "text",
+      label: "Message",
+      required: true,
+      placeholder: "Describe the change",
+    },
+  ],
+  resultKind: "text",
+  keywords: ["commit", "save", "snapshot"],
+};
+
+export default manifest;

--- a/frontend/src/palette/result.tsx
+++ b/frontend/src/palette/result.tsx
@@ -1,0 +1,58 @@
+import type { CSSProperties } from "react";
+import type { ResultKind } from "./types";
+
+const boxStyle: CSSProperties = {
+  marginTop: 12,
+  padding: "10px 12px",
+  background: "var(--surface-base-bg)",
+  border: "1px solid var(--surface-base-border)",
+  borderRadius: 4,
+  fontSize: 12,
+};
+
+const preStyle: CSSProperties = {
+  ...boxStyle,
+  margin: "12px 0 0",
+  maxHeight: 280,
+  overflow: "auto",
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-word",
+  fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+  color: "var(--surface-base-text)",
+};
+
+interface OpResultProps {
+  value: unknown;
+  kind?: ResultKind;
+}
+
+/** Renders a command's return value per its {@link ResultKind} hint. */
+export default function OpResult({ value, kind = "json" }: OpResultProps) {
+  if (kind === "void") {
+    return (
+      <div style={{ ...boxStyle, color: "var(--surface-success-text)" }}>
+        ✓ Done
+      </div>
+    );
+  }
+
+  if (kind === "text") {
+    const text =
+      value === null || value === undefined ? "" : String(value);
+    return (
+      <div style={{ ...boxStyle, color: "var(--surface-base-text)" }}>
+        {text || <em style={{ color: "var(--surface-base-text-secondary)" }}>empty</em>}
+      </div>
+    );
+  }
+
+  // json (default)
+  let pretty: string;
+  try {
+    pretty = JSON.stringify(value, null, 2);
+  } catch {
+    pretty = String(value);
+  }
+  if (pretty === undefined) pretty = "undefined";
+  return <pre style={preStyle}>{pretty}</pre>;
+}

--- a/frontend/src/palette/types.ts
+++ b/frontend/src/palette/types.ts
@@ -1,0 +1,85 @@
+/**
+ * Command-palette manifest model.
+ *
+ * Every lore-vm op the GUI can invoke is described by one {@link OpManifest}
+ * (one file per op under `manifest/<domain>/<op>.ts`). The palette renders a
+ * form from the op's {@link FieldSpec}s, collects values, and invokes the named
+ * Tauri command. This is the single unit of parity work: add a manifest entry
+ * and the op becomes reachable from Ctrl-K with a generated form.
+ */
+
+export type FieldKind =
+  | "text"
+  | "number"
+  | "boolean"
+  | "enum"
+  | "string-list";
+
+/** One argument of an op, rendered as one form control. */
+export interface FieldSpec {
+  /**
+   * The argument key sent to the Tauri command. Use the exact camelCase key the
+   * command expects (Tauri v2 maps camelCase JS keys to snake_case Rust args),
+   * matching the corresponding `api.ts` call site.
+   */
+  name: string;
+  kind: FieldKind;
+  /** Control label. */
+  label: string;
+  /** Optional helper text shown under the control. */
+  description?: string;
+  /** Required fields block submit until filled. Defaults to false. */
+  required?: boolean;
+  /** Initial value. For `string-list` an array; for `boolean` a bool. */
+  default?: string | number | boolean | string[];
+  placeholder?: string;
+  /** Options for `kind === "enum"`. */
+  options?: { value: string; label: string }[];
+}
+
+/** How the palette renders a command's return value. */
+export type ResultKind =
+  | "void" // no meaningful return — show "Done"
+  | "text" // a plain string
+  | "json"; // anything else — pretty-printed (default)
+
+/** A single invokable op. */
+export interface OpManifest {
+  /** Stable id `"<domain>.<op>"` — used for search, sort, and dedupe. */
+  id: string;
+  /** Op domain, e.g. "repository". */
+  domain: string;
+  /** Op leaf name, e.g. "status". */
+  op: string;
+  /** Human label shown in the palette, e.g. "Repository: Status". */
+  label: string;
+  /** One-line description of what the op does. */
+  description?: string;
+  /** The registered Tauri command name to invoke. */
+  command: string;
+  /** Ordered argument fields → generated form. Empty for no-arg ops. */
+  args: FieldSpec[];
+  /** Result rendering hint. Defaults to "json". */
+  resultKind?: ResultKind;
+  /** Extra search terms beyond id/label/description. */
+  keywords?: string[];
+}
+
+/** Build a default form-values record from a manifest's field specs. */
+export function defaultValues(manifest: OpManifest): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const f of manifest.args) {
+    if (f.default !== undefined) {
+      out[f.name] = f.default;
+    } else if (f.kind === "boolean") {
+      out[f.name] = false;
+    } else if (f.kind === "string-list") {
+      out[f.name] = [];
+    } else if (f.kind === "number") {
+      out[f.name] = "";
+    } else {
+      out[f.name] = "";
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
Phase 0 of the **command-palette parity** epic — the foundation that makes every lore-vm op reachable from the GUI. A single Ctrl/Cmd-K palette fuzzy-searches all ops and invokes the selected one through a form generated from its manifest.

### What's here (infra)
- `palette/types.ts` — `FieldSpec` + `OpManifest` model; one file per op is the unit of parity work.
- `palette/form.tsx` — generated form (text / number / boolean / enum / string-list) with required-field validation and typed arg building.
- `palette/result.tsx` — `void` / `text` / `json` result rendering.
- `palette/CommandPalette.tsx` — the Ctrl-K overlay: fuzzy search, keyboard nav, `invoke`, result/error display. Inline-styled via theme vars (re-themes with any theme).
- `palette/manifest/index.ts` — append-only registry (the only shared file; merge-safe).
- **3 reference entries** exercising each path: `repository.status` (no-arg → JSON), `file.stage` (string-list → void), `revision.commit` (required text → text).
- Topbar `⌘K` launcher + global shortcut wired into `App`.
- `palette/README.md` documents the per-op fan-out pattern for the pipeline.

### Next (fan-out, tracked in Jira)
Per-op manifest entries across 14 domain stories (+ tauri command/api.ts binding for the ~65 ops that lack one). One file per op, append to the index.

### Verification
`tsc && vite build` green (50 modules). The three reference ops invoke real, registered commands (`status`, `stage`, `commit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)