### PR TITLE
SBAI-3893: repository config_get command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/repository/config_get.ts
+++ b/frontend/src/palette/manifest/repository/config_get.ts
@@ -1,0 +1,31 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.config_get`.
+ *
+ * Reads a configuration value (e.g. `remote_url`, `identity`) from the
+ * repository config. Single-field form + JSON result.
+ */
+const manifest: OpManifest = {
+  id: "repository.config_get",
+  domain: "repository",
+  op: "config_get",
+  label: "Repository: Get Config",
+  description: "Read a configuration value from the repository config.",
+  command: "config_get",
+  args: [
+    {
+      name: "key",
+      kind: "text",
+      label: "Config Key",
+      description:
+        "The configuration key to read (e.g. remote_url, identity).",
+      required: true,
+      placeholder: "remote_url",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["config", "configuration", "setting", "get", "read", "key"],
+};
+
+export default manifest;


### PR DESCRIPTION
## Summary

Add command-palette manifest entry for `repository.config_get` at `frontend/src/palette/manifest/repository/config_get.ts` following the Phase 0 reference entries.

The lore-vm binding (`crates/lore-vm/src/ops/repository/config_get.rs`) already exists on main. This manifest makes the op reachable from the Ctrl-K command palette with a generated form for the config key argument.

## Files Changed

- `frontend/src/palette/manifest/repository/config_get.ts` — new manifest entry with single `key` text field, JSON result kind

## Testing

- `cargo check -p lore-vm`: PASS
- `cargo fmt --all --check`: PASS
- `node frontend/scripts/palette-parity.mjs`: PASS (parity OK)

Resolves SBAI-3893