### PR TITLE
SBAI-3968: repository store_immutable_query command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/repository/store_immutable_query.ts
+++ b/frontend/src/palette/manifest/repository/store_immutable_query.ts
@@ -1,0 +1,46 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.store_immutable_query`.
+ *
+ * Queries the local immutable store for fragments matching a given address.
+ * Returns matching entries with address, status, payload/content sizes, and flags.
+ */
+const manifest: OpManifest = {
+  id: "repository.store_immutable_query",
+  domain: "repository",
+  op: "store_immutable_query",
+  label: "Repository: Query Immutable Store",
+  description:
+    "Query the local immutable store for fragments matching an address.",
+  command: "store_immutable_query",
+  args: [
+    {
+      name: "address",
+      kind: "text",
+      label: "Fragment Address",
+      description: "The fragment address to query in the immutable store.",
+      required: true,
+      placeholder: "abc123",
+    },
+    {
+      name: "recurse",
+      kind: "boolean",
+      label: "Recurse",
+      description: "When true, recurse into and query subfragments.",
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: [
+    "store",
+    "immutable",
+    "query",
+    "fragment",
+    "address",
+    "payload",
+    "content",
+  ],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3968

## Summary
- Add command-palette manifest entry for `repository.store_immutable_query`
- The Rust op binding (`crates/lore-vm/src/ops/repository/store_immutable_query.rs`) was already fully implemented with args, result types, event collection, and 8 passing tests
- This PR adds only the palette manifest so the op appears in Ctrl-K

## Files Changed
- `frontend/src/palette/manifest/repository/store_immutable_query.ts` (new) — palette manifest with address (text, required) and recurse (boolean, default false) fields

## Testing
- `cargo check -p lore-vm`: pass
- `cargo test -p lore-vm` (store_immutable_query tests): 8/8 pass
- `npm --prefix frontend run build`: pass
- `node frontend/scripts/palette-parity.mjs`: pass (22/88 exposed, up from 21)

Co-authored-by: Biloxi Studios <brandon.f@graeinc.co>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>