### PR TITLE
SBAI-3882: auth local_user_info command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/auth/local_user_info.ts
+++ b/frontend/src/palette/manifest/auth/local_user_info.ts
@@ -1,0 +1,43 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Manifest entry for auth.local_user_info.
+ *
+ * Resolves user identities from locally cached JWT tokens. Returns user info
+ * and optionally token details for identities with cached credentials.
+ */
+const manifest: OpManifest = {
+  id: "auth.local_user_info",
+  domain: "auth",
+  op: "local_user_info",
+  label: "Auth: Local User Info",
+  description: "Resolve user identities from locally cached JWT tokens.",
+  command: "auth_local_user_info",
+  args: [
+    {
+      name: "authEndpoint",
+      kind: "text",
+      label: "Auth Endpoint",
+      required: false,
+      placeholder: "ucs-auth://auth.example.com",
+    },
+    {
+      name: "userIds",
+      kind: "string-list",
+      label: "User IDs",
+      required: false,
+      default: [],
+    },
+    {
+      name: "withToken",
+      kind: "boolean",
+      label: "With Token",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["auth", "user", "local", "jwt", "token"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3882

## Summary
Adds command-palette manifest entry for `auth.local_user_info` operation, making it accessible via Ctrl-K.

## Files Changed
- `frontend/src/palette/manifest/auth/local_user_info.ts` (new): Defines the manifest with args (authEndpoint, userIds, withToken) and JSON result type.

## Testing
- Manifest follows the Phase 0 reference pattern (same as revision.commit, file.stage)
- Arguments match the existing Tauri command `auth_local_user_info` and API function `localUserInfo()`
- Result type set to "json" for structured data (users + tokens arrays)

## Notes
- Does NOT edit `manifest/index.ts` (integration manager handles that in batched passes)