### PR TITLE
SBAI-3920: revision find command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/revision/find.ts
+++ b/frontend/src/palette/manifest/revision/find.ts
@@ -1,0 +1,45 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Manifest for revision.find — searches revisions by metadata key/value or revision number.
+ * Finds matching revisions across local and remote shared stores.
+ */
+const manifest: OpManifest = {
+  id: "revision.find",
+  domain: "revision",
+  op: "find",
+  label: "Revision: Find",
+  description: "Find revisions by metadata key/value or revision number, searching local and remote stores.",
+  command: "revision_find",
+  args: [
+    {
+      name: "key",
+      kind: "text",
+      label: "Metadata Key",
+      description: "Search by this metadata key (e.g. 'tag', 'author'). Leave empty to search by revision number.",
+      required: false,
+      placeholder: "tag",
+    },
+    {
+      name: "value",
+      kind: "text",
+      label: "Metadata Value",
+      description: "Match this value for the given key.",
+      required: false,
+      placeholder: "release-1.0",
+    },
+    {
+      name: "number",
+      kind: "number",
+      label: "Revision Number",
+      description: "Search by revision number when key is empty.",
+      required: false,
+      default: 0,
+      placeholder: "42",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["search", "query", "metadata", "revision-number"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3920

## Summary
Adds command-palette manifest entry for `revision.find` operation, making it discoverable and invocable via Ctrl-K.

## Files Changed
- `frontend/src/palette/manifest/revision/find.ts` (new file)

## Implementation Details
The manifest follows the Phase 0 reference pattern:
- Uses `revision_find` Tauri command (already wired in commands.rs and api.ts)
- Defines three optional search arguments:
  - `key`: metadata key (e.g. 'tag', 'author')
  - `value`: metadata value to match
  - `number`: revision number (used when key is empty)
- Returns JSON result (array of revision signatures)
- Includes search keywords: 'search', 'query', 'metadata', 'revision-number'

## Testing
The underlying lore-vm op (`crates/lore-vm/src/ops/revision/find.rs`) is already implemented with full test coverage. The Tauri wrapper (`src-tauri/src/commands.rs::revision_find`) and API binding (`frontend/src/api.ts::revisionFindApi`) are already in place. This PR only adds the manifest to wire the command into the palette UI.

Acceptance criteria: op appears in Ctrl-K palette, form generates correctly, and invoking the command returns matching revisions.