### PR TITLE
SBAI-3939: repository list command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/repository/list.ts
+++ b/frontend/src/palette/manifest/repository/list.ts
@@ -1,0 +1,28 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Reference manifest entry (Phase 0). A single-arg op whose result is a typed
+ * JSON object — exercises the single-field-form + JSON-result path of the palette.
+ */
+const manifest: OpManifest = {
+  id: "repository.list",
+  domain: "repository",
+  op: "list",
+  label: "Repository: List",
+  description: "List all repositories available at a remote URL.",
+  command: "list",
+  args: [
+    {
+      name: "url",
+      kind: "text",
+      label: "Remote URL",
+      description: "The lore:// URL to query for available repositories.",
+      required: true,
+      placeholder: "lore://example.com/myrepo",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["list", "repositories", "remote", "discover"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3939

## Summary
Add Phase 0 manifest entry for `repository.list` operation at `frontend/src/palette/manifest/repository/list.ts`.

## Files Changed
- `frontend/src/palette/manifest/repository/list.ts` (new file)

## Implementation Details
- Follows the Phase 0 reference pattern from `repository/status.ts`
- Defines a single `url` argument (text field, required)
- Keywords: list, repositories, remote, discover
- Result kind: json (returns RepositoryListResult with url + entries)

## Dependencies (Pre-existing)
- Tauri command `repository_list` already exists in `src-tauri/src/commands.rs:495-500`
- API binding `list()` already exists in `frontend/src/api.ts:204-206`
- Rust op implementation `crates/lore-vm/src/ops/repository/list.rs` is complete

## Acceptance Criteria
- [x] Manifest file created with correct structure
- [ ] Op appears in Ctrl-K (pending manifest index update by integration manager)
- [ ] Generated form invokes the command (pending manifest index update)
- [ ] Result renders correctly (pending manifest index update)

## Notes
Per scope: "One file per op; do not edit the manifest index."
The integration manager will update `frontend/src/palette/manifest/index.ts` and verify end-to-end functionality.