### PR TITLE
SBAI-3972: revision revert_resolve_mine command-palette manifest

### DIFF
--- a/frontend/src/palette/manifest/revision/revert_resolve_mine.ts
+++ b/frontend/src/palette/manifest/revision/revert_resolve_mine.ts
@@ -1,0 +1,31 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Manifest entry for `revision.revert_resolve_mine`.
+ *
+ * Resolves the specified conflicted paths during an in-progress revert by
+ * keeping the "mine" (local/current-branch) version of each file.
+ */
+const manifest: OpManifest = {
+  id: "revision.revert_resolve_mine",
+  domain: "revision",
+  op: "revert_resolve_mine",
+  label: "Revision: Revert Resolve Mine",
+  description:
+    "Resolve revert conflicts on the given paths by keeping the local (mine) version.",
+  command: "revert_resolve_mine",
+  args: [
+    {
+      name: "paths",
+      kind: "string-list",
+      label: "Paths",
+      description: "Repository-relative paths to resolve in favor of mine (local).",
+      required: true,
+      placeholder: "src/main.rs\nREADME.md",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["revert", "resolve", "mine", "conflict", "local"],
+};
+
+export default manifest;


### PR DESCRIPTION
Resolves SBAI-3972

## Summary
- Add command-palette manifest entry for `revision.revert_resolve_mine`
- Op resolves revert conflicts on given paths by keeping the local (mine) version
- Takes a `string-list` arg for repository-relative paths
- Rust op binding was already fully implemented on main

## Files Changed
- `frontend/src/palette/manifest/revision/revert_resolve_mine.ts` (new)

## Testing
- `npm --prefix frontend run build`: clean
- `node frontend/scripts/palette-parity.mjs`: OK (22/88 exposed, 25%)
- `cargo check -p lore-vm`: green
- `cargo test -p lore-vm -- revision::revert_resolve_mine`: 6/6 passed