### PR TITLE
SBAI-3921: file info command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/file/info.ts
+++ b/frontend/src/palette/manifest/file/info.ts
@@ -1,0 +1,54 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `file.info`.
+ *
+ * Retrieves metadata for one or more files: size, hash, staged status,
+ * modification flags, and optionally local/filtered sizes.
+ */
+const manifest: OpManifest = {
+  id: "file.info",
+  domain: "file",
+  op: "info",
+  label: "File: Info",
+  description:
+    "Show metadata for files — size, hash, flags, and staging status.",
+  command: "file_info",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths",
+      description: "Repository-relative paths to query (one per line).",
+      required: true,
+      placeholder: "src/main.rs\nassets/model.fbx",
+    },
+    {
+      name: "revision",
+      kind: "text",
+      label: "Revision",
+      description:
+        "Revision specifier to query (leave empty for working copy).",
+      required: false,
+      placeholder: "",
+    },
+    {
+      name: "local",
+      kind: "boolean",
+      label: "Include Local Info",
+      description: "Calculate the filtered local filesystem hash and size.",
+      default: false,
+    },
+    {
+      name: "filtered",
+      kind: "boolean",
+      label: "Include Filtered Size",
+      description: "Calculate the filtered repository size.",
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["file", "info", "metadata", "size", "hash", "status", "stat"],
+};
+
+export default manifest;


### PR DESCRIPTION
## Summary
- Add command-palette manifest entry for `file.info` at `frontend/src/palette/manifest/file/info.ts`
- The lore-vm binding, Tauri command (`file_info`), and api.ts binding (`fileInfoApi`) already exist
- Manifest exposes the op in Ctrl-K with a generated form for: paths (string-list), revision (text), local (boolean), filtered (boolean)

## Files Changed
- `frontend/src/palette/manifest/file/info.ts` (new) — palette manifest entry

## Testing
- `node frontend/scripts/palette-parity.mjs` passes — file_info now covered
- Pre-existing TS build errors in ThemeEditor/ThemeProvider are unrelated

Resolves SBAI-3921