### PR TITLE
SBAI-3960: branch protect command-palette manifest

### DIFF
--- a/frontend/scripts/palette-parity-allowlist.json
+++ b/frontend/scripts/palette-parity-allowlist.json
@@ -25,7 +25,6 @@
     "branch_merge_start",
     "branch_merge_unresolve",
     "branch_metadata_get",
-    "branch_protect",
     "branch_reset",
     "branch_unprotect",
     "branches",

--- a/frontend/src/palette/manifest/branch/protect.ts
+++ b/frontend/src/palette/manifest/branch/protect.ts
@@ -1,0 +1,31 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for branch.protect.
+ *
+ * Applies write protection to a branch, preventing direct commits.
+ * Protected branches require merge requests for changes.
+ */
+const manifest: OpManifest = {
+  id: "branch.protect",
+  domain: "branch",
+  op: "protect",
+  label: "Branch: Protect",
+  description:
+    "Apply write protection to a branch, preventing direct commits.",
+  command: "branch_protect",
+  args: [
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch",
+      description: "Name of the branch to protect.",
+      required: true,
+      placeholder: "e.g. main",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["branch", "protect", "lock", "write", "guard", "permission"],
+};
+
+export default manifest;


### PR DESCRIPTION
## Summary

Add command-palette manifest entry for `branch.protect` at `frontend/src/palette/manifest/branch/protect.ts` following the Phase 0 reference entries.

The lore-vm binding (`crates/lore-vm/src/ops/branch/protect.rs`), Tauri command wrapper, and `api.ts` binding already exist. This manifest makes the op reachable from the Ctrl-K command palette with a generated form for the branch name argument.

## Files Changed

- `frontend/src/palette/manifest/branch/protect.ts` — New palette manifest entry
- `frontend/scripts/palette-parity-allowlist.json` — Removed `branch_protect` from deferred list (now covered)

## Testing

- `cargo check -p lore-vm` — GREEN
- `cargo fmt --all --check` — GREEN
- `node frontend/scripts/palette-parity.mjs` — GREEN (23/88 commands exposed, 67 deferred)

Resolves SBAI-3960