### PR TITLE
SBAI-4028: disable sccache to fix linker bus error in cargo test

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+# Disable sccache for this project.
+#
+# The shared sccache at /srv/cargo-shared/sccache is used by many concurrent
+# worker build trees and frequently corrupts cache entries under load, causing
+# linker bus errors (signal 7) during test compilation.
+#
+# See: SBAI-4028
+[build]
+rustc-wrapper = ""


### PR DESCRIPTION
Resolves SBAI-4028

## Summary
Fixed linker bus error (signal 7) during `cargo test -p lore-vm` by disabling sccache in `.cargo/config.toml`.

The shared sccache at `/srv/cargo-shared/sccache` is used by many concurrent worker build trees and frequently corrupts cache entries under load. This causes the linker (`rust-lld`) to receive corrupted object files, resulting in `Bus error (core dumped)` during test compilation.

## Root Cause
- sccache 0.7.7 with 67K compile requests, 129 cache errors, 19 cache write errors
- Multiple zombie sccache processes (`<defunct>`) from concurrent builds
- sccache server crashes under load from 20+ parallel worktree compilations

## Fix
Added `.cargo/config.toml` with `rustc-wrapper = ""` to bypass sccache entirely for this project.

## Files Changed
- `.cargo/config.toml` — New file, disables sccache

## Testing
- `cargo test -p lore-vm` — All 400+ tests pass (verified with sccache disabled)
- `cargo test -p lore-vm --test file_metadata_get` — 16/16 tests pass
- `cargo check -p lore-vm` — Green