### PR TITLE
SBAI-3992: link remove command-palette manifest

### DIFF
--- a/frontend/scripts/palette-parity-allowlist.json
+++ b/frontend/scripts/palette-parity-allowlist.json
@@ -38,7 +38,6 @@
     "file_obliterate",
     "file_stage",
     "file_write",
-    "link_remove",
     "lock_file_acquire_as_owner",
     "lock_file_query",
     "lock_file_release",

--- a/frontend/src/palette/manifest/link/remove.ts
+++ b/frontend/src/palette/manifest/link/remove.ts
@@ -1,0 +1,33 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for link.remove.
+ *
+ * Removes a link from the repository at the specified path. The link
+ * and its configuration are deleted; the linked content is no longer
+ * tracked at that path.
+ */
+const manifest: OpManifest = {
+  id: "link.remove",
+  domain: "link",
+  op: "remove",
+  label: "Link: Remove",
+  description:
+    "Remove a link from the repository at the specified path.",
+  command: "link_remove",
+  args: [
+    {
+      name: "linkPath",
+      kind: "text",
+      label: "Link Path",
+      description:
+        "Path within this repository where the link to remove is located.",
+      required: true,
+      placeholder: "deps/external",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["link", "remove", "delete", "unlink", "detach"],
+};
+
+export default manifest;


### PR DESCRIPTION
## Summary
- Add palette manifest entry for link.remove so the op appears in Ctrl-K with a generated form
- Remove link_remove from the parity allowlist deferred list since it is now covered

## Files Changed
- frontend/src/palette/manifest/link/remove.ts — new manifest entry
- frontend/scripts/palette-parity-allowlist.json — removed deferred entry

## Testing
- cargo check -p lore-vm — green
- cargo test -p lore-vm -- remove — all 18 tests pass
- node frontend/scripts/palette-parity.mjs — passes (58% coverage)

Resolves SBAI-3992