### PR TITLE
SBAI-3878: shared_store command-palette manifests (3 ops)

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -107,9 +107,26 @@ export const api = {
     invoke<void>("storage_obliterate", { key }),
   sharedStoreCreate: (path: string) =>
     invoke<string>("shared_store_create", { path }),
+  sharedStoreInfo: () =>
+    invoke<SharedStoreInfoResult>("shared_store_info"),
+  sharedStoreSetUseAutomatically: (enabled: boolean) =>
+    invoke<void>("shared_store_set_use_automatically", { enabled }),
   serviceStart: (installAutorun: boolean) =>
     invoke<void>("service_start", { installAutorun }),
 };
+
+// --- shared_store info ---
+
+export interface SharedStoreEntry {
+  remote_url: string;
+  path: string;
+  exists: boolean;
+}
+
+export interface SharedStoreInfoResult {
+  use_automatically: boolean;
+  stores: SharedStoreEntry[];
+}
 
 // --- repository create (ops-layer) ---
 

--- a/frontend/src/palette/manifest/shared_store/create.ts
+++ b/frontend/src/palette/manifest/shared_store/create.ts
@@ -1,0 +1,49 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Shared-store create manifest.
+ *
+ * Creates a new shared store at the specified path, optionally setting it as
+ * the default. Remote URL and path are required; make_default defaults to false.
+ */
+const manifest: OpManifest = {
+  id: "shared_store.create",
+  domain: "shared_store",
+  op: "create",
+  label: "Shared Store: Create",
+  description:
+    "Create a new shared store at the specified path, optionally setting it as the default.",
+  command: "shared_store_create",
+  args: [
+    {
+      name: "remoteUrl",
+      kind: "text",
+      label: "Remote URL",
+      description: "Remote URL backing the store (leave empty for local store).",
+      required: false,
+      default: "",
+      placeholder: "https://example.com/repo",
+    },
+    {
+      name: "path",
+      kind: "text",
+      label: "Path",
+      description: "Filesystem path where the store will be created (empty for default location).",
+      required: false,
+      default: "",
+      placeholder: "/home/user/.lore/shared-store",
+    },
+    {
+      name: "makeDefault",
+      kind: "boolean",
+      label: "Make Default",
+      description: "Set this as the default shared store in global config.",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["shared", "store", "create", "new", "init"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/shared_store/info.ts
+++ b/frontend/src/palette/manifest/shared_store/info.ts
@@ -1,0 +1,23 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Shared-store info manifest.
+ *
+ * Returns information about the configured default shared stores including
+ * their remote URLs, filesystem paths, existence status, and whether they're
+ * used automatically.
+ */
+const manifest: OpManifest = {
+  id: "shared_store.info",
+  domain: "shared_store",
+  op: "info",
+  label: "Shared Store: Info",
+  description:
+    "Show information about configured default shared stores — remote URLs, paths, existence status, and auto-use setting.",
+  command: "shared_store_info",
+  args: [],
+  resultKind: "json",
+  keywords: ["shared", "store", "info", "status", "list"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/shared_store/set_use_automatically.ts
+++ b/frontend/src/palette/manifest/shared_store/set_use_automatically.ts
@@ -1,0 +1,30 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Shared-store set_use_automatically manifest.
+ *
+ * Sets whether the configured default shared store should be used automatically.
+ */
+const manifest: OpManifest = {
+  id: "shared_store.set_use_automatically",
+  domain: "shared_store",
+  op: "set_use_automatically",
+  label: "Shared Store: Set Auto-Use",
+  description:
+    "Set whether to automatically use the configured default shared store for this repository.",
+  command: "shared_store_set_use_automatically",
+  args: [
+    {
+      name: "enabled",
+      kind: "boolean",
+      label: "Enable Auto-Use",
+      description: "When true, the default shared store is used automatically.",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "void",
+  keywords: ["shared", "store", "auto", "automatic", "enable", "disable"],
+};
+
+export default manifest;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1352,6 +1352,31 @@ pub async fn shared_store_create(
     Ok(result.path)
 }
 
+// --- shared_store info ---
+
+use lore_vm::ops::shared_store::info::{info as op_shared_store_info, SharedStoreInfoArgs, SharedStoreInfoResult};
+
+#[tauri::command]
+pub async fn shared_store_info(
+    state: State<'_, AppState>,
+) -> Result<SharedStoreInfoResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_shared_store_info(&api, SharedStoreInfoArgs).await
+}
+
+// --- shared_store set_use_automatically ---
+
+use lore_vm::ops::shared_store::set_use_automatically::{set_use_automatically as op_shared_store_set_use_automatically, SetUseAutomaticallyArgs, SetUseAutomaticallyResult};
+
+#[tauri::command]
+pub async fn shared_store_set_use_automatically(
+    state: State<'_, AppState>,
+    enabled: bool,
+) -> Result<SetUseAutomaticallyResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_shared_store_set_use_automatically(&api, SetUseAutomaticallyArgs { enabled }).await
+}
+
 // --- repository clone ---
 
 use lore_vm::ops::repository::clone::{clone as op_repository_clone, CloneArgs};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -96,6 +96,8 @@ pub fn run() {
             commands::storage_get,
             commands::storage_obliterate,
             commands::shared_store_create,
+            commands::shared_store_info,
+            commands::shared_store_set_use_automatically,
             commands::repository_clone,
             commands::auth_login_interactive,
             commands::auth_login_with_token,


### PR DESCRIPTION
Resolves SBAI-3878

## Summary
Adds command-palette manifest entries for the 3 shared_store ops (create, info, set_use_automatically), plus Tauri command wrappers and TypeScript API bindings for the 2 ops that lacked them.

## Files Changed
### Created
- `frontend/src/palette/manifest/shared_store/create.ts` — manifest with remoteUrl, path, makeDefault args
- `frontend/src/palette/manifest/shared_store/info.ts` — no-arg manifest returning store list
- `frontend/src/palette/manifest/shared_store/set_use_automatically.ts` — single boolean arg manifest

### Modified
- `src-tauri/src/commands.rs` — added `shared_store_info` and `shared_store_set_use_automatically` command wrappers
- `src-tauri/src/lib.rs` — registered new commands in invoke_handler
- `frontend/src/api.ts` — added `sharedStoreInfo` and `sharedStoreSetUseAutomatically` bindings with `SharedStoreInfoResult` and `SharedStoreEntry` types

## Testing
- Rust: `cargo check -p lore-vm` and `cargo check` (Tauri) both pass with only pre-existing warnings
- Pattern matches Phase 0 reference entries from SBAI-3866 (repository/status.ts, file/stage.ts, revision/commit.ts)
- Each manifest file follows the exact shape: `{id, domain, op, label, description, command, args, resultKind, keywords}`

## Notes
- Did NOT edit `frontend/src/palette/manifest/index.ts` — integration manager assembles the registry
- The `shared_store_create` command already existed; this PR adds only the missing `info` and `set_use_automatically` wrappers