### PR TITLE
SBAI-3890: add repository.clone command-palette manifest entry

### DIFF
--- a/frontend/scripts/palette-parity-allowlist.json
+++ b/frontend/scripts/palette-parity-allowlist.json
@@ -46,7 +46,6 @@
     "log",
     "merge_branch",
     "push",
-    "repository_clone",
     "repository_create",
     "repository_delete",
     "repository_dump",

--- a/frontend/src/palette/manifest/index.ts
+++ b/frontend/src/palette/manifest/index.ts
@@ -1,4 +1,5 @@
 import type { OpManifest } from "../types";
+import repositoryClone from "./repository/clone";
 import repositoryStatus from "./repository/status";
 import fileStage from "./file/stage";
 import revisionCommit from "./revision/commit";
@@ -12,6 +13,7 @@ import revisionCommit from "./revision/commit";
  */
 export const OP_MANIFEST: OpManifest[] = [
   fileStage,
+  repositoryClone,
   repositoryStatus,
   revisionCommit,
 ];

--- a/frontend/src/palette/manifest/repository/clone.ts
+++ b/frontend/src/palette/manifest/repository/clone.ts
@@ -1,0 +1,35 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Manifest entry for `repository.clone`. Requires the repository URL to clone
+ * from and a local destination path. Invokes the `repository_clone` Tauri
+ * command.
+ */
+const manifest: OpManifest = {
+  id: "repository.clone",
+  domain: "repository",
+  op: "clone",
+  label: "Repository: Clone",
+  description: "Clone a remote repository to a local directory.",
+  command: "repository_clone",
+  args: [
+    {
+      name: "url",
+      kind: "text",
+      label: "Repository URL",
+      required: true,
+      placeholder: "lore://host/repo",
+    },
+    {
+      name: "dest",
+      kind: "text",
+      label: "Destination",
+      required: true,
+      placeholder: "/path/to/clone",
+    },
+  ],
+  resultKind: "void",
+  keywords: ["clone", "checkout", "download", "fetch"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3890

## Summary
Add the command-palette manifest entry for `repository.clone` so it appears in Ctrl-K. The lore-vm op, Tauri command wrapper, and api.ts binding were already implemented in SBAI-3706. This was the last missing piece.

## Files Changed
- `frontend/src/palette/manifest/repository/clone.ts` (new) — manifest entry with two required text args: `url` and `dest\)
- `frontend/src/palette/manifest/index.ts` — added import + array entry
- `frontend/scripts/palette-parity-allowlist.json` — removed `repository_clone` from deferred (now covered by manifest)

## Testing
- TypeScript compiles cleanly (no new errors introduced)
- Lore-vm cargo check was already green (no changes to Rust code)
- Acceptance criteria: op appears in Ctrl-K ✓, generated form has url + dest fields ✓, result renders as void ✓