### PR TITLE
SBAI-3872: Command Palette — link domain manifests (5 ops)

### DIFF
--- a/frontend/src/palette/manifest/link/add.ts
+++ b/frontend/src/palette/manifest/link/add.ts
@@ -1,0 +1,60 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for `link add`.
+ *
+ * Adds a new link to a linked repository at the specified path.
+ */
+const manifest: OpManifest = {
+  id: "link.add",
+  domain: "link",
+  op: "add",
+  label: "Link: Add",
+  description: "Add a new link to a linked repository at the specified path.",
+  command: "link_add",
+  args: [
+    {
+      name: "link",
+      kind: "text",
+      label: "Link",
+      description: "Link repository URL or identifier.",
+      required: true,
+      placeholder: "https://example.com/repo or repo-name",
+    },
+    {
+      name: "linkPath",
+      kind: "text",
+      label: "Link path",
+      description: "Path within this repository where the link is added.",
+      required: true,
+      placeholder: "deps/external",
+    },
+    {
+      name: "sourcePath",
+      kind: "text",
+      label: "Source path",
+      description: "Source path within the linked repository; / or \\ means the root.",
+      required: false,
+      placeholder: "/",
+    },
+    {
+      name: "pin",
+      kind: "text",
+      label: "Pin",
+      description: "Branch or revision to set the link pin at.",
+      required: false,
+      placeholder: "main",
+    },
+    {
+      name: "disableBranching",
+      kind: "boolean",
+      label: "Disable branching",
+      description: "Disable automatic branch creation in the linked repository.",
+      required: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["link", "add", "bind", "connect"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/link/list.ts
+++ b/frontend/src/palette/manifest/link/list.ts
@@ -1,0 +1,20 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for `link list`.
+ *
+ * Lists all linked repositories registered in the current repository.
+ */
+const manifest: OpManifest = {
+  id: "link.list",
+  domain: "link",
+  op: "list",
+  label: "Link: List",
+  description: "List all linked repositories registered in the current repository.",
+  command: "link_list",
+  args: [],
+  resultKind: "json",
+  keywords: ["link", "list", "show", "display"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/link/list_staged.ts
+++ b/frontend/src/palette/manifest/link/list_staged.ts
@@ -1,0 +1,20 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for `link list_staged`.
+ *
+ * Lists links with staged changes in the current repository.
+ */
+const manifest: OpManifest = {
+  id: "link.list_staged",
+  domain: "link",
+  op: "list_staged",
+  label: "Link: List Staged",
+  description: "List all links with staged changes in the current repository.",
+  command: "link_list_staged",
+  args: [],
+  resultKind: "json",
+  keywords: ["link", "list", "staged", "changes", "pending"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/link/remove.ts
+++ b/frontend/src/palette/manifest/link/remove.ts
@@ -1,0 +1,29 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for `link remove`.
+ *
+ * Removes a link from the repository at the specified path.
+ */
+const manifest: OpManifest = {
+  id: "link.remove",
+  domain: "link",
+  op: "remove",
+  label: "Link: Remove",
+  description: "Remove a link from the repository at the specified path.",
+  command: "link_remove",
+  args: [
+    {
+      name: "linkPath",
+      kind: "text",
+      label: "Link path",
+      description: "Path within this repository where the link is removed.",
+      required: true,
+      placeholder: "deps/external",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["link", "remove", "delete", "unlink"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/link/update.ts
+++ b/frontend/src/palette/manifest/link/update.ts
@@ -1,0 +1,30 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for `link update`.
+ *
+ * Updates an existing link in the repository.
+ * NOTE: This op is currently a stub in lore-vm and needs implementation.
+ */
+const manifest: OpManifest = {
+  id: "link.update",
+  domain: "link",
+  op: "update",
+  label: "Link: Update",
+  description: "Update an existing link in the repository.",
+  command: "link_update",
+  args: [
+    {
+      name: "linkPath",
+      kind: "text",
+      label: "Link path",
+      description: "Path of the link to update.",
+      required: true,
+      placeholder: "deps/external",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["link", "update", "modify", "change"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3872

## Summary
Add command-palette manifest entries for all 5 link domain operations following the Phase 0 pattern from SBAI-3866 and SBAI-3867 (auth domain).

## Files Changed
- frontend/src/palette/manifest/link/add.ts - Link add manifest (5 args)
- frontend/src/palette/manifest/link/list.ts - Link list manifest (no args)
- frontend/src/palette/manifest/link/list_staged.ts - Link list_staged manifest (no args)
- frontend/src/palette/manifest/link/remove.ts - Link remove manifest (1 arg)
- frontend/src/palette/manifest/link/update.ts - Link update manifest (1 arg, NOTE: lore-vm op is a stub)

## Implementation Notes
Each manifest exports an OpManifest that describes the op's arguments, result type, and metadata for the Ctrl-K palette. The manifests follow the pattern established in:
- SBAI-3866: Phase 0 command-palette infra
- SBAI-3867: auth domain manifests (reference pattern)

**SCOPE NOTE:** This PR includes ONLY the frontend manifest files. The Tauri command wrappers (link_add, link_list, link_list_staged, link_update) and api.ts bindings that the ticket description mentions are NOT included. Those require editing src-tauri/** and frontend/api.ts which are forbidden by the LOREGUI-SPECIFIC SCOPE constraints that apply to this ticket type. Those may need to be added in a follow-up ticket if the integration manager determines they're needed.

**Current state of Tauri commands (src-tauri/src/lib.rs):**
- Only link_remove is registered
- Missing: link_add, link_list, link_list_staged, link_update

**Current state of api.ts bindings:**
- Only linkRemoveApi exists
- Missing: linkAddApi, linkListApi, linkListStagedApi, linkUpdateApi

## Testing
- Each manifest follows the OpManifest type contract
- Field kinds and argument names match the lore-vm op signatures
- Commands are ready for palette integration once Tauri wrappers are added

## Questions for Reviewer
1. Should the Tauri command wrappers and api.ts bindings be added in a follow-up ticket?
2. Is the scope constraint (LOREGUI-SPECIFIC SCOPE) correctly applied here, or should this have been routed differently?