### PR TITLE
SBAI-3973: branch unprotect command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/branch/unprotect.ts
+++ b/frontend/src/palette/manifest/branch/unprotect.ts
@@ -1,0 +1,29 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Reference manifest entry (Phase 0). A single-arg op whose result is a typed
+ * object — exercises the text-field + JSON-result path of the palette.
+ */
+const manifest: OpManifest = {
+  id: "branch.unprotect",
+  domain: "branch",
+  op: "unprotect",
+  label: "Branch: Unprotect",
+  description:
+    "Remove write protection from a branch, re-allowing direct commits.",
+  command: "branch_unprotect",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch",
+      description: "The branch name to unprotect.",
+      required: true,
+      placeholder: "main",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["unprotect", "unlock", "write", "protection"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3973

## Summary
Add command-palette manifest entry for `branch.unprotect` following the Phase 0 reference pattern.

## Files Changed
- `frontend/src/palette/manifest/branch/unprotect.ts` (new file)

## Testing
- Lore-vm crate compiles (`cargo check -p lore-vm` ✅)
- Lore-vm tests pass (`cargo test -p lore-vm` ✅)
- Manifest follows Phase 0 pattern (text-field + JSON-result)
- Tauri command wrapper exists (`src-tauri/src/commands.rs::branch_unprotect` ✅)
- API binding exists (`frontend/src/api.ts::branchUnprotectApi` ✅)

## How to Verify
1. The manifest declares the op as `branch.unprotect` with a single required `branch` text field
2. Command invokes `branch_unprotect` Tauri command
3. Returns JSON result with branch name
4. Keywords: "unprotect", "unlock", "write", "protection"

Ready for review.