### PR TITLE
SBAI-3903: branch latest_list command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/branch/latest_list.ts
+++ b/frontend/src/palette/manifest/branch/latest_list.ts
@@ -1,0 +1,41 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for branch.latest_list.
+ *
+ * Lists the LATEST revision history for a branch, returning one entry per
+ * revision pointer in the branch's latest-chain. Each entry carries the
+ * branch identifier and the revision hash.
+ */
+const manifest: OpManifest = {
+  id: "branch.latest_list",
+  domain: "branch",
+  op: "latest_list",
+  label: "Branch: Latest List",
+  description:
+    "List the latest revision history for a branch (newest first).",
+  command: "branch_latest_list",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch",
+      description: "Branch name; empty for current branch.",
+      required: false,
+      placeholder: "e.g. main",
+    },
+    {
+      name: "limit",
+      kind: "number",
+      label: "Limit",
+      description:
+        "Maximum entries to return; 0 uses the default of 30.",
+      required: false,
+      default: 0,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["latest", "branch", "history", "revisions", "chain"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3903

## Summary
- Add command-palette manifest entry for `branch.latest_list` at `frontend/src/palette/manifest/branch/latest_list.ts`
- Follows the Phase 0 reference pattern (matching `revision/history.ts` etc.)
- The lore-vm binding, Tauri command wrapper, and api.ts binding already exist

## Files Changed
- `frontend/src/palette/manifest/branch/latest_list.ts` (new) — palette manifest with branch (text) and limit (number) args

## Testing
- `cargo check -p lore-vm` — green
- `node frontend/scripts/palette-parity.mjs` — green (branch_latest_list moved from deferred to covered)

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>