### PR TITLE
SBAI-3948: file reset_to_last_merged palette entry

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -472,6 +472,35 @@ export const fileDirtyMoveApi = {
     invoke<FileDirtyMoveResult>("file_dirty_move", { fromPath, toPath }),
 };
 
+// --- file reset_to_last_merged ---
+
+export interface FileResetToLastMergedEntry {
+  path: string;
+  action: string;
+  from_path: string;
+}
+
+export interface FileResetToLastMergedCounts {
+  directory_reset_count: number;
+  directory_delete_count: number;
+  file_reset_count: number;
+  file_delete_count: number;
+}
+
+export interface FileResetToLastMergedResult {
+  files: FileResetToLastMergedEntry[];
+  counts: FileResetToLastMergedCounts;
+}
+
+export const fileResetToLastMergedApi = {
+  resetToLastMerged: (paths: string[], branch: string, purge: boolean) =>
+    invoke<FileResetToLastMergedResult>("file_reset_to_last_merged", {
+      paths,
+      branch,
+      purge,
+    }),
+};
+
 // --- file obliterate ---
 
 export interface FileObliterateEntry {

--- a/frontend/src/palette/manifest/file/reset_to_last_merged.ts
+++ b/frontend/src/palette/manifest/file/reset_to_last_merged.ts
@@ -1,0 +1,45 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for file.reset_to_last_merged. Exercises the
+ * `string-list`, `text`, and `boolean` field kinds; the result is rendered
+ * as pretty-printed JSON.
+ */
+const manifest: OpManifest = {
+  id: "file.reset_to_last_merged",
+  domain: "file",
+  op: "reset_to_last_merged",
+  label: "File: Reset to Last Merged",
+  description: "Reset one or more files to the state they were in at the last merged revision on a given branch.",
+  command: "file_reset_to_last_merged",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths",
+      description: "Repository-relative paths to reset. One path per line.",
+      required: true,
+      placeholder: "src/main.rs\nREADME.md",
+    },
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch",
+      description: "Branch whose last merged revision to reset to.",
+      required: true,
+      placeholder: "main",
+    },
+    {
+      name: "purge",
+      kind: "boolean",
+      label: "Purge untracked files",
+      description: "Whether to purge untracked files.",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["reset", "revert", "merge", "branch"],
+};
+
+export default manifest;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -807,6 +807,32 @@ pub async fn file_dirty_move(
     op_file_dirty_move(&api, FileDirtyMoveArgs { from_path, to_path }).await
 }
 
+// --- file reset_to_last_merged ---
+
+use lore_vm::ops::file::reset_to_last_merged::{
+    reset_to_last_merged as op_file_reset_to_last_merged, FileResetToLastMergedArgs,
+    FileResetToLastMergedResult,
+};
+
+#[tauri::command]
+pub async fn file_reset_to_last_merged(
+    state: State<'_, AppState>,
+    paths: Vec<String>,
+    branch: String,
+    purge: bool,
+) -> Result<FileResetToLastMergedResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_file_reset_to_last_merged(
+        &api,
+        FileResetToLastMergedArgs {
+            paths,
+            branch,
+            purge,
+        },
+    )
+    .await
+}
+
 // --- revision sync ---
 
 use lore_vm::ops::revision::sync::{

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,6 +58,7 @@ pub fn run() {
             commands::file_dirty_copy,
             commands::file_dirty_move,
             commands::file_obliterate,
+            commands::file_reset_to_last_merged,
             commands::repository_dump,
             commands::repository_delete,
             commands::repository_list,


### PR DESCRIPTION
Resolves SBAI-3948

## Summary
Add command-palette manifest entry for `file.reset_to_last_merged` operation, following Phase 0 pattern. This enables the operation to be discovered via Ctrl-K and invoked with auto-generated form fields.

## Files Changed
- `frontend/src/palette/manifest/file/reset_to_last_merged.ts` — New manifest file with paths (string-list), branch (string), and purge (boolean) args
- `src-tauri/src/commands.rs` — Added `file_reset_to_last_merged` Tauri command wrapper
- `frontend/src/api.ts` — Added TypeScript interfaces and `fileResetToLastMergedApi` binding

## Testing
- Manifest follows exact pattern of existing entries (e.g., `file/stage.ts`)
- Tauri command wrapper matches pattern of `file_stage`, `file_dirty` etc.
- TypeScript binding uses standard `invoke<T>` pattern with correct types matching Rust structs