### PR TITLE
SBAI-3885: auth logout palette manifest + Tauri wiring

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -83,6 +83,8 @@ export const api = {
   authLoginWithToken: (remoteUrl: string, token: string) =>
     invoke<UserInfo>("auth_login_with_token", { remoteUrl, token }),
   authUserInfo: () => invoke<UserInfo | null>("auth_user_info"),
+  authLogout: (authUrl: string, resource: string, userId: string) =>
+    invoke<void>("auth_logout", { authUrl, resource, userId }),
   repositoryClone: (url: string, dest: string) =>
     invoke<void>("repository_clone", { url, dest }),
   // The wizard supplies a filesystem path + a repo name. The underlying

--- a/frontend/src/palette/manifest/auth/logout.ts
+++ b/frontend/src/palette/manifest/auth/logout.ts
@@ -1,0 +1,55 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Manifest entry for auth.logout.
+ *
+ * Removes stored authentication and authorization tokens. Behavior depends
+ * on which arguments are provided:
+ * - auth_url empty: resolved from the current repository's remote config.
+ * - user_id empty: removes all identities for the auth URL.
+ * - user_id set, resource empty: removes the user's authentication token
+ *   and all authorization tokens for the auth URL.
+ * - user_id + resource set: removes only that specific authorization token.
+ */
+const manifest: OpManifest = {
+  id: "auth.logout",
+  domain: "auth",
+  op: "logout",
+  label: "Auth: Logout",
+  description:
+    "Remove stored authentication and authorization tokens for a remote.",
+  command: "auth_logout",
+  args: [
+    {
+      name: "authUrl",
+      kind: "text",
+      label: "Auth URL",
+      description:
+        "Auth service URL (e.g. ucs-auth://auth.example.com). Leave empty to resolve from repo config.",
+      required: false,
+      placeholder: "ucs-auth://auth.example.com",
+    },
+    {
+      name: "resource",
+      kind: "text",
+      label: "Resource",
+      description:
+        "Resource ID (e.g. urc-{id}). Leave empty to remove all tokens for the auth URL.",
+      required: false,
+      placeholder: "urc-abc123",
+    },
+    {
+      name: "userId",
+      kind: "text",
+      label: "User ID",
+      description:
+        "User identity to remove. Leave empty to remove all identities for the auth URL.",
+      required: false,
+      placeholder: "",
+    },
+  ],
+  resultKind: "void",
+  keywords: ["auth", "logout", "sign out", "token", "remove", "identity"],
+};
+
+export default manifest;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1704,6 +1704,30 @@ pub async fn auth_user_info(state: State<'_, AppState>) -> Result<Option<UserInf
     }))
 }
 
+// --- auth logout ---
+
+use lore_vm::ops::auth::logout::{logout as op_auth_logout, LogoutArgs};
+
+#[tauri::command]
+pub async fn auth_logout(
+    state: State<'_, AppState>,
+    auth_url: String,
+    resource: String,
+    user_id: String,
+) -> Result<(), LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_auth_logout(
+        &api,
+        LogoutArgs {
+            auth_url,
+            resource,
+            user_id,
+        },
+    )
+    .await?;
+    Ok(())
+}
+
 // --- service start ---
 
 use lore_vm::ops::service::start::start as op_service_start;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -109,6 +109,7 @@ pub fn run() {
             commands::auth_login_interactive,
             commands::auth_login_with_token,
             commands::auth_user_info,
+            commands::auth_logout,
             commands::service_start,
             subscribe_notifications,
             unsubscribe_notifications,


### PR DESCRIPTION
Resolves SBAI-3885

## Summary
Wires the `auth.logout` operation through all layers so it appears in the Ctrl-K command palette:
- **Palette manifest** (`frontend/src/palette/manifest/auth/logout.ts`): describes the op's form fields (auth_url, resource, user_id — all optional) with `resultKind: "void"`
- **Tauri command** (`src-tauri/src/commands.rs`): `#[tauri::command] auth_logout` thin wrapper calling `lore_vm::ops::auth::logout`
- **Handler registration** (`src-tauri/src/lib.rs`): added to `generate_handler!`
- **API binding** (`frontend/src/api.ts`): `authLogout(authUrl, resource, userId)` typed invoke

The lore-vm Rust binding (`crates/lore-vm/src/ops/auth/logout.rs`) was already implemented in SBAI-3704 PR #79. This PR wires it through to the GUI.

## Files Changed
- `frontend/src/palette/manifest/auth/logout.ts` (new) — palette manifest entry
- `frontend/src/api.ts` — added `authLogout` binding
- `src-tauri/src/commands.rs` — added `auth_logout` Tauri command
- `src-tauri/src/lib.rs` — registered `auth_logout` in handler

## Testing
- `cargo check -p lore-vm` — green
- `cargo check -p loregui` — green (pre-existing warnings only)
- `cargo fmt --all --check` — clean
- `node frontend/scripts/palette-parity.mjs` — passes