### PR TITLE
SBAI-3933: revision info command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/revision/info.ts
+++ b/frontend/src/palette/manifest/revision/info.ts
@@ -1,0 +1,46 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for revision.info.
+ *
+ * Retrieves metadata and file-change information for a revision.
+ * Optionally includes per-file deltas and key/value metadata entries.
+ */
+const manifest: OpManifest = {
+  id: "revision.info",
+  domain: "revision",
+  op: "info",
+  label: "Revision: Info",
+  description: "Show metadata and file changes for a revision.",
+  command: "revision_info",
+  args: [
+    {
+      name: "revision",
+      kind: "text",
+      label: "Revision",
+      description: "Revision to inspect; empty for current.",
+      required: false,
+      placeholder: "e.g. abc123def",
+    },
+    {
+      name: "delta",
+      kind: "boolean",
+      label: "Include Delta",
+      description: "Include per-file changes against the parent revision.",
+      required: false,
+      default: false,
+    },
+    {
+      name: "metadata",
+      kind: "boolean",
+      label: "Include Metadata",
+      description: "Include key/value metadata entries.",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["info", "details", "inspect", "revision", "metadata", "delta"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3933

## Summary
- Adds palette manifest entry for `revision.info` at `frontend/src/palette/manifest/revision/info.ts`
- Exposes the existing `revision_info` Tauri command in the Ctrl-K command palette
- Fields: revision (text, optional), delta (boolean), metadata (boolean)
- The lore-vm binding (SBAI-3752) and Tauri command wrapper already exist

## Files Changed
- `frontend/src/palette/manifest/revision/info.ts` — new palette manifest entry

## Testing
- TypeScript transpile: OK
- Palette parity check: OK (revision_info now counted as covered, 23/88 commands exposed)