### PR TITLE
SBAI-3957: revision.revert command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/revision/revert.ts
+++ b/frontend/src/palette/manifest/revision/revert.ts
@@ -1,0 +1,43 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Reference manifest entry (Phase 0). Reverts the working directory to a
+ * specified revision. Exercises `text` (revision), `text` (message), and
+ * `boolean` (noCommit) fields with a `json` result showing conflict status.
+ */
+const manifest: OpManifest = {
+  id: "revision.revert",
+  domain: "revision",
+  op: "revert",
+  label: "Revision: Revert",
+  description:
+    "Revert the working directory to a specified revision by applying the inverse of its changes.",
+  command: "revision_revert_local",
+  args: [
+    {
+      name: "revision",
+      kind: "text",
+      label: "Revision",
+      required: true,
+      placeholder: "abc123...",
+    },
+    {
+      name: "message",
+      kind: "text",
+      label: "Message",
+      description: "Commit message for the auto-commit when no conflicts arise.",
+      placeholder: "Describe the revert",
+    },
+    {
+      name: "noCommit",
+      kind: "boolean",
+      label: "No Commit",
+      description: "Skip auto-commit even if there are no conflicts.",
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["revert", "undo", "rollback"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3957

## Summary
Adds Phase 0 command-palette manifest entry for the revision.revert operation, enabling users to invoke revert from Ctrl-K with a generated form.

## Files Changed
- frontend/src/palette/manifest/revision/revert.ts (NEW)

## Implementation Details
The manifest maps to the existing `revision_revert_local` Tauri command (already wired in commands.rs and api.ts), so no additional backend bindings were needed.

Args exposed:
- revision (text, required): Target revision to revert to
- message (text, optional): Auto-commit message when no conflicts
- noCommit (boolean, optional): Skip auto-commit even if successful

Result: JSON object showing conflict status (has_conflicts, conflict_files, committed_revision)

## Testing
- Manifest follows Phase 0 reference pattern (text/text/boolean fields, JSON result)
- Command name matches existing Tauri command: `revision_revert_local`
- Args structure matches the Tauri command's expected parameters (revision, message, no_commit)
- Keywords: revert, undo, rollback for discoverability

## How to Verify
1. Open the app
2. Press Ctrl-K to open command palette
3. Search for "revert" or filter by "revision"
4. The "Revision: Revert" operation should appear with a form to enter revision, optional message, and noCommit checkbox