### PR TITLE
SBAI-4012: storage put command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/storage/put.ts
+++ b/frontend/src/palette/manifest/storage/put.ts
@@ -1,0 +1,39 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Store a content-addressed buffer in an open store. The key is an opaque
+ * caller-chosen label used to correlate a later get or obliterate call.
+ */
+const manifest: OpManifest = {
+  id: "storage.put",
+  domain: "storage",
+  op: "put",
+  label: "Storage: Put",
+  description:
+    "Write a content-addressed buffer to an open store by key. The key lets you retrieve or obliterate the data later.",
+  command: "storage_put",
+  args: [
+    {
+      name: "key",
+      kind: "text",
+      label: "Key",
+      description: "Opaque label that correlates this write with a later get or obliterate.",
+      required: true,
+      placeholder: "my-data-key",
+    },
+    {
+      name: "data",
+      kind: "text",
+      label: "Data (JSON byte array)",
+      description:
+        "The bytes to store, as a JSON array of numbers (e.g. [72, 101, 108, 108, 111]).",
+      required: true,
+      placeholder: "[72, 101, 108, 108, 111]",
+    },
+  ],
+  resultKind: "void",
+  keywords: ["storage", "put", "write", "store", "content", "address"],
+  surface: "palette",
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-4012

## Summary
Add command-palette manifest entry for `storage.put` at `frontend/src/palette/manifest/storage/put.ts`. The Tauri command (`storage_put`), api.ts binding, and lore-vm op binding were already implemented — this adds the palette manifest so the op appears in Ctrl-K.

## Files Changed
- `frontend/src/palette/manifest/storage/put.ts` (new) — palette manifest with key + data args, void result, palette surface

## Testing
- `node frontend/scripts/palette-parity.mjs` — passes, `storage_put` now recognized as covered

Co-authored-by: Biloxi Studios <brandon.f@graeinc.co>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>