### PR TITLE
SBAI-3986: revision cherry_pick_restart command-palette manifest

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1297,6 +1297,17 @@ export const storageApi = {
     invoke<StorageUploadResult>("storage_upload", { handle, partition, address }),
 };
 
+// --- revision cherry_pick_restart ---
+
+export interface CherryPickRestartResult {
+  paths: string[];
+}
+
+export const revisionCherryPickRestartApi = {
+  cherryPickRestart: (paths: string[]) =>
+    invoke<CherryPickRestartResult>("revision_cherry_pick_restart", { paths }),
+};
+
 // --- shared_store: info + auto-use ---
 
 export interface SharedStoreEntry {

--- a/frontend/src/palette/manifest/revision/cherry_pick_restart.ts
+++ b/frontend/src/palette/manifest/revision/cherry_pick_restart.ts
@@ -1,0 +1,40 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for revision.cherry_pick_restart.
+ *
+ * Re-materialises the specified paths for resolution during an in-progress
+ * cherry-pick conflict, discarding any partial resolution work so the user
+ * can start over on those paths.
+ */
+const manifest: OpManifest = {
+  id: "revision.cherry_pick_restart",
+  domain: "revision",
+  op: "cherry_pick_restart",
+  label: "Revision: Cherry-Pick Restart",
+  description:
+    "Restart resolution for specified paths during an in-progress cherry-pick conflict.",
+  command: "revision_cherry_pick_restart",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths",
+      required: true,
+      description:
+        "Repository-relative paths to re-materialise for resolution (one per line).",
+      placeholder: "src/main.rs",
+    },
+  ],
+  resultKind: "json",
+  keywords: [
+    "cherry-pick",
+    "restart",
+    "conflict",
+    "resolve",
+    "redo",
+    "rematerialise",
+  ],
+};
+
+export default manifest;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1768,6 +1768,21 @@ pub async fn dependency_remove(
     op_dependency_remove(&api, DependencyRemoveArgs { sources }).await
 }
 
+// --- revision cherry_pick_restart ---
+
+use lore_vm::ops::revision::cherry_pick_restart::{
+    cherry_pick_restart as op_cherry_pick_restart, CherryPickRestartArgs, CherryPickRestartResult,
+};
+
+#[tauri::command]
+pub async fn revision_cherry_pick_restart(
+    state: State<'_, AppState>,
+    paths: Vec<String>,
+) -> Result<CherryPickRestartResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_cherry_pick_restart(&api, CherryPickRestartArgs { paths }).await
+}
+
 // --- service start ---
 
 use lore_vm::ops::service::start::start as op_service_start;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -112,6 +112,7 @@ pub fn run() {
             commands::auth_login_interactive,
             commands::auth_login_with_token,
             commands::auth_user_info,
+            commands::revision_cherry_pick_restart,
             commands::service_start,
             subscribe_notifications,
             unsubscribe_notifications,


### PR DESCRIPTION
## Summary

- Add palette manifest entry so `revision.cherry_pick_restart` appears in Ctrl-K with a string-list form for paths
- Wire `#[tauri::command] revision_cherry_pick_restart` in commands.rs + register in lib.rs
- Add typed api.ts binding (`revisionCherryPickRestartApi`)

The lore-vm binding was already fully implemented (SBAI-3768, PR #15).

## Files Changed

- `frontend/src/palette/manifest/revision/cherry_pick_restart.ts` — new manifest
- `src-tauri/src/commands.rs` — new Tauri command
- `src-tauri/src/lib.rs` — register in generate_handler!
- `frontend/src/api.ts` — typed binding

## Testing

- `cargo fmt --all --check` — clean
- `node frontend/scripts/palette-parity.mjs` — passes

Resolves SBAI-3986