### PR TITLE
SBAI-3879: Add 10 storage command-palette manifests

### DIFF
--- a/frontend/src/palette/manifest/storage/close.ts
+++ b/frontend/src/palette/manifest/storage/close.ts
@@ -1,0 +1,28 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Storage close manifest. Releases a storage handle acquired via storage open.
+ * The upstream call unregisters the handle and returns any diagnostic log messages.
+ */
+const manifest: OpManifest = {
+  id: "storage.close",
+  domain: "storage",
+  op: "close",
+  label: "Storage: Close",
+  description:
+    "Release a storage handle acquired via storage open. Invalidates the handle and drains in-flight ops.",
+  command: "storage_close",
+  args: [
+    {
+      name: "handle",
+      kind: "number",
+      label: "Handle ID",
+      description: "Handle ID of the open storage instance to close.",
+      required: true,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["close", "release", "storage", "handle"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/storage/copy.ts
+++ b/frontend/src/palette/manifest/storage/copy.ts
@@ -1,0 +1,37 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Storage copy manifest. Copies content between partition/context tuples
+ * in the same open store. Each item runs independently.
+ */
+const manifest: OpManifest = {
+  id: "storage.copy",
+  domain: "storage",
+  op: "copy",
+  label: "Storage: Copy",
+  description:
+    "Copy content between (partition, context) tuples in the same open store. Each item runs independently.",
+  command: "storage_copy",
+  args: [
+    {
+      name: "handle",
+      kind: "number",
+      label: "Handle ID",
+      description: "Handle ID returned by a prior storage open call.",
+      required: true,
+    },
+    {
+      name: "items",
+      kind: "text",
+      label: "Copy Items (JSON)",
+      description:
+        'Array of copy items: [{"id": 1, "sourcePartition": "<hex>", "targetPartition": "<hex>", "sourceAddress": "<hash>-<context>", "targetContext": "<hex>"}]',
+      required: true,
+      placeholder: '[{"id":1,"sourcePartition":"...","targetPartition":"...","sourceAddress":"...","targetContext":"..."}]',
+    },
+  ],
+  resultKind: "json",
+  keywords: ["copy", "storage", "partition", "address"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/storage/flush.ts
+++ b/frontend/src/palette/manifest/storage/flush.ts
@@ -1,0 +1,28 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Storage flush manifest. Flushes pending writes through an open storage handle.
+ * Disk-backed stores call fsync; in-memory stores no-op.
+ */
+const manifest: OpManifest = {
+  id: "storage.flush",
+  domain: "storage",
+  op: "flush",
+  label: "Storage: Flush",
+  description:
+    "Flush pending writes through an open storage handle. Disk-backed stores call fsync.",
+  command: "storage_flush",
+  args: [
+    {
+      name: "handle",
+      kind: "number",
+      label: "Handle ID",
+      description: "Handle ID of the open storage instance to flush.",
+      required: true,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["flush", "fsync", "storage", "write"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/storage/get.ts
+++ b/frontend/src/palette/manifest/storage/get.ts
@@ -1,0 +1,38 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Storage get manifest. Reads one or more content-addressed buffers
+ * from an open store handle. Each item can emit per-fragment events or
+ * a single reassembled buffer.
+ */
+const manifest: OpManifest = {
+  id: "storage.get",
+  domain: "storage",
+  op: "get",
+  label: "Storage: Get",
+  description:
+    "Read one or more content-addressed buffers from an open store handle. Each item runs independently.",
+  command: "storage_get",
+  args: [
+    {
+      name: "handle",
+      kind: "number",
+      label: "Handle ID",
+      description: "Handle ID returned by a prior storage open call.",
+      required: true,
+    },
+    {
+      name: "items",
+      kind: "text",
+      label: "Get Items (JSON)",
+      description:
+        'Array of items to retrieve: [{"id": 1, "partition": "<hex>", "address": "<hash>-<context>", "streaming": false, "localCache": true}]',
+      required: true,
+      placeholder: '[{"id":1,"partition":"...","address":"...","streaming":false,"localCache":true}]',
+    },
+  ],
+  resultKind: "json",
+  keywords: ["get", "read", "fetch", "storage", "content"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/storage/get_metadata.ts
+++ b/frontend/src/palette/manifest/storage/get_metadata.ts
@@ -1,0 +1,38 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Storage get_metadata manifest. Fetches fragment metadata (flags, payload size,
+ * content size) for one or more content-addressed items without transferring
+ * payload bytes.
+ */
+const manifest: OpManifest = {
+  id: "storage.get_metadata",
+  domain: "storage",
+  op: "get_metadata",
+  label: "Storage: Get Metadata",
+  description:
+    "Fetch fragment metadata (flags, payload size, content size) for items without transferring payload bytes.",
+  command: "storage_get_metadata",
+  args: [
+    {
+      name: "handle",
+      kind: "number",
+      label: "Handle ID",
+      description: "Handle ID returned by a prior storage open call.",
+      required: true,
+    },
+    {
+      name: "items",
+      kind: "text",
+      label: "Items (JSON)",
+      description:
+        'Array of items to look up: [{"id": 1, "partition": "<hex>", "address": "<hash>-<context>"}]',
+      required: true,
+      placeholder: '[{"id":1,"partition":"...","address":"..."}]',
+    },
+  ],
+  resultKind: "json",
+  keywords: ["metadata", "storage", "fragment", "size", "flags"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/storage/obliterate.ts
+++ b/frontend/src/palette/manifest/storage/obliterate.ts
@@ -1,0 +1,38 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Storage obliterate manifest. Permanently deletes content at
+ * (partition, address) from an open storage handle. Runs local and
+ * remote obliteration in parallel when configured.
+ */
+const manifest: OpManifest = {
+  id: "storage.obliterate",
+  domain: "storage",
+  op: "obliterate",
+  label: "Storage: Obliterate",
+  description:
+    "Permanently delete content at (partition, address) from an open storage handle. Runs local and remote in parallel.",
+  command: "storage_obliterate",
+  args: [
+    {
+      name: "handle",
+      kind: "number",
+      label: "Handle ID",
+      description: "Handle ID returned by a prior storage open call.",
+      required: true,
+    },
+    {
+      name: "items",
+      kind: "text",
+      label: "Items (JSON)",
+      description:
+        'Array of items to obliterate: [{"id": 1, "partition": "<hex>", "address": "<hash>-<context>"}]',
+      required: true,
+      placeholder: '[{"id":1,"partition":"...","address":"..."}]',
+    },
+  ],
+  resultKind: "json",
+  keywords: ["obliterate", "delete", "remove", "storage"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/storage/open.ts
+++ b/frontend/src/palette/manifest/storage/open.ts
@@ -1,0 +1,62 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Storage open manifest. Acquires a handle to a content-addressed store,
+ * either disk-backed or fully in-memory. Returns an opaque handle ID for
+ * subsequent storage operations.
+ */
+const manifest: OpManifest = {
+  id: "storage.open",
+  domain: "storage",
+  op: "open",
+  label: "Storage: Open",
+  description:
+    "Open a content-addressed store (disk-backed or in-memory) and return its handle for subsequent operations.",
+  command: "storage_open",
+  args: [
+    {
+      name: "repositoryPath",
+      kind: "text",
+      label: "Repository Path",
+      description: "Path to an existing lore repository (empty when inMemory is true).",
+      required: false,
+      default: "",
+    },
+    {
+      name: "inMemory",
+      kind: "boolean",
+      label: "In-Memory",
+      description: "Open a fresh in-memory store (repositoryPath must be empty when set).",
+      required: false,
+      default: false,
+    },
+    {
+      name: "remoteUrl",
+      kind: "text",
+      label: "Remote URL",
+      description: "Optional remote endpoint URL for ops that consult a peer service.",
+      required: false,
+      default: "",
+    },
+    {
+      name: "cacheTargetBytes",
+      kind: "number",
+      label: "Cache Target Bytes",
+      description: "Soft cap on total immutable-store bytes (0 selects default).",
+      required: false,
+      default: 0,
+    },
+    {
+      name: "cacheTargetFragments",
+      kind: "number",
+      label: "Cache Target Fragments",
+      description: "Soft cap on immutable-store fragment count (0 selects default).",
+      required: false,
+      default: 0,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["open", "store", "storage", "handle", "repository"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/storage/put.ts
+++ b/frontend/src/palette/manifest/storage/put.ts
@@ -1,0 +1,42 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Storage put manifest. Writes one or more content-addressed buffers
+ * to an open storage handle. Each item is hashed and stored independently.
+ */
+const manifest: OpManifest = {
+  id: "storage.put",
+  domain: "storage",
+  op: "put",
+  label: "Storage: Put",
+  description:
+    "Write one or more content-addressed buffers to an open storage handle. Each item is hashed and stored independently.",
+  command: "storage_put",
+  args: [
+    {
+      name: "handle",
+      kind: "number",
+      label: "Handle ID",
+      description: "Handle ID of an already-open store (from storage open).",
+      required: true,
+    },
+    {
+      name: "key",
+      kind: "text",
+      label: "Key",
+      description: "Opaque key for this put operation.",
+      required: true,
+    },
+    {
+      name: "data",
+      kind: "text",
+      label: "Data (base64)",
+      description: "Bytes to store, encoded as base64 string.",
+      required: true,
+    },
+  ],
+  resultKind: "void",
+  keywords: ["put", "write", "store", "storage", "content"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/storage/put_file.ts
+++ b/frontend/src/palette/manifest/storage/put_file.ts
@@ -1,0 +1,37 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Storage put_file manifest. Reads one or more files from disk and stores
+ * their contents at content-addressed locations in an open storage handle.
+ */
+const manifest: OpManifest = {
+  id: "storage.put_file",
+  domain: "storage",
+  op: "put_file",
+  label: "Storage: Put File",
+  description:
+    "Read one or more files from disk and store their contents at content-addressed locations.",
+  command: "storage_put_file",
+  args: [
+    {
+      name: "handle",
+      kind: "number",
+      label: "Handle ID",
+      description: "Handle ID of an already-open store (from storage open).",
+      required: true,
+    },
+    {
+      name: "items",
+      kind: "text",
+      label: "File Items (JSON)",
+      description:
+        'Array of files to store: [{"id": 1, "partition": "<hex>", "context": "<hex>", "path": "/path/to/file", "remoteWrite": false, "localCache": false, "fixedSizeChunk": 0}]',
+      required: true,
+      placeholder: '[{"id":1,"partition":"...","context":"...","path":"/path/to/file"}]',
+    },
+  ],
+  resultKind: "json",
+  keywords: ["put_file", "file", "storage", "upload", "disk"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/storage/upload.ts
+++ b/frontend/src/palette/manifest/storage/upload.ts
@@ -1,0 +1,38 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Storage upload manifest. Pushes one or more locally-stored,
+ * not-yet-durable content entries to the remote store attached to an
+ * open storage handle.
+ */
+const manifest: OpManifest = {
+  id: "storage.upload",
+  domain: "storage",
+  op: "upload",
+  label: "Storage: Upload",
+  description:
+    "Push locally-stored content entries to the remote store attached to an open storage handle.",
+  command: "storage_upload",
+  args: [
+    {
+      name: "handle",
+      kind: "number",
+      label: "Handle ID",
+      description: "Handle ID of an already-open store (must have remote config).",
+      required: true,
+    },
+    {
+      name: "items",
+      kind: "text",
+      label: "Items (JSON)",
+      description:
+        'Array of items to upload: [{"id": 1, "partition": "<hex>", "address": "<hash>-<context>"}]',
+      required: true,
+      placeholder: '[{"id":1,"partition":"...","address":"..."}]',
+    },
+  ],
+  resultKind: "json",
+  keywords: ["upload", "remote", "sync", "storage", "push"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3879

## Summary
Created 10 command-palette manifest entries for storage operations in LoreGUI. Each manifest follows the Phase 0 pattern established in SBAI-3866, exposing storage ops to the Ctrl-K palette system.

## Files Changed
- frontend/src/palette/manifest/storage/close.ts — close storage handle
- frontend/src/palette/manifest/storage/copy.ts — copy content between partitions
- frontend/src/palette/manifest/storage/flush.ts — flush pending writes
- frontend/src/palette/manifest/storage/get.ts — read content-addressed buffers
- frontend/src/palette/manifest/storage/get_metadata.ts — fetch fragment metadata
- frontend/src/palette/manifest/storage/obliterate.ts — delete content
- frontend/src/palette/manifest/storage/open.ts — open content-addressed store
- frontend/src/palette/manifest/storage/put.ts — write buffers to storage
- frontend/src/palette/manifest/storage/put_file.ts — store files from disk
- frontend/src/palette/manifest/storage/upload.ts — push to remote store

## Notes
- **get_file omitted**: crates/lore-vm/src/ops/storage/get_file.rs is still a TODO stub. Created follow-up ticket SBAI-4022.
- **Tauri commands**: Ticket description mentions adding Tauri wrappers + api.ts bindings, but LOREGUI-SPECIFIC SCOPE says NOT to touch those files. Awaiting manager clarification on whether those additions are in scope for this ticket.
- Existing onboarding storage commands (storage_open, storage_put, storage_get, storage_obliterate) remain in place — these are simplified versions for the wizard, not the full ops.

## Testing
- TypeScript syntax verified for all manifest files
- Follows exact pattern from Phase 0 reference (SBAI-3866)
- No changes to manifest index/registry (as instructed, manager assembles those)