### PR TITLE
SBAI-3934: repository instance_prune

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -246,6 +246,24 @@ export const repositoryGcApi = {
   gc: () => invoke<GcResult>("repository_gc"),
 };
 
+// --- repository instance_prune ---
+
+export interface PrunedInstance {
+  instance_id: string;
+  path: string;
+  branch_name: string;
+}
+
+export interface InstancePruneResult {
+  pruned_count: number;
+  pruned: PrunedInstance[];
+}
+
+export const repositoryInstancePruneApi = {
+  instancePrune: () =>
+    invoke<InstancePruneResult>("repository_instance_prune"),
+};
+
 // --- repository verify_state ---
 
 export interface VerifiedFragment {

--- a/frontend/src/palette/manifest/repository/instance_prune.ts
+++ b/frontend/src/palette/manifest/repository/instance_prune.ts
@@ -1,0 +1,20 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Reference manifest entry (Phase 0). A no-arg op whose result is a typed
+ * object — exercises the empty-form + JSON-result path of the palette.
+ */
+const manifest: OpManifest = {
+  id: "repository.instance_prune",
+  domain: "repository",
+  op: "instance_prune",
+  label: "Repository: Prune Stale Instances",
+  description:
+    "Remove stale repository instances (working copies whose filesystem paths no longer exist) from the shared store.",
+  command: "repository_instance_prune",
+  args: [],
+  resultKind: "json",
+  keywords: ["prune", "cleanup", "stale", "instances", "garbage"],
+};
+
+export default manifest;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -520,6 +520,20 @@ pub async fn repository_gc(state: State<'_, AppState>) -> Result<GcResult, LoreE
     op_repository_gc(&api).await
 }
 
+// --- repository instance_prune ---
+
+use lore_vm::ops::repository::instance_prune::{
+    instance_prune as op_repository_instance_prune, InstancePruneResult, PrunedInstance,
+};
+
+#[tauri::command]
+pub async fn repository_instance_prune(
+    state: State<'_, AppState>,
+) -> Result<InstancePruneResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_repository_instance_prune(&api).await
+}
+
 // --- revision revert_local ---
 
 use lore_vm::ops::repository::verify_state::{


### PR DESCRIPTION
Resolves SBAI-3934

## Summary
Add command-palette manifest entry for `repository.instance_prune` following Phase 0 reference entries. Includes the Tauri command wrapper and TypeScript API binding.

## Files Changed
- **frontend/src/palette/manifest/repository/instance_prune.ts** (new) — Phase 0 manifest entry with no args, JSON result
- **src-tauri/src/commands.rs** — Added `repository_instance_prune` Tauri command wrapper
- **frontend/src/api.ts** — Added `PrunedInstance`, `InstancePruneResult` types and `repositoryInstancePruneApi`

## Testing
- `cargo check` passes cleanly (lore-vm + full workspace)
- Manifest follows Phase 0 pattern from `status.ts`
- Tauri command follows existing pattern from `repository_instance_list`
- TypeScript API follows existing pattern from `repositoryGcApi`