### PR TITLE
SBAI-3974: repository verify_state

### DIFF
--- a/frontend/src/palette/manifest/repository/verify_state.ts
+++ b/frontend/src/palette/manifest/repository/verify_state.ts
@@ -1,0 +1,38 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Reference manifest entry (Phase 0). A two-arg op with a JSON result —
+ * exercises the multi-arg-form + object-result path of the palette.
+ */
+const manifest: OpManifest = {
+  id: "repository.verify_state",
+  domain: "repository",
+  op: "verify_state",
+  label: "Repository: Verify State",
+  description:
+    "Verify repository integrity; optionally heal detected inconsistencies. " +
+    "Returns fragment-level verification events and a typed summary.",
+  command: "verify_state",
+  args: [
+    {
+      name: "path",
+      kind: "text",
+      label: "Path",
+      description: "Repository-relative path to verify; empty verifies the whole repository.",
+      required: false,
+      default: "",
+    },
+    {
+      name: "heal",
+      kind: "boolean",
+      label: "Heal",
+      description: "When true, attempt to heal detected inconsistencies.",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["verify", "integrity", "heal", "check", "repository", "state", "corruption"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3974

## Summary
Add command-palette manifest entry for `repository.verify_state` following the Phase 0 pattern from `repository/status.ts`.

## What Changed
- Created `frontend/src/palette/manifest/repository/verify_state.ts` - two-arg op (path, heal) with JSON result

## What Was Already There
- Rust lore-vm binding: `crates/lore-vm/src/ops/repository/verify_state.rs` (fully implemented)
- Tauri command wrapper: `repository_verify_state` in `src-tauri/src/commands.rs`
- API binding: `repositoryVerifyStateApi.verifyState` in `frontend/src/api.ts`
- UI: Verify buttons already exist in `App.tsx`

## Testing
- TypeScript compiles without errors
- Manifest follows the established Phase 0 pattern
- Args: `path` (text, optional, default "") + `heal` (boolean, optional, default false)
- Result kind: JSON (pretty-printed)

## Notes
- Did NOT edit `manifest/index.ts` per ticket instructions (integration manager handles that)
- Manifest will be reachable from Ctrl-K once indexed by the integration manager