### PR TITLE
SBAI-3868: Command Palette — branch (22 ops)

### DIFF
--- a/frontend/src/palette/manifest/branch/archive.ts
+++ b/frontend/src/palette/manifest/branch/archive.ts
@@ -1,0 +1,23 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.archive",
+  domain: "branch",
+  op: "archive",
+  label: "Branch: Archive",
+  description: "Archive a branch locally and on the remote, preventing further commits.",
+  command: "branch_archive",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch name",
+      required: false,
+      placeholder: "Branch to archive (empty for current)",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["archive", "freeze", "lock"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/create.ts
+++ b/frontend/src/palette/manifest/branch/create.ts
@@ -1,0 +1,39 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.create",
+  domain: "branch",
+  op: "create",
+  label: "Branch: Create",
+  description: "Create a new branch with the given name and category.",
+  command: "branch_create",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch name",
+      required: true,
+      placeholder: "feature/x",
+    },
+    {
+      name: "category",
+      kind: "text",
+      label: "Category",
+      required: false,
+      placeholder: "feature",
+      default: "",
+    },
+    {
+      name: "id",
+      kind: "text",
+      label: "Branch ID (optional)",
+      required: false,
+      placeholder: "Hex-encoded 16-byte context",
+      default: "",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "new", "create"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/diff.ts
+++ b/frontend/src/palette/manifest/branch/diff.ts
@@ -1,0 +1,45 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.diff",
+  domain: "branch",
+  op: "diff",
+  label: "Branch: Diff",
+  description: "Compute the diff between two branches, reporting changed and conflicting files.",
+  command: "branch_diff",
+  args: [
+    {
+      name: "source",
+      kind: "text",
+      label: "Source branch",
+      required: true,
+      placeholder: "feature/x",
+    },
+    {
+      name: "target",
+      kind: "text",
+      label: "Target branch",
+      required: true,
+      placeholder: "main",
+    },
+    {
+      name: "path",
+      kind: "text",
+      label: "Path filter",
+      required: false,
+      placeholder: "Leave empty for all files",
+      default: "",
+    },
+    {
+      name: "autoResolve",
+      kind: "boolean",
+      label: "Auto-resolve conflicts",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "diff", "compare", "changes"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/info.ts
+++ b/frontend/src/palette/manifest/branch/info.ts
@@ -1,0 +1,24 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.info",
+  domain: "branch",
+  op: "info",
+  label: "Branch: Info",
+  description: "Retrieve metadata for a branch including name, id, category, protection status, parent, and archive state.",
+  command: "branch_info",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch name",
+      required: false,
+      placeholder: "Leave empty for current branch",
+      default: "",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "info", "metadata", "details"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/latest_list.ts
+++ b/frontend/src/palette/manifest/branch/latest_list.ts
@@ -1,0 +1,32 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.latest_list",
+  domain: "branch",
+  op: "latest_list",
+  label: "Branch: Latest List",
+  description: "List the LATEST revision history for a branch (newest first).",
+  command: "branch_latest_list",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch name",
+      required: false,
+      placeholder: "Leave empty for current branch",
+      default: "",
+    },
+    {
+      name: "limit",
+      kind: "number",
+      label: "Max entries",
+      required: false,
+      placeholder: "0 for default (30)",
+      default: 0,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "latest", "history", "revisions"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/list.ts
+++ b/frontend/src/palette/manifest/branch/list.ts
@@ -1,0 +1,23 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.list",
+  domain: "branch",
+  op: "list",
+  label: "Branch: List",
+  description: "List all branches in the repository with their metadata.",
+  command: "branch_list",
+  args: [
+    {
+      name: "archived",
+      kind: "boolean",
+      label: "Include archived branches",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "list", "branches", "all"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/merge_abort.ts
+++ b/frontend/src/palette/manifest/branch/merge_abort.ts
@@ -1,0 +1,30 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.merge_abort",
+  domain: "branch",
+  op: "merge_abort",
+  label: "Branch: Merge Abort",
+  description: "Abort an in-progress branch merge, reverting to the pre-merge state.",
+  command: "branch_merge_abort",
+  args: [
+    {
+      name: "link",
+      kind: "text",
+      label: "Link",
+      required: false,
+      default: "",
+    },
+    {
+      name: "ignoreLinks",
+      kind: "boolean",
+      label: "Ignore links",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "merge", "abort", "cancel"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/merge_into.ts
+++ b/frontend/src/palette/manifest/branch/merge_into.ts
@@ -1,0 +1,53 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.merge_into",
+  domain: "branch",
+  op: "merge_into",
+  label: "Branch: Merge Into",
+  description: "Merge the current branch's staged changes into a target branch.",
+  command: "branch_merge_into",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Target branch",
+      required: false,
+      placeholder: "main",
+      default: "",
+    },
+    {
+      name: "branchId",
+      kind: "text",
+      label: "Target branch ID",
+      required: false,
+      default: "",
+    },
+    {
+      name: "message",
+      kind: "text",
+      label: "Merge message",
+      required: false,
+      placeholder: "Describe the merge",
+      default: "",
+    },
+    {
+      name: "link",
+      kind: "text",
+      label: "Link",
+      required: false,
+      default: "",
+    },
+    {
+      name: "ignoreLinks",
+      kind: "boolean",
+      label: "Ignore links",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "merge", "into", "target"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/merge_resolve.ts
+++ b/frontend/src/palette/manifest/branch/merge_resolve.ts
@@ -1,0 +1,23 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.merge_resolve",
+  domain: "branch",
+  op: "merge_resolve",
+  label: "Branch: Merge Resolve",
+  description: "Mark conflicted paths as resolved during an in-progress merge.",
+  command: "branch_merge_resolve",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Resolved paths",
+      required: true,
+      placeholder: "One path per line",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "merge", "resolve", "conflict"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/merge_resolve_mine.ts
+++ b/frontend/src/palette/manifest/branch/merge_resolve_mine.ts
@@ -1,0 +1,23 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.merge_resolve_mine",
+  domain: "branch",
+  op: "merge_resolve_mine",
+  label: "Branch: Merge Resolve (Mine)",
+  description: "Resolve merge conflicts by accepting the local (mine) version.",
+  command: "branch_merge_resolve_mine",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths to resolve",
+      required: true,
+      placeholder: "One path per line",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "merge", "resolve", "mine", "local"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/merge_resolve_theirs.ts
+++ b/frontend/src/palette/manifest/branch/merge_resolve_theirs.ts
@@ -1,0 +1,23 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.merge_resolve_theirs",
+  domain: "branch",
+  op: "merge_resolve_theirs",
+  label: "Branch: Merge Resolve (Theirs)",
+  description: "Resolve merge conflicts by accepting the incoming (theirs) version.",
+  command: "branch_merge_resolve_theirs",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths to resolve",
+      required: true,
+      placeholder: "One path per line",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "merge", "resolve", "theirs", "incoming"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/merge_restart.ts
+++ b/frontend/src/palette/manifest/branch/merge_restart.ts
@@ -1,0 +1,23 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.merge_restart",
+  domain: "branch",
+  op: "merge_restart",
+  label: "Branch: Merge Restart",
+  description: "Re-apply merge conflict resolution and re-materialize working copies.",
+  command: "branch_merge_restart",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths to restart",
+      required: true,
+      placeholder: "One path per line",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "merge", "restart", "re-apply"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/merge_start.ts
+++ b/frontend/src/palette/manifest/branch/merge_start.ts
@@ -1,0 +1,52 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.merge_start",
+  domain: "branch",
+  op: "merge_start",
+  label: "Branch: Merge Start",
+  description: "Begin merging a source branch into the current branch.",
+  command: "branch_merge_start",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Source branch",
+      required: true,
+      placeholder: "feature/x",
+    },
+    {
+      name: "message",
+      kind: "text",
+      label: "Merge message",
+      required: false,
+      placeholder: "Describe the merge",
+      default: "",
+    },
+    {
+      name: "noCommit",
+      kind: "boolean",
+      label: "No auto-commit",
+      required: false,
+      default: false,
+    },
+    {
+      name: "link",
+      kind: "text",
+      label: "Link",
+      required: false,
+      default: "",
+    },
+    {
+      name: "ignoreLinks",
+      kind: "boolean",
+      label: "Ignore links",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "merge", "start", "begin"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/merge_unresolve.ts
+++ b/frontend/src/palette/manifest/branch/merge_unresolve.ts
@@ -1,0 +1,23 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.merge_unresolve",
+  domain: "branch",
+  op: "merge_unresolve",
+  label: "Branch: Merge Unresolve",
+  description: "Mark previously resolved merge paths as unresolved, restoring conflict state.",
+  command: "branch_merge_unresolve",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths to unresolve",
+      required: true,
+      placeholder: "One path per line",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "merge", "unresolve", "conflict"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/metadata_clear.ts
+++ b/frontend/src/palette/manifest/branch/metadata_clear.ts
@@ -1,0 +1,31 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.metadata_clear",
+  domain: "branch",
+  op: "metadata_clear",
+  label: "Branch: Metadata Clear",
+  description: "Clear metadata keys from a branch.",
+  command: "branch_metadata_clear",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch name",
+      required: false,
+      placeholder: "Leave empty for current branch",
+      default: "",
+    },
+    {
+      name: "keys",
+      kind: "string-list",
+      label: "Keys to clear",
+      required: true,
+      placeholder: "One key per line (e.g., description, owner)",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "metadata", "clear", "remove"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/metadata_get.ts
+++ b/frontend/src/palette/manifest/branch/metadata_get.ts
@@ -1,0 +1,32 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.metadata_get",
+  domain: "branch",
+  op: "metadata_get",
+  label: "Branch: Metadata Get",
+  description: "Retrieve metadata from a branch. Leave key empty to get all entries.",
+  command: "branch_metadata_get",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch name",
+      required: false,
+      placeholder: "Leave empty for current branch",
+      default: "",
+    },
+    {
+      name: "key",
+      kind: "text",
+      label: "Metadata key",
+      required: false,
+      placeholder: "Leave empty for all entries",
+      default: "",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "metadata", "get", "read"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/metadata_set.ts
+++ b/frontend/src/palette/manifest/branch/metadata_set.ts
@@ -1,0 +1,46 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.metadata_set",
+  domain: "branch",
+  op: "metadata_set",
+  label: "Branch: Metadata Set",
+  description: "Set key-value metadata pairs on a branch.",
+  command: "branch_metadata_set",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch name",
+      required: false,
+      placeholder: "Leave empty for current branch",
+      default: "",
+    },
+    {
+      name: "keys",
+      kind: "string-list",
+      label: "Keys",
+      required: true,
+      placeholder: "One key per line",
+    },
+    {
+      name: "values",
+      kind: "string-list",
+      label: "Values",
+      required: true,
+      placeholder: "One value per line (parallel with keys)",
+    },
+    {
+      name: "formats",
+      kind: "string-list",
+      label: "Formats (optional)",
+      required: false,
+      placeholder: "string|numeric|binary per line",
+      default: [],
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "metadata", "set", "write"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/protect.ts
+++ b/frontend/src/palette/manifest/branch/protect.ts
@@ -1,0 +1,24 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.protect",
+  domain: "branch",
+  op: "protect",
+  label: "Branch: Protect",
+  description: "Apply write protection to a branch, preventing direct commits.",
+  command: "branch_protect",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch name",
+      required: false,
+      placeholder: "Branch to protect",
+      default: "",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "protect", "lock", "freeze"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/push.ts
+++ b/frontend/src/palette/manifest/branch/push.ts
@@ -1,0 +1,23 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.push",
+  domain: "branch",
+  op: "push",
+  label: "Branch: Push",
+  description: "Push a branch to the remote repository.",
+  command: "branch_push",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch name",
+      required: true,
+      placeholder: "Branch to push",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "push", "upload", "sync"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/reset.ts
+++ b/frontend/src/palette/manifest/branch/reset.ts
@@ -1,0 +1,31 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.reset",
+  domain: "branch",
+  op: "reset",
+  label: "Branch: Reset",
+  description: "Reset the local LATEST pointer of a branch to a specific revision.",
+  command: "branch_reset",
+  args: [
+    {
+      name: "revision",
+      kind: "text",
+      label: "Revision",
+      required: true,
+      placeholder: "Target revision hash",
+    },
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch name",
+      required: false,
+      placeholder: "Leave empty for current branch",
+      default: "",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "reset", "move", "pointer"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/switch.ts
+++ b/frontend/src/palette/manifest/branch/switch.ts
@@ -1,0 +1,45 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.switch",
+  domain: "branch",
+  op: "switch",
+  label: "Branch: Switch",
+  description: "Switch the working tree to a different branch.",
+  command: "branch_switch",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Target branch",
+      required: true,
+      placeholder: "Branch to switch to",
+    },
+    {
+      name: "revision",
+      kind: "text",
+      label: "Specific revision",
+      required: false,
+      placeholder: "Leave empty for latest",
+      default: "",
+    },
+    {
+      name: "reset",
+      kind: "boolean",
+      label: "Reset local changes",
+      required: false,
+      default: false,
+    },
+    {
+      name: "bare",
+      kind: "boolean",
+      label: "Create bare working tree",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "switch", "checkout", "change"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/branch/unprotect.ts
+++ b/frontend/src/palette/manifest/branch/unprotect.ts
@@ -1,0 +1,24 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "branch.unprotect",
+  domain: "branch",
+  op: "unprotect",
+  label: "Branch: Unprotect",
+  description: "Remove write protection from a branch, re-allowing direct commits.",
+  command: "branch_unprotect",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch name",
+      required: false,
+      placeholder: "Branch to unprotect",
+      default: "",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "unprotect", "unlock", "allow"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3868

## Summary
Add command-palette manifest entries for all 22 branch domain operations. Each manifest entry maps a lore-vm branch operation to a searchable, form-driven command palette item (Ctrl-K).

## Files Changed
Created `src/palette/manifest/branch/` directory with 22 OpManifest files:
- **archive.ts**: Archive a branch
- **create.ts**: Create a new branch
- **diff.ts**: Compute diff between branches
- **info.ts**: Get branch metadata
- **latest_list.ts**: List latest revision history
- **list.ts**: List all branches
- **merge_abort.ts**: Abort in-progress merge
- **merge_into.ts**: Merge current branch into target
- **merge_resolve.ts**: Mark conflicts as resolved
- **merge_resolve_mine.ts**: Resolve conflicts using local version
- **merge_resolve_theirs.ts**: Resolve conflicts using incoming version
- **merge_restart.ts**: Re-apply conflict resolution
- **merge_start.ts**: Begin branch merge
- **merge_unresolve.ts**: Restore conflict state
- **metadata_clear.ts**: Clear branch metadata keys
- **metadata_get.ts**: Read branch metadata
- **metadata_set.ts**: Set branch metadata key-value pairs
- **protect.ts**: Apply write protection
- **push.ts**: Push branch to remote
- **reset.ts**: Reset branch LATEST pointer
- **switch.ts**: Switch working tree to branch
- **unprotect.ts**: Remove write protection

## Approach
Each manifest:
- Exports an `OpManifest` object matching the types.ts contract
- Maps to the corresponding Tauri command (already registered in commands.rs)
- Defines argument fields (text, number, boolean, string-list) matching lore-vm op signatures
- Sets `resultKind: "json"` for structured output
- Provides search keywords for discoverability

Follows the Phase 0 reference pattern from SBAI-3866 (repository/status, file/stage, revision/commit).

## Testing
- TypeScript syntax verified (no errors in created files)
- All manifests follow the OpManifest contract
- File structure matches existing pattern (revision/commit.ts reference)

## Notes
- Manifest index/registry updates are handled separately by the integration manager (not part of this PR per ticket instructions)
- The `push` op is a stub in lore-vm (TODO comment present), but manifest included for completeness