### PR TITLE
SBAI-3897: revision amend command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/revision/amend.ts
+++ b/frontend/src/palette/manifest/revision/amend.ts
@@ -1,0 +1,29 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for revision.amend.
+ *
+ * Amends the most recent revision by replacing its commit message.
+ * Returns the amended revision hash, number, and branch.
+ */
+const manifest: OpManifest = {
+  id: "revision.amend",
+  domain: "revision",
+  op: "amend",
+  label: "Revision: Amend",
+  description: "Amend the most recent revision's commit message.",
+  command: "revision_amend",
+  args: [
+    {
+      name: "message",
+      kind: "text",
+      label: "Message",
+      required: true,
+      placeholder: "New commit message",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["amend", "edit", "reword", "message", "revision"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3897

## Summary
- Add palette manifest entry for `revision.amend` at `frontend/src/palette/manifest/revision/amend.ts`
- Op appears in Ctrl-K with a required `message` text field
- Tauri command (`revision_amend`), api.ts binding, and Rust op were already wired

## Files Changed
- `frontend/src/palette/manifest/revision/amend.ts` (new) — palette manifest entry

## Testing
- `cargo check -p lore-vm` — green
- `node frontend/scripts/palette-parity.mjs` — green (revision_amend now covered, removed from deferred list)
- File parses without errors