### PR TITLE
SBAI-3922: repository gc command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/repository/gc.ts
+++ b/frontend/src/palette/manifest/repository/gc.ts
@@ -1,0 +1,32 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `repository.gc`.
+ *
+ * Runs garbage collection on the local repository store to reclaim space from
+ * unreferenced data. No arguments required — invokes `repository_gc` and
+ * displays any diagnostic log messages from the GC run.
+ */
+const manifest: OpManifest = {
+  id: "repository.gc",
+  domain: "repository",
+  op: "gc",
+  label: "Repository: Garbage Collect",
+  description:
+    "Run garbage collection on the local repository store to reclaim space.",
+  command: "repository_gc",
+  args: [],
+  resultKind: "json",
+  keywords: [
+    "gc",
+    "garbage",
+    "collect",
+    "clean",
+    "reclaim",
+    "space",
+    "prune",
+    "housekeeping",
+  ],
+};
+
+export default manifest;


### PR DESCRIPTION
## Summary
- Add command-palette manifest entry for `repository.gc` at `frontend/src/palette/manifest/repository/gc.ts`
- The Rust binding (`crates/lore-vm/src/ops/repository/gc.rs`), Tauri command (`repository_gc`), and api.ts binding already exist and are fully functional
- The manifest entry enables the op in Ctrl-K with appropriate keywords (gc, garbage, collect, clean, reclaim, space, prune, housekeeping)

## Files Changed
- `frontend/src/palette/manifest/repository/gc.ts` (new) — palette manifest entry, no args, JSON result kind

## Testing
- `cargo check -p lore-vm` — green
- `cargo test -p lore-vm --lib ops::repository::gc` — 3/3 tests pass
- `cargo fmt --all --check` — clean
- `npm --prefix frontend run build` — clean
- `node frontend/scripts/palette-parity.mjs` — passes, `repository_gc` now covered (23/88 commands, 26%)

Resolves SBAI-3922