### PR TITLE
SBAI-3970: branch switch command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/branch/switch.ts
+++ b/frontend/src/palette/manifest/branch/switch.ts
@@ -1,0 +1,31 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for branch.switch.
+ *
+ * Switches the working tree to a different branch. Uses the existing
+ * `switch_branch` Tauri command which takes a branch name.
+ */
+const manifest: OpManifest = {
+  id: "branch.switch",
+  domain: "branch",
+  op: "switch",
+  label: "Branch: Switch",
+  description:
+    "Switch the working tree to a different branch.",
+  command: "switch_branch",
+  args: [
+    {
+      name: "name",
+      kind: "text",
+      label: "Branch",
+      description: "Name of the branch to switch to.",
+      required: true,
+      placeholder: "e.g. main",
+    },
+  ],
+  resultKind: "void",
+  keywords: ["branch", "switch", "checkout", "change"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3970

## Summary
Add command-palette manifest entry for `branch.switch` at `frontend/src/palette/manifest/branch/switch.ts` following the Phase 0 reference entries.

## Files Changed
- `frontend/src/palette/manifest/branch/switch.ts` (new) — palette manifest wiring `switch_branch` Tauri command with `name` arg

## Testing
- `node frontend/scripts/palette-parity.mjs` — passes, op appears in coverage