### PR TITLE
SBAI-3961: revision revert_abort command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/revision/revert_abort.ts
+++ b/frontend/src/palette/manifest/revision/revert_abort.ts
@@ -1,0 +1,22 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for revision.revert_abort.
+ *
+ * Aborts an in-progress revert and restores the working directory to its
+ * prior state. Takes no arguments beyond the repository context.
+ */
+const manifest: OpManifest = {
+  id: "revision.revert_abort",
+  domain: "revision",
+  op: "revert_abort",
+  label: "Revision: Abort Revert",
+  description:
+    "Abort an in-progress revert operation and restore the working directory.",
+  command: "revert_abort",
+  args: [],
+  resultKind: "json",
+  keywords: ["revert", "abort", "cancel", "undo"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3961

## Summary
- Add command-palette manifest entry for `revision.revert_abort` at `frontend/src/palette/manifest/revision/revert_abort.ts`
- The lore-vm binding already exists (implemented in SBAI-3774, commit e469807)
- Tauri command wrapper and api.ts binding are not yet wired — deferred to the integration manager's batched pass

## Files Changed
- `frontend/src/palette/manifest/revision/revert_abort.ts` (new) — palette manifest with id, label, description, empty args array, and keywords

## Testing
- `cargo check -p lore-vm` — passes (no Rust changes)
- `node frontend/scripts/palette-parity.mjs` — passes (22/88 commands, 25%)
- Frontend TS errors are pre-existing (ThemeEditor/ThemeProvider missing react types)