### PR TITLE
SBAI-3924: branch merge_resolve command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/branch/merge_resolve.ts
+++ b/frontend/src/palette/manifest/branch/merge_resolve.ts
@@ -1,0 +1,31 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for branch.merge_resolve.
+ *
+ * Marks specified conflicted paths as resolved during an in-progress merge.
+ * Returns the list of resolved paths and the updated staged revision.
+ */
+const manifest: OpManifest = {
+  id: "branch.merge_resolve",
+  domain: "branch",
+  op: "merge_resolve",
+  label: "Branch: Merge Resolve",
+  description:
+    "Mark conflicted files as resolved during an in-progress merge.",
+  command: "branch_merge_resolve",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths",
+      description: "Conflicted file paths to mark as resolved.",
+      required: false,
+      default: [],
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "merge", "resolve", "conflict", "paths"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3924

## Summary
- Add command-palette manifest entry for `branch.merge_resolve` at `frontend/src/palette/manifest/branch/merge_resolve.ts`
- Op marks conflicted file paths as resolved during an in-progress merge
- Takes a `paths` string-list arg, returns JSON with resolved paths and revision
- Binding, Tauri command, and api.ts wrapper already existed — only the palette entry was missing

## Files Changed
- `frontend/src/palette/manifest/branch/merge_resolve.ts` (new)

## Testing
- `cargo check -p lore-vm` — green
- `cargo test -p lore-vm` — green (all tests pass)
- `node frontend/scripts/palette-parity.mjs` — green (23/88, branch_merge_resolve now covered)