### PR TITLE
SBAI-3937: revision metadata_clear manifest

### DIFF
--- a/frontend/src/palette/manifest/revision/metadata_clear.ts
+++ b/frontend/src/palette/manifest/revision/metadata_clear.ts
@@ -1,0 +1,39 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Manifest entry for revision.metadata_clear.
+ *
+ * Clears metadata keys from a revision. If revision is empty, clears from
+ * the current HEAD (committed). Use metadata_get to read keys and
+ * metadata_set to write them; metadata_clear removes them entirely.
+ */
+const manifest: OpManifest = {
+  id: "revision.metadata_clear",
+  domain: "revision",
+  op: "metadata_clear",
+  label: "Revision: Metadata Clear",
+  description: "Clear metadata keys from a revision.",
+  command: "metadata_clear",
+  args: [
+    {
+      name: "keys",
+      kind: "string-list",
+      label: "Keys",
+      description: "One metadata key per line.",
+      required: true,
+      placeholder: "change-request\nreviewed-by",
+    },
+    {
+      name: "revision",
+      kind: "text",
+      label: "Revision",
+      description: "Leave empty for current HEAD.",
+      required: false,
+      placeholder: "abc123def",
+    },
+  ],
+  resultKind: "void",
+  keywords: ["metadata", "clear", "delete", "remove"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3937

## Summary
Add command-palette manifest entry for revision.metadata_clear following the Phase 0 reference pattern.

## Changes
- Created `frontend/src/palette/manifest/revision/metadata_clear.ts`
  - Uses command: `metadata_clear`
  - Accepts `keys` (string-list, required) - one metadata key per line
  - Accepts `revision` (text, optional) - leave empty for current HEAD
  - Result type: void

## Pattern
Follows the Phase 0 reference entries (repository.status, file.stage, revision.commit):
- Single file per operation
- Append-only manifest/index.ts (integration manager handles this)
- Tauri command wrapper and api.ts binding added in separate batch by integration manager

## Testing
- TypeScript compilation passes (no errors in metadata_clear.ts)
- Follows existing patterns from Phase 0 reference entries

## Notes
The Tauri command wrapper `revision_metadata_clear` and api.ts binding do not exist yet. Per LOREGUI-SPECIFIC SCOPE, these will be added by the integration manager in a batched pass. The manifest file is complete and ready for integration.