### PR TITLE
SBAI-3942: branch merge_unresolve command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/branch/merge_unresolve.ts
+++ b/frontend/src/palette/manifest/branch/merge_unresolve.ts
@@ -1,0 +1,29 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Mark merge conflict files as unresolved. During a merge, conflicts can be
+ * resolved by accepting one side or the other; this operation reverses that
+ * resolution, returning the specified paths to an unresolved conflict state.
+ */
+const manifest: OpManifest = {
+  id: "branch.merge_unresolve",
+  domain: "branch",
+  op: "merge_unresolve",
+  label: "Branch: Unresolve Merge Conflicts",
+  description: "Mark files as unresolved during a merge, reverting previous conflict resolutions.",
+  command: "branch_merge_unresolve",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Files to unresolve",
+      description: "Paths to mark as unresolved (empty = all conflicted files)",
+      required: false,
+      default: [],
+    },
+  ],
+  resultKind: "json",
+  keywords: ["merge", "conflict", "unresolve", "revert", "undo"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3942

## Summary
Add command-palette manifest entry for `branch.merge_unresolve` operation.

## Files Changed
- `frontend/src/palette/manifest/branch/merge_unresolve.ts` (new)

## What Changed
- Created manifest file for `branch.merge_unresolve` operation
- Follows Phase 0 pattern for command-palette entries
- Uses `string-list` field kind for optional `paths` parameter
- Tauri command `branch_merge_unresolve` already exists in api.ts (lines 356-365)

## Testing
- TypeScript compilation passes (`npx tsc --noEmit`)
- Manifest structure matches OpManifest type
- Command binding already exists in frontend/src/api.ts

## How to Verify
1. Open LoreGUI
2. Press Ctrl-K to open command palette
3. Search for "unresolve" or "merge conflict"
4. The operation should appear with form for file paths
5. Invoking should call the existing `branch_merge_unresolve` Tauri command

The integration manager will add this entry to the manifest index in a future batched pass.