### PR TITLE
SBAI-3910: file hash command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/file/hash.ts
+++ b/frontend/src/palette/manifest/file/hash.ts
@@ -1,0 +1,31 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `file.hash`.
+ *
+ * Computes the content hash (BLAKE3) and size of one or more files in
+ * the repository. Returns one entry per file with path, size, and hash.
+ */
+const manifest: OpManifest = {
+  id: "file.hash",
+  domain: "file",
+  op: "hash",
+  label: "File: Hash",
+  description:
+    "Compute the BLAKE3 content hash and size of one or more files.",
+  command: "hash",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths",
+      description: "File paths to hash (relative to repository root).",
+      required: true,
+      placeholder: "src/foo.txt\nassets/bar.png",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["hash", "blake3", "checksum", "size", "digest", "file"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3910

## Summary
- Add command-palette manifest entry for file.hash at frontend/src/palette/manifest/file/hash.ts
- The lore-vm binding already exists (PR #27)
- This manifest makes the op reachable from Ctrl-K with a generated form for file paths

## Files Changed
- frontend/src/palette/manifest/file/hash.ts — new palette manifest entry

## Testing
- cargo check/test -p lore-vm: GREEN
- palette-parity: GREEN