### PR TITLE
feat(palette): service domain — start + stop (SBAI-3877)

### DIFF
--- a/frontend/scripts/palette-parity-allowlist.json
+++ b/frontend/scripts/palette-parity-allowlist.json
@@ -67,7 +67,6 @@
     "revision_revert_local",
     "revision_revert_resolve",
     "revision_sync",
-    "service_start",
     "shared_store_create",
     "storage_get",
     "storage_obliterate",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -109,6 +109,7 @@ export const api = {
     invoke<string>("shared_store_create", { path }),
   serviceStart: (installAutorun: boolean) =>
     invoke<void>("service_start", { installAutorun }),
+  serviceStop: (all: boolean) => invoke<unknown>("service_stop", { all }),
 };
 
 // --- repository create (ops-layer) ---

--- a/frontend/src/palette/manifest/service/start.ts
+++ b/frontend/src/palette/manifest/service/start.ts
@@ -1,0 +1,23 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "service.start",
+  domain: "service",
+  op: "start",
+  label: "Service: Start",
+  description: "Start the local lore background service.",
+  command: "service_start",
+  args: [
+    {
+      name: "installAutorun",
+      kind: "boolean",
+      label: "Install as autorun service",
+      description: "Register the service to start on login (where supported).",
+      default: false,
+    },
+  ],
+  resultKind: "void",
+  keywords: ["service", "daemon", "start", "background"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/service/stop.ts
+++ b/frontend/src/palette/manifest/service/stop.ts
@@ -1,0 +1,23 @@
+import type { OpManifest } from "../../types";
+
+const manifest: OpManifest = {
+  id: "service.stop",
+  domain: "service",
+  op: "stop",
+  label: "Service: Stop",
+  description: "Stop the local lore background service.",
+  command: "service_stop",
+  args: [
+    {
+      name: "all",
+      kind: "boolean",
+      label: "Stop all instances",
+      description: "Stop every running service instance, not just this repo's.",
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["service", "daemon", "stop", "shutdown"],
+};
+
+export default manifest;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1473,3 +1473,16 @@ pub async fn service_start(
     op_service_start(&api).await?;
     Ok(())
 }
+
+// --- service stop (ops-layer) ---
+
+use lore_vm::ops::service::stop::{stop as op_service_stop, ServiceStopArgs, ServiceStopResult};
+
+#[tauri::command]
+pub async fn service_stop(
+    state: State<'_, AppState>,
+    all: bool,
+) -> Result<ServiceStopResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_service_stop(&api, ServiceStopArgs { all }).await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -101,6 +101,7 @@ pub fn run() {
             commands::auth_login_with_token,
             commands::auth_user_info,
             commands::service_start,
+            commands::service_stop,
             subscribe_notifications,
             unsubscribe_notifications,
         ])


### PR DESCRIPTION
Pilot domain for the command-palette fan-out, proving the full vertical.

- **Phase 1:** `service_stop` Tauri command + `api.ts` binding (service_start already existed).
- **Phase 2:** palette manifest entries `service.start` + `service.stop`.
- **Ratchet:** `service_start` removed from the `deferred` allowlist; `palette-parity` green at 5/77 exposed.

Verification: `cargo check -p loregui`, `cargo fmt --check`, `vite build`, and the parity gate all pass. Reference pattern for the per-domain fan-out (SBAI-3865).

🤖 Generated with [Claude Code](https://claude.com/claude-code)