### PR TITLE
SBAI-3923: revision find_local command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/revision/find_local.ts
+++ b/frontend/src/palette/manifest/revision/find_local.ts
@@ -1,0 +1,48 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for revision.find_local.
+ *
+ * Finds revisions matching a metadata key/value pair or revision number,
+ * searching only the local repository (no remote dispatch).
+ */
+const manifest: OpManifest = {
+  id: "revision.find_local",
+  domain: "revision",
+  op: "find_local",
+  label: "Revision: Find Local",
+  description:
+    "Find revisions by metadata key/value or revision number (local only).",
+  command: "revision_find_local",
+  args: [
+    {
+      name: "key",
+      kind: "text",
+      label: "Metadata Key",
+      required: false,
+      placeholder: "e.g. tag, author",
+      description: "Metadata key to search for; leave empty to search by number.",
+    },
+    {
+      name: "value",
+      kind: "text",
+      label: "Metadata Value",
+      required: false,
+      placeholder: "e.g. release-1.0",
+      description: "Value to match against the metadata key.",
+    },
+    {
+      name: "number",
+      kind: "number",
+      label: "Revision Number",
+      required: false,
+      default: 0,
+      placeholder: "0",
+      description: "Revision number to find; used when key is empty. 0 disables.",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["find", "search", "local", "revision", "metadata", "lookup"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3923

## Summary
- Adds command-palette manifest entry for revision.find_local
- The lore-vm binding, Tauri command wrapper, and api.ts binding already existed on main
- Only the palette manifest entry was missing

## Files Changed
- frontend/src/palette/manifest/revision/find_local.ts (new)

## Testing
- palette-parity.mjs passes
- cargo check -p lore-vm passes