### PR TITLE
SBAI-3954: Palette: repository release

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -246,6 +246,16 @@ export const repositoryGcApi = {
   gc: () => invoke<GcResult>("repository_gc"),
 };
 
+// --- repository release ---
+
+export interface ReleaseResult {
+  log_messages: string[];
+}
+
+export const repositoryReleaseApi = {
+  release: () => invoke<ReleaseResult>("repository_release"),
+};
+
 // --- repository verify_state ---
 
 export interface VerifiedFragment {

--- a/frontend/src/palette/manifest/repository/release.ts
+++ b/frontend/src/palette/manifest/repository/release.ts
@@ -1,0 +1,19 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Manifest for `repository.release` — releases cached store references for the
+ * current repository path.
+ */
+const manifest: OpManifest = {
+  id: "repository.release",
+  domain: "repository",
+  op: "release",
+  label: "Repository: Release",
+  description: "Release cached store references for the current repository path.",
+  command: "repository_release",
+  args: [],
+  resultKind: "json",
+  keywords: ["release", "store", "cache", "unlock", "free"],
+};
+
+export default manifest;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -520,6 +520,16 @@ pub async fn repository_gc(state: State<'_, AppState>) -> Result<GcResult, LoreE
     op_repository_gc(&api).await
 }
 
+// --- repository release ---
+
+use lore_vm::ops::repository::release::{release as op_repository_release, ReleaseResult};
+
+#[tauri::command]
+pub async fn repository_release(state: State<'_, AppState>) -> Result<ReleaseResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_repository_release(&api).await
+}
+
 // --- revision revert_local ---
 
 use lore_vm::ops::repository::verify_state::{

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,6 +64,7 @@ pub fn run() {
             commands::repository_verify_state,
             commands::repository_flush,
             commands::repository_gc,
+            commands::repository_release,
             commands::repository_metadata_get,
             commands::repository_metadata_set,
             commands::revision_diff,


### PR DESCRIPTION
Resolves SBAI-3954

## Summary
Integrated the `repository.release` operation into the command palette.
Added Tauri command wrapper, frontend API binding, and palette manifest.

## Files Changed
- `src-tauri/src/commands.rs`: Added `repository_release` Tauri command.
- `src-tauri/src/lib.rs`: Registered the new command.
- `frontend/src/api.ts`: Added `repositoryReleaseApi` binding.
- `frontend/src/palette/manifest/repository/release.ts`: Created the manifest entry.

## Testing
- Verified with `node frontend/scripts/palette-parity.mjs` (ratchet passed).
- Verified `cargo check -p lore-vm` and `cargo test -p lore-vm` are green.