### PR TITLE
SBAI-3988: link add command-palette manifest

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -916,6 +916,29 @@ export const dependencyRemoveApi = {
     invoke<DependencyRemoveResult>("dependency_remove", { sources }),
 };
 
+// --- link add ---
+
+export interface LinkAddResult {
+  link_path: string;
+}
+
+export const linkAddApi = {
+  add: (
+    link: string,
+    linkPath: string,
+    sourcePath: string = "/",
+    pin: string = "",
+    disableBranching: boolean = false,
+  ) =>
+    invoke<LinkAddResult>("link_add", {
+      link,
+      linkPath,
+      sourcePath,
+      pin,
+      disableBranching,
+    }),
+};
+
 // --- link remove ---
 
 export interface LinkRemoveResult {

--- a/frontend/src/palette/manifest/link/add.ts
+++ b/frontend/src/palette/manifest/link/add.ts
@@ -1,0 +1,66 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for link.add.
+ *
+ * Adds a new link to a linked repository at the specified path.
+ * Links connect one repository to another, pulling content from
+ * a source path in the linked repo into a local link path.
+ */
+const manifest: OpManifest = {
+  id: "link.add",
+  domain: "link",
+  op: "add",
+  label: "Link: Add",
+  description:
+    "Add a link to a remote repository at the specified path.",
+  command: "link_add",
+  args: [
+    {
+      name: "link",
+      kind: "text",
+      label: "Link URL",
+      description: "URL or identifier of the repository to link.",
+      required: true,
+      placeholder: "https://example.com/repo",
+    },
+    {
+      name: "linkPath",
+      kind: "text",
+      label: "Link Path",
+      description: "Path within this repository where the link is added.",
+      required: true,
+      placeholder: "deps/external",
+    },
+    {
+      name: "sourcePath",
+      kind: "text",
+      label: "Source Path",
+      description:
+        'Path within the linked repository to pull from. "/" means the root.',
+      required: false,
+      default: "/",
+    },
+    {
+      name: "pin",
+      kind: "text",
+      label: "Pin",
+      description: "Branch or revision to pin the link at.",
+      required: false,
+      default: "",
+    },
+    {
+      name: "disableBranching",
+      kind: "boolean",
+      label: "Disable Branching",
+      description:
+        "Disable automatic branch creation in the linked repository.",
+      required: false,
+      default: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["link", "add", "remote", "connect", "external", "dependency"],
+};
+
+export default manifest;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -578,6 +578,35 @@ pub async fn revision_revert_resolve(
     op_revision_revert_resolve(&api, RevertResolveArgs { paths }).await
 }
 
+// --- link add ---
+
+use lore_vm::ops::link::add::{
+    add as op_link_add, AddArgs as LinkAddArgs, AddResult as LinkAddResult,
+};
+
+#[tauri::command]
+pub async fn link_add(
+    state: State<'_, AppState>,
+    link: String,
+    link_path: String,
+    source_path: String,
+    pin: String,
+    disable_branching: bool,
+) -> Result<LinkAddResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_link_add(
+        &api,
+        LinkAddArgs {
+            link,
+            link_path,
+            source_path,
+            pin,
+            disable_branching,
+        },
+    )
+    .await
+}
+
 // --- link remove ---
 
 use lore_vm::ops::link::remove::{remove as op_link_remove, RemoveArgs, RemoveResult};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,6 +93,7 @@ pub fn run() {
             commands::dependency_add,
             commands::dependency_list,
             commands::dependency_remove,
+            commands::link_add,
             commands::link_remove,
             commands::storage_open,
             commands::storage_put,


### PR DESCRIPTION
Resolves SBAI-3988

## Summary
Adds the `link.add` operation to the command palette with full wiring across all layers:

- **`src-tauri/src/commands.rs`** — `#[tauri::command] link_add` wrapper that unpacks args and calls `lore_vm::ops::link::add::add`
- **`src-tauri/src/lib.rs`** — registered `link_add` in `generate_handler!`
- **`frontend/src/api.ts`** — typed `linkAddApi.add()` binding with defaults for optional args
- **`frontend/src/palette/manifest/link/add.ts`** — palette manifest entry with 5 fields (link URL, link path, source path, pin, disable branching)

The Rust binding (`crates/lore-vm/src/ops/link/add.rs`) was already implemented in PR #50.

## Files Changed
- `src-tauri/src/commands.rs` — added `link_add` Tauri command
- `src-tauri/src/lib.rs` — registered command in handler macro
- `frontend/src/api.ts` — added `LinkAddResult` interface + `linkAddApi`
- `frontend/src/palette/manifest/link/add.ts` — new palette manifest entry

## Testing
- `cargo check -p lore-vm` — green
- `cargo fmt --all --check` — green
- `node frontend/scripts/palette-parity.mjs` — green (23/89 commands, 26%)
- Pre-existing TS errors in ThemeEditor/ThemeProvider unrelated to these changes