### PR TITLE
SBAI-3967: file write command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/file/write.ts
+++ b/frontend/src/palette/manifest/file/write.ts
@@ -1,0 +1,57 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for `file.write`.
+ *
+ * Writes file content from the repository to a destination filesystem path.
+ * Can resolve files by path+revision or by direct content address.
+ */
+const manifest: OpManifest = {
+  id: "file.write",
+  domain: "file",
+  op: "write",
+  label: "File: Write",
+  description:
+    "Write a file from the repository to a destination path on the filesystem.",
+  command: "file_write",
+  args: [
+    {
+      name: "address",
+      kind: "text",
+      label: "Address",
+      description:
+        "Content address to write; takes precedence over path when set.",
+      required: false,
+      placeholder: "e.g. abc123def456",
+    },
+    {
+      name: "path",
+      kind: "text",
+      label: "Path",
+      description:
+        "Repository-relative path to the file (used when address is empty).",
+      required: false,
+      placeholder: "e.g. src/main.rs",
+    },
+    {
+      name: "revision",
+      kind: "text",
+      label: "Revision",
+      description: "Revision of the file to write (used with path).",
+      required: false,
+      placeholder: "e.g. abc123",
+    },
+    {
+      name: "output",
+      kind: "text",
+      label: "Output Path",
+      description: "Destination filesystem path to write the file to.",
+      required: true,
+      placeholder: "/tmp/output.rs",
+    },
+  ],
+  resultKind: "text",
+  keywords: ["write", "export", "output", "file", "save", "copy"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3967

## Summary
Added command-palette manifest entry for the `file.write` operation. The Rust backend (lore-vm binding), Tauri command wrapper, and api.ts binding were already implemented (SBAI-3793). This PR adds the missing frontend manifest that makes the op discoverable and invocable from the Ctrl-K palette.

## Files Changed
- `frontend/src/palette/manifest/file/write.ts` — New manifest entry with 4 args (address, path, revision, output), resultKind=text, and search keywords

## Testing
- TypeScript compilation passes for the new file (no errors)
- Pattern matches existing Phase 0 reference entries (file/stage.ts, repository/config_get.ts)
- The `file_write` Tauri command and `fileWriteApi.write` api.ts binding already exist and are correctly referenced