### PR TITLE
feat(agents): LoreGUI expert-agent + skill system for full-app coherence (SBAI-4024)

### DIFF
--- a/.claude/agents/loregui-auth-expert.md
+++ b/.claude/agents/loregui-auth-expert.md
@@ -1,0 +1,39 @@
+---
+name: loregui-auth-expert
+description: LoreGUI authentication & identity domain expert. Spawn for any auth-domain op or flow — login (interactive/token), logout, user_info, session, and authentication providers. Knows the correct flows, security boundaries, and how identity surfaces in the UI.
+tools: Bash, Read, Grep, Glob
+---
+
+You are the authentication/identity expert for LoreGUI. You define correct,
+secure auth behavior and how it appears in the UI.
+
+## Read first
+`docs/domains/auth.md`, `crates/lore-vm/src/ops/auth/*`, `frontend/src/onboarding/ClientConnect.tsx`, `frontend/src/api.ts` (auth* methods).
+
+## The auth op surface (7)
+`login_interactive`, `login_with_token`, `user_info`, `local_user_info`, `list`,
+`logout`, `clear`. The cloud/SaaS path issues RS256 JWTs from the accounts service;
+self-hosted lore uses its own identity. Providers: interactive (browser/device
+flow), token (paste a PAT), and SSO/OAuth where configured.
+
+## Behavior rules
+- **Never store secrets in component state longer than needed**; tokens live in
+  memory, not logs. Don't print tokens/JWTs.
+- `login_interactive(remoteUrl)` returns a `UserInfo {id,name}` — drive the
+  onboarding ClientConnect + a top-bar identity menu from it.
+- `logout`/`clear` must visibly reset identity UI and any cached session.
+- `user_info` vs `local_user_info`: remote (server-verified) vs the local device
+  identity; label them distinctly so users aren't confused.
+- Respect the **accounts security boundary** (see the StudioBrain root docs): this
+  desktop app reads JWT claims, it does not implement billing/PII/SSO config UI.
+
+## UI placement (per IA)
+Identity lives in a **top-bar identity menu** (current user, switch, logout) and
+in **onboarding** (connect to server). Login flows get clear states: prompting,
+authenticating, success (show user), error (real message + retry). `list`/admin
+ops → palette / Settings. Provide help for "connect to a server" and "use a token".
+
+## Your output
+For a ticket: the correct flow, the exact op + args, security cautions, the UI
+placement + copy, and the states to handle. Defer visual review to
+`loregui-ux-designer` and implementation to `loregui-frontend-engineer`.

--- a/.claude/agents/loregui-docs-writer.md
+++ b/.claude/agents/loregui-docs-writer.md
@@ -1,0 +1,31 @@
+---
+name: loregui-docs-writer
+description: LoreGUI help & tutorial author. Spawn to write in-app help, empty-state copy, guided tutorials/how-tos for multi-step flows, and the op descriptions that satisfy the help gate. Keeps wording consistent with lore terminology and the design-system copy voice.
+tools: Bash, Read, Grep, Glob, Edit, Write
+---
+
+You write the words users read. Clear, short, correct.
+
+## Read first
+`docs/DESIGN-SYSTEM.md` (copy voice), the relevant `docs/domains/<domain>.md`, and
+the op/flow you're documenting.
+
+## What you produce
+- **Op descriptions** — one plain sentence: what it does + its effect. Goes in the
+  palette manifest `description` (the help gate requires non-empty). Verb-led
+  labels.
+- **Empty states** — what the area is + the single next action ("No locks yet —
+  acquire one from a file's menu.").
+- **Tutorials / how-tos** — for multi-step flows (onboarding, merge, server setup,
+  connect-to-server): numbered steps, each a concrete action and what to expect,
+  with the failure/retry note. Place in-app (a help panel / first-run coachmarks)
+  and/or `website/` docs.
+- **Tooltips** for any unavoidable jargon (partition, fragment, shared store).
+
+## Rules
+- Match **lore terminology** exactly (revision, branch, fragment, partition, shared
+  store, dirty, stage) — define it once, then use it.
+- No marketing voice in-app; imperative and concrete.
+- Don't document behavior you haven't confirmed in the op/source — ask the domain
+  expert if unsure.
+- Keep help versioned with the feature (same PR), so it never drifts.

--- a/.claude/agents/loregui-frontend-engineer.md
+++ b/.claude/agents/loregui-frontend-engineer.md
@@ -1,0 +1,38 @@
+---
+name: loregui-frontend-engineer
+description: LoreGUI frontend implementer. Spawn to build the React 19 + Tauri v2 + TS UI for an op or domain — palette manifest entries, panels, generated forms, result views, navigation — to a ux-designer spec, using the theme tokens. Also wires the #[tauri::command] + api.ts seam when an op lacks one.
+tools: Bash, Read, Grep, Glob, Edit, Write
+---
+
+You implement LoreGUI's frontend to a design spec, coherently and to a clean build.
+
+## Always read first
+`CLAUDE.md`, `docs/DESIGN-SYSTEM.md`, `docs/INFORMATION-ARCHITECTURE.md`,
+`frontend/src/palette/README.md`, and the reference entries
+(`palette/manifest/{repository/status,file/stage,revision/commit}.ts`) and the
+service example (`palette/manifest/service/*`, `commands.rs` `service_stop`).
+
+## The four layers (wire what's missing)
+1. **lore-vm binding** exists for all ops (`crates/lore-vm/src/ops/<domain>/<op>.rs`).
+2. **Command** — if no `#[tauri::command]` for the op, add a thin wrapper in
+   `src-tauri/src/commands.rs` (read the op's Args/Result; build `LoreApi::new(state.dir())`;
+   construct Args from the command params; return the Result) and register it in
+   `src-tauri/src/lib.rs` `generate_handler!`.
+3. **api.ts** — add a typed wrapper only if a panel needs it (the palette invokes
+   the command directly).
+4. **GUI** — palette manifest entry (always) + panel/menu per the IA + spec.
+
+## Rules
+- Theme tokens only — inline styles use `var(--surface-*)`; CSS files use the
+  legacy aliases. Never hardcode colors.
+- Reuse: the generated form (`OpForm` / `FieldSpec`), `OpResult`, existing panels.
+  `FieldSpec.name` = the camelCase command param (Tauri maps to snake_case).
+- Handle empty/loading/error/success in every view.
+- One op = one manifest file (auto-globbed; never edit the manifest index).
+- TS strict; no `any` leaks; match the surrounding style (2-space, double quotes,
+  hooks).
+
+## Verify before handing off (all must pass)
+`cargo check -p loregui` · `cargo fmt --all && cargo fmt --all --check` ·
+`npm --prefix frontend run build` · `node frontend/scripts/palette-parity.mjs`.
+Then request a `loregui-ux-designer` review and address its findings.

--- a/.claude/agents/loregui-integration-manager.md
+++ b/.claude/agents/loregui-integration-manager.md
@@ -1,0 +1,36 @@
+---
+name: loregui-integration-manager
+description: LoreGUI integration manager / orchestrator. Spawn to decompose a domain or feature into expert+engineer work, sequence it, run the coherence gates, and merge PRs in registry order. The conductor that keeps the fan-out coherent and merge-safe.
+tools: Bash, Read, Grep, Glob, Edit, Write
+---
+
+You orchestrate LoreGUI delivery so the whole app stays coherent and merge-safe.
+
+## Read first
+`docs/EXPERT-AGENTS.md`, `docs/COMMAND-PALETTE-PLAN.md`, `docs/INFORMATION-ARCHITECTURE.md`, current open PRs + Jira (SBAI-3865, SBAI-4024).
+
+## Per domain / feature, run the `integrate-endpoint` flow
+1. **Decompose:** list the domain's ops; for each, the surface(s) per the IA.
+2. **Behavior:** spawn the domain expert (`loregui-{auth,storage,vcs}-...`) for the
+   correct ops/flows/gotchas.
+3. **Design:** spawn `loregui-ux-designer` for the placement + spec.
+4. **Build:** spawn `loregui-frontend-engineer` (commands + palette + panel/menu).
+5. **Help:** spawn `loregui-docs-writer` for descriptions/empty-states/tutorials.
+6. **Review:** `loregui-ux-designer` runs `design-review`; address findings.
+7. **Gate + merge:** all of `cargo check -p loregui`, `cargo fmt --check`,
+   `npm build`, `palette-parity` (+ IA/help gates) green; then merge.
+
+## Merge discipline (critical at scale)
+- Manifest entries auto-glob → conflict-free. The shared files are
+  `src-tauri/src/{commands.rs,lib.rs}`, `frontend/src/api.ts`,
+  `palette-parity-allowlist.json` (and any nav registry). **Serialize** merges of
+  these; resolve the expected append/edit conflicts; never let two PRs reorder a
+  registry.
+- Don't compete with the BrainMon pipeline: if a ticket already has a worker PR,
+  review/merge it rather than re-authoring. Keep the parity gate contention-free.
+- Keep `main` green; rebase stale branches; fix fmt/parity at merge if a worker
+  missed it.
+
+## Output
+A status line per domain: ops done / surfaces wired / gates green / merged, and the
+next domain to pick up. Update Jira (SBAI-4024 children) as domains pass.

--- a/.claude/agents/loregui-storage-expert.md
+++ b/.claude/agents/loregui-storage-expert.md
@@ -1,0 +1,41 @@
+---
+name: loregui-storage-expert
+description: LoreGUI storage & shared-store domain expert. Spawn for storage/shared_store ops, backend selection (local/S3/MinIO/Garage), the content-addressed model, connectivity validation, and the server-install storage flow. Knows the real fragment/partition/handle semantics.
+tools: Bash, Read, Grep, Glob
+---
+
+You are the storage expert for LoreGUI.
+
+## Read first
+`docs/domains/storage.md`, `crates/lore-vm/src/ops/storage/*`, `crates/lore-vm/src/ops/shared_store/*`, `frontend/src/onboarding/server/*` (BackendPicker, ValidateConnectivity, InitStore), `src-tauri/src/commands.rs` (storage_* + the storage session).
+
+## The model (get this right — bugs hide here)
+- **Content-addressed.** `storage_open` returns a **handle**; `put` hashes a buffer
+  and returns its **address**; `get`/`obliterate` operate by `(partition, address)`.
+  The GUI keeps a key→(partition,address) session (`AppState.storage_session`).
+- **Partitions** are 32-hex namespaces. The **zero partition is rejected**
+  (INVALID_ARGUMENTS) — use a non-zero one (`ONBOARDING_PARTITION`).
+- **Backends:** `local` packfiles (a path) and object storage `s3`/`minio`/`garage`
+  (endpoint+bucket+region+keys). A separate **mutable KV store** holds branch
+  pointers. `StorageBackendConfig` carries all of this.
+- **Shared store:** `create(path)` returns the store path; `info`;
+  `set_use_automatically`. Used by host/server setup before creating repos.
+- **FFI caution:** `LoreBytes` is a borrowed view that can't be serde-deserialized —
+  build put items by direct struct construction, not `serde_json::from_value`.
+
+## Op surface
+storage: `open close flush put put_file get get_file get_metadata copy obliterate upload`.
+shared_store: `create info set_use_automatically`.
+
+## UI placement (per IA)
+A **Storage panel** (chosen backend, connectivity status, fragment/usage view) plus
+the **onboarding host flow** (BackendPicker → ValidateConnectivity → InitStore).
+Low-level ops (put/get/copy/obliterate/upload) are **palette-only / power-user**.
+Connectivity validation must do a real round-trip (open→put→get→obliterate) and
+report pass/fail with the actual error. Secrets (access keys) are masked inputs,
+never logged.
+
+## Your output
+For a ticket: the correct op + args (mind partitions/handles), the backend nuances,
+the UI placement + states, and any FFI/round-trip gotchas. Defer visuals to
+`loregui-ux-designer`, implementation to `loregui-frontend-engineer`.

--- a/.claude/agents/loregui-ux-designer.md
+++ b/.claude/agents/loregui-ux-designer.md
@@ -1,0 +1,40 @@
+---
+name: loregui-ux-designer
+description: LoreGUI design & UX authority. Spawn to design a domain's UI surfaces (panel/menu/palette placement, layout, copy, states) and as the REQUIRED reviewer that checks "does this make sense to a real user?" before any UI PR merges. Owns the design system and information architecture.
+tools: Bash, Read, Grep, Glob, Edit, Write
+---
+
+You are the **UX & design authority** for LoreGUI. Your job is coherence: a user
+should never feel the app was assembled one API endpoint at a time.
+
+## Always read first
+`docs/DESIGN-SYSTEM.md`, `docs/INFORMATION-ARCHITECTURE.md`, the relevant
+`docs/domains/<domain>.md`, and the current `frontend/src/` (App, palette, theme,
+onboarding) so your guidance matches what exists.
+
+## When DESIGNING a domain/op
+Produce a concrete spec: which surface(s) per the IA rule (panel / menu / palette),
+the layout (reusing existing components), every control's label + helper copy, the
+empty/loading/error/success states, the primary action, and where it sits in the
+nav. Map each op to its placement. Prefer reusing the generated form + result
+renderer over bespoke UI. Output a checklist the frontend-engineer can implement
+verbatim.
+
+## When REVIEWING (your gate role)
+Run the `design-review` skill's checklist against the diff. PASS only if all hold,
+else return specific, actionable fixes (file:line). Check:
+- **Tokens:** no hardcoded colors/fonts/shadows; uses `--surface-*` / legacy
+  aliases; re-themes correctly (light + dark).
+- **Placement:** op is in the right surface per the IA; in a sensible nav location;
+  not buried or duplicated.
+- **Copy:** label is a clear verb; description is one plain sentence; matches lore
+  terminology; no unexplained jargon.
+- **States:** empty/loading/error/success all handled; destructive actions confirm;
+  errors show the real message + a retry.
+- **Consistency:** matches sibling domains (a branch action looks like a revision
+  action); reuses components; one primary action per view.
+- **A11y:** semantic elements, labels tied to inputs, keyboard-reachable, focus
+  visible, meaning not by color alone.
+- **Help:** non-trivial flows have help/tutorial; first-use is discoverable.
+
+Be decisive and specific. You are the last line before a user sees it.

--- a/.claude/agents/loregui-vcs-domain-expert.md
+++ b/.claude/agents/loregui-vcs-domain-expert.md
@@ -1,0 +1,42 @@
+---
+name: loregui-vcs-domain-expert
+description: LoreGUI version-control domain expert for branch, revision, file/staging, lock, link, layer, and dependency ops. Spawn to get the correct lore VCS mental model so UIs match how lore actually behaves (revisions, merges, staging, locks, fragments).
+tools: Bash, Read, Grep, Glob
+---
+
+You are the lore VCS domain expert. You ensure UIs reflect how lore *actually*
+works, not git assumptions.
+
+## Read first
+`docs/domains/<domain>.md` for the domain in question, the op files under
+`crates/lore-vm/src/ops/<domain>/`, and the upstream `lore` source for that
+domain (`~/.cargo/git/checkouts/lore-*/<rev>/lore/src/<domain>.rs`).
+
+## Mental model (lore ≠ git)
+- **Revisions** are content-addressed snapshots on a **branch**; history is linear
+  per branch with explicit **merge** ops (`merge_start` → resolve mine/theirs/
+  unresolve → `merge_resolve`/`abort`/`restart`). Surface merges as a guided,
+  stateful flow, not a single button.
+- **Staging:** files are `dirty` (modified) → `stage` → `commit`. There's
+  `dirty_copy`/`dirty_move`, `stage_move`/`stage_merge`, `unstage`, `obliterate`
+  (permanent removal), `reset`/`reset_to_last_merged`. Map these to the Changes
+  panel precisely — obliterate is destructive, confirm it.
+- **Locks** are per-file advisory locks: `acquire`/`acquire_as_owner`/`query`/
+  `status`/`release`. Show who holds a lock; releasing someone else's is an
+  owner action.
+- **Links / Layers** compose content; `dependency` is the file-dependency graph.
+- **Metadata** ops (`metadata_get/set/clear`) exist per domain — key/value editors.
+- **revert** (with resolve/abort/restart/unresolve variants) and **cherry_pick**/
+  **bisect** are stateful; cherry_pick/bisect may be **deferred** (no upstream
+  exported fn yet) — check before promising UI.
+
+## UI guidance (per IA)
+Branches → Branches panel + row menus; revisions → History panel + row menus;
+files → Changes panel; locks → Locks panel + file menu. Stateful flows (merge,
+revert, cherry-pick) need a **wizard with explicit state** and clear next-step
+copy. Destructive ops confirm and explain consequences.
+
+## Your output
+For a ticket: the correct op sequence/state machine, what each arg means, what's
+destructive, and the right panel/menu placement. Defer visuals to
+`loregui-ux-designer`, implementation to `loregui-frontend-engineer`.

--- a/.claude/skills/add-domain-ui/SKILL.md
+++ b/.claude/skills/add-domain-ui/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: add-domain-ui
+description: Build a whole domain's UI surface coherently — its panel, nav entry, palette entries for every op, and help — per the information architecture. Use to bring a domain from palette-only to a first-class part of the app.
+---
+
+# Add a domain's UI
+
+Bring one domain (e.g. branch, storage, lock) to first-class coherence.
+
+## Steps
+
+1. **Map.** List the domain's ops (`crates/lore-vm/src/ops/<domain>/`). Spawn the
+   domain expert for behavior/state machines. Per the IA, classify each op:
+   panel-primary / row-menu / palette-only.
+2. **Spec.** Spawn `loregui-ux-designer` for the panel layout (reusing components),
+   the nav entry, every op's placement + copy, and the four states.
+3. **Commands.** Ensure every op has a registered `#[tauri::command]`; add the
+   missing ones (`integrate-endpoint` step 4).
+4. **Palette.** Add a manifest entry for **every** op (`palette-entry` skill).
+5. **Panel + nav.** Build the domain panel and add its **navigation entry**
+   (sidebar for daily domains, Settings/Manage for admin) per the IA. Wire routing.
+   Reuse existing panels' structure (`.section`, cards, `OpForm`, `OpResult`).
+6. **Help.** `loregui-docs-writer`: op descriptions, the panel's empty state, and a
+   tutorial for any multi-step flow (e.g. merge, server setup).
+7. **Review + gate.** `design-review`; then `cargo check -p loregui`,
+   `cargo fmt --all --check`, `npm build`, `palette-parity` (+ IA/help) all green.
+8. **Update the IA doc** if you added/moved a nav entry.
+
+## Done when
+The domain has a navigable panel, every op is reachable (palette + its prescribed
+surface), help exists, it's themed and consistent with sibling domains, gates green,
+design review passed. This is the bar every domain must reach (Epic SBAI-4024).

--- a/.claude/skills/design-review/SKILL.md
+++ b/.claude/skills/design-review/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: design-review
+description: Run the LoreGUI coherence checklist over a UI diff — pass/fail with specific fixes. Use before merging any UI PR (the ux-designer's gate). Checks tokens, placement, copy, states, consistency, accessibility, help.
+---
+
+# Design review
+
+Review a diff (default: `git diff main...HEAD`) against the checklist. Read
+`docs/DESIGN-SYSTEM.md` + `docs/INFORMATION-ARCHITECTURE.md` first. For each item:
+PASS, or FAIL with `file:line` + the concrete fix.
+
+## Checklist
+
+- [ ] **Tokens** — no hardcoded hex/rgb/font-size/shadow; uses `--surface-*` or the
+  legacy aliases. Renders correctly in **both** light and dark themes.
+- [ ] **Placement** — op is in the surface(s) the IA prescribes; correct nav
+  location; not duplicated or buried.
+- [ ] **Copy** — label is a clear verb; `description` is one plain sentence;
+  matches lore terminology; jargon has a tooltip.
+- [ ] **States** — empty (helpful + next action), loading (disabled + "…"), error
+  (`--surface-error-*`, real message, retry), success all handled.
+- [ ] **Destructive** — obliterate/delete/reset confirm and explain consequences.
+- [ ] **Consistency** — looks/behaves like sibling domains; reuses `OpForm`/
+  `OpResult`/existing panels; one primary action per view.
+- [ ] **A11y** — semantic `button`/`label[htmlFor]`/`role=dialog`; keyboard-
+  reachable; visible focus; meaning not by color alone.
+- [ ] **Help** — non-trivial flow has help/tutorial; first use is discoverable.
+- [ ] **Gates** — `palette-parity` (+ IA/help) green; build green.
+
+## Output
+`DESIGN REVIEW: PASS` or `FAIL` + a numbered list of fixes (file:line, what, why).
+Be specific and actionable; do not approve incoherent or unthemed UI.

--- a/.claude/skills/integrate-endpoint/SKILL.md
+++ b/.claude/skills/integrate-endpoint/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: integrate-endpoint
+description: Integrate one lore op into the FULL LoreGUI app coherently — binding → #[tauri::command] → palette entry → panel/menu if warranted → help/tutorial → design review. Use for any ticket that exposes or changes an op. Ensures it's not just a palette row.
+---
+
+# Integrate an endpoint (full vertical)
+
+The end-to-end procedure to add/expose one op so it lands coherently in the app.
+
+## Steps
+
+1. **Context.** Read `CLAUDE.md`, `docs/DESIGN-SYSTEM.md`,
+   `docs/INFORMATION-ARCHITECTURE.md`, `docs/domains/<domain>.md`.
+2. **Behavior.** Spawn the domain expert (`loregui-storage-expert` /
+   `loregui-auth-expert` / `loregui-vcs-domain-expert`) for the correct op, args,
+   state machine, destructiveness, and gotchas.
+3. **Surface decision.** Per the IA rule, decide: panel? menu? palette-only?
+   (Every op gets at least a palette entry.)
+4. **Command layer.** If the op has no `#[tauri::command]`, add a thin wrapper in
+   `src-tauri/src/commands.rs` (read the op's Args/Result; `LoreApi::new(state.dir())`;
+   build Args from params; return Result) and register in `lib.rs` `generate_handler!`.
+   Add an `api.ts` wrapper only if a panel needs it.
+5. **Palette entry.** Use the `palette-entry` skill: `palette/manifest/<domain>/<op>.ts`.
+6. **Panel/menu.** If the IA calls for it, build/extend the domain panel or add the
+   row/menu action (spawn `loregui-frontend-engineer` to the ux-designer spec).
+7. **Help.** Spawn `loregui-docs-writer` for the op `description`, empty/error copy,
+   and a tutorial if the flow is multi-step.
+8. **Review.** Run the `design-review` skill (`loregui-ux-designer`). Fix findings.
+9. **Gate.** All green: `cargo check -p loregui`, `cargo fmt --all --check`,
+   `npm --prefix frontend run build`, `node frontend/scripts/palette-parity.mjs`.
+10. **PR.** One op = one file per layer. Reference the SBAI ticket. Don't touch the
+    manifest index or unrelated registries.
+
+## Done when
+The op is invokable from ⌘K with a generated form **and** sits in its correct
+panel/menu with help, themed, all states handled, design review passed, gates green.

--- a/.claude/skills/palette-entry/SKILL.md
+++ b/.claude/skills/palette-entry/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: palette-entry
+description: Add one op's command-palette manifest entry (the mechanical Phase-2 unit). Use when an op already has a registered Tauri command and just needs to be exposed in the palette. Formalizes frontend/src/palette/README.md.
+---
+
+# Add a palette manifest entry
+
+1. Confirm the op's **registered command** name in `src-tauri/src/lib.rs`
+   `generate_handler!`. If none exists, this isn't a pure palette-entry task — use
+   `integrate-endpoint` to add the command first.
+2. Read the command's signature in `src-tauri/src/commands.rs` to get the exact
+   parameter names + types.
+3. Create `frontend/src/palette/manifest/<domain>/<op>.ts`:
+   ```ts
+   import type { OpManifest } from "../../types";
+   const manifest: OpManifest = {
+     id: "<domain>.<op>", domain: "<domain>", op: "<op>",
+     label: "<Domain>: <Op>",            // verb-led, Title Case
+     description: "<one plain sentence: what it does + effect>",
+     command: "<registered_command_name>",
+     args: [ /* one FieldSpec per command param */ ],
+     resultKind: "void" | "text" | "json",   // by the command's return type
+     keywords: ["<search terms>"],
+     // surface?: "panel" | "menu" | "palette"  // per docs/INFORMATION-ARCHITECTURE.md
+   };
+   export default manifest;
+   ```
+   - `FieldSpec.name` = the **camelCase** command param (Tauri maps to snake_case).
+   - `kind`: `text|number|boolean|enum|string-list`; `enum` needs `options`.
+   - Mark `required` where the op needs a non-empty value.
+   - `description` is mandatory (help gate).
+4. Do **not** edit the manifest index (auto-globbed) or the allowlist — the gate is
+   contention-free.
+5. Verify: `npm --prefix frontend run build` and
+   `node frontend/scripts/palette-parity.mjs` (OK).
+
+Reference entries: `manifest/{repository/status,file/stage,revision/commit}.ts`
+and `manifest/service/{start,stop}.ts`.

--- a/.claude/skills/write-tutorial/SKILL.md
+++ b/.claude/skills/write-tutorial/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: write-tutorial
+description: Write a guided how-to / in-app help for a multi-step LoreGUI flow (onboarding, connect-to-server, merge, host setup, etc.). Use to satisfy the help gate for non-trivial flows. Produces step-by-step copy placed in-app and/or in website docs.
+---
+
+# Write a tutorial / how-to
+
+For a multi-step flow, produce help users can follow without prior knowledge.
+
+## Steps
+
+1. **Confirm the flow** with the domain expert: the exact op sequence, each step's
+   inputs, what success/failure looks like, and any state (e.g. merge resolve loop).
+2. **Write the steps** — numbered; each step = one concrete action + what to expect
+   + the failure/retry note. Lead with the goal and prerequisites. Match lore
+   terminology (define jargon once, then reuse).
+3. **Place it:**
+   - In-app: a help panel / first-run coachmarks / an info affordance next to the
+     flow. Keep it in the same PR as the feature so it never drifts.
+   - Optionally `website/` docs for the long-form version; link from in-app.
+4. **Voice:** concise, imperative, concrete — per `docs/DESIGN-SYSTEM.md`. No
+   marketing tone in-app.
+5. **Verify** every instruction against the real UI/op — don't document aspirational
+   behavior.
+
+## Output
+The tutorial content + where it's wired in, and a one-line entry for the op/flow's
+manifest `description` if missing. Hand visuals to `loregui-ux-designer`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md — LoreGUI
+
+Cross-platform **Tauri v2 + React 19 + TypeScript** desktop GUI for Epic Games'
+[`lore`](https://github.com/EpicGames/lore) VCS. Public, MIT. Binds the upstream
+`lore` crate **in-process** (never shells out to the CLI). Canonical checkout on
+BRAINZ at `/srv/studiobrain-dev/loregui`. Jira project **SBAI**.
+
+## Architecture (one op, four layers)
+
+```
+crates/lore-vm/src/ops/<domain>/<op>.rs   1. binding — calls lore's async fn, collects events → typed result
+src-tauri/src/commands.rs (+ lib.rs)      2. #[tauri::command] — thin wrapper, registered in generate_handler!
+frontend/src/api.ts                       3. typed invoke wrappers
+frontend/src/palette/ + panels/views      4. GUI — command palette (universal) + panels/menus (rich)
+```
+
+- **Plans:** `docs/IMPLEMENTATION-PLAN.md` (full-parity), `docs/COMMAND-PALETTE-PLAN.md` (palette parity, Epic SBAI-3865), `docs/EXPERT-AGENTS.md` (this system, Epic SBAI-4024).
+- **CI gates:** `ci.yml` (`core-check` = fmt+clippy+test on lore-vm; `palette-parity` = GUI coverage ratchet), `integration.yml`, `windows-build.yml`. `main` is not branch-protected.
+
+## The coherence mandate (READ BEFORE ANY UI WORK)
+
+Exposing an op is **not** just adding a command-palette row. Every endpoint must
+land in the **full** app coherently. When you touch any op or domain you MUST:
+
+1. Read `docs/DESIGN-SYSTEM.md` and `docs/INFORMATION-ARCHITECTURE.md` and the
+   relevant `docs/domains/<domain>.md`.
+2. Use the theme **semantic surface tokens** (`--surface-*`) — never hardcode
+   colors (see DESIGN-SYSTEM). The app is fully themeable; your UI must re-theme.
+3. Decide the op's **surface** per the IA: a rich **panel**, a **menu/nav** entry,
+   and/or a **command-palette** entry. Add a palette manifest entry at minimum
+   (the parity gate requires it).
+4. Add **help**: a clear `description` on the palette entry; for multi-step flows,
+   a tutorial / in-app help (use the `write-tutorial` skill / `docs-writer`).
+5. Get a **design review** (`design-review` skill / `loregui-ux-designer`) before
+   opening the PR — buttons, labels, empty/error states, and placement must make
+   sense to a real user.
+
+This applies to autonomous pipeline workers too — there is no human to catch an
+incoherent UI. Acceptance for any UI ticket: **palette-parity + IA + help gates
+green, and design review passed.**
+
+## Expert agents & skills
+
+`docs/EXPERT-AGENTS.md` lists them. Spawn the domain expert (`loregui-storage-expert`,
+`loregui-auth-expert`, `loregui-vcs-domain-expert`) for behavior, `loregui-frontend-engineer`
+for implementation, `loregui-ux-designer` for review, `loregui-docs-writer` for help.
+Skills: `integrate-endpoint`, `add-domain-ui`, `design-review`, `write-tutorial`,
+`palette-entry`.
+
+## Conventions
+
+- One op = one file per layer. Manifest entries auto-discover via `import.meta.glob`
+  (no index edits). Don't reformat or touch files outside your op.
+- Verify before PR: `cargo check -p loregui`, `cargo fmt --all --check`,
+  `npm --prefix frontend run build`, `node frontend/scripts/palette-parity.mjs`.
+- Every commit/PR references its SBAI ticket. Never use plan mode in autonomous runs.
+- Pipeline workers: claim via `/opt/BrainMon/monitoring/lib/claim-ticket.sh SBAI-XXXX`.

--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -1,0 +1,75 @@
+# LoreGUI — Design System
+
+The single visual contract. All UI consumes **semantic theme tokens** so it
+re-themes with any user theme (build/save/share is shipped). Never hardcode a
+color, font, or shadow.
+
+## Tokens (CSS custom properties on `:root`)
+
+Written by `frontend/src/theme/theme.ts::applyTheme`. 12 surfaces × 7 slots:
+
+```
+--surface-<name>-bg | -text | -text-secondary | -border | -hover | -active | -shadow
+```
+
+| Surface | Use for |
+|---|---|
+| `base` | page background, primary content, body text |
+| `elevated` | cards, panels, raised content (`--shadow-md`) |
+| `overlay` | modals, dropdowns, the command palette, tooltips (`--shadow-lg`) |
+| `primary` | primary buttons / CTAs |
+| `secondary` | secondary buttons / neutral actions |
+| `accent` | highlights, badges, emphasis |
+| `success` `warning` `error` `info` | status: confirmations, cautions, errors, info |
+| `navigation` | top bar, sidebars, menus |
+| `input` | text fields, selects, textareas |
+
+Also: `--shadow-sm/-md/-lg`, `--base-font-size`, `--font-family`.
+
+**Rules**
+- Use `var(--surface-<x>-bg)` etc. In plain-CSS files prefer the legacy aliases
+  (`--bg`, `--panel`, `--accent`, `--text`, `--muted`, `--green/--red/--amber`)
+  which are mapped to surfaces in `styles.css`. In inline styles (palette, theme
+  editor) reference the `--surface-*` vars directly.
+- Buttons: primary action → `--surface-primary-*`; everything else → default
+  button (secondary). One primary action per view.
+- Status colors are semantic only — success/warning/error/info, never decorative.
+- Respect `--base-font-size`/`--font-family`; don't set absolute px font sizes on
+  body text.
+
+## Components (reuse, don't reinvent)
+
+- **Button** — base `button` (secondary); `--surface-primary-*` for the primary.
+- **Field** — `.onboarding-field` pattern (label + input/select/textarea using
+  `--surface-input-*`) or the palette `OpForm` generated fields.
+- **Card / panel** — `--surface-elevated-bg` + 1px `--surface-elevated-border` +
+  8px radius + `--shadow-md`. See `.branch-info-panel`, `.file-info-panel`.
+- **Modal / overlay** — `--surface-overlay-*` + `--shadow-lg`, click-scrim to
+  close, `Esc` to dismiss. See the theme modal and `CommandPalette`.
+- **Command palette** — `frontend/src/palette/` (Ctrl/Cmd-K). The universal way to
+  run any op via a generated form.
+- **Generated form** — `palette/form.tsx` renders `FieldSpec[]`. Reuse its field
+  kinds (`text|number|boolean|enum|string-list`) instead of bespoke inputs.
+- **Result view** — `palette/result.tsx` (`void|text|json`). Rich domains get a
+  typed renderer (reuse existing status/diff/history panels).
+
+## Interaction & states
+
+Every view handles the **four states**: empty (helpful, points to the next
+action), loading (disabled control + "…"), error (`--surface-error-*`, the real
+message, a retry), success. Destructive actions confirm. Keyboard: `Esc` closes
+overlays; the palette is `Ctrl/Cmd-K`; forms submit on Enter.
+
+## Copy voice
+
+Concise, imperative, lowercase-tech-terms. Labels are verbs for actions
+("Stage", "Commit", "Acquire lock"). Descriptions are one plain sentence of what
+the op does + its effect. No jargon without a tooltip. Match lore's own
+terminology (revision, branch, fragment, partition, shared store).
+
+## Accessibility
+
+Semantic elements (`button`, `label`+`htmlFor`, `role="dialog"`/`aria-modal`).
+Keyboard-reachable; visible focus. Don't encode meaning in color alone (pair an
+icon/word). Contrast must hold across themes — rely on the paired `-text` slot of
+a surface, never a guessed color.

--- a/docs/EXPERT-AGENTS.md
+++ b/docs/EXPERT-AGENTS.md
@@ -1,0 +1,81 @@
+# LoreGUI — Expert Agents & Skills (master list)
+
+**Epic:** SBAI-4024 · **Status:** active
+
+## Purpose
+
+Every lore API endpoint — new or existing — must be integrated into the **full**
+application coherently: command palette **and** panels, navigation/menus, buttons,
+help, tutorials, and correct auth/storage/VCS behavior. Mechanical "op → palette
+row" is not enough. This is achieved by a roster of **domain-expert agents** that
+share **single sources of design truth** and are held to **coherence gates**.
+
+## Where things live (so ALL agents load them)
+
+Pipeline workers run `claude` inside a loregui repo worktree, so anything in the
+repo is automatically available to **both** the BrainMon pipeline workers and
+Claude Code. BrainMon holds only the thin worker wiring that points at the repo.
+
+| Artifact | Location | Consumed by |
+|---|---|---|
+| Repo overview + mandate | `loregui/CLAUDE.md` | every agent in the repo (auto-loaded) |
+| Design system | `docs/DESIGN-SYSTEM.md` | all UI work |
+| Information architecture | `docs/INFORMATION-ARCHITECTURE.md` | all UI work |
+| Per-domain expert guides | `docs/domains/<domain>.md` | the domain's tickets |
+| Expert subagents | `.claude/agents/loregui-*.md` | Claude Code + repo workers (spawn) |
+| Skills | `.claude/skills/*/SKILL.md` | Claude Code + repo workers (invoke) |
+| Pipeline worker wiring | `/opt/BrainMon/agents/loregui-domain-worker.md` | BrainMon dispatch |
+
+## Agents
+
+| Agent | File | Owns / expertise |
+|---|---|---|
+| **ux-designer** | `.claude/agents/loregui-ux-designer.md` | design system, information architecture, accessibility, copy voice; the **"does this make sense?" reviewer** on every domain PR |
+| **frontend-engineer** | `.claude/agents/loregui-frontend-engineer.md` | React 19 + Tauri v2 + TS patterns; palette, panels, forms, state, error handling, the `api.ts` seam |
+| **auth-expert** | `.claude/agents/loregui-auth-expert.md` | auth domain; login/session/token flows; providers (interactive, token, OAuth/SSO); the accounts security boundary |
+| **storage-expert** | `.claude/agents/loregui-storage-expert.md` | storage + shared_store; backends (local/S3/MinIO/Garage); content-addressed model; onboarding storage flow |
+| **vcs-domain-expert** | `.claude/agents/loregui-vcs-domain-expert.md` | branch/revision/file/lock/link/layer/dependency — the lore VCS mental model so UIs match real behavior |
+| **docs-writer** | `.claude/agents/loregui-docs-writer.md` | in-app help, empty states, tutorials, how-tos, the website docs |
+| **integration-manager** | `.claude/agents/loregui-integration-manager.md` | decompose work, assign experts, run gates, merge PRs in registry order |
+
+## Skills
+
+| Skill | Dir | What it does |
+|---|---|---|
+| **integrate-endpoint** | `.claude/skills/integrate-endpoint/` | the full vertical for one op: lore-vm binding → `#[tauri::command]` → palette entry → panel/menu if warranted → help + tutorial → design review |
+| **add-domain-ui** | `.claude/skills/add-domain-ui/` | build a domain's whole UI surface: panel, nav entry, palette entries, help — coherently, per the IA |
+| **design-review** | `.claude/skills/design-review/` | run the ux-designer coherence checklist over a diff; pass/fail with specifics |
+| **write-tutorial** | `.claude/skills/write-tutorial/` | generate a guided how-to / in-app help for a flow |
+| **palette-entry** | `.claude/skills/palette-entry/` | add one op's palette manifest entry (the mechanical Phase-2 unit; formalizes `palette/README.md`) |
+
+## Coherence gates (CI + review)
+
+Beyond the **palette parity ratchet** (`frontend/scripts/palette-parity.mjs`):
+
+1. **IA ratchet** — every op declares a `surface` (`panel` | `menu` | `palette`)
+   and every domain has a navigation entry. (`scripts/ia-parity.mjs`, planned.)
+2. **Help ratchet** — every palette manifest entry has a non-empty `description`;
+   multi-step flows link a tutorial. (extend the parity script.)
+3. **Design review** — `loregui-ux-designer` is a required reviewer on every
+   domain PR; the `design-review` skill encodes the checklist.
+
+## Ticket-reference protocol (how a worker uses this)
+
+Every LoreGUI ticket body must include a **Build context** block, e.g.:
+
+> **Build context:** domain=`storage`. Read `docs/domains/storage.md`,
+> `docs/DESIGN-SYSTEM.md`, `docs/INFORMATION-ARCHITECTURE.md`. Use the
+> `integrate-endpoint` skill. Spawn `loregui-storage-expert` for behavior and
+> `loregui-ux-designer` for the design review before opening the PR. Acceptance:
+> palette-parity + IA + help gates green, design review passed.
+
+`CLAUDE.md` makes this mandatory so even tickets that forget the block are held to
+it. The BrainMon `loregui-domain-worker` injects the block from the ticket's
+domain label when missing.
+
+## Rollout
+
+1. Foundation: this doc + CLAUDE.md + DESIGN-SYSTEM + INFORMATION-ARCHITECTURE +
+   all agents + all skills.
+2. Template: ship **storage** as a complete coherent slice.
+3. Iterate every domain until all coherence gates pass.

--- a/docs/INFORMATION-ARCHITECTURE.md
+++ b/docs/INFORMATION-ARCHITECTURE.md
@@ -1,0 +1,70 @@
+# LoreGUI — Information Architecture
+
+Where every op lives in the app, and the rule for choosing its surface(s).
+
+## Top-level structure
+
+```
+┌ Top bar (navigation surface) ───────────────────────────────┐
+│ LoreGUI · <repo>            ⌘K  Theme  Sync  Push  Verify    │
+├──────────────┬──────────────────────────────────────────────┤
+│ Sidebar nav  │  Main work area (domain panels)              │
+│  Changes     │   (status / staging / history / diff …)      │
+│  Branches    │                                              │
+│  History     │                                              │
+│  Locks       │                                              │
+│  Storage     │                                              │
+│  …per domain │                                              │
+└──────────────┴──────────────────────────────────────────────┘
+Command palette (⌘K) overlays everything — runs ANY op.
+First run → OnboardingFlow (client connect | host setup).
+```
+
+- **Top bar** = global actions + identity + repo + ⌘K + Theme.
+- **Sidebar** = one entry per **primary domain** the user works in daily
+  (Changes, Branches, History, Locks, Storage, Links, Layers). Secondary/admin
+  domains (service, dependency, repository-admin) live under a **Settings/Manage**
+  area, not the main sidebar.
+- **Command palette** = the universal surface; **every** op is here (parity gate).
+- **Per-domain panel** = the rich home for a domain's common workflow.
+
+## Choosing an op's surface(s)
+
+Each op declares a `surface` in its palette manifest (`surface?: "panel" | "menu"
+| "palette"`, default `palette`). Decision rule:
+
+| If the op is… | Surface(s) |
+|---|---|
+| part of the **daily core loop** (status, stage, commit, branch switch, sync, history, diff, lock acquire/release) | **panel** (primary, rich UI) **+ palette** |
+| a **per-entity action** (branch protect, file obliterate, revision revert, lock release) | **menu** (context/row action on the entity) **+ palette** |
+| **occasional / admin** (repository gc/flush/delete, instance prune, service start/stop, dependency edit, metadata get/set) | **menu** under Settings/Manage **+ palette** |
+| **rare / power-user / scriptable** (store_immutable_query, verify_fragment, storage put/get, config_get) | **palette only** |
+| **streaming / non-request-response** (notification subscribe/unsubscribe) | neither — wired into live UI, `excluded` from palette |
+
+Every op is **at least** in the palette. Panels and menus are added when the rule
+above warrants — coherently, not one-off.
+
+## Per-domain placement (summary)
+
+| Domain | Primary surface | Notes |
+|---|---|---|
+| repository | top bar (open/clone) + Settings/Manage panel | status is its own Changes panel |
+| branch | **Branches** panel + row menus | create/switch/list/merge/protect |
+| revision | **History** panel + revision row menus | commit via Changes; diff/info/revert/restore |
+| file | **Changes** panel (staging) + file row menus | stage/unstage/dirty/obliterate/diff/history |
+| lock | **Locks** panel + file row menu | acquire/release/query/status |
+| link | **Links** panel | add/remove/update/list |
+| layer | **Layers** panel | add/remove/list |
+| dependency | file detail / Settings | add/remove/list |
+| storage | **Storage** panel + onboarding | backends, fragments; see `docs/domains/storage.md` |
+| shared_store | Storage panel / onboarding | create/info/set_use_automatically |
+| auth | top bar identity menu + onboarding | login/logout/user_info/providers |
+| service | Settings/Manage | start/stop |
+| notification | live (toasts/badges) | not in palette |
+
+## Adding to the IA
+
+When a domain gets its panel, add a **sidebar/Settings entry** (navigation
+surface) and route it. The IA ratchet (planned `scripts/ia-parity.mjs`) checks
+every domain with `surface: panel` ops has a nav entry, and every manifest entry
+has a valid `surface`. Update this doc when structure changes.

--- a/docs/domains/storage.md
+++ b/docs/domains/storage.md
@@ -1,0 +1,51 @@
+# Domain guide: storage + shared_store
+
+Expert reference for the storage domain. Paired with `loregui-storage-expert`.
+
+## Ops
+
+**storage** (11): `open close flush put put_file get get_file get_metadata copy
+obliterate upload`.
+**shared_store** (3): `create info set_use_automatically`.
+
+## Model
+
+- **Content-addressed.** `open(config)` → **handle**. `put(handle, items)` hashes
+  each buffer → returns its **address**. `get`/`obliterate`/`copy` address fragments
+  by `(partition, address)`. The GUI bridges user keys → `(partition,address)` in
+  `AppState.storage_session`.
+- **Partition** = 32-hex namespace. **Zero partition is rejected** — use a non-zero
+  one (`ONBOARDING_PARTITION = "0…01"`).
+- **Backends:** `local` (packfiles path) | `s3`/`minio`/`garage` (endpoint, bucket,
+  region, access key, secret). Separate **mutable KV store** for branch pointers.
+  `StorageBackendConfig` (see `api.ts`) carries all fields.
+- **Shared store:** `create(path)` → store path; `info`; `set_use_automatically`.
+  Host setup creates a shared store before repositories.
+- **FFI gotcha:** `LoreBytes` is a borrowed view; build put items by direct struct
+  construction, not serde (see `ops/storage/put.rs`).
+
+## UI (per IA)
+
+- **Storage panel** (sidebar, daily): current backend + connection status; a
+  connectivity test (open→put→get→obliterate round-trip, pass/fail + real error);
+  fragment/usage info (`get_metadata`); flush.
+- **Onboarding host flow:** `BackendPicker` → `ValidateConnectivity` → `InitStore`
+  (shared store + first repo) → `ServiceSetup`. Already built; the Storage panel
+  reuses `BackendPicker`'s config shape.
+- **Palette-only / power-user:** `put put_file get get_file copy obliterate upload
+  close get_metadata`. `shared_store_*` → Storage panel / Settings.
+
+## States & safety
+
+Mask secret inputs (access keys); never log them. Connectivity test must use a
+real round-trip and surface the actual error. `obliterate` is destructive — confirm.
+Empty state: "No storage backend configured — choose one." Loading/error per
+DESIGN-SYSTEM.
+
+## Surfaces map
+
+| op | surface |
+|---|---|
+| open, close, flush, get_metadata | Storage panel + palette |
+| put, put_file, get, get_file, copy, obliterate, upload | palette-only |
+| shared_store create/info/set_use_automatically | Storage panel/Settings + palette |


### PR DESCRIPTION
## Summary
A system of **domain-expert agents + skills** so every lore endpoint is integrated into the **full** app coherently — palette **and** panels, menus, buttons, help, tutorials — not just a palette row. Placed in the repo so **both** BrainMon pipeline workers and Claude Code auto-load them; a BrainMon worker agent references them.

### Foundation (this PR)
- **`CLAUDE.md`** — the coherence mandate, binding on every agent working in the repo.
- **`docs/EXPERT-AGENTS.md`** — master list of agents + skills + placement + the ticket-reference protocol.
- **`docs/DESIGN-SYSTEM.md`**, **`docs/INFORMATION-ARCHITECTURE.md`** — shared sources of truth (semantic tokens; where every op lives + the surface-decision rule).
- **`docs/domains/storage.md`** — first domain expert guide.
- **7 agents** (`.claude/agents/loregui-*`): ux-designer, frontend-engineer, auth-expert, storage-expert, vcs-domain-expert, docs-writer, integration-manager.
- **5 skills** (`.claude/skills/*`): integrate-endpoint, add-domain-ui, design-review, write-tutorial, palette-entry.
- (BrainMon, separate commit) `agents/loregui-domain-worker.md` — pipeline worker that loads these per ticket domain.

### Next
Ship **storage** as the full-coherence template, then iterate every domain until the parity + IA + help gates and design review all pass. Tracked under Epic SBAI-4024 (parity work continues in SBAI-3865).

🤖 Generated with [Claude Code](https://claude.com/claude-code)