### PR TITLE
SBAI-3898: Add dependency.dependency_add command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/dependency/dependency_add.ts
+++ b/frontend/src/palette/manifest/dependency/dependency_add.ts
@@ -1,0 +1,55 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Manifest entry for dependency.dependency_add.
+ *
+ * Adds file dependencies to the current repository. Each entry defines
+ * a source file and its dependencies with optional tags (e.g., "texture",
+ * "compile"). Cycle detection is performed unless force is set.
+ *
+ * Note: The sources parameter uses a JSON text field due to the nested
+ * array structure [{path, dependencies: [{dependency, tags: []}]}]
+ * not being expressible with current FieldKind types. Future schema-driven
+ * forms will render proper nested controls.
+ *
+ * Example sources JSON:
+ * [
+ *   {
+ *     "path": "/src/main.txt",
+ *     "dependencies": [
+ *       {"dependency": "/assets/texture.png", "tags": ["texture"]},
+ *       {"dependency": "/lib/common.txt", "tags": ["compile"]}
+ *     ]
+ *   }
+ * ]
+ */
+const manifest: OpManifest = {
+  id: "dependency.dependency_add",
+  domain: "dependency",
+  op: "dependency_add",
+  label: "Dependency: Add",
+  description: "Add file dependencies to repository sources.",
+  command: "dependency_add",
+  args: [
+    {
+      name: "sources",
+      kind: "text",
+      label: "Sources (JSON)",
+      required: true,
+      description: "Array of {path, dependencies: [{dependency, tags: []}]}. See manifest docstring for example.",
+      placeholder: '[{"path":"/src/file.txt","dependencies":[{"dependency":"/dep.txt","tags":["compile"]}]}]',
+    },
+    {
+      name: "force",
+      kind: "boolean",
+      label: "Force",
+      description: "Skip cycle detection when true.",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["dependency", "add", "link", "edge"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3898

## Summary
Creates manifest entry for `dependency.dependency_add` op following Phase 0 reference pattern.

## Implementation Notes
- Uses JSON text field for `sources` parameter due to nested array structure `[{path, dependencies: [{dependency, tags: []}]}]` not being expressible with current FieldKind types (text, number, boolean, enum, string-list).
- Future schema-driven form feature will render proper nested controls.
- The Tauri command wrapper `dependency_add` and api.ts binding are prerequisites that need to be added by the integration manager.

## Files Changed
- `frontend/src/palette/manifest/dependency/dependency_add.ts` (new file)

## Testing
- TypeScript compiles without new errors (pre-existing react type errors unrelated)
- Manifest follows Phase 0 pattern from `revision/commit.ts` and `file/stage.ts`

## Notes
Per ticket instructions: manifest index NOT edited (integration manager handles that in batched passes).