### PR TITLE
SBAI-3877: Command Palette — service start/stop operations

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -59,6 +59,10 @@ export interface UserInfo {
   name: string;
 }
 
+export interface ServiceStopResult {
+  log_messages: string[];
+}
+
 export const api = {
   currentRepository: () => invoke<string>("current_repository"),
   openRepository: (path: string) => invoke<void>("open_repository", { path }),
@@ -109,6 +113,8 @@ export const api = {
     invoke<string>("shared_store_create", { path }),
   serviceStart: (installAutorun: boolean) =>
     invoke<void>("service_start", { installAutorun }),
+  serviceStop: (all: boolean = false) =>
+    invoke<ServiceStopResult>("service_stop", { all }),
 };
 
 // --- repository create (ops-layer) ---

--- a/frontend/src/palette/manifest/service/start.ts
+++ b/frontend/src/palette/manifest/service/start.ts
@@ -1,0 +1,22 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest entry for `service start`.
+ *
+ * Starts the Lore service process for the current repository. The upstream
+ * lore-vm op takes no arguments; the Tauri command accepts an `installAutorun`
+ * flag for forward compatibility but does not yet act on it.
+ */
+const manifest: OpManifest = {
+  id: "service.start",
+  domain: "service",
+  op: "start",
+  label: "Service: Start",
+  description: "Start the Lore service process for the current repository.",
+  command: "service_start",
+  args: [],
+  resultKind: "void",
+  keywords: ["start", "service", "daemon", "run"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/service/stop.ts
+++ b/frontend/src/palette/manifest/service/stop.ts
@@ -1,0 +1,32 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest entry for `service stop`.
+ *
+ * Stops the Lore service process for the current repository (or all repositories
+ * when `all` is set). Returns diagnostic log messages from the stop operation.
+ */
+const manifest: OpManifest = {
+  id: "service.stop",
+  domain: "service",
+  op: "stop",
+  label: "Service: Stop",
+  description:
+    "Stop the Lore service process for the current repository (or all repositories).",
+  command: "service_stop",
+  args: [
+    {
+      name: "all",
+      kind: "boolean",
+      label: "All repositories",
+      description:
+        "Stop the service for all repositories rather than just the current one.",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["stop", "service", "daemon", "halt", "shutdown"],
+};
+
+export default manifest;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1473,3 +1473,17 @@ pub async fn service_start(
     op_service_start(&api).await?;
     Ok(())
 }
+
+// --- service stop ---
+
+use lore_vm::ops::service::stop::{stop as op_service_stop, ServiceStopArgs, ServiceStopResult};
+
+#[tauri::command]
+pub async fn service_stop(
+    state: State<'_, AppState>,
+    all: bool,
+) -> Result<ServiceStopResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    let result = op_service_stop(&api, ServiceStopArgs { all }).await?;
+    Ok(result)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -101,6 +101,7 @@ pub fn run() {
             commands::auth_login_with_token,
             commands::auth_user_info,
             commands::service_start,
+            commands::service_stop,
             subscribe_notifications,
             unsubscribe_notifications,
         ])


### PR DESCRIPTION
Resolves SBAI-3877

## Summary
Added command-palette manifest entries for the two service domain operations (start, stop), plus the missing Tauri command wrapper and API binding for service_stop.

## Files Changed
- `frontend/src/palette/manifest/service/start.ts` — NEW manifest for service start operation (no args, void result)
- `frontend/src/palette/manifest/service/stop.ts` — NEW manifest for service stop operation (all: bool arg, json result with log_messages)
- `src-tauri/src/commands.rs` — ADDED service_stop Tauri command wrapper (was missing)
- `src-tauri/src/lib.rs` — REGISTERED service_stop command in the invoke handler
- `frontend/src/api.ts` — ADDED ServiceStopResult interface and serviceStop API binding

## Testing
- Rust compilation: `cargo check -p loregui` passes
- lore-vm tests: All passing
- TypeScript compilation: No errors in the new manifest files

## Implementation Notes
- Followed the Phase 0 manifest pattern from SBAI-3866
- service start: No args (matching the lore-vm op), void result (matching Tauri command)
- service stop: Optional `all` boolean arg, returns ServiceStopResult with log_messages
- Did NOT modify manifest/index.ts (integration manager handles that)
- Did NOT touch lore-vm ops (they already existed)