### PR TITLE
SBAI-4034: file hash and metadata_list integration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,9 @@ import {
   branchMergeUnresolveApi,
   branchProtectApi,
   branchUnprotectApi,
+  fileHashApi,
   fileInfoApi,
+  fileMetadataListApi,
   fileObliterateApi,
   repositoryFlushApi,
   repositoryGcApi,
@@ -37,6 +39,7 @@ import {
   type BranchMetadataGetResult,
   type FileChange,
   type FileInfoEntry,
+  type FileMetadataListResult,
   type MetadataEntry,
   type RepoStatus,
   type RepositoryEntry,
@@ -106,6 +109,12 @@ export default function App() {
   const [fileInfoData, setFileInfoData] = useState<FileInfoEntry | null>(null);
   const [fileInfoPath, setFileInfoPath] = useState<string | null>(null);
   const [fileInfoLoading, setFileInfoLoading] = useState(false);
+
+  // --- file metadata state ---
+  const [fileMetaData, setFileMetaData] = useState<FileMetadataListResult | null>(
+    null,
+  );
+  const [fileMetaLoading, setFileMetaLoading] = useState(false);
 
   // --- repository metadata ---
   const [metadataData, setMetadataData] = useState<RepositoryMetadataGetResult | null>(null);
@@ -234,6 +243,37 @@ export default function App() {
     },
     [fileInfoPath],
   );
+
+  const fetchFileMetadata = useCallback(
+    async (path: string) => {
+      if (fileMetaData && fileInfoPath === path) {
+        setFileMetaData(null);
+        return;
+      }
+      setFileMetaLoading(true);
+      try {
+        const data = await fileMetadataListApi.list(path);
+        setFileMetaData(data);
+      } catch {
+        setFileMetaData(null);
+      } finally {
+        setFileMetaLoading(false);
+      }
+    },
+    [fileMetaData, fileInfoPath],
+  );
+
+  const fetchFileHash = useCallback(async (path: string) => {
+    await run(async () => {
+      const res = await fileHashApi.hash([path]);
+      const entry = res.files[0];
+      if (entry) {
+        window.alert(
+          `File: ${entry.path}\nSize: ${entry.size} bytes\nHash: ${entry.hash}`,
+        );
+      }
+    });
+  }, [run]);
 
   const fetchRevisionDiff = useCallback(
     async (hash: string) => {
@@ -799,8 +839,31 @@ export default function App() {
                   {!fileInfoData.flag_conflict && !fileInfoData.flag_modified && !fileInfoData.flag_added && !fileInfoData.flag_deleted && <span>clean</span>}
                 </dd>
               </dl>
+              <div className="file-info-actions" style={{ marginTop: 12, display: "flex", gap: 8 }}>
+                <button onClick={() => void fetchFileHash(fileInfoPath!)}>Compute BLAKE3 Hash</button>
+                <button onClick={() => void fetchFileMetadata(fileInfoPath!)}>
+                  {fileMetaLoading ? "Loading Metadata..." : "List Metadata"}
+                </button>
+              </div>
+              {fileMetaData && fileInfoPath && (
+                <div className="file-metadata-results" style={{ marginTop: 16, borderTop: "1px solid var(--surface-base-border)", paddingTop: 12 }}>
+                  <h4>File Metadata</h4>
+                  {fileMetaData.entries.length === 0 && <p className="empty">No metadata entries</p>}
+                  {fileMetaData.entries.length > 0 && (
+                    <dl className="metadata-dl">
+                      {fileMetaData.entries.map((entry) => (
+                        <span key={entry.key}>
+                          <dt>{entry.key} <span className="badge">{entry.type}</span></dt>
+                          <dd><code>{entry.value}</code></dd>
+                        </span>
+                      ))}
+                    </dl>
+                  )}
+                </div>
+              )}
             </div>
           )}
+
           <div className="commit">
             <textarea
               placeholder="Commit message"

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -539,6 +539,46 @@ export const fileWriteApi = {
     }),
 };
 
+// --- file hash ---
+
+export interface FileHashEntry {
+  path: string;
+  size: number;
+  hash: string;
+}
+
+export interface FileHashResult {
+  files: FileHashEntry[];
+}
+
+export const fileHashApi = {
+  hash: (paths: string[]) => invoke<FileHashResult>("file_hash", { paths }),
+};
+
+// --- file metadata_list ---
+
+export interface FileMetadataEntry {
+  key: string;
+  value: string;
+  type:
+    | "address"
+    | "boolean"
+    | "binary"
+    | "context"
+    | "hash"
+    | "numeric"
+    | "string";
+}
+
+export interface FileMetadataListResult {
+  entries: FileMetadataEntry[];
+}
+
+export const fileMetadataListApi = {
+  list: (path: string, revision: string = "") =>
+    invoke<FileMetadataListResult>("file_metadata_list", { path, revision }),
+};
+
 // --- file info ---
 
 export interface FileInfoEntry {

--- a/frontend/src/palette/manifest/file/hash.ts
+++ b/frontend/src/palette/manifest/file/hash.ts
@@ -13,7 +13,7 @@ const manifest: OpManifest = {
   label: "File: Hash",
   description:
     "Compute the BLAKE3 content hash and size of one or more files.",
-  command: "hash",
+  command: "file_hash",
   args: [
     {
       name: "paths",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -277,6 +277,35 @@ pub async fn file_info(
     .await
 }
 
+// --- file hash ---
+
+use lore_vm::ops::file::hash::{hash as op_file_hash, FileHashArgs, FileHashResult};
+
+#[tauri::command]
+pub async fn file_hash(
+    state: State<'_, AppState>,
+    paths: Vec<String>,
+) -> Result<FileHashResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_file_hash(&api, FileHashArgs { paths }).await
+}
+
+// --- file metadata_list ---
+
+use lore_vm::ops::file::metadata_list::{
+    metadata_list as op_file_metadata_list, MetadataListArgs, MetadataListResult,
+};
+
+#[tauri::command]
+pub async fn file_metadata_list(
+    state: State<'_, AppState>,
+    path: String,
+    revision: String,
+) -> Result<MetadataListResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_file_metadata_list(&api, MetadataListArgs { path, revision }).await
+}
+
 // --- file obliterate ---
 
 use lore_vm::ops::file::obliterate::{

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -51,6 +51,8 @@ pub fn run() {
             commands::branch_merge_unresolve,
             commands::branch_merge_into,
             commands::file_info,
+            commands::file_hash,
+            commands::file_metadata_list,
             commands::file_write,
             commands::file_dump,
             commands::file_stage,


### PR DESCRIPTION
Resolves SBAI-4034

## Summary
Added Tauri command wrappers and registration for existing `file_hash` and `file_metadata_list` Rust operations.
Updated the frontend to use these commands, including:
- Correcting the command name in the `file.hash` palette manifest.
- Adding TypeScript bindings in `api.ts`.
- Surfacing Hash and Metadata actions in the File Info panel in `App.tsx`.

## Files Changed
- `src-tauri/src/commands.rs`: Added `file_hash` and `file_metadata_list` `#[tauri::command]` wrappers.
- `src-tauri/src/lib.rs`: Registered the new commands.
- `frontend/src/palette/manifest/file/hash.ts`: Fixed command name to `file_hash`.
- `frontend/src/api.ts`: Added `fileHashApi` and `fileMetadataListApi`.
- `frontend/src/App.tsx`: Added UI buttons and results display for Hash and Metadata.

## Testing
- `cargo check -p loregui`: Green.
- `cargo test -p lore-vm`: Green (668 tests pass).
- `node frontend/scripts/palette-parity.mjs`: Green.
- `node frontend/scripts/command-registration.mjs`: Green.
- `npm --prefix frontend run build`: Green.