### PR TITLE
SBAI-3927: branch merge_resolve_mine command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/branch/merge_resolve_mine.ts
+++ b/frontend/src/palette/manifest/branch/merge_resolve_mine.ts
@@ -1,0 +1,41 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for branch.merge_resolve_mine.
+ *
+ * Resolves merge conflicts for specified paths by accepting the local
+ * ("mine") version. Returns the list of resolved paths and the updated
+ * staged revision.
+ */
+const manifest: OpManifest = {
+  id: "branch.merge_resolve_mine",
+  domain: "branch",
+  op: "merge_resolve_mine",
+  label: "Branch: Merge Resolve Mine",
+  description:
+    "Resolve merge conflicts by accepting the local (mine) version for the specified paths.",
+  command: "branch_merge_resolve_mine",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths",
+      description:
+        "File paths to resolve using the local version (one per line).",
+      required: false,
+      placeholder: "e.g. src/main.rs",
+    },
+  ],
+  resultKind: "json",
+  keywords: [
+    "merge",
+    "resolve",
+    "mine",
+    "conflict",
+    "local",
+    "accept",
+    "branch",
+  ],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3927

## Summary
- Add command-palette manifest entry for `branch.merge_resolve_mine` at `frontend/src/palette/manifest/branch/merge_resolve_mine.ts`
- The op resolves merge conflicts by accepting the local ("mine") version for specified paths
- Uses `string-list` arg kind for the paths parameter, `json` result kind

## Files Changed
- `frontend/src/palette/manifest/branch/merge_resolve_mine.ts` (new) — palette manifest entry

## Testing
- `node frontend/scripts/palette-parity.mjs` passes — `branch_merge_resolve_mine` now covered
- Rust op, Tauri command, and api.ts binding already exist from SBAI-3741

Co-authored-by: Biloxi Studios <brandon.f@graeinc.co>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>