### PR TITLE
SBAI-4043: autostart at login + minimize-to-tray (tauri-plugin-autostart)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,7 +1003,16 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
 ]
 
 [[package]]
@@ -1001,7 +1021,18 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1012,7 +1043,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1145,7 +1176,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2721,6 +2752,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tokio",
  "tracing",
@@ -3847,6 +3879,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -4727,7 +4770,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4777,7 +4820,7 @@ checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4845,6 +4888,20 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5490,7 +5547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -6378,6 +6435,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -6408,7 +6474,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import OnboardingFlow from "./onboarding/OnboardingFlow";
 import ThemeEditor from "./theme/ThemeEditor";
+import SettingsPanel from "./SettingsPanel";
 import StoragePanel from "./StoragePanel";
 import RepositoryPanel from "./RepositoryPanel";
 import LocksPanel from "./LocksPanel";
@@ -88,6 +89,7 @@ export default function App() {
   const [historyPanelOpen, setHistoryPanelOpen] = useState(false);
   const [branchesPanelOpen, setBranchesPanelOpen] = useState(false);
   const [accountPanelOpen, setAccountPanelOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [status, setStatus] = useState<RepoStatus | null>(null);
   const [branches, setBranches] = useState<Branch[]>([]);
   const [history, setHistory] = useState<Revision[]>([]);
@@ -349,6 +351,12 @@ export default function App() {
             title="Account: signed-in identity, local device accounts, connect to a server"
           >
             Account
+          </button>
+          <button
+            onClick={() => setSettingsOpen(true)}
+            title="Desktop settings: autostart, close to tray"
+          >
+            Settings
           </button>
           <button
             onClick={() => setBranchesPanelOpen(true)}
@@ -980,6 +988,10 @@ export default function App() {
             <ThemeEditor />
           </div>
         </div>
+      )}
+
+      {settingsOpen && (
+        <SettingsPanel onClose={() => setSettingsOpen(false)} />
       )}
 
       {branchesPanelOpen && (

--- a/frontend/src/SettingsPanel.tsx
+++ b/frontend/src/SettingsPanel.tsx
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useState } from "react";
+import { api, desktopSettingsApi } from "../api";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function SettingsPanel({ open, onClose }: Props) {
+  const [autostart, setAutostart] = useState(false);
+  const [closeToTray, setCloseToTray] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState<string | null>(null);
+
+  const loadSettings = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const s = await desktopSettingsApi.get();
+      setAutostart(s.autostart_enabled);
+      setCloseToTray(s.close_to_tray);
+    } catch (e) {
+      setError(typeof e === "string" ? e : JSON.stringify(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) void loadSettings();
+  }, [open, loadSettings]);
+
+  const handleAutostart = useCallback(
+    async (val: boolean) => {
+      setSaving("autostart");
+      setError(null);
+      try {
+        await desktopSettingsApi.setAutostart(val);
+        setAutostart(val);
+      } catch (e) {
+        setError(typeof e === "string" ? e : JSON.stringify(e));
+        // Revert on failure.
+        setAutostart(!val);
+      } finally {
+        setSaving(null);
+      }
+    },
+    [],
+  );
+
+  const handleCloseToTray = useCallback(
+    async (val: boolean) => {
+      setSaving("closeToTray");
+      setError(null);
+      try {
+        await desktopSettingsApi.setCloseToTray(val);
+        setCloseToTray(val);
+      } catch (e) {
+        setError(typeof e === "string" ? e : JSON.stringify(e));
+        // Revert on failure.
+        setCloseToTray(!val);
+      } finally {
+        setSaving(null);
+      }
+    },
+    [],
+  );
+
+  if (!open) return null;
+
+  return (
+    <div className="settings-panel-overlay" onClick={onClose}>
+      <div className="settings-panel" onClick={(e) => e.stopPropagation()}>
+        <div className="settings-header">
+          <h2>Desktop Settings</h2>
+          <button className="settings-close" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+
+        {error && <div className="error">{error}</div>}
+
+        {loading ? (
+          <p className="settings-loading">Loading settings…</p>
+        ) : (
+          <div className="settings-body">
+            <div className="settings-row">
+              <div className="settings-row-label">
+                <strong>Start LoreGUI at login</strong>
+                <p className="settings-row-desc">
+                  Automatically launch the application when you log in to your
+                  computer.
+                </p>
+              </div>
+              <div className="settings-row-action">
+                <label className="toggle">
+                  <input
+                    type="checkbox"
+                    checked={autostart}
+                    onChange={(e) => void handleAutostart(e.target.checked)}
+                    disabled={saving === "autostart"}
+                  />
+                  <span className="toggle-slider" />
+                </label>
+                {saving === "autostart" && (
+                  <span className="settings-saving">Saving…</span>
+                )}
+              </div>
+            </div>
+
+            <div className="settings-row">
+              <div className="settings-row-label">
+                <strong>Close to tray</strong>
+                <p className="settings-row-desc">
+                  When closing the window, hide to the system tray instead of
+                  quitting the application.
+                </p>
+              </div>
+              <div className="settings-row-action">
+                <label className="toggle">
+                  <input
+                    type="checkbox"
+                    checked={closeToTray}
+                    onChange={(e) =>
+                      void handleCloseToTray(e.target.checked)
+                    }
+                    disabled={saving === "closeToTray"}
+                  />
+                  <span className="toggle-slider" />
+                </label>
+                {saving === "closeToTray" && (
+                  <span className="settings-saving">Saving…</span>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1464,3 +1464,18 @@ export const sharedStoreApi = {
   setUseAutomatically: (enabled: boolean) =>
     invoke<void>("shared_store_set_use_automatically", { enabled }),
 };
+
+// --- desktop settings (autostart + close-to-tray) ---
+
+export interface DesktopSettingsResult {
+  autostart_enabled: boolean;
+  close_to_tray: boolean;
+}
+
+export const desktopSettingsApi = {
+  get: () => invoke<DesktopSettingsResult>("get_desktop_settings"),
+  setAutostart: (enabled: boolean) =>
+    invoke<void>("set_autostart", { enabled }),
+  setCloseToTray: (enabled: boolean) =>
+    invoke<void>("set_close_to_tray", { enabled }),
+};

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -780,3 +780,155 @@ h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; color: v
   font-size: 12px;
   color: var(--surface-overlay-text, var(--text));
 }
+
+/* --- Settings Panel --- */
+.settings-panel-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--surface-overlay-bg, rgba(0, 0, 0, 0.4));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.settings-panel {
+  background: var(--surface-elevated-bg, var(--bg));
+  color: var(--surface-elevated-text, var(--text));
+  border: 1px solid var(--surface-elevated-border, var(--border));
+  border-radius: 10px;
+  box-shadow: var(--surface-overlay-shadow, 0 8px 32px rgba(0, 0, 0, 0.2));
+  width: 90%;
+  max-width: 480px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--surface-elevated-border, var(--border));
+}
+
+.settings-header h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.settings-close {
+  background: none;
+  border: none;
+  color: var(--surface-elevated-text, var(--text));
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.settings-close:hover {
+  background: var(--surface-elevated-hover, var(--panel2));
+}
+
+.settings-body {
+  padding: 16px 20px;
+}
+
+.settings-loading {
+  padding: 20px;
+  text-align: center;
+  color: var(--muted);
+}
+
+.settings-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--surface-elevated-border, var(--border));
+}
+
+.settings-row:last-child {
+  border-bottom: none;
+}
+
+.settings-row-label {
+  flex: 1;
+}
+
+.settings-row-label strong {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.settings-row-desc {
+  margin: 0;
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.settings-row-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.settings-saving {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+/* Toggle switch */
+.toggle {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+}
+
+.toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: var(--border);
+  border-radius: 24px;
+  transition: background 0.2s;
+}
+
+.toggle-slider::before {
+  content: "";
+  position: absolute;
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background: white;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+.toggle input:checked + .toggle-slider {
+  background: var(--accent, #5b9dd9);
+}
+
+.toggle input:checked + .toggle-slider::before {
+  transform: translateX(20px);
+}
+
+.toggle input:disabled + .toggle-slider {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,8 +16,9 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-dialog = "2"
+tauri-plugin-autostart = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1,0 +1,67 @@
+//! Desktop integration commands: autostart at login and close-to-tray behavior.
+//!
+//! Exposes Tauri commands for the frontend to toggle "Start at login" and
+//! "Close to tray instead of quitting" preferences.
+
+use crate::settings::SettingsManager;
+use serde::Serialize;
+use tauri::State;
+use tauri_plugin_autostart::ManagerExt;
+
+/// Result returned when querying or changing desktop settings.
+#[derive(Debug, Clone, Serialize)]
+pub struct SettingsResult {
+    pub autostart_enabled: bool,
+    pub close_to_tray: bool,
+}
+
+/// Get the current desktop integration settings.
+#[tauri::command]
+pub fn get_desktop_settings(
+    settings: State<'_, SettingsManager>,
+) -> Result<SettingsResult, String> {
+    let s = settings.get();
+    Ok(SettingsResult {
+        autostart_enabled: s.autostart_enabled,
+        close_to_tray: s.close_to_tray,
+    })
+}
+
+/// Enable or disable autostart at login.
+///
+/// This delegates to `tauri-plugin-autostart` for the platform-specific
+/// registration (launchd plist on macOS, registry on Windows, .desktop on Linux).
+#[tauri::command]
+pub async fn set_autostart(
+    app_handle: tauri::AppHandle,
+    settings: State<'_, SettingsManager>,
+    enabled: bool,
+) -> Result<(), String> {
+    // Update the persisted setting.
+    settings.update(|s| s.autostart_enabled = enabled);
+
+    // Register or unregister with the autostart plugin.
+    if enabled {
+        app_handle
+            .autolaunch()
+            .enable()
+            .map_err(|e| format!("failed to enable autostart: {e}"))?;
+    } else {
+        app_handle
+            .autolaunch()
+            .disable()
+            .map_err(|e| format!("failed to disable autostart: {e}"))?;
+    }
+
+    Ok(())
+}
+
+/// Enable or disable "close to tray" behavior.
+#[tauri::command]
+pub fn set_close_to_tray(
+    settings: State<'_, SettingsManager>,
+    enabled: bool,
+) -> Result<(), String> {
+    settings.update(|s| s.close_to_tray = enabled);
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,12 +1,17 @@
 mod commands;
+mod desktop;
 mod operations;
+mod settings;
 
 use commands::AppState;
+use desktop::{get_desktop_settings, set_autostart, set_close_to_tray};
 use operations::subscribe::subscribe_notifications;
 use operations::unsubscribe::unsubscribe_notifications;
+use settings::SettingsManager;
 use std::collections::HashSet;
 use std::sync::atomic::AtomicU64;
 use std::sync::Mutex;
+use tauri::Manager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -20,6 +25,34 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            Some(vec!["--hidden"]),
+        ))
+        .setup(|app| {
+            // Load settings from the app config directory.
+            let config_dir = app.path().app_config_dir().unwrap_or_else(|_| {
+                tracing::warn!("could not resolve app config dir, using fallback");
+                std::env::temp_dir().join("loregui")
+            });
+            app.manage(SettingsManager::new(config_dir));
+
+            // Set up the system tray icon.
+            setup_tray(app)?;
+
+            Ok(())
+        })
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                let settings = window.state::<SettingsManager>();
+                if settings.get().close_to_tray {
+                    // Prevent the window from closing; hide it to tray instead.
+                    api.prevent_close();
+                    let _ = window.hide();
+                }
+                // Otherwise let the close proceed normally (app quits).
+            }
+        })
         .manage(AppState {
             working_dir: Mutex::new(initial_dir),
             subscription_counter: AtomicU64::new(0),
@@ -140,7 +173,43 @@ pub fn run() {
             commands::revision_metadata_clear,
             subscribe_notifications,
             unsubscribe_notifications,
+            get_desktop_settings,
+            set_autostart,
+            set_close_to_tray,
         ])
         .run(tauri::generate_context!())
         .expect("error while running loregui");
+}
+
+/// Set up the system tray icon with a menu for quick actions.
+fn setup_tray(app: &tauri::App) -> tauri::Result<()> {
+    use tauri::menu::{MenuBuilder, MenuItemBuilder};
+    use tauri::tray::TrayIconBuilder;
+
+    let show_item = MenuItemBuilder::with_id("show", "Open LoreGUI").build(app)?;
+    let quit_item = MenuItemBuilder::with_id("quit", "Quit").build(app)?;
+    let menu = MenuBuilder::new(app)
+        .items(&[&show_item, &quit_item])
+        .build()?;
+
+    let _tray = TrayIconBuilder::new()
+        .menu(&menu)
+        .tooltip("LoreGUI")
+        .show_menu_on_left_click(true)
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            "show" => {
+                // Show and focus the main window.
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                }
+            }
+            "quit" => {
+                app.exit(0);
+            }
+            _ => {}
+        })
+        .build(app)?;
+
+    Ok(())
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,0 +1,61 @@
+//! Application settings persistence.
+//!
+//! Stores user preferences (autostart, close-to-tray) in a JSON file
+//! in the app's config directory.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+/// User-configurable application settings.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AppSettings {
+    /// Whether LoreGUI should start automatically at login.
+    #[serde(default)]
+    pub autostart_enabled: bool,
+    /// Whether closing the main window hides to tray instead of quitting.
+    #[serde(default)]
+    pub close_to_tray: bool,
+}
+
+/// Manages loading and saving app settings to disk.
+pub struct SettingsManager {
+    settings_path: PathBuf,
+    cache: Mutex<AppSettings>,
+}
+
+impl SettingsManager {
+    /// Create a new settings manager, loading from the config directory.
+    pub fn new(config_dir: PathBuf) -> Self {
+        let settings_path = config_dir.join("settings.json");
+        let cache = Mutex::new(Self::load_from_disk(&settings_path));
+        Self {
+            settings_path,
+            cache,
+        }
+    }
+
+    fn load_from_disk(path: &PathBuf) -> AppSettings {
+        match std::fs::read_to_string(path) {
+            Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+            Err(_) => AppSettings::default(),
+        }
+    }
+
+    /// Get the current settings.
+    pub fn get(&self) -> AppSettings {
+        self.cache.lock().unwrap().clone()
+    }
+
+    /// Save updated settings to disk.
+    pub fn update(&self, f: impl FnOnce(&mut AppSettings)) {
+        let mut settings = self.cache.lock().unwrap();
+        f(&mut settings);
+        if let Ok(json) = serde_json::to_string_pretty(&*settings) {
+            if let Some(parent) = self.settings_path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            let _ = std::fs::write(&self.settings_path, json);
+        }
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,6 +21,12 @@
     ],
     "security": {
       "csp": null
+    },
+    "trayIcon": {
+      "iconPath": "icons/icon.png",
+      "id": "main",
+      "tooltip": "LoreGUI",
+      "showMenuOnLeftClick": true
     }
   },
   "bundle": {


### PR DESCRIPTION
Resolves SBAI-4043

## Summary
Implements two desktop client UX features:
1. **Start at login** — uses `tauri-plugin-autostart` to register/unregister the app in the OS autostart mechanism (launchd on macOS, registry on Windows, .desktop on Linux)
2. **Close to tray** — intercepts window close events and hides to the system tray instead of quitting the application

## Files Changed
- **src-tauri/Cargo.toml** — Added `tauri-plugin-autostart = "2"` and enabled `tray-icon` feature on tauri
- **src-tauri/src/settings.rs** (new) — Settings persistence module (JSON file in app config dir)
- **src-tauri/src/desktop.rs** (new) — Tauri commands: `get_desktop_settings`, `set_autostart`, `set_close_to_tray`
- **src-tauri/src/lib.rs** — Wired autostart plugin, tray icon setup, window close event handler, new commands
- **src-tauri/tauri.conf.json** — Added tray icon configuration
- **frontend/src/api.ts** — Added `desktopSettingsApi` wrapper
- **frontend/src/SettingsPanel.tsx** (new) — Settings panel with toggle UI for both features
- **frontend/src/App.tsx** — Added Settings button to topbar, renders SettingsPanel
- **frontend/src/styles.css** — CSS for settings panel overlay, rows, toggle switches
- **Cargo.lock** — Auto-updated with new dependencies

## Testing
- `cargo check -p loregui` — clean (only pre-existing warnings)
- `cargo check -p lore-vm` — clean
- `cargo test -p lore-vm` — all 6 unit tests pass