### PR TITLE
SBAI-3963: file unstage command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/file/unstage.ts
+++ b/frontend/src/palette/manifest/file/unstage.ts
@@ -1,0 +1,28 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Manifest entry for `file.unstage` — remove paths from the staged changeset.
+ * Mirrors the Phase 0 reference entry for `file.stage`.
+ */
+const manifest: OpManifest = {
+  id: "file.unstage",
+  domain: "file",
+  op: "unstage",
+  label: "File: Unstage",
+  description: "Remove one or more paths from the staged changeset.",
+  command: "unstage",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths",
+      description: "One path per line to unstage.",
+      required: true,
+      placeholder: "src/foo.txt\nsrc/bar.txt",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["unstage", "discard", "remove", "changeset", "index"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3963

## Summary
Added frontend command-palette manifest entry for `file.unstage` operation.

## Files Changed
- `frontend/src/palette/manifest/file/unstage.ts` — New manifest entry following the Phase 0 reference pattern from `file/stage.ts`

## What this enables
- Op appears in Ctrl-K command palette
- Generated form accepts string-list of paths to unstage
- Result renders as JSON (FileUnstageResult with files array and summary counts)
- Keywords: unstage, discard, remove, changeset, index

## Rust op status
The Rust implementation at `crates/lore-vm/src/ops/file/unstage.rs` was already fully implemented on origin/main with comprehensive tests — no changes needed there.

## Testing
- `cargo check -p lore-vm` passes green (pre-existing, Rust op already complete)
- TypeScript compilation errors are pre-existing (missing node_modules — React, @tauri-apps types)
- New file has zero TypeScript errors