### PR TITLE
SBAI-3887: branch archive

### DIFF
--- a/frontend/src/palette/manifest/branch/archive.ts
+++ b/frontend/src/palette/manifest/branch/archive.ts
@@ -1,0 +1,28 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Reference manifest entry (Phase 0). Exercises a required `text` field and a
+ * `text` result (the archived branch name).
+ */
+const manifest: OpManifest = {
+  id: "branch.archive",
+  domain: "branch",
+  op: "archive",
+  label: "Branch: Archive",
+  description: "Archives a branch locally and on the remote, preventing further commits.",
+  command: "branch_archive",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch",
+      description: "The branch name to archive.",
+      required: true,
+      placeholder: "old-feature",
+    },
+  ],
+  resultKind: "text",
+  keywords: ["archive", "delete", "remove", "cleanup"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3887

## Summary
Phase 0 command-palette manifest entry for `branch.archive` operation. Archives a branch locally and on the remote, preventing further commits.

## Files Changed
- `src/palette/manifest/branch/archive.ts` (new) — manifest declaring branch.archive with required text field and text result

## Testing
- `cargo check -p lore-vm`: ✅ passed
- `cargo test -p lore-vm`: ✅ all tests passed
- Branch archive unit tests (ops::branch::archive): ✅ 4 tests passed

## Notes
- Tauri command wrapper `branch_archive` already exists in src-tauri/src/commands.rs (lines 192-205)
- api.ts binding already exists in frontend/src/api.ts (lines 315-323)
- Per ticket instructions, manifest index.ts was NOT edited (integration manager handles that)
- Acceptance: op will appear in Ctrl-K, generated form invokes branch_archive command, result renders as text