### PR TITLE
SBAI-3929: revision history command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/revision/history.ts
+++ b/frontend/src/palette/manifest/revision/history.ts
@@ -1,0 +1,63 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for revision.history.
+ *
+ * Retrieves the revision history for the current branch or a specified
+ * revision. Returns a list of revision entries with hashes, numbers,
+ * and parent references.
+ */
+const manifest: OpManifest = {
+  id: "revision.history",
+  domain: "revision",
+  op: "history",
+  label: "Revision: History",
+  description: "Show revision history for the current branch or a specified revision.",
+  command: "revision_history",
+  args: [
+    {
+      name: "revision",
+      kind: "text",
+      label: "Revision",
+      description: "Start from this revision; empty for current.",
+      required: false,
+      placeholder: "e.g. abc123def",
+    },
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch",
+      description: "Restrict to this branch; empty for current.",
+      required: false,
+      placeholder: "e.g. main",
+    },
+    {
+      name: "date",
+      kind: "number",
+      label: "Date",
+      description: "Stop at revisions created before this Unix timestamp; 0 disables.",
+      required: false,
+      default: 0,
+    },
+    {
+      name: "length",
+      kind: "number",
+      label: "Length",
+      description: "Maximum number of revisions to return; 0 for unlimited.",
+      required: false,
+      default: 0,
+    },
+    {
+      name: "onlyBranch",
+      kind: "boolean",
+      label: "Only Branch",
+      description: "Stop when reaching a different branch.",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["history", "log", "revisions", "commits"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3929

## Summary
Add command-palette manifest entry for revision.history at frontend/src/palette/manifest/revision/history.ts following the Phase 0 reference entries.

The lore-vm core op (crates/lore-vm/src/ops/revision/history.rs) already exists from SBAI-3753. This manifest makes it reachable from the Ctrl-K command palette with a generated form.

## Files Changed
- frontend/src/palette/manifest/revision/history.ts (new file)

## Testing
- Manifest follows the pattern from existing entries (commit.ts, status.ts, stage.ts)
- Uses correct field mappings (camelCase for Tauri v2)
- All 5 op arguments are declared as optional fields with appropriate defaults
- Result type is json (returns RevisionHistoryResult with entries array)

Note: Per ticket instructions, the manifest index (frontend/src/palette/manifest/index.ts) was NOT edited. The integration manager will handle that in a batched pass.