### PR TITLE
SBAI-3899: file dirty_move

### DIFF
--- a/frontend/src/palette/manifest/file/dirty_move.ts
+++ b/frontend/src/palette/manifest/file/dirty_move.ts
@@ -1,0 +1,36 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Reference manifest entry (Phase 0). Exercises two required `text` fields and a
+ * structured JSON result.
+ */
+const manifest: OpManifest = {
+  id: "file.dirty_move",
+  domain: "file",
+  op: "dirty_move",
+  label: "File: Dirty Move",
+  description: "Mark a file as moved in the staging area.",
+  command: "file_dirty_move",
+  args: [
+    {
+      name: "fromPath",
+      kind: "text",
+      label: "From Path",
+      description: "Original path of the file to move.",
+      required: true,
+      placeholder: "src/foo.txt",
+    },
+    {
+      name: "toPath",
+      kind: "text",
+      label: "To Path",
+      description: "New destination path.",
+      required: true,
+      placeholder: "src/bar.txt",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["move", "rename", "relocate"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3899

## Summary
Add command-palette manifest entry for `file.dirty_move` operation following Phase 0 pattern.

## Files Changed
- `frontend/src/palette/manifest/file/dirty_move.ts` (new)

## What Changed
Created manifest entry that registers the `dirty_move` file operation in the Ctrl-K command palette with:
- Two required text arguments: `fromPath` and `toPath`
- JSON result rendering (returns object with `from_path` and `to_path` fields)
- Keywords: move, rename, relocate

## Infrastructure Already Present
- Tauri command wrapper `file_dirty_move` already exists in `src-tauri/src/commands.rs`
- Frontend API binding `fileDirtyMoveApi` already exists in `frontend/src/api.ts`
- lore-vm op binding already implemented in `crates/lore-vm/src/ops/file/dirty_move.rs`

Only the manifest file was needed to expose the operation via the palette UI.

## Testing
- Manifest follows exact pattern of existing Phase 0 entries (stage.ts, commit.ts, status.ts)
- TypeScript syntax matches the established pattern
- Operation will appear in Ctrl-K palette once manifest index is updated by integration manager
- Generated form will invoke the existing Tauri command with correct argument mapping