### PR TITLE
SBAI-3965: revision revert_local palette manifest

### DIFF
--- a/frontend/src/palette/manifest/revision/revert_local.ts
+++ b/frontend/src/palette/manifest/revision/revert_local.ts
@@ -1,0 +1,44 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Manifest entry for `revision.revert_local`.
+ *
+ * Reverts the working directory to a specified revision by applying the
+ * inverse of its changes. Supports optional auto-commit when no conflicts
+ * arise.
+ */
+const manifest: OpManifest = {
+  id: "revision.revert_local",
+  domain: "revision",
+  op: "revert_local",
+  label: "Revision: Revert Local",
+  description:
+    "Revert the working directory to a specified revision by applying the inverse of its changes.",
+  command: "revert_local",
+  args: [
+    {
+      name: "revision",
+      kind: "text",
+      label: "Revision",
+      required: true,
+      placeholder: "abc123",
+    },
+    {
+      name: "message",
+      kind: "text",
+      label: "Message",
+      description: "Commit message for the auto-commit when no conflicts arise.",
+      placeholder: "Revert to revision",
+    },
+    {
+      name: "noCommit",
+      kind: "boolean",
+      label: "No Auto-Commit",
+      description: "Skip auto-commit even if there are no conflicts.",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["revert", "undo", "rollback"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3965

## Summary
Added command-palette manifest entry for `revision.revert_local`. The Rust op, mod.rs declaration, and `api.ts` Tauri binding already existed — only the frontend manifest file was missing.

## Files Changed
- `frontend/src/palette/manifest/revision/revert_local.ts` — New manifest file with three args (revision, message, noCommit) following Phase 0 reference pattern (commit.ts)

## Testing
- TypeScript compilation verified (no errors in new file)
- Follows established Phase 0 manifest pattern
- `revision_revert_local` already present in palette-parity-allowlist.json