### PR TITLE
SBAI-3874: notification subscribe + unsubscribe command-palette manifests

### DIFF
--- a/frontend/src/palette/manifest/notification/subscribe.ts
+++ b/frontend/src/palette/manifest/notification/subscribe.ts
@@ -1,0 +1,23 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Manifest entry for notification subscribe operation.
+ *
+ * Subscribes to repository push-event notifications. The subscription remains
+ * active until a corresponding unsubscribe call.
+ *
+ * Phase 1 reference: no-arg op with JSON result.
+ */
+const manifest: OpManifest = {
+  id: "notification.subscribe",
+  domain: "notification",
+  op: "subscribe",
+  label: "Notification: Subscribe",
+  description: "Subscribe to repository push-event notifications.",
+  command: "notification_subscribe",
+  args: [],
+  resultKind: "json",
+  keywords: ["notification", "subscribe", "events", "watch"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/notification/unsubscribe.ts
+++ b/frontend/src/palette/manifest/notification/unsubscribe.ts
@@ -1,0 +1,23 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Manifest entry for notification unsubscribe operation.
+ *
+ * Unsubscribes from repository push-event notifications that were established
+ * by a prior subscribe call.
+ *
+ * Phase 1 reference: no-arg op with JSON result.
+ */
+const manifest: OpManifest = {
+  id: "notification.unsubscribe",
+  domain: "notification",
+  op: "unsubscribe",
+  label: "Notification: Unsubscribe",
+  description: "Unsubscribe from repository push-event notifications.",
+  command: "notification_unsubscribe",
+  args: [],
+  resultKind: "json",
+  keywords: ["notification", "unsubscribe", "events", "unwatch"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3874

## Summary
Add Phase 1 command-palette manifest entries for notification domain ops (subscribe, unsubscribe). Both ops are no-arg with JSON result, matching the Phase 0 pattern from repository/status (SBAI-3866).

## Files Changed
- src/palette/manifest/notification/subscribe.ts (new)
- src/palette/manifest/notification/unsubscribe.ts (new)

## Implementation Notes
- Created per-op manifest files following the Phase 0 reference pattern
- Both notification ops have no parameters (empty args struct)
- resultKind: json for both
- Did NOT edit manifest/index.ts per ticket instructions (manager assembles registry)
- Tauri command wrappers and api.ts bindings NOT added due to scope constraints

## How to Verify
1. Files exist at src/palette/manifest/notification/subscribe.ts and unsubscribe.ts
2. Manifests follow OpManifest contract (id, domain, op, label, description, command, args, resultKind, keywords)
3. TypeScript compilation has no errors in the notification manifest files

## Notes for Manager
- Core LoreGUI ops (subscribe, unsubscribe) were implemented in SBAI-3830 and SBAI-3831
- This PR adds only the command-palette manifest layer
- No changes to Tauri commands or api.ts due to scope constraints — those may need a follow-up ticket
- Manifest index/registry integration handled by manager per ticket instructions