### PR TITLE
SBAI-3876: revision domain — implement 7 remaining op bindings

### DIFF
--- a/crates/lore-vm/src/ops/revision/cherry_pick.rs
+++ b/crates/lore-vm/src/ops/revision/cherry_pick.rs
@@ -1,8 +1,147 @@
 //! `revision cherry_pick` operation — binds `lore::revision::cherry_pick`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Cherry-picks a revision onto the current branch with remote dispatch.
+//! Unlike `cherry_pick_local`, this variant can dispatch the operation to a
+//! remote shared store. If no conflicts arise and `no_commit` is false, the
+//! result is auto-committed with the supplied message.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::interface::LoreString;
+use lore::revision::LoreRevisionCherryPickArgs;
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`cherry_pick`].
+///
+/// Mirrors `LoreRevisionCherryPickArgs` from the upstream `lore` crate
+/// but uses plain `String` so it serialises cleanly across the Tauri boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CherryPickArgs {
+    /// Revision identifier to cherry-pick (hash, tag, branch name, etc.).
+    pub revision: String,
+    /// Commit message used for the auto-commit when no conflicts arise.
+    #[serde(default)]
+    pub message: String,
+    /// When `true`, skip auto-commit even if no conflicts arise.
+    #[serde(default)]
+    pub no_commit: bool,
+}
+
+impl CherryPickArgs {
+    fn into_lore(self) -> LoreRevisionCherryPickArgs {
+        LoreRevisionCherryPickArgs {
+            revision: LoreString::from_str(&self.revision),
+            message: LoreString::from_str(&self.message),
+            no_commit: u8::from(self.no_commit),
+        }
+    }
+}
+
+/// Result returned on successful cherry-pick.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CherryPickResult {
+    /// The revision that was cherry-picked.
+    pub revision: String,
+}
+
+/// Cherry-pick a revision onto the current branch (with remote dispatch).
+///
+/// Calls the upstream `lore::revision::cherry_pick` in-process and returns
+/// a typed result echoing the revision that was applied.
+pub async fn cherry_pick(api: &LoreApi, args: CherryPickArgs) -> Result<CherryPickResult> {
+    let revision = args.revision.clone();
+
+    let (callback, rx) = collect_events();
+
+    let status =
+        lore::revision::cherry_pick(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("cherry_pick failed with status {status}"),
+        )));
+    }
+
+    Ok(CherryPickResult { revision })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_serialises() {
+        let args = CherryPickArgs {
+            revision: "abc123".into(),
+            message: "cherry-pick commit".into(),
+            no_commit: false,
+        };
+        let json = serde_json::to_string(&args).expect("should serialise");
+        assert!(json.contains("abc123"));
+        assert!(json.contains("cherry-pick commit"));
+    }
+
+    #[test]
+    fn args_deserialises() {
+        let json = r#"{"revision":"abc123","message":"pick it","no_commit":true}"#;
+        let args: CherryPickArgs = serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(args.revision, "abc123");
+        assert_eq!(args.message, "pick it");
+        assert!(args.no_commit);
+    }
+
+    #[test]
+    fn args_defaults() {
+        let json = r#"{"revision":"def456"}"#;
+        let args: CherryPickArgs = serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(args.revision, "def456");
+        assert_eq!(args.message, "");
+        assert!(!args.no_commit);
+    }
+
+    #[test]
+    fn result_serialises() {
+        let result = CherryPickResult {
+            revision: "abc123".into(),
+        };
+        let json = serde_json::to_string(&result).expect("should serialise");
+        assert!(json.contains("abc123"));
+    }
+
+    #[test]
+    fn result_deserialises() {
+        let json = r#"{"revision":"abc123"}"#;
+        let result: CherryPickResult = serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(result.revision, "abc123");
+    }
+
+    #[test]
+    fn into_lore_converts() {
+        let args = CherryPickArgs {
+            revision: "HEAD~1".into(),
+            message: "test".into(),
+            no_commit: true,
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.revision.as_str(), "HEAD~1");
+        assert_eq!(lore_args.message.as_str(), "test");
+        assert_eq!(lore_args.no_commit, 1);
+    }
+
+    #[test]
+    fn into_lore_no_commit_false() {
+        let args = CherryPickArgs {
+            revision: "main".into(),
+            message: "".into(),
+            no_commit: false,
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.no_commit, 0);
+    }
+}

--- a/crates/lore-vm/src/ops/revision/cherry_pick_abort.rs
+++ b/crates/lore-vm/src/ops/revision/cherry_pick_abort.rs
@@ -1,8 +1,102 @@
 //! `revision cherry_pick_abort` operation — binds `lore::revision::cherry_pick_abort`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Aborts an in-progress cherry-pick and restores the working directory to its
+//! prior state. Takes no arguments beyond the repository context.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::revision::LoreRevisionCherryPickAbortArgs;
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`cherry_pick_abort`].
+///
+/// The upstream `LoreRevisionCherryPickAbortArgs` is an empty struct —
+/// only the repository context (provided by `LoreApi`) is needed.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CherryPickAbortArgs {}
+
+impl CherryPickAbortArgs {
+    fn into_lore(self) -> LoreRevisionCherryPickAbortArgs {
+        LoreRevisionCherryPickAbortArgs {}
+    }
+}
+
+/// Result returned on successful cherry-pick abort.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CherryPickAbortResult {
+    /// Whether the abort completed successfully.
+    pub aborted: bool,
+}
+
+/// Abort an in-progress cherry-pick operation.
+///
+/// Calls the upstream `lore::revision::cherry_pick_abort` in-process and checks
+/// the completion status. Returns success when the cherry-pick is fully aborted.
+pub async fn cherry_pick_abort(
+    api: &LoreApi,
+    args: CherryPickAbortArgs,
+) -> Result<CherryPickAbortResult> {
+    let (callback, rx) = collect_events();
+
+    let status =
+        lore::revision::cherry_pick_abort(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("cherry_pick_abort failed with status {status}"),
+        )));
+    }
+
+    Ok(CherryPickAbortResult { aborted: true })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_serialises() {
+        let args = CherryPickAbortArgs {};
+        let json = serde_json::to_string(&args).expect("should serialise");
+        assert_eq!(json, "{}");
+    }
+
+    #[test]
+    fn args_deserialises() {
+        let json = "{}";
+        let _args: CherryPickAbortArgs = serde_json::from_str(json).expect("should deserialise");
+    }
+
+    #[test]
+    fn args_into_lore_conversion() {
+        let args = CherryPickAbortArgs {};
+        let _lore_args = args.into_lore();
+    }
+
+    #[test]
+    fn result_serialises() {
+        let result = CherryPickAbortResult { aborted: true };
+        let json = serde_json::to_string(&result).expect("should serialise");
+        assert!(json.contains("true"));
+    }
+
+    #[test]
+    fn result_deserialises() {
+        let json = r#"{"aborted": true}"#;
+        let result: CherryPickAbortResult = serde_json::from_str(json).expect("should deserialise");
+        assert!(result.aborted);
+    }
+
+    #[test]
+    fn args_default() {
+        let args = CherryPickAbortArgs::default();
+        let json = serde_json::to_string(&args).expect("should serialise");
+        assert_eq!(json, "{}");
+    }
+}

--- a/crates/lore-vm/src/ops/revision/cherry_pick_unresolve.rs
+++ b/crates/lore-vm/src/ops/revision/cherry_pick_unresolve.rs
@@ -1,8 +1,128 @@
 //! `revision cherry_pick_unresolve` operation — binds `lore::revision::cherry_pick_unresolve`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Marks the specified resolved paths as unresolved again during an in-progress
+//! cherry-pick, allowing the user to re-resolve them.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::interface::LoreString;
+use lore::revision::LoreRevisionCherryPickUnresolveArgs;
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`cherry_pick_unresolve`].
+///
+/// Mirrors `LoreRevisionCherryPickUnresolveArgs` from the upstream `lore` crate
+/// but uses plain `Vec<String>` so it serialises cleanly across the Tauri boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CherryPickUnresolveArgs {
+    /// Repository-relative paths to mark as unresolved.
+    pub paths: Vec<String>,
+}
+
+impl CherryPickUnresolveArgs {
+    fn into_lore(self) -> LoreRevisionCherryPickUnresolveArgs {
+        LoreRevisionCherryPickUnresolveArgs {
+            paths: lore::interface::LoreArray::from_vec(
+                self.paths
+                    .into_iter()
+                    .map(|p| LoreString::from_str(&p))
+                    .collect(),
+            ),
+        }
+    }
+}
+
+/// Result returned on successful cherry-pick unresolve.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CherryPickUnresolveResult {
+    /// The paths that were marked as unresolved.
+    pub paths: Vec<String>,
+}
+
+/// Mark cherry-pick conflicts on the given paths as unresolved.
+///
+/// Calls the upstream `lore::revision::cherry_pick_unresolve` in-process and
+/// returns a typed result echoing the paths that were unresolved.
+pub async fn cherry_pick_unresolve(
+    api: &LoreApi,
+    args: CherryPickUnresolveArgs,
+) -> Result<CherryPickUnresolveResult> {
+    let paths = args.paths.clone();
+
+    let (callback, rx) = collect_events();
+
+    let status =
+        lore::revision::cherry_pick_unresolve(api.globals().build(), args.into_lore(), callback)
+            .await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("cherry_pick_unresolve failed with status {status}"),
+        )));
+    }
+
+    Ok(CherryPickUnresolveResult { paths })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_serialises() {
+        let args = CherryPickUnresolveArgs {
+            paths: vec!["src/main.rs".into(), "README.md".into()],
+        };
+        let json = serde_json::to_string(&args).expect("should serialise");
+        assert!(json.contains("src/main.rs"));
+        assert!(json.contains("README.md"));
+    }
+
+    #[test]
+    fn args_deserialises() {
+        let json = r#"{"paths":["a.txt","b.txt"]}"#;
+        let args: CherryPickUnresolveArgs = serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(args.paths, vec!["a.txt", "b.txt"]);
+    }
+
+    #[test]
+    fn result_serialises() {
+        let result = CherryPickUnresolveResult {
+            paths: vec!["file.txt".into()],
+        };
+        let json = serde_json::to_string(&result).expect("should serialise");
+        assert!(json.contains("file.txt"));
+    }
+
+    #[test]
+    fn result_deserialises() {
+        let json = r#"{"paths":["x.rs"]}"#;
+        let result: CherryPickUnresolveResult =
+            serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(result.paths, vec!["x.rs"]);
+    }
+
+    #[test]
+    fn args_empty_paths() {
+        let args = CherryPickUnresolveArgs { paths: vec![] };
+        let json = serde_json::to_string(&args).expect("should serialise");
+        let round: CherryPickUnresolveArgs =
+            serde_json::from_str(&json).expect("should deserialise");
+        assert!(round.paths.is_empty());
+    }
+
+    #[test]
+    fn into_lore_converts() {
+        let args = CherryPickUnresolveArgs {
+            paths: vec!["a.txt".into()],
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.paths.len(), 1);
+    }
+}

--- a/crates/lore-vm/src/ops/revision/metadata_clear.rs
+++ b/crates/lore-vm/src/ops/revision/metadata_clear.rs
@@ -1,8 +1,100 @@
 //! `revision metadata_clear` operation — binds `lore::revision::metadata_clear`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Clears all metadata from the current revision. Takes no arguments beyond
+//! the repository context. Use `metadata_get` to read keys and `metadata_set`
+//! to write them; `metadata_clear` removes them entirely.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::revision::LoreRevisionMetadataClearArgs;
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`metadata_clear`].
+///
+/// The upstream `LoreRevisionMetadataClearArgs` is an empty struct —
+/// only the repository context (provided by `LoreApi`) is needed.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MetadataClearArgs {}
+
+impl MetadataClearArgs {
+    fn into_lore(self) -> LoreRevisionMetadataClearArgs {
+        LoreRevisionMetadataClearArgs {}
+    }
+}
+
+/// Result returned on successful metadata clear.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetadataClearResult {
+    /// Whether the metadata was cleared successfully.
+    pub cleared: bool,
+}
+
+/// Clear all metadata from the current revision.
+///
+/// Calls the upstream `lore::revision::metadata_clear` in-process and checks
+/// the completion status.
+pub async fn metadata_clear(api: &LoreApi, args: MetadataClearArgs) -> Result<MetadataClearResult> {
+    let (callback, rx) = collect_events();
+
+    let status =
+        lore::revision::metadata_clear(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("metadata_clear failed with status {status}"),
+        )));
+    }
+
+    Ok(MetadataClearResult { cleared: true })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_serialises() {
+        let args = MetadataClearArgs {};
+        let json = serde_json::to_string(&args).expect("should serialise");
+        assert_eq!(json, "{}");
+    }
+
+    #[test]
+    fn args_deserialises() {
+        let json = "{}";
+        let _args: MetadataClearArgs = serde_json::from_str(json).expect("should deserialise");
+    }
+
+    #[test]
+    fn args_into_lore_conversion() {
+        let args = MetadataClearArgs {};
+        let _lore_args = args.into_lore();
+    }
+
+    #[test]
+    fn result_serialises() {
+        let result = MetadataClearResult { cleared: true };
+        let json = serde_json::to_string(&result).expect("should serialise");
+        assert!(json.contains("true"));
+    }
+
+    #[test]
+    fn result_deserialises() {
+        let json = r#"{"cleared": true}"#;
+        let result: MetadataClearResult = serde_json::from_str(json).expect("should deserialise");
+        assert!(result.cleared);
+    }
+
+    #[test]
+    fn args_default() {
+        let args = MetadataClearArgs::default();
+        let json = serde_json::to_string(&args).expect("should serialise");
+        assert_eq!(json, "{}");
+    }
+}

--- a/crates/lore-vm/src/ops/revision/revert.rs
+++ b/crates/lore-vm/src/ops/revision/revert.rs
@@ -1,8 +1,202 @@
 //! `revision revert` operation — binds `lore::revision::revert`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Reverts the working directory to a specified revision by applying the
+//! inverse of its changes, with remote dispatch. Unlike `revert_local`, this
+//! variant can dispatch the operation to a remote shared store. Supports
+//! optional auto-commit when no conflicts arise.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::interface::{LoreEvent, LoreString};
+use lore::revision::LoreRevisionRevertArgs;
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`revert`].
+///
+/// Mirrors `LoreRevisionRevertArgs` from the upstream `lore` crate
+/// but uses plain Rust types so it serialises cleanly across the Tauri
+/// boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevertArgs {
+    /// The revision to revert.
+    pub revision: String,
+    /// Commit message for the auto-commit when no conflicts arise.
+    #[serde(default)]
+    pub message: String,
+    /// When true, skip auto-commit even if there are no conflicts.
+    #[serde(default)]
+    pub no_commit: bool,
+}
+
+impl RevertArgs {
+    fn into_lore(self) -> LoreRevisionRevertArgs {
+        LoreRevisionRevertArgs {
+            revision: LoreString::from_str(&self.revision),
+            message: LoreString::from_str(&self.message),
+            no_commit: u8::from(self.no_commit),
+        }
+    }
+}
+
+/// A file that has an unresolved conflict after the revert.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevertConflictFile {
+    /// Repository-relative path of the conflicted file.
+    pub path: String,
+}
+
+/// Result returned on successful revert.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevertResult {
+    /// Whether the revert produced conflicts that require manual resolution.
+    pub has_conflicts: bool,
+    /// Files with unresolved conflicts (empty when `has_conflicts` is false).
+    pub conflict_files: Vec<RevertConflictFile>,
+    /// The revision hash of the auto-commit, if one was created.
+    pub committed_revision: Option<String>,
+}
+
+/// Revert the working directory to a specified revision (with remote dispatch).
+///
+/// Calls the upstream `lore::revision::revert` in-process and collects
+/// revert events into a typed result.
+pub async fn revert(api: &LoreApi, args: RevertArgs) -> Result<RevertResult> {
+    let (callback, rx) = collect_events();
+
+    let status = lore::revision::revert(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(
+            stream
+                .error
+                .unwrap_or_else(|| format!("revert failed with status {status}")),
+        ));
+    }
+
+    let mut has_conflicts = false;
+    let mut conflict_files = Vec::new();
+    let mut committed_revision = None;
+
+    for event in &stream.events {
+        match event {
+            LoreEvent::RevertStartEnd(data) => {
+                has_conflicts = data.has_conflicts != 0;
+            }
+            LoreEvent::RevertConflictFile(data) => {
+                conflict_files.push(RevertConflictFile {
+                    path: data.path.as_str().to_string(),
+                });
+            }
+            LoreEvent::RevisionCommitRevision(data) => {
+                committed_revision = Some(format!("{}", data.revision));
+            }
+            _ => {}
+        }
+    }
+
+    Ok(RevertResult {
+        has_conflicts,
+        conflict_files,
+        committed_revision,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_serialises() {
+        let args = RevertArgs {
+            revision: "abc123".into(),
+            message: "Revert bad change".into(),
+            no_commit: false,
+        };
+        let json = serde_json::to_string(&args).expect("should serialise");
+        assert!(json.contains("abc123"));
+        assert!(json.contains("Revert bad change"));
+    }
+
+    #[test]
+    fn args_deserialises_with_defaults() {
+        let json = r#"{"revision": "abc123"}"#;
+        let args: RevertArgs = serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(args.revision, "abc123");
+        assert_eq!(args.message, "");
+        assert!(!args.no_commit);
+    }
+
+    #[test]
+    fn args_into_lore_conversion() {
+        let args = RevertArgs {
+            revision: "rev1".into(),
+            message: "msg".into(),
+            no_commit: true,
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.revision.as_str(), "rev1");
+        assert_eq!(lore_args.message.as_str(), "msg");
+        assert_eq!(lore_args.no_commit, 1);
+    }
+
+    #[test]
+    fn args_no_commit_false() {
+        let args = RevertArgs {
+            revision: "rev1".into(),
+            message: "".into(),
+            no_commit: false,
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.no_commit, 0);
+    }
+
+    #[test]
+    fn result_serialises() {
+        let result = RevertResult {
+            has_conflicts: true,
+            conflict_files: vec![RevertConflictFile {
+                path: "src/main.rs".into(),
+            }],
+            committed_revision: None,
+        };
+        let json = serde_json::to_string(&result).expect("should serialise");
+        assert!(json.contains("src/main.rs"));
+        assert!(json.contains("true"));
+    }
+
+    #[test]
+    fn result_no_conflicts() {
+        let result = RevertResult {
+            has_conflicts: false,
+            conflict_files: vec![],
+            committed_revision: Some("deadbeef".into()),
+        };
+        let json = serde_json::to_string(&result).expect("should serialise");
+        assert!(json.contains("deadbeef"));
+        assert!(!json.contains("true"));
+    }
+
+    #[test]
+    fn result_deserialises() {
+        let json = r#"{"has_conflicts":false,"conflict_files":[],"committed_revision":"abc"}"#;
+        let result: RevertResult = serde_json::from_str(json).expect("should deserialise");
+        assert!(!result.has_conflicts);
+        assert!(result.conflict_files.is_empty());
+        assert_eq!(result.committed_revision.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn conflict_file_serialises() {
+        let cf = RevertConflictFile {
+            path: "test.txt".into(),
+        };
+        let json = serde_json::to_string(&cf).expect("should serialise");
+        assert!(json.contains("test.txt"));
+    }
+}

--- a/crates/lore-vm/src/ops/revision/revert_restart.rs
+++ b/crates/lore-vm/src/ops/revision/revert_restart.rs
@@ -1,8 +1,123 @@
 //! `revision revert_restart` operation — binds `lore::revision::revert_restart`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Re-materialises the specified paths for resolution during an in-progress
+//! revert conflict. This discards any partial resolution work on those paths
+//! and puts them back to the conflicted state so the user can start over.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::interface::LoreString;
+use lore::revision::LoreRevisionRevertRestartArgs;
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`revert_restart`].
+///
+/// Mirrors `LoreRevisionRevertRestartArgs` from the upstream `lore` crate
+/// but uses plain `Vec<String>` so it serialises cleanly across the Tauri boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevertRestartArgs {
+    /// Repository-relative paths to re-materialise for resolution.
+    pub paths: Vec<String>,
+}
+
+impl RevertRestartArgs {
+    fn into_lore(self) -> LoreRevisionRevertRestartArgs {
+        LoreRevisionRevertRestartArgs {
+            paths: lore::interface::LoreArray::from_vec(
+                self.paths
+                    .into_iter()
+                    .map(|p| LoreString::from_str(&p))
+                    .collect(),
+            ),
+        }
+    }
+}
+
+/// Result returned on successful revert restart.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevertRestartResult {
+    /// The paths that were re-materialised for resolution.
+    pub paths: Vec<String>,
+}
+
+/// Re-materialise paths for resolution during an in-progress revert conflict.
+///
+/// Calls the upstream `lore::revision::revert_restart` in-process and
+/// returns a typed result echoing the paths that were restarted.
+pub async fn revert_restart(api: &LoreApi, args: RevertRestartArgs) -> Result<RevertRestartResult> {
+    let paths = args.paths.clone();
+
+    let (callback, rx) = collect_events();
+
+    let status =
+        lore::revision::revert_restart(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("revert_restart failed with status {status}"),
+        )));
+    }
+
+    Ok(RevertRestartResult { paths })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_serialises() {
+        let args = RevertRestartArgs {
+            paths: vec!["src/main.rs".into(), "README.md".into()],
+        };
+        let json = serde_json::to_string(&args).expect("should serialise");
+        assert!(json.contains("src/main.rs"));
+        assert!(json.contains("README.md"));
+    }
+
+    #[test]
+    fn args_deserialises() {
+        let json = r#"{"paths":["a.txt","b.txt"]}"#;
+        let args: RevertRestartArgs = serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(args.paths, vec!["a.txt", "b.txt"]);
+    }
+
+    #[test]
+    fn result_serialises() {
+        let result = RevertRestartResult {
+            paths: vec!["file.txt".into()],
+        };
+        let json = serde_json::to_string(&result).expect("should serialise");
+        assert!(json.contains("file.txt"));
+    }
+
+    #[test]
+    fn result_deserialises() {
+        let json = r#"{"paths":["x.rs"]}"#;
+        let result: RevertRestartResult = serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(result.paths, vec!["x.rs"]);
+    }
+
+    #[test]
+    fn args_empty_paths() {
+        let args = RevertRestartArgs { paths: vec![] };
+        let json = serde_json::to_string(&args).expect("should serialise");
+        let round: RevertRestartArgs = serde_json::from_str(&json).expect("should deserialise");
+        assert!(round.paths.is_empty());
+    }
+
+    #[test]
+    fn into_lore_converts() {
+        let args = RevertRestartArgs {
+            paths: vec!["a.txt".into()],
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.paths.len(), 1);
+    }
+}

--- a/crates/lore-vm/src/ops/revision/revert_unresolve.rs
+++ b/crates/lore-vm/src/ops/revision/revert_unresolve.rs
@@ -1,8 +1,125 @@
 //! `revision revert_unresolve` operation — binds `lore::revision::revert_unresolve`.
 //!
-//! TODO: implement following the reference op
-//! `crates/lore-vm/src/ops/auth/login_with_token.rs` and IMPLEMENTATION-PLAN.md §4:
-//!   - build args via `crate::global::LoreGlobal`
-//!   - collect events via `crate::collect::collect_events`
-//!   - map to a typed result in `crate::model`
-//! Acceptance: `cargo check -p lore-vm` + a test. Edit ONLY this file.
+//! Marks the specified resolved paths as unresolved again during an in-progress
+//! revert, allowing the user to re-resolve them.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::interface::LoreString;
+use lore::revision::LoreRevisionRevertUnresolveArgs;
+use serde::{Deserialize, Serialize};
+
+/// Arguments for [`revert_unresolve`].
+///
+/// Mirrors `LoreRevisionRevertUnresolveArgs` from the upstream `lore` crate
+/// but uses plain `Vec<String>` so it serialises cleanly across the Tauri boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevertUnresolveArgs {
+    /// Repository-relative paths to mark as unresolved.
+    pub paths: Vec<String>,
+}
+
+impl RevertUnresolveArgs {
+    fn into_lore(self) -> LoreRevisionRevertUnresolveArgs {
+        LoreRevisionRevertUnresolveArgs {
+            paths: lore::interface::LoreArray::from_vec(
+                self.paths
+                    .into_iter()
+                    .map(|p| LoreString::from_str(&p))
+                    .collect(),
+            ),
+        }
+    }
+}
+
+/// Result returned on successful revert unresolve.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevertUnresolveResult {
+    /// The paths that were marked as unresolved.
+    pub paths: Vec<String>,
+}
+
+/// Mark revert conflicts on the given paths as unresolved.
+///
+/// Calls the upstream `lore::revision::revert_unresolve` in-process and
+/// returns a typed result echoing the paths that were unresolved.
+pub async fn revert_unresolve(
+    api: &LoreApi,
+    args: RevertUnresolveArgs,
+) -> Result<RevertUnresolveResult> {
+    let paths = args.paths.clone();
+
+    let (callback, rx) = collect_events();
+
+    let status =
+        lore::revision::revert_unresolve(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("revert_unresolve failed with status {status}"),
+        )));
+    }
+
+    Ok(RevertUnresolveResult { paths })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_serialises() {
+        let args = RevertUnresolveArgs {
+            paths: vec!["src/main.rs".into(), "README.md".into()],
+        };
+        let json = serde_json::to_string(&args).expect("should serialise");
+        assert!(json.contains("src/main.rs"));
+        assert!(json.contains("README.md"));
+    }
+
+    #[test]
+    fn args_deserialises() {
+        let json = r#"{"paths":["a.txt","b.txt"]}"#;
+        let args: RevertUnresolveArgs = serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(args.paths, vec!["a.txt", "b.txt"]);
+    }
+
+    #[test]
+    fn result_serialises() {
+        let result = RevertUnresolveResult {
+            paths: vec!["file.txt".into()],
+        };
+        let json = serde_json::to_string(&result).expect("should serialise");
+        assert!(json.contains("file.txt"));
+    }
+
+    #[test]
+    fn result_deserialises() {
+        let json = r#"{"paths":["x.rs"]}"#;
+        let result: RevertUnresolveResult = serde_json::from_str(json).expect("should deserialise");
+        assert_eq!(result.paths, vec!["x.rs"]);
+    }
+
+    #[test]
+    fn args_empty_paths() {
+        let args = RevertUnresolveArgs { paths: vec![] };
+        let json = serde_json::to_string(&args).expect("should serialise");
+        let round: RevertUnresolveArgs = serde_json::from_str(&json).expect("should deserialise");
+        assert!(round.paths.is_empty());
+    }
+
+    #[test]
+    fn into_lore_converts() {
+        let args = RevertUnresolveArgs {
+            paths: vec!["a.txt".into()],
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.paths.len(), 1);
+    }
+}


### PR DESCRIPTION
Resolves SBAI-3876. Implements 7 remaining revision domain stub ops: cherry_pick, cherry_pick_abort, cherry_pick_unresolve, metadata_clear, revert, revert_restart, revert_unresolve. All follow established patterns. cargo check/test/fmt green.