### PR TITLE
SBAI-3894: Add palette manifest for file.dirty_copy

### DIFF
--- a/frontend/src/palette/manifest/file/dirty_copy.ts
+++ b/frontend/src/palette/manifest/file/dirty_copy.ts
@@ -1,0 +1,40 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Manifest for file.dirty_copy operation.
+ *
+ * Creates a new staged destination node flagged as DirtyCopy. The source
+ * node is unchanged — this is a metadata-only staging operation with no
+ * filesystem I/O.
+ */
+const manifest: OpManifest = {
+  id: "file.dirty_copy",
+  domain: "file",
+  op: "dirty_copy",
+  label: "File: Dirty Copy",
+  description:
+    "Stage a file copy without touching the filesystem. Creates a DirtyCopy node.",
+  command: "file_dirty_copy",
+  args: [
+    {
+      name: "fromPath",
+      kind: "text",
+      label: "From Path",
+      description: "Source path of the file to copy.",
+      required: true,
+      placeholder: "src/main.rs",
+    },
+    {
+      name: "toPath",
+      kind: "text",
+      label: "To Path",
+      description: "Destination path for the copy.",
+      required: true,
+      placeholder: "src/main_copy.rs",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["copy", "dirty", "stage", "duplicate"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3894

## Summary
Adds command-palette manifest entry for `file.dirty_copy` operation.

The lore-vm op, Tauri command, and api.ts binding already exist from
SBAI-3786 — this manifest makes the op discoverable and invokable via
Ctrl-K with a generated form.

## Files Changed
- `frontend/src/palette/manifest/file/dirty_copy.ts` (new)

## Manifest Details
- Two text fields: `fromPath` and `toPath`
- JSON result rendering for `FileDirtyCopyResult`
- Keywords: copy, dirty, stage, duplicate

## Testing
- Manifest follows Phase 0 pattern established by `file/stage.ts`
- Field names match `api.ts` binding signature (`fileDirtyCopyApi.dirtyCopy(fromPath, toPath)`)
- Result kind set to 'json' to display `FileDirtyCopyResult`

## Notes
- Per ticket instructions, manifest index.ts was NOT edited (integration manager handles that)
- One-file-per-op rule followed