### PR TITLE
SBAI-3969: revision revert_resolve command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/revision/revert_resolve.ts
+++ b/frontend/src/palette/manifest/revision/revert_resolve.ts
@@ -1,0 +1,33 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Manifest entry for `revision.revert_resolve`.
+ *
+ * Marks the specified conflicted paths as resolved during an in-progress
+ * revert. The user is expected to have manually edited the working-tree
+ * copies before invoking this command.
+ */
+const manifest: OpManifest = {
+  id: "revision.revert_resolve",
+  domain: "revision",
+  op: "revert_resolve",
+  label: "Revision: Revert Resolve",
+  description:
+    "Mark conflicted paths as resolved during an in-progress revert.",
+  command: "revision_revert_resolve",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths",
+      required: true,
+      placeholder: "src/main.rs",
+      description:
+        "Repository-relative paths to mark as resolved.",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["revert", "resolve", "conflict", "merge"],
+};
+
+export default manifest;


### PR DESCRIPTION
## Summary
- Add command-palette manifest entry for `revision.revert_resolve` op
- The Rust binding, Tauri command, and api.ts wrapper already exist on main
- This adds the palette manifest so the op appears in Ctrl-K with a generated form

## Files Changed
- `frontend/src/palette/manifest/revision/revert_resolve.ts` (new)

## Testing
- `cargo check -p lore-vm` — green
- `cargo test -p lore-vm -- revision::revert_resolve` — 6/6 pass
- `node frontend/scripts/palette-parity.mjs` — passes, shows `revision_revert_resolve` now covered
- No TS errors from the new file

Resolves SBAI-3969