### PR TITLE
SBAI-3905: Add command-palette manifest entry for file.dump

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -524,6 +524,25 @@ export const fileInfoApi = {
     }),
 };
 
+// --- file dump ---
+
+export interface FileDumpEntry {
+  address: string;
+  flags: number;
+  size_payload: number;
+  size_content: number;
+  match_made: boolean;
+}
+
+export interface FileDumpResult {
+  entries: FileDumpEntry[];
+}
+
+export const fileDumpApi = {
+  dump: (address: string = "", path: string = "") =>
+    invoke<FileDumpResult>("file_dump", { address, path }),
+};
+
 // --- repository metadata_get ---
 
 export interface MetadataEntry {

--- a/frontend/src/palette/manifest/file/dump.ts
+++ b/frontend/src/palette/manifest/file/dump.ts
@@ -1,0 +1,36 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Manifest entry for file.dump operation.
+ *
+ * Dumps the binary content of a file by path or address.
+ * Returns entries with address, flags, sizes, and match status.
+ */
+const manifest: OpManifest = {
+  id: "file.dump",
+  domain: "file",
+  op: "dump",
+  label: "File: Dump",
+  description: "Dump the binary content of a file by path or address.",
+  command: "dump",
+  args: [
+    {
+      name: "address",
+      kind: "text",
+      label: "Address",
+      required: false,
+      placeholder: "Content address (takes precedence over path)",
+    },
+    {
+      name: "path",
+      kind: "text",
+      label: "Path",
+      required: false,
+      placeholder: "Repository-relative path to dump",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["dump", "content", "inspect", "binary"],
+};
+
+export default manifest;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -680,6 +680,20 @@ pub async fn file_write(
     .await
 }
 
+// --- file dump ---
+
+use lore_vm::ops::file::dump::{dump as op_file_dump, FileDumpArgs, FileDumpResult};
+
+#[tauri::command]
+pub async fn file_dump(
+    state: State<'_, AppState>,
+    address: String,
+    path: String,
+) -> Result<FileDumpResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_file_dump(&api, FileDumpArgs { address, path }).await
+}
+
 // --- file stage ---
 
 use lore_vm::ops::file::stage::{

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,6 +52,7 @@ pub fn run() {
             commands::branch_merge_into,
             commands::file_info,
             commands::file_write,
+            commands::file_dump,
             commands::file_stage,
             commands::file_dirty,
             commands::file_dirty_copy,


### PR DESCRIPTION
Resolves SBAI-3905

## Summary
Adds command-palette manifest entry for the file.dump operation, following the Phase 0 pattern established by other file operations (stage, dirty, dirty_move, etc.).

## Changes
- **frontend/src/palette/manifest/file/dump.ts** (new): Manifest entry for file.dump with address and path arguments (both optional, defaulting to empty strings)
- **src-tauri/src/commands.rs**: Added `file_dump` Tauri command wrapper that delegates to `lore_vm::ops::file::dump`
- **src-tauri/src/lib.rs**: Registered `file_dump` in the invoke_handler
- **frontend/src/api.ts**: Added `fileDumpApi` binding with `FileDumpEntry` and `FileDumpResult` TypeScript interfaces

## Testing
- `cargo check -p lore-vm` passes
- `cargo test -p lore-vm` passes (all tests green)
- TypeScript compilation: no new errors introduced (pre-existing theme editor errors unrelated to this change)

## Acceptance
- ✅ Manifest file created at frontend/src/palette/manifest/file/dump.ts
- ✅ Tauri command wrapper added for file_dump
- ✅ api.ts binding added (fileDumpApi)
- ❓ Manifest index NOT edited (per ticket requirement: "one file per op")
- ❓ Op will appear in Ctrl-K after integration manager adds manifest to index
- ❓ Generated form will invoke the command and render results after full integration