### PR TITLE
SBAI-3895: branch info command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/branch/info.ts
+++ b/frontend/src/palette/manifest/branch/info.ts
@@ -1,0 +1,31 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for branch.info.
+ *
+ * Retrieves metadata for a branch including its name, id, category,
+ * protection status, parent, creation time, and archive state.
+ */
+const manifest: OpManifest = {
+  id: "branch.info",
+  domain: "branch",
+  op: "info",
+  label: "Branch: Info",
+  description:
+    "Show metadata for a branch — name, category, parent, creator, timestamps, and archive state.",
+  command: "branch_info",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch",
+      description: "Branch name; leave empty for the current branch.",
+      required: false,
+      placeholder: "e.g. main",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "info", "metadata", "details", "status"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3895

## Summary
Add command-palette manifest entry for `branch.info` at `frontend/src/palette/manifest/branch/info.ts` following the Phase 0 reference pattern.

The Rust binding (`crates/lore-vm/src/ops/branch/info.rs`), Tauri command (`branch_info`), and `api.ts` binding were already fully implemented. This PR adds the palette manifest so the op appears in Ctrl-K.

## Files Changed
- `frontend/src/palette/manifest/branch/info.ts` — new manifest entry (single optional `branch` text arg, JSON result)

## Testing
- `node frontend/scripts/palette-parity.mjs` — passes (branch_info now covered)
- `cargo check -p lore-vm` — passes