### PR TITLE
SBAI-3915: revision diff command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/revision/diff.ts
+++ b/frontend/src/palette/manifest/revision/diff.ts
@@ -1,0 +1,45 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for revision.diff.
+ *
+ * Computes file-level differences between two revisions, showing
+ * which files were added, deleted, moved, copied, or kept.
+ */
+const manifest: OpManifest = {
+  id: "revision.diff",
+  domain: "revision",
+  op: "diff",
+  label: "Revision: Diff",
+  description: "Show file-level differences between two revisions.",
+  command: "revision_diff",
+  args: [
+    {
+      name: "revisionSource",
+      kind: "text",
+      label: "Source Revision",
+      description: "Revision to diff from.",
+      required: true,
+      placeholder: "e.g. abc123def",
+    },
+    {
+      name: "revisionTarget",
+      kind: "text",
+      label: "Target Revision",
+      description: "Revision to diff to; empty for current working state.",
+      required: false,
+      placeholder: "e.g. def456abc",
+    },
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths",
+      description: "Restrict diff to these repository-relative paths; empty for all files.",
+      required: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["diff", "compare", "changes", "files", "revision"],
+};
+
+export default manifest;


### PR DESCRIPTION
## Summary
- Add palette manifest entry for `revision.diff` at `frontend/src/palette/manifest/revision/diff.ts`
- The Rust binding (`crates/lore-vm/src/ops/revision/diff.rs`), Tauri command (`revision_diff`), and `api.ts` binding (`revisionDiffApi`) already existed — this adds the palette entry so the op appears in Ctrl-K

## Files Changed
- `frontend/src/palette/manifest/revision/diff.ts` (new) — manifest with source revision (required), target revision (optional), and paths (optional string-list)

## Testing
- `cargo check -p lore-vm` — green
- `cargo test -p lore-vm -- ops::revision::diff` — 7/7 tests pass
- `node frontend/scripts/palette-parity.mjs` — passes (revision_diff now covered)
- Pre-existing TS errors in ThemeEditor/ThemeProvider unrelated to this change

Resolves SBAI-3915