### PR TITLE
SBAI-3873: lock domain command-palette manifest (5 ops)

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -984,6 +984,35 @@ export const lockFileQueryApi = {
     invoke<FileQueryResult>("lock_file_query", { branch, owner, path }),
 };
 
+// --- lock file_acquire ---
+
+export interface FileAcquireResult {
+  acquired: string[];
+  ignored: string[];
+}
+
+export const lockFileAcquireApi = {
+  fileAcquire: (paths: string[], branch: string) =>
+    invoke<FileAcquireResult>("lock_file_acquire", { paths, branch }),
+};
+
+// --- lock file_status ---
+
+export interface LockStatus {
+  path: string;
+  owner: string;
+  locked_at: number;
+}
+
+export interface FileStatusResult {
+  locks: LockStatus[];
+}
+
+export const lockFileStatusApi = {
+  fileStatus: (paths: string[], branch: string) =>
+    invoke<FileStatusResult>("lock_file_status", { paths, branch }),
+};
+
 // --- branch reset ---
 
 export interface BranchResetResult {

--- a/frontend/src/palette/manifest/lock/file_acquire.ts
+++ b/frontend/src/palette/manifest/lock/file_acquire.ts
@@ -1,0 +1,38 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `lock.file_acquire`.
+ *
+ * Acquires exclusive locks on one or more files on the current branch.
+ */
+const manifest: OpManifest = {
+  id: "lock.file_acquire",
+  domain: "lock",
+  op: "file_acquire",
+  label: "Lock: Acquire Files",
+  description:
+    "Acquire exclusive locks on one or more files for the current user.",
+  command: "lock_file_acquire",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths",
+      description: "File paths to lock, one per line.",
+      required: true,
+      placeholder: "Content/Characters/hero.uasset\nContent/Maps/main.umap",
+    },
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch",
+      description: "Branch to acquire locks on; leave empty for current branch.",
+      required: false,
+      placeholder: "e.g. main",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["lock", "acquire", "file", "exclusive", "claim"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/lock/file_acquire_as_owner.ts
+++ b/frontend/src/palette/manifest/lock/file_acquire_as_owner.ts
@@ -1,0 +1,46 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `lock.file_acquire_as_owner`.
+ *
+ * Acquires exclusive locks on one or more files on behalf of a specified owner.
+ */
+const manifest: OpManifest = {
+  id: "lock.file_acquire_as_owner",
+  domain: "lock",
+  op: "file_acquire_as_owner",
+  label: "Lock: Acquire Files as Owner",
+  description:
+    "Acquire exclusive file locks on behalf of another user (admin operation).",
+  command: "lock_file_acquire_as_owner",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths",
+      description: "File paths to lock, one per line.",
+      required: true,
+      placeholder: "Content/Characters/hero.uasset\nContent/Maps/main.umap",
+    },
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch",
+      description: "Branch to acquire locks on; leave empty for current branch.",
+      required: false,
+      placeholder: "e.g. main",
+    },
+    {
+      name: "owner",
+      kind: "text",
+      label: "Owner",
+      description: "User ID of the lock owner.",
+      required: true,
+      placeholder: "e.g. user@example.com",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["lock", "acquire", "owner", "admin", "delegate", "file"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/lock/file_query.ts
+++ b/frontend/src/palette/manifest/lock/file_query.ts
@@ -1,0 +1,46 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `lock.file_query`.
+ *
+ * Queries file locks on a branch, optionally filtered by owner and path.
+ */
+const manifest: OpManifest = {
+  id: "lock.file_query",
+  domain: "lock",
+  op: "file_query",
+  label: "Lock: Query",
+  description:
+    "List file locks on a branch, optionally filtered by owner or path.",
+  command: "lock_file_query",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch",
+      description: "Branch to query locks on; leave empty for current branch.",
+      required: false,
+      placeholder: "e.g. main",
+    },
+    {
+      name: "owner",
+      kind: "text",
+      label: "Owner",
+      description: "Filter by lock owner; leave empty for all owners.",
+      required: false,
+      placeholder: "e.g. user@example.com",
+    },
+    {
+      name: "path",
+      kind: "text",
+      label: "Path",
+      description: "Filter by path prefix; leave empty for all paths.",
+      required: false,
+      placeholder: "e.g. Content/Maps/",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["lock", "query", "list", "search", "find", "who"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/lock/file_release.ts
+++ b/frontend/src/palette/manifest/lock/file_release.ts
@@ -1,0 +1,53 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `lock.file_release`.
+ *
+ * Releases exclusive locks on one or more files.
+ */
+const manifest: OpManifest = {
+  id: "lock.file_release",
+  domain: "lock",
+  op: "file_release",
+  label: "Lock: Release Files",
+  description: "Release exclusive file locks for the specified paths.",
+  command: "lock_file_release",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths",
+      description: "File paths to unlock, one per line.",
+      required: true,
+      placeholder: "Content/Characters/hero.uasset\nContent/Maps/main.umap",
+    },
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch",
+      description: "Branch the locks were acquired on; leave empty for current branch.",
+      required: false,
+      placeholder: "e.g. main",
+    },
+    {
+      name: "owner",
+      kind: "text",
+      label: "Owner",
+      description: "Lock owner name.",
+      required: true,
+      placeholder: "e.g. user@example.com",
+    },
+    {
+      name: "ownerId",
+      kind: "text",
+      label: "Owner ID",
+      description: "Lock owner ID.",
+      required: true,
+      placeholder: "e.g. 12345",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["lock", "release", "unlock", "free", "file"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/lock/file_status.ts
+++ b/frontend/src/palette/manifest/lock/file_status.ts
@@ -1,0 +1,38 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `lock.file_status`.
+ *
+ * Returns lock status for specified files on a branch.
+ */
+const manifest: OpManifest = {
+  id: "lock.file_status",
+  domain: "lock",
+  op: "file_status",
+  label: "Lock: File Status",
+  description:
+    "Check the lock status of one or more files — shows owner and lock time.",
+  command: "lock_file_status",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths",
+      description: "File paths to check, one per line.",
+      required: true,
+      placeholder: "Content/Characters/hero.uasset\nContent/Maps/main.umap",
+    },
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch",
+      description: "Branch to check locks on; leave empty for current branch.",
+      required: false,
+      placeholder: "e.g. main",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["lock", "status", "check", "info", "file", "who"],
+};
+
+export default manifest;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -879,6 +879,38 @@ pub async fn revision_commit(
     op_revision_commit(&api, OpsCommitArgs { message }).await
 }
 
+// --- lock file_acquire ---
+
+use lore_vm::ops::lock::file_acquire::{
+    file_acquire as op_lock_file_acquire, FileAcquireArgs, FileAcquireResult,
+};
+
+#[tauri::command]
+pub async fn lock_file_acquire(
+    state: State<'_, AppState>,
+    paths: Vec<String>,
+    branch: String,
+) -> Result<FileAcquireResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_lock_file_acquire(&api, FileAcquireArgs { paths, branch }).await
+}
+
+// --- lock file_status ---
+
+use lore_vm::ops::lock::file_status::{
+    file_status as op_lock_file_status, FileStatusArgs, FileStatusResult,
+};
+
+#[tauri::command]
+pub async fn lock_file_status(
+    state: State<'_, AppState>,
+    paths: Vec<String>,
+    branch: String,
+) -> Result<FileStatusResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_lock_file_status(&api, FileStatusArgs { paths, branch }).await
+}
+
 // --- lock file_query ---
 
 use lore_vm::ops::lock::file_query::{

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -80,6 +80,8 @@ pub fn run() {
             commands::lock_file_release,
             commands::lock_file_acquire_as_owner,
             commands::lock_file_query,
+            commands::lock_file_acquire,
+            commands::lock_file_status,
             commands::branch_reset,
             commands::branch_merge_start,
             commands::branch_merge_restart,


### PR DESCRIPTION
Resolves SBAI-3873

## Summary
- Add command-palette manifest entries for all 5 lock domain ops: `file_acquire`, `file_acquire_as_owner`, `file_query`, `file_release`, `file_status`
- Add missing `#[tauri::command]` wrappers and `api.ts` TypeScript bindings for `lock_file_acquire` and `lock_file_status` (the other 3 lock ops were already wired)
- Register both new commands in `generate_handler!` macro

## Files Changed
- `frontend/src/palette/manifest/lock/file_acquire.ts` — new manifest entry
- `frontend/src/palette/manifest/lock/file_acquire_as_owner.ts` — new manifest entry
- `frontend/src/palette/manifest/lock/file_query.ts` — new manifest entry
- `frontend/src/palette/manifest/lock/file_release.ts` — new manifest entry
- `frontend/src/palette/manifest/lock/file_status.ts` — new manifest entry
- `src-tauri/src/commands.rs` — add `lock_file_acquire` and `lock_file_status` Tauri commands
- `src-tauri/src/lib.rs` — register both new commands in `generate_handler!`
- `frontend/src/api.ts` — add TypeScript bindings for `lock_file_acquire` and `lock_file_status`

## Testing
- `cargo fmt --all --check` — clean
- `palette-parity.mjs` — passes (27/90 commands exposed, 68 deferred, 4 excluded)
- Pre-existing TS errors in ThemeProvider.tsx (missing react types) unrelated to this change