### PR TITLE
SBAI-3883: Add command-palette manifest for auth.login_interactive

### DIFF
--- a/frontend/src/palette/manifest/auth/login_interactive.ts
+++ b/frontend/src/palette/manifest/auth/login_interactive.ts
@@ -1,0 +1,33 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Auth manifest entry — authenticate against a remote via browser-based flow.
+ *
+ * The palette renders a single optional `remoteUrl` field; when submitted,
+ * it invokes `auth_login_interactive` which opens a browser window for OAuth.
+ * On success, the result contains the user's identity ID and display name.
+ */
+const manifest: OpManifest = {
+  id: "auth.login_interactive",
+  domain: "auth",
+  op: "login_interactive",
+  label: "Auth: Login (Interactive)",
+  description:
+    "Authenticate against a remote via browser-based OAuth flow. Returns user identity on success.",
+  command: "login_interactive",
+  args: [
+    {
+      name: "remoteUrl",
+      kind: "text",
+      label: "Remote URL",
+      description:
+        "Remote API URL; empty resolves from the repository config.",
+      required: false,
+      placeholder: "https://api.example.com",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["login", "auth", "sign-in", "browser", "oauth"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3883

## Summary
Adds command-palette manifest entry for `auth.login_interactive`, enabling Ctrl-K access to browser-based interactive authentication.

## Files Changed
- `frontend/src/palette/manifest/auth/login_interactive.ts` (new file, 33 lines)
  - Defines OpManifest with id `auth.login_interactive`
  - Single optional text arg: `remoteUrl` (defaults to repository config)
  - Result type: JSON (returns UserInfo with user_id + display_name)
  - Keywords: login, auth, sign-in, browser, oauth

## Testing
- TypeScript type checking passes (no new type errors)
- Manifest follows Phase 0 pattern established by `repository/status.ts`, `file/stage.ts`, `revision/commit.ts`
- Arg name `remoteUrl` matches Tauri command `auth_login_interactive` signature in `src-tauri/src/commands.rs`

## Notes
- Per ticket scope, did NOT edit `manifest/index.ts` (integration manager will wire the import)
- Rust op `login_interactive.rs` was already fully implemented
- Tauri command wrapper and api.ts binding already existed
- This PR adds only the frontend manifest file