### PR TITLE
feat(website): real screenshot gallery + user guide (SBAI-4024)

### DIFF
--- a/website/src/app/guide/page.tsx
+++ b/website/src/app/guide/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { Header } from "@/components/Header";
+import { Guide } from "@/components/Guide";
+import { Footer } from "@/components/Footer";
+
+export const metadata: Metadata = {
+  title: "User Guide — LoreGUI",
+  description:
+    "How to use LoreGUI: first launch, connecting to or hosting a server, the ⌘K command palette, branches and merging, history, storage backends, locks, dependencies, and theming — with real screenshots.",
+  alternates: {
+    canonical: "/guide",
+  },
+  openGraph: {
+    title: "LoreGUI User Guide",
+    description:
+      "A walkthrough of every surface in LoreGUI — onboarding, the command palette, branches, history, storage, locks and theming — with real screenshots.",
+    url: "/guide",
+    type: "article",
+  },
+};
+
+export default function GuidePage() {
+  return (
+    <>
+      <Header />
+      <main>
+        <Guide />
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -1,12 +1,20 @@
 import type { MetadataRoute } from "next";
 
+const SITE_URL = "https://loregui.com";
+
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: "https://loregui.com",
+      url: SITE_URL,
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 1,
+    },
+    {
+      url: `${SITE_URL}/guide`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
     },
   ];
 }

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -6,10 +6,11 @@ const STUDIO_URL = "https://biloxistudios.com";
 
 const footerLinks: Record<string, { label: string; href: string; external?: boolean }[]> = {
   Product: [
-    { label: "Features", href: "#features" },
-    { label: "Full API", href: "#api" },
-    { label: "Screenshots", href: "#screens" },
-    { label: "Install", href: "#install" },
+    { label: "Features", href: "/#features" },
+    { label: "Full API", href: "/#api" },
+    { label: "Screenshots", href: "/#screens" },
+    { label: "User guide", href: "/guide" },
+    { label: "Install", href: "/#install" },
   ],
   Project: [
     { label: "Lore on GitHub", href: GITHUB_URL, external: true },
@@ -30,7 +31,7 @@ export function Footer() {
         <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
           <div>
             <a
-              href="#top"
+              href="/#top"
               className="flex items-center gap-2"
               aria-label="LoreGUI Home"
             >

--- a/website/src/components/Guide.tsx
+++ b/website/src/components/Guide.tsx
@@ -1,0 +1,302 @@
+import Image from "next/image";
+import { Container } from "@/components/ui/Container";
+import { Card } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { GradientText } from "@/components/ui/GradientText";
+import { AppWindow } from "@/components/mockups/AppWindow";
+
+type Shot = {
+  src: string;
+  alt: string;
+  title: string;
+  /** Intrinsic width/height — every harness capture is 1440×900,
+   *  native captures are 1400×900. */
+  width?: number;
+  height?: number;
+};
+
+type GuideSectionData = {
+  id: string;
+  step: string;
+  heading: string;
+  body: string;
+  shots: Shot[];
+  /** Lay shots out side by side (e.g. light vs dark theme). */
+  sideBySide?: boolean;
+};
+
+const sections: GuideSectionData[] = [
+  {
+    id: "getting-started",
+    step: "01",
+    heading: "Getting started",
+    body: "Launch LoreGUI and you land on “Choose Your Setup Mode.” Pick whether you’re joining an existing server or hosting your own — everything else is guided from there. No config files, no CLI bootstrap.",
+    shots: [
+      {
+        src: "/screenshots/native-onboarding.png",
+        alt: "LoreGUI first launch: the Choose Your Setup Mode welcome screen in the native desktop binary.",
+        title: "First launch",
+        width: 1400,
+        height: 900,
+      },
+      {
+        src: "/screenshots/onboarding-mode-select.png",
+        alt: "LoreGUI onboarding: choosing between connecting as a client or hosting a server.",
+        title: "Client or host",
+      },
+    ],
+  },
+  {
+    id: "connect",
+    step: "02",
+    heading: "Connect to a server",
+    body: "Joining a team? Point LoreGUI at your server’s address and sign in. It binds the connection in-process and pulls only the files you open — so even a multi-terabyte project is ready in seconds.",
+    shots: [
+      {
+        src: "/screenshots/onboarding-client-step1.png",
+        alt: "LoreGUI onboarding step for connecting to an existing server.",
+        title: "Connect as a client",
+      },
+    ],
+  },
+  {
+    id: "host",
+    step: "03",
+    heading: "Host a server",
+    body: "Standing up a new repository? Choose a storage backend — local disk, an S3 bucket, or a hosted endpoint — and LoreGUI provisions and serves it. On Windows it can register a service so checkouts stay synced and autorun on boot.",
+    shots: [
+      {
+        src: "/screenshots/onboarding-host-step1.png",
+        alt: "LoreGUI onboarding host step: choosing a storage backend for a new server.",
+        title: "Pick a storage backend",
+      },
+    ],
+  },
+  {
+    id: "command-palette",
+    step: "04",
+    heading: "The command palette",
+    body: "Press ⌘K (Ctrl K on Windows and Linux) to open the palette and fuzzy-search every operation in the app — branch, merge, commit, lock, revert and more. It’s the fastest path to any action, and every endpoint LoreGUI exposes lives here.",
+    shots: [
+      {
+        src: "/screenshots/palette-query-dark.png",
+        alt: "LoreGUI command palette open with a fuzzy search for 'branch' listing matching operations.",
+        title: "⌘K — run anything",
+      },
+    ],
+  },
+  {
+    id: "changes-history",
+    step: "05",
+    heading: "Working with changes & history",
+    body: "The main view puts branches, your staged and unstaged changes, and the revision history side by side. Stage files, write a commit message, and watch the new revision land in history. Open any revision to inspect its diff, cherry-pick it, or revert it.",
+    shots: [
+      {
+        src: "/screenshots/main-view-dark.png",
+        alt: "LoreGUI main view with branches, changes and history side by side.",
+        title: "Branches · Changes · History",
+      },
+      {
+        src: "/screenshots/panel-history-dark.png",
+        alt: "LoreGUI history panel listing revisions with diff and revert actions.",
+        title: "History panel",
+      },
+    ],
+  },
+  {
+    id: "branches",
+    step: "06",
+    heading: "Branches & merging",
+    body: "Create, protect, reset and archive branches from the branches panel. When two branches diverge, LoreGUI walks you through a guided three-way merge — resolve each conflict as mine, theirs, or a manual blend, then finish the merge in one place.",
+    shots: [
+      {
+        src: "/screenshots/panel-branches-dark.png",
+        alt: "LoreGUI branches panel showing the branch list and the guided merge flow.",
+        title: "Branches panel",
+      },
+    ],
+  },
+  {
+    id: "storage",
+    step: "07",
+    heading: "Storage backends",
+    body: "The storage panel shows which backend a repository is bound to and whether it’s reachable. Content is chunked and hashed with BLAKE3, so identical data is stored exactly once — backends stay small and integrity is verifiable down to the chunk.",
+    shots: [
+      {
+        src: "/screenshots/panel-storage-dark.png",
+        alt: "LoreGUI storage panel showing the configured backend and connectivity status.",
+        title: "Storage panel",
+      },
+    ],
+  },
+  {
+    id: "locks",
+    step: "08",
+    heading: "Locks",
+    body: "Binary assets can’t be merged. Claim an exclusive lock before you edit a texture, mesh or audio file, see who holds what in real time, and release it with one click when you’re done.",
+    shots: [
+      {
+        src: "/screenshots/panel-locks-dark.png",
+        alt: "LoreGUI locks panel listing held file locks and their owners.",
+        title: "Locks panel",
+      },
+    ],
+  },
+  {
+    id: "dependencies",
+    step: "09",
+    heading: "Dependencies",
+    body: "Track the links between files and the assets they reference. The dependencies panel surfaces what depends on what, so you can change shared assets with confidence and remove links cleanly.",
+    shots: [
+      {
+        src: "/screenshots/panel-dependencies-dark.png",
+        alt: "LoreGUI dependencies panel showing links between files and referenced assets.",
+        title: "Dependencies panel",
+      },
+    ],
+  },
+  {
+    id: "manage",
+    step: "10",
+    heading: "Repository management",
+    body: "Administer the repository itself from the manage panel — create and delete repositories, flush and garbage-collect storage, verify integrity, and set metadata. The maintenance operations that used to live behind CLI flags, made visible.",
+    shots: [
+      {
+        src: "/screenshots/panel-manage-dark.png",
+        alt: "LoreGUI repository manage panel with administration and maintenance actions.",
+        title: "Manage panel",
+      },
+    ],
+  },
+  {
+    id: "account",
+    step: "11",
+    heading: "Account",
+    body: "Review your identity and the server you’re signed in to from the account panel. LoreGUI resolves your user info from the connection, so you always know who you are and where your commits land.",
+    shots: [
+      {
+        src: "/screenshots/panel-account-dark.png",
+        alt: "LoreGUI account panel showing the signed-in identity.",
+        title: "Account panel",
+      },
+    ],
+  },
+  {
+    id: "theming",
+    step: "12",
+    heading: "Theming",
+    body: "Every surface in LoreGUI is a semantic token. The theme editor lets you build a palette, save it, and share it — the entire app re-themes instantly. Ship a dark theme for late nights and a light one for the studio, from the same controls.",
+    shots: [
+      {
+        src: "/screenshots/panel-theme-light.png",
+        alt: "LoreGUI theme editor in a light theme, exposing semantic surface tokens.",
+        title: "Theme editor — light",
+      },
+      {
+        src: "/screenshots/panel-theme-dark.png",
+        alt: "LoreGUI theme editor in a dark theme, exposing semantic surface tokens.",
+        title: "Theme editor — dark",
+      },
+    ],
+    sideBySide: true,
+  },
+];
+
+function GuideShot({ shot }: { shot: Shot }) {
+  return (
+    <AppWindow title={`LoreGUI — ${shot.title}`}>
+      <Image
+        src={shot.src}
+        alt={shot.alt}
+        width={shot.width ?? 1440}
+        height={shot.height ?? 900}
+        className="w-full"
+      />
+    </AppWindow>
+  );
+}
+
+function GuideSection({ section }: { section: GuideSectionData }) {
+  const multi = section.shots.length > 1;
+  return (
+    <section
+      id={section.id}
+      className="scroll-mt-24 border-t border-brand-muted/10 py-12 first:border-t-0 sm:py-16"
+    >
+      <div className="flex items-baseline gap-3">
+        <span className="font-mono text-sm text-brand-accent">
+          {section.step}
+        </span>
+        <h2 className="font-heading text-2xl font-bold tracking-tight text-brand-text-bright sm:text-3xl">
+          {section.heading}
+        </h2>
+      </div>
+      <p className="mt-3 max-w-3xl text-base leading-relaxed text-brand-muted">
+        {section.body}
+      </p>
+
+      <div
+        className={`mt-8 grid gap-6 ${
+          multi ? "lg:grid-cols-2" : "max-w-4xl"
+        }`}
+      >
+        {section.shots.map((shot) => (
+          <GuideShot key={shot.src} shot={shot} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function Guide() {
+  return (
+    <div className="pt-32 pb-20 sm:pt-40">
+      {/* Header */}
+      <Container>
+        <div className="mx-auto max-w-3xl text-center">
+          <Badge variant="accent" className="mb-6">
+            User guide
+          </Badge>
+          <h1 className="font-heading text-4xl font-bold tracking-tight sm:text-5xl">
+            Get the most out of <GradientText>LoreGUI.</GradientText>
+          </h1>
+          <p className="mx-auto mt-6 max-w-2xl text-lg text-brand-muted">
+            From first launch to theming, here’s how every surface of LoreGUI
+            works — illustrated with real screenshots of the desktop app.
+          </p>
+        </div>
+
+        {/* Contents */}
+        <Card className="mx-auto mt-12 max-w-3xl">
+          <h2 className="font-heading text-sm font-semibold tracking-wide text-brand-text-bright uppercase">
+            On this page
+          </h2>
+          <ol className="mt-4 grid gap-x-6 gap-y-2 sm:grid-cols-2">
+            {sections.map((s) => (
+              <li key={s.id}>
+                <a
+                  href={`#${s.id}`}
+                  className="inline-flex items-baseline gap-2 text-sm text-brand-muted transition-colors hover:text-brand-text-bright"
+                >
+                  <span className="font-mono text-xs text-brand-accent">
+                    {s.step}
+                  </span>
+                  {s.heading}
+                </a>
+              </li>
+            ))}
+          </ol>
+        </Card>
+      </Container>
+
+      {/* Sections */}
+      <Container className="mt-8">
+        <div className="mx-auto max-w-5xl">
+          {sections.map((section) => (
+            <GuideSection key={section.id} section={section} />
+          ))}
+        </div>
+      </Container>
+    </div>
+  );
+}

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -9,10 +9,11 @@ const GITHUB_URL = "https://github.com/BiloxiStudios/loregui";
 const RELEASES_URL = "https://github.com/BiloxiStudios/loregui/releases";
 
 const navLinks = [
-  { label: "Features", href: "#features" },
-  { label: "API", href: "#api" },
-  { label: "Screens", href: "#screens" },
-  { label: "Install", href: "#install" },
+  { label: "Features", href: "/#features" },
+  { label: "API", href: "/#api" },
+  { label: "Screens", href: "/#screens" },
+  { label: "Guide", href: "/guide" },
+  { label: "Install", href: "/#install" },
 ];
 
 export function Header() {
@@ -23,7 +24,7 @@ export function Header() {
       <Container>
         <div className="flex h-16 items-center justify-between">
           <a
-            href="#top"
+            href="/#top"
             className="flex items-center gap-2"
             aria-label="LoreGUI Home"
           >

--- a/website/src/components/Screenshots.tsx
+++ b/website/src/components/Screenshots.tsx
@@ -1,6 +1,52 @@
 import Image from "next/image";
 import { Container } from "@/components/ui/Container";
+import { Button } from "@/components/ui/Button";
 import { AppWindow } from "@/components/mockups/AppWindow";
+import { ArrowRightIcon } from "@/components/icons";
+
+/** A captioned surface in the feature gallery. All shots are 1440×900. */
+const surfaces: {
+  src: string;
+  alt: string;
+  title: string;
+  caption: string;
+}[] = [
+  {
+    src: "/screenshots/main-view-dark.png",
+    alt: "LoreGUI main view: branches on the left, staged and unstaged changes with a commit box in the center, and revision history on the right.",
+    title: "Branches · Changes · History",
+    caption:
+      "The whole repository in one window — pick a branch, stage and commit changes, and read the history without ever touching the command line.",
+  },
+  {
+    src: "/screenshots/panel-branches-dark.png",
+    alt: "LoreGUI branches panel showing the branch list and a guided merge flow.",
+    title: "Branches & merging",
+    caption:
+      "Create, protect, reset and archive branches, then drive a guided three-way merge with conflict resolution built in.",
+  },
+  {
+    src: "/screenshots/panel-history-dark.png",
+    alt: "LoreGUI history panel listing revisions with diffs and a revert action.",
+    title: "Revisions & diff",
+    caption:
+      "Walk every revision, compare any two side by side, and cherry-pick or revert a change with a single action.",
+  },
+  {
+    src: "/screenshots/panel-storage-dark.png",
+    alt: "LoreGUI storage panel showing the configured backend and connectivity status.",
+    title: "Storage backends",
+    caption:
+      "See which backend a repository is bound to and confirm connectivity at a glance — local disk, an S3 bucket, or a hosted server.",
+  },
+  {
+    src: "/screenshots/panel-theme-dark.png",
+    alt: "LoreGUI theme editor exposing semantic surface tokens for light and dark themes.",
+    title: "Theme editor",
+    caption:
+      "Every surface is a semantic token. Build a theme, save it, and share it — the whole app re-themes instantly, light or dark.",
+  },
+];
 
 export function Screenshots() {
   return (
@@ -11,50 +57,74 @@ export function Screenshots() {
             Your whole repo, made legible
           </h2>
           <p className="mt-4 text-lg text-brand-muted">
-            One window for status, history and branches — purpose-built for
-            projects where the binaries are bigger than the code.
+            One window for status, history and branches — plus a command palette
+            that runs any operation. Purpose-built for projects where the
+            binaries are bigger than the code.
           </p>
         </div>
 
-        <div className="mt-16 grid gap-8">
-          {/* Wide: full app — status + branches + history */}
-          <AppWindow title="LoreGUI — astral-engine · feature/boss-ai">
+        {/* Hero shot: the command palette */}
+        <div className="relative mx-auto mt-16 max-w-5xl">
+          <AppWindow title="LoreGUI — ⌘K command palette">
             <Image
-              src="/screenshots/app-full.png"
-              alt="LoreGUI desktop app: branches, staged and unstaged changes, commit box, and revision history side by side."
-              width={2880}
-              height={1240}
+              src="/screenshots/palette-query-dark.png"
+              alt="LoreGUI command palette open with a fuzzy search for 'branch', listing matching operations."
+              width={1440}
+              height={900}
               className="w-full"
               priority
             />
           </AppWindow>
-
-          {/* Two-up: status close-up + history */}
-          <div className="grid items-start gap-8 lg:grid-cols-2">
-            <AppWindow title="LoreGUI — Status">
-              <Image
-                src="/screenshots/app-status.png"
-                alt="LoreGUI status view: staged and unstaged file changes with add, modify, delete and untracked markers, and a commit message box."
-                width={1080}
-                height={962}
-                className="w-full"
-              />
-            </AppWindow>
-            <AppWindow title="LoreGUI — History">
-              <Image
-                src="/screenshots/app-history.png"
-                alt="LoreGUI history view: a list of revisions with short hashes, commit messages and authors."
-                width={640}
-                height={996}
-                className="w-full"
-              />
-            </AppWindow>
-          </div>
+          <div
+            className="pointer-events-none absolute -inset-4 -z-10 rounded-xl bg-vapor-pink/10 blur-2xl"
+            aria-hidden="true"
+          />
+          <p className="mt-4 text-center text-sm text-brand-muted">
+            Press{" "}
+            <kbd className="rounded border border-brand-muted/30 bg-brand-surface-light px-1.5 py-0.5 font-mono text-xs text-brand-text">
+              ⌘K
+            </kbd>{" "}
+            to fuzzy-search and run any operation in the app.
+          </p>
         </div>
 
-        <p className="mt-8 text-center text-sm text-brand-muted">
-          Real screenshots of the LoreGUI desktop app.
-        </p>
+        {/* Captioned surface gallery */}
+        <div className="mt-16 grid gap-8 lg:grid-cols-2">
+          {surfaces.map((surface, i) => (
+            <figure
+              key={surface.src}
+              className={i === 0 ? "lg:col-span-2" : ""}
+            >
+              <AppWindow title={`LoreGUI — ${surface.title}`}>
+                <Image
+                  src={surface.src}
+                  alt={surface.alt}
+                  width={1440}
+                  height={900}
+                  className="w-full"
+                />
+              </AppWindow>
+              <figcaption className="mt-4">
+                <h3 className="font-heading text-base font-semibold text-brand-text-bright">
+                  {surface.title}
+                </h3>
+                <p className="mt-1 text-sm leading-relaxed text-brand-muted">
+                  {surface.caption}
+                </p>
+              </figcaption>
+            </figure>
+          ))}
+        </div>
+
+        <div className="mt-12 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <p className="text-sm text-brand-muted">
+            Real screenshots of the LoreGUI desktop app.
+          </p>
+          <Button variant="secondary" size="sm" href="/guide">
+            Read the user guide
+            <ArrowRightIcon className="ml-2 h-4 w-4" />
+          </Button>
+        </div>
       </Container>
     </section>
   );


### PR DESCRIPTION
Upgrades the Screenshots gallery to real captures (palette/main-view/panels) + adds a /guide route with 12 sections (getting started, palette, panels, theming) using the committed light/dark screenshots. next build passes.