### PR TITLE
SBAI-3932: file metadata_list command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/file/metadata_list.ts
+++ b/frontend/src/palette/manifest/file/metadata_list.ts
@@ -1,0 +1,41 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `file.metadata_list`.
+ *
+ * Lists all metadata key/value pairs associated with a file at a given
+ * revision. Returns entries with key, value, and type (address, boolean,
+ * binary, context, hash, numeric, string).
+ */
+const manifest: OpManifest = {
+  id: "file.metadata_list",
+  domain: "file",
+  op: "metadata_list",
+  label: "File: List Metadata",
+  description:
+    "List all metadata key/value pairs for a file at a given revision.",
+  command: "file_metadata_list",
+  args: [
+    {
+      name: "path",
+      kind: "text",
+      label: "Path",
+      description: "Path to the file to list metadata for.",
+      required: true,
+      placeholder: "src/main.rs",
+    },
+    {
+      name: "revision",
+      kind: "text",
+      label: "Revision",
+      description: "Revision to query; leave empty for the current revision.",
+      required: false,
+      default: "",
+      placeholder: "e.g. abc123def",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["metadata", "list", "file", "key", "value", "attributes"],
+};
+
+export default manifest;


### PR DESCRIPTION
## Summary

Add command-palette manifest entry for `file.metadata_list` at
`frontend/src/palette/manifest/file/metadata_list.ts` following the Phase 0
reference entries.

The lore-vm binding (`crates/lore-vm/src/ops/file/metadata_list.rs`) already
exists and is fully implemented. This manifest makes it reachable from Ctrl-K
with a generated form for path and revision arguments. Result renders as JSON
showing metadata entries with key, value, and type.

## Files Changed

- `frontend/src/palette/manifest/file/metadata_list.ts` — new manifest entry

## Testing

- `node frontend/scripts/palette-parity.mjs` — passes (22/88 commands exposed)
- Pre-existing TS build errors in ThemeProvider.tsx (missing react types) unrelated to this change

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>