### PR TITLE
SBAI-3911: Palette: revision commit_with_metadata

### DIFF
--- a/frontend/src/palette/manifest/revision/commit_with_metadata.ts
+++ b/frontend/src/palette/manifest/revision/commit_with_metadata.ts
@@ -1,0 +1,59 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Manifest entry for revision.commit_with_metadata.
+ *
+ * Commits staged changes as a new revision with attached metadata key-value
+ * pairs. Each metadata entry has a key, value, and format type (Binary,
+ * Numeric, or String). The parallel arrays keys/values/formats must have
+ * matching lengths — one entry per index.
+ *
+ * Use metadata_get to read keys and metadata_set to write them on existing
+ * revisions; commit_with_metadata attaches them atomically at commit time.
+ */
+const manifest: OpManifest = {
+  id: "revision.commit_with_metadata",
+  domain: "revision",
+  op: "commit_with_metadata",
+  label: "Revision: Commit with Metadata",
+  description: "Commit staged changes with attached metadata key-value pairs.",
+  command: "commit_with_metadata",
+  args: [
+    {
+      name: "message",
+      kind: "text",
+      label: "Message",
+      description: "Commit message describing the revision.",
+      required: true,
+      placeholder: "Describe the change",
+    },
+    {
+      name: "keys",
+      kind: "string-list",
+      label: "Keys",
+      description: "One metadata key per line. Must match values/formats length.",
+      required: false,
+      placeholder: "author\npriority\nticket",
+    },
+    {
+      name: "values",
+      kind: "string-list",
+      label: "Values",
+      description: "One value per line. Must match keys/formats length.",
+      required: false,
+      placeholder: "alice\n42\nSBAI-3911",
+    },
+    {
+      name: "formats",
+      kind: "string-list",
+      label: "Format Types",
+      description: "One format per line (binary, numeric, or string). Must match keys/values length.",
+      required: false,
+      placeholder: "string\nstring\nstring",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["commit", "metadata", "tag", "annotate"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3911

## Summary
Add command-palette manifest entry for `revision.commit_with_metadata` following the Phase 0 reference pattern.

## Files Changed
- `frontend/src/palette/manifest/revision/commit_with_metadata.ts` (new file)

## Implementation Details
The manifest defines the command-palette entry for `revision.commit_with_metadata`, which commits staged changes as a new revision with attached metadata key-value pairs.

**Arguments:**
- `message` (text, required) - Commit message describing the revision
- `keys` (string-list, optional) - Metadata keys (one per line)
- `values` (string-list, optional) - Metadata values (one per line)
- `formats` (string-list, optional) - Format types per entry (binary/numeric/string)

The parallel arrays (keys/values/formats) must have matching lengths — one metadata entry per index.

**Result:** JSON object with `revision`, `revision_number`, and `branch` fields.

## Testing
- TypeScript compilation verified with `npx tsc --noEmit` (no errors)
- Follows the established Phase 0 pattern from `commit.ts` and `metadata_clear.ts`
- Uses correct field kinds (text, string-list) matching the Rust op signature

## Notes
- The underlying Rust op (`crates/lore-vm/src/ops/revision/commit_with_metadata.rs`) was already fully implemented
- This manifest makes the op reachable from the Ctrl-K command palette with a generated form
- The Tauri command wrapper integration will be handled separately by the integration manager