### PR TITLE
SBAI-3875: repository domain command-palette manifest (15 ops)

### DIFF
--- a/frontend/src/palette/manifest/repository/create.ts
+++ b/frontend/src/palette/manifest/repository/create.ts
@@ -1,0 +1,65 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.create`.
+ *
+ * Creates a new repository at the configured working directory.
+ * Returns the created repository id, name, and path.
+ */
+const manifest: OpManifest = {
+  id: "repository.create",
+  domain: "repository",
+  op: "create",
+  label: "Repository: Create",
+  description: "Create a new local repository.",
+  command: "repository_create",
+  args: [
+    {
+      name: "repositoryUrl",
+      kind: "text",
+      label: "Repository URL",
+      description:
+        "URL for the new repository (e.g. lore://localhost/<name>).",
+      required: true,
+      placeholder: "lore://localhost/my-repo",
+    },
+    {
+      name: "description",
+      kind: "text",
+      label: "Description",
+      description: "Optional description for the repository.",
+      required: false,
+      default: "",
+    },
+    {
+      name: "id",
+      kind: "text",
+      label: "ID",
+      description:
+        "Optional repository UUID; leave empty to auto-generate.",
+      required: false,
+      default: "",
+    },
+    {
+      name: "useSharedStore",
+      kind: "boolean",
+      label: "Use Shared Store",
+      description: "Use the shared store instead of a local immutable store.",
+      required: false,
+      default: false,
+    },
+    {
+      name: "sharedStorePath",
+      kind: "text",
+      label: "Shared Store Path",
+      description:
+        "Path for the shared store; leave empty for the default.",
+      required: false,
+      default: "",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["create", "new", "init", "repository"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/repository/create_with_metadata.ts
+++ b/frontend/src/palette/manifest/repository/create_with_metadata.ts
@@ -1,0 +1,80 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.create_with_metadata`.
+ *
+ * Creates a new repository with explicit creator and creation-time metadata.
+ * Returns the created repository id, name, and path.
+ */
+const manifest: OpManifest = {
+  id: "repository.create_with_metadata",
+  domain: "repository",
+  op: "create_with_metadata",
+  label: "Repository: Create with Metadata",
+  description:
+    "Create a new repository with explicit creator and timestamp metadata.",
+  command: "repository_create_with_metadata",
+  args: [
+    {
+      name: "repositoryUrl",
+      kind: "text",
+      label: "Repository URL",
+      description:
+        "URL for the new repository (e.g. lore://localhost/<name>).",
+      required: true,
+      placeholder: "lore://localhost/my-repo",
+    },
+    {
+      name: "creator",
+      kind: "text",
+      label: "Creator",
+      description: "Username or identifier of the repository creator.",
+      required: true,
+    },
+    {
+      name: "created",
+      kind: "number",
+      label: "Created (epoch ms)",
+      description: "Creation timestamp in milliseconds since Unix epoch.",
+      required: true,
+    },
+    {
+      name: "description",
+      kind: "text",
+      label: "Description",
+      description: "Optional description for the repository.",
+      required: false,
+      default: "",
+    },
+    {
+      name: "id",
+      kind: "text",
+      label: "ID",
+      description:
+        "Optional repository UUID; leave empty to auto-generate.",
+      required: false,
+      default: "",
+    },
+    {
+      name: "useSharedStore",
+      kind: "boolean",
+      label: "Use Shared Store",
+      description: "Use the shared store instead of a local immutable store.",
+      required: false,
+      default: false,
+    },
+    {
+      name: "sharedStorePath",
+      kind: "text",
+      label: "Shared Store Path",
+      description:
+        "Path for the shared store; leave empty for the default.",
+      required: false,
+      default: "",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["create", "new", "init", "repository", "metadata", "creator"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/repository/delete.ts
+++ b/frontend/src/palette/manifest/repository/delete.ts
@@ -1,0 +1,29 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.delete`.
+ *
+ * Deletes a repository by its URL. Returns log messages from the operation.
+ */
+const manifest: OpManifest = {
+  id: "repository.delete",
+  domain: "repository",
+  op: "delete",
+  label: "Repository: Delete",
+  description: "Delete a repository by URL.",
+  command: "repository_delete",
+  args: [
+    {
+      name: "repositoryUrl",
+      kind: "text",
+      label: "Repository URL",
+      description: "URL of the repository to delete.",
+      required: true,
+      placeholder: "lore://localhost/my-repo",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["delete", "remove", "destroy", "repository"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/repository/dump.ts
+++ b/frontend/src/palette/manifest/repository/dump.ts
@@ -1,0 +1,49 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.dump`.
+ *
+ * Dumps the repository tree structure at a given revision and path.
+ * Returns repository id, revision state, and a list of tree nodes.
+ */
+const manifest: OpManifest = {
+  id: "repository.dump",
+  domain: "repository",
+  op: "dump",
+  label: "Repository: Dump Tree",
+  description:
+    "Dump the repository tree structure at a given revision and path.",
+  command: "repository_dump",
+  args: [
+    {
+      name: "revision",
+      kind: "text",
+      label: "Revision",
+      description:
+        "Revision to dump; leave empty for the current revision.",
+      required: false,
+      default: "",
+    },
+    {
+      name: "path",
+      kind: "text",
+      label: "Path",
+      description:
+        "Repository-relative path to dump from; leave empty for the root.",
+      required: false,
+      default: "",
+    },
+    {
+      name: "maxDepth",
+      kind: "number",
+      label: "Max Depth",
+      description: "Maximum tree traversal depth; 0 means unlimited.",
+      required: false,
+      default: 0,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["dump", "tree", "structure", "nodes", "listing"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/repository/flush.ts
+++ b/frontend/src/palette/manifest/repository/flush.ts
@@ -1,0 +1,21 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.flush`.
+ *
+ * Flushes pending repository data to persistent storage.
+ * Returns log messages from the operation.
+ */
+const manifest: OpManifest = {
+  id: "repository.flush",
+  domain: "repository",
+  op: "flush",
+  label: "Repository: Flush",
+  description: "Flush pending repository data to persistent storage.",
+  command: "repository_flush",
+  args: [],
+  resultKind: "json",
+  keywords: ["flush", "sync", "persist", "write", "save"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/repository/gc.ts
+++ b/frontend/src/palette/manifest/repository/gc.ts
@@ -1,0 +1,22 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.gc`.
+ *
+ * Runs garbage collection on the local repository, cleaning up
+ * unreferenced data. Returns log messages from the operation.
+ */
+const manifest: OpManifest = {
+  id: "repository.gc",
+  domain: "repository",
+  op: "gc",
+  label: "Repository: Garbage Collect",
+  description:
+    "Run garbage collection on the repository to clean up unreferenced data.",
+  command: "repository_gc",
+  args: [],
+  resultKind: "json",
+  keywords: ["gc", "garbage", "collect", "cleanup", "compact"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/repository/info.ts
+++ b/frontend/src/palette/manifest/repository/info.ts
@@ -1,0 +1,33 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.info`.
+ *
+ * Retrieves metadata about a remote repository — name, URL, default
+ * branch, creator, and creation time.
+ */
+const manifest: OpManifest = {
+  id: "repository.info",
+  domain: "repository",
+  op: "info",
+  label: "Repository: Info",
+  description:
+    "Retrieve metadata about a repository (name, URL, default branch, creator).",
+  command: "repository_info",
+  args: [
+    {
+      name: "repositoryUrl",
+      kind: "text",
+      label: "Repository URL",
+      description:
+        "URL of the repository to query; leave empty to use the current repository.",
+      required: false,
+      default: "",
+      placeholder: "lore://example.com/repo",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["info", "metadata", "details", "repository", "remote"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/repository/instance_list.ts
+++ b/frontend/src/palette/manifest/repository/instance_list.ts
@@ -1,0 +1,22 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.instance_list`.
+ *
+ * Lists all repository instances (working copies) registered in the
+ * shared store, including their paths, branches, and stale status.
+ */
+const manifest: OpManifest = {
+  id: "repository.instance_list",
+  domain: "repository",
+  op: "instance_list",
+  label: "Repository: List Instances",
+  description:
+    "List all repository instances (working copies) in the shared store.",
+  command: "repository_instance_list",
+  args: [],
+  resultKind: "json",
+  keywords: ["instances", "working", "copies", "list", "shared", "store"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/repository/metadata_clear.ts
+++ b/frontend/src/palette/manifest/repository/metadata_clear.ts
@@ -1,0 +1,32 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.metadata_clear`.
+ *
+ * Clears user-defined metadata keys from the repository. When no keys
+ * are specified, all user-defined metadata is removed.
+ */
+const manifest: OpManifest = {
+  id: "repository.metadata_clear",
+  domain: "repository",
+  op: "metadata_clear",
+  label: "Repository: Clear Metadata",
+  description:
+    "Clear user-defined metadata keys from the repository (empty list clears all).",
+  command: "repository_metadata_clear",
+  args: [
+    {
+      name: "keys",
+      kind: "string-list",
+      label: "Keys",
+      description:
+        "Metadata keys to clear; leave empty to clear all user-defined keys.",
+      required: false,
+      default: [],
+    },
+  ],
+  resultKind: "json",
+  keywords: ["metadata", "clear", "remove", "delete", "keys"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/repository/metadata_get.ts
+++ b/frontend/src/palette/manifest/repository/metadata_get.ts
@@ -1,0 +1,32 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.metadata_get`.
+ *
+ * Reads one or all metadata entries from the repository. When key is
+ * empty, returns all entries with their types.
+ */
+const manifest: OpManifest = {
+  id: "repository.metadata_get",
+  domain: "repository",
+  op: "metadata_get",
+  label: "Repository: Get Metadata",
+  description:
+    "Read metadata entries from the repository (empty key returns all).",
+  command: "repository_metadata_get",
+  args: [
+    {
+      name: "key",
+      kind: "text",
+      label: "Key",
+      description:
+        "Metadata key to read; leave empty to return all entries.",
+      required: false,
+      default: "",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["metadata", "get", "read", "key", "value"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/repository/metadata_set.ts
+++ b/frontend/src/palette/manifest/repository/metadata_set.ts
@@ -1,0 +1,46 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.metadata_set`.
+ *
+ * Sets one or more metadata key-value pairs on the repository.
+ * Keys and values are parallel arrays; formats default to "string".
+ */
+const manifest: OpManifest = {
+  id: "repository.metadata_set",
+  domain: "repository",
+  op: "metadata_set",
+  label: "Repository: Set Metadata",
+  description: "Set metadata key-value pairs on the repository.",
+  command: "repository_metadata_set",
+  args: [
+    {
+      name: "keys",
+      kind: "string-list",
+      label: "Keys",
+      description: "Metadata keys to set (one per line).",
+      required: true,
+    },
+    {
+      name: "values",
+      kind: "string-list",
+      label: "Values",
+      description:
+        "Values for each key (one per line, parallel to keys).",
+      required: true,
+    },
+    {
+      name: "formats",
+      kind: "string-list",
+      label: "Formats",
+      description:
+        'Format for each key: "string", "numeric", or "binary". Defaults to "string" for missing entries.',
+      required: false,
+      default: [],
+    },
+  ],
+  resultKind: "json",
+  keywords: ["metadata", "set", "write", "key", "value", "update"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/repository/release.ts
+++ b/frontend/src/palette/manifest/repository/release.ts
@@ -1,0 +1,21 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.release`.
+ *
+ * Releases the repository, freeing associated resources. Returns log
+ * messages from the operation.
+ */
+const manifest: OpManifest = {
+  id: "repository.release",
+  domain: "repository",
+  op: "release",
+  label: "Repository: Release",
+  description: "Release the repository and free associated resources.",
+  command: "repository_release",
+  args: [],
+  resultKind: "json",
+  keywords: ["release", "free", "close", "detach"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/repository/repository_update_path.ts
+++ b/frontend/src/palette/manifest/repository/repository_update_path.ts
@@ -1,0 +1,23 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.repository_update_path`.
+ *
+ * Updates the stored path of the current repository instance in the
+ * shared store to match the current working directory. Returns log
+ * messages from the operation.
+ */
+const manifest: OpManifest = {
+  id: "repository.repository_update_path",
+  domain: "repository",
+  op: "repository_update_path",
+  label: "Repository: Update Path",
+  description:
+    "Update the stored repository path to match the current working directory.",
+  command: "repository_update_path",
+  args: [],
+  resultKind: "json",
+  keywords: ["update", "path", "move", "relocate", "working", "directory"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/repository/store_immutable_query.ts
+++ b/frontend/src/palette/manifest/repository/store_immutable_query.ts
@@ -1,0 +1,45 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.store_immutable_query`.
+ *
+ * Queries the immutable store for a fragment by address. Returns store
+ * entries with status, size, and location information.
+ */
+const manifest: OpManifest = {
+  id: "repository.store_immutable_query",
+  domain: "repository",
+  op: "store_immutable_query",
+  label: "Repository: Query Immutable Store",
+  description:
+    "Query the immutable store for a fragment by address.",
+  command: "repository_store_immutable_query",
+  args: [
+    {
+      name: "address",
+      kind: "text",
+      label: "Fragment Address",
+      description: "The fragment address (hash) to look up in the store.",
+      required: true,
+    },
+    {
+      name: "recurse",
+      kind: "boolean",
+      label: "Recurse",
+      description: "Recursively query sub-fragments.",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: [
+    "store",
+    "immutable",
+    "query",
+    "fragment",
+    "address",
+    "lookup",
+  ],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/repository/verify_fragment.ts
+++ b/frontend/src/palette/manifest/repository/verify_fragment.ts
@@ -1,0 +1,56 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.verify_fragment`.
+ *
+ * Verifies the integrity of a specific fragment by hash. Optionally
+ * heals detected corruption.
+ */
+const manifest: OpManifest = {
+  id: "repository.verify_fragment",
+  domain: "repository",
+  op: "verify_fragment",
+  label: "Repository: Verify Fragment",
+  description:
+    "Verify the integrity of a specific fragment by hash; optionally heal corruption.",
+  command: "repository_verify_fragment",
+  args: [
+    {
+      name: "hash",
+      kind: "text",
+      label: "Fragment Hash",
+      description: "The fragment hash (hex string) to verify.",
+      required: true,
+    },
+    {
+      name: "context",
+      kind: "text",
+      label: "Context",
+      description:
+        "Optional context filter; leave empty to match any context.",
+      required: false,
+      default: "",
+    },
+    {
+      name: "heal",
+      kind: "boolean",
+      label: "Heal",
+      description:
+        "When true, attempt to heal detected corruption.",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: [
+    "verify",
+    "fragment",
+    "integrity",
+    "hash",
+    "heal",
+    "corruption",
+    "check",
+  ],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3875

## Summary
- Adds palette manifest entries for the 15 remaining repository domain ops: `create`, `create_with_metadata`, `delete`, `dump`, `flush`, `gc`, `info`, `instance_list`, `metadata_clear`, `metadata_get`, `metadata_set`, `release`, `repository_update_path`, `store_immutable_query`, `verify_fragment`
- Combined with the 6 existing entries (`clone`, `config_get`, `instance_prune`, `list`, `status`, `verify_state`), this completes all 21 repository domain ops
- Each manifest entry includes appropriate args matching the Rust op signatures, result kind, and search keywords

## Files Changed
15 new files at `frontend/src/palette/manifest/repository/<op>.ts`

## Testing
- `node frontend/scripts/palette-parity.mjs` passes (30/88 commands exposed, parity OK)
- Pre-existing TS errors in `ThemeEditor.tsx`/`ThemeProvider.tsx` are unrelated

## Notes
- 7 ops (`create_with_metadata`, `info`, `metadata_clear`, `release`, `repository_update_path`, `store_immutable_query`, `verify_fragment`) do not yet have `#[tauri::command]` wrappers — manifest entries are created with expected command names for future wiring