### PR TITLE
SBAI-3966: branch reset command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/branch/reset.ts
+++ b/frontend/src/palette/manifest/branch/reset.ts
@@ -1,0 +1,38 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for branch.reset.
+ *
+ * Resets the local LATEST pointer of a branch to a specific revision.
+ */
+const manifest: OpManifest = {
+  id: "branch.reset",
+  domain: "branch",
+  op: "reset",
+  label: "Branch: Reset",
+  description:
+    "Reset the local LATEST pointer of a branch to a specific revision.",
+  command: "branch_reset",
+  args: [
+    {
+      name: "revision",
+      kind: "text",
+      label: "Revision",
+      description: "Revision to reset the branch to.",
+      required: true,
+      placeholder: "e.g. abc123",
+    },
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch",
+      description: "Branch to reset; leave empty for the current branch.",
+      required: false,
+      placeholder: "e.g. main",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "reset", "revert", "pointer", "latest"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3966

## Summary
- Add command-palette manifest entry for `branch.reset` at `frontend/src/palette/manifest/branch/reset.ts`
- Tauri command (`branch_reset`) and `api.ts` binding already exist — this just exposes the op in Ctrl-K

## Files Changed
- `frontend/src/palette/manifest/branch/reset.ts` (new) — palette manifest with revision (required) and branch (optional) args

## Testing
- `cargo check -p lore-vm`: pass
- `node frontend/scripts/palette-parity.mjs`: pass (branch_reset now covered)