### PR TITLE
SBAI-3906: dependency dependency_remove

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1077,3 +1077,14 @@ export const authLocalUserInfoApi = {
       withToken,
     }),
 };
+
+// --- dependency remove ---
+
+export interface DependencyRemoveResult {
+  removed_count: number;
+}
+
+export const dependencyRemoveApi = {
+  remove: (entries: string[]) =>
+    invoke<DependencyRemoveResult>("dependency_remove", { entries }),
+};

--- a/frontend/src/palette/manifest/dependency/dependency_remove.ts
+++ b/frontend/src/palette/manifest/dependency/dependency_remove.ts
@@ -1,0 +1,35 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Dependency remove manifest entry.
+ *
+ * Removes file dependencies from source files. Each line specifies:
+ * source_path dependency_path [tag1,tag2,...]
+ *
+ * If tags are omitted, the entire dependency edge is removed.
+ * If tags are specified, only those tags are removed (edge removed when no tags remain).
+ */
+const manifest: OpManifest = {
+  id: "dependency.remove",
+  domain: "dependency",
+  op: "remove",
+  label: "Dependency: Remove",
+  description:
+    "Remove file dependencies from source files. Format: one entry per line as 'source_path dependency_path tag1,tag2,...'. Omit tags to remove the entire dependency edge.",
+  command: "dependency_remove",
+  args: [
+    {
+      name: "entries",
+      kind: "string-list",
+      label: "Dependency entries",
+      description:
+        "One entry per line: source_path dependency_path [tag1,tag2,...]. Example: /foo.txt /bar.txt compile,test",
+      required: true,
+      placeholder: "/src/main.ts /src/utils.ts helper\n/src/app.ts /lib/config.json",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["dependency", "remove", "unlink", "detach"],
+};
+
+export default manifest;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1473,3 +1473,66 @@ pub async fn service_start(
     op_service_start(&api).await?;
     Ok(())
 }
+
+// --- dependency remove ---
+
+use lore_vm::ops::dependency::dependency_remove::{
+    dependency_remove as op_dependency_remove, DependencyRemoveArgs, DependencyRemoveEntry,
+    DependencyRemoveSource, DependencyRemoveResult,
+};
+
+#[tauri::command]
+pub async fn dependency_remove(
+    state: State<'_, AppState>,
+    entries: Vec<String>,
+) -> Result<DependencyRemoveResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+
+    // Parse entries from the format: "source_path dependency_path tag1,tag2,..."
+    // Group by source_path and collect dependencies per source
+    use std::collections::HashMap;
+
+    let mut sources_map: HashMap<String, Vec<DependencyRemoveEntry>> = HashMap::new();
+
+    for entry in &entries {
+        let parts: Vec<&str> = entry.split_whitespace().collect();
+        if parts.len() < 2 {
+            return Err(LoreError::CommandFailed(format!(
+                "Invalid entry format: '{entry}'. Expected: 'source_path dependency_path [tag1,tag2,...]'"
+            )));
+        }
+
+        let source_path = parts[0].to_string();
+        let dependency_path = parts[1].to_string();
+
+        // Parse tags if provided (comma-separated)
+        let tags: Vec<String> = if parts.len() > 2 {
+            parts[2..]
+                .iter()
+                .flat_map(|s| s.split(','))
+                .map(|s| s.to_string())
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        sources_map
+            .entry(source_path)
+            .or_default()
+            .push(DependencyRemoveEntry {
+                dependency: dependency_path,
+                tags,
+            });
+    }
+
+    // Convert to the expected format
+    let sources: Vec<DependencyRemoveSource> = sources_map
+        .into_iter()
+        .map(|(path, dependencies)| DependencyRemoveSource {
+            path,
+            dependencies,
+        })
+        .collect();
+
+    op_dependency_remove(&api, DependencyRemoveArgs { sources }).await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -101,6 +101,7 @@ pub fn run() {
             commands::auth_login_with_token,
             commands::auth_user_info,
             commands::service_start,
+            commands::dependency_remove,
             subscribe_notifications,
             unsubscribe_notifications,
         ])


### PR DESCRIPTION
Resolves SBAI-3906

## Summary
Adds command-palette manifest entry for dependency.dependency_remove, following the Phase 0 reference pattern. This enables the dependency_remove op to be invoked via Ctrl-K with a generated form.

## Files Changed
- `frontend/src/palette/manifest/dependency/dependency_remove.ts` — New manifest file (one entry per op)
- `src-tauri/src/commands.rs` — Added `dependency_remove` Tauri command wrapper with entry parsing
- `src-tauri/src/lib.rs` — Registered `dependency_remove` in invoke_handler
- `frontend/src/api.ts` — Added `dependencyRemoveApi.remove()` binding

## Testing
- Rust compiles: `cargo check` ✓ (no new errors)
- TypeScript compiles: `npx tsc --noEmit` ✓ (no dependency-related errors)
- lore-vm op tests pass: `cargo test -p lore-vm dependency_remove` ✓ (4/4 tests)
- Pattern follows Phase 0 reference entries (repository/status, file/stage, revision/commit)

## How to Verify
1. Open LoreGUI and press Ctrl-K
2. Search for "dependency" or "remove"
3. The "Dependency: Remove" op should appear
4. The form should accept entries in format: `source_path dependency_path [tag1,tag2,...]`
5. Submitting should invoke the command and display the result (removed_count)

## Notes
- The lore-vm binding for dependency_remove was already implemented in SBAI-3833 (PR #68)
- This PR only adds the frontend palette manifest, Tauri command wrapper, and api.ts binding
- No manifest index changes (per ticket scope: one file per op, index managed separately)