### PR TITLE
SBAI-3930: repository instance_list command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/repository/instance_list.ts
+++ b/frontend/src/palette/manifest/repository/instance_list.ts
@@ -1,0 +1,23 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.instance_list`.
+ *
+ * Lists all registered instances (working copies) of a repository from the
+ * shared store. No-arg op — returns instance metadata including staleness,
+ * branch, and revision info.
+ */
+const manifest: OpManifest = {
+  id: "repository.instance_list",
+  domain: "repository",
+  op: "instance_list",
+  label: "Repository: List Instances",
+  description:
+    "List all registered instances (working copies) of the repository, including branch, revision, and staleness info.",
+  command: "repository_instance_list",
+  args: [],
+  resultKind: "json",
+  keywords: ["instances", "working copies", "list", "registered", "stale"],
+};
+
+export default manifest;


### PR DESCRIPTION
## Summary

Add command-palette manifest entry for `repository.instance_list` at
`frontend/src/palette/manifest/repository/instance_list.ts` following
the Phase 0 reference entries.

The lore-vm binding already exists (SBAI-3723, PR #57). This manifest makes
the op reachable from Ctrl-K as a no-arg command returning JSON instance
metadata (instance ID, path, branch, revision, staleness).

## Files Changed

- `frontend/src/palette/manifest/repository/instance_list.ts` (new) — palette manifest entry

## Testing

- `cargo check -p lore-vm` — green (no Rust changes)
- `node frontend/scripts/palette-parity.mjs` — green, `repository_instance_list` moved from deferred to covered
- Pre-existing TS errors in `ThemeEditor.tsx`/`ThemeProvider.tsx` unrelated to this change

Resolves SBAI-3930