### PR TITLE
SBAI-3886: auth resolve_user_info command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/auth/resolve_user_info.ts
+++ b/frontend/src/palette/manifest/auth/resolve_user_info.ts
@@ -1,0 +1,22 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for auth.resolve_user_info.
+ *
+ * Resolves the currently authenticated user via the remote authentication
+ * service. Returns user ID and display name if authenticated, or null if
+ * no user session exists.
+ */
+const manifest: OpManifest = {
+  id: "auth.resolve_user_info",
+  domain: "auth",
+  op: "resolve_user_info",
+  label: "Auth: Resolve User Info",
+  description: "Resolve the currently authenticated user's ID and display name.",
+  command: "auth_user_info",
+  args: [],
+  resultKind: "json",
+  keywords: ["user", "whoami", "identity", "profile", "auth", "login"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3886

## Summary
Add command-palette manifest entry for `auth.resolve_user_info` at
`frontend/src/palette/manifest/auth/resolve_user_info.ts`.

The lore-vm core op and Tauri command wrapper (`auth_user_info`) already exist.
This manifest makes the op reachable from Ctrl-K with a no-arg form that returns
the current user's ID and display name as JSON.

## Files Changed
- `frontend/src/palette/manifest/auth/resolve_user_info.ts` (new) — manifest entry

## Testing
- `cargo check -p lore-vm` — passes
- `cargo test -p lore-vm` — passes
- `node frontend/scripts/palette-parity.mjs` — passes (auth_user_info now covered)