### PR TITLE
feat(website): 'For agents (MCP)' section — LoreGUI as an agent toolkit (SBAI-4024)

### DIFF
--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -2,6 +2,7 @@ import { Header } from "@/components/Header";
 import { Hero } from "@/components/Hero";
 import { Features } from "@/components/Features";
 import { BuiltOnApi } from "@/components/BuiltOnApi";
+import { ForAgents } from "@/components/ForAgents";
 import { Screenshots } from "@/components/Screenshots";
 import { Install } from "@/components/Install";
 import { Footer } from "@/components/Footer";
@@ -14,6 +15,7 @@ export default function Home() {
         <Hero />
         <Features />
         <BuiltOnApi />
+        <ForAgents />
         <Screenshots />
         <Install />
       </main>

--- a/website/src/components/ForAgents.tsx
+++ b/website/src/components/ForAgents.tsx
@@ -1,0 +1,129 @@
+import { Container } from "@/components/ui/Container";
+import { Card } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { CodeBlock } from "@/components/CodeBlock";
+import {
+  TerminalIcon,
+  GitCompareIcon,
+  BoltIcon,
+  CheckIcon,
+} from "@/components/icons";
+
+// The exact shape an agent drops into its MCP config — matches lore-mcp/README.md.
+const mcpRegistration = [
+  '"lore": {',
+  '  "command": "/path/to/loregui/lore-mcp/venv/bin/python",',
+  '  "args": ["/path/to/loregui/lore-mcp/server.py"],',
+  '  "env": {',
+  '    "LORE_REPO": "/path/to/repo",',
+  '    "LORE_OFFLINE": "1"',
+  "  }",
+  "}",
+];
+
+const points = [
+  {
+    icon: TerminalIcon,
+    title: "One tool per lore op",
+    description:
+      "The MCP server exposes each lore operation as its own tool — commit, branch, stage, lock and more — so an agent calls them natively instead of guessing at a CLI.",
+  },
+  {
+    icon: GitCompareIcon,
+    title: "Schemas from the same manifests",
+    description:
+      "Every tool's name, description and input schema is generated from the GUI's command-palette manifests — the agent and the app stay in lock-step from one source of truth.",
+  },
+  {
+    icon: BoltIcon,
+    title: "Read tools are repo intelligence",
+    description:
+      "status, history, diff, file-history and locks — the git/p4-equivalent read & metrics surface — give an agent a structured, real-time picture of the repository before it acts.",
+  },
+];
+
+export function ForAgents() {
+  return (
+    <section
+      id="agents"
+      className="relative overflow-hidden border-t border-brand-muted/10 py-20 sm:py-32"
+    >
+      <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+        <div className="absolute right-1/4 top-0 h-[300px] w-[500px] translate-x-1/2 rounded-full bg-brand-accent/5 blur-3xl" />
+      </div>
+
+      <Container className="relative">
+        <div className="mx-auto max-w-3xl text-center">
+          <Badge variant="accent" className="mb-6">
+            <TerminalIcon className="mr-1.5 h-4 w-4" />
+            Drive LoreGUI from AI agents (MCP)
+          </Badge>
+          <h2 className="font-heading text-3xl font-bold tracking-tight text-brand-text-bright sm:text-4xl">
+            Built for agents, too
+          </h2>
+          <p className="mt-4 text-lg leading-relaxed text-brand-muted">
+            LoreGUI isn&rsquo;t just a desktop app — it&rsquo;s a toolkit. The
+            same in-process lore binding that powers the command palette and
+            panels also ships as an{" "}
+            <span className="font-semibold text-brand-text">MCP server</span>,
+            so agents like Claude Code drive Epic&rsquo;s lore VCS the same way a
+            person uses the GUI.
+          </p>
+          <p className="mt-4 text-lg leading-relaxed text-brand-muted">
+            Point an agent at the server and it gets native lore access — status,
+            history, diff, branches, file-history and locks — plus the mutations
+            to commit, branch, stage and lock. It lives in the repo at{" "}
+            <code className="rounded bg-brand-deep/70 px-1.5 py-0.5 font-mono text-sm text-brand-text">
+              lore-mcp/
+            </code>{" "}
+            and pairs with the desktop app.
+          </p>
+        </div>
+
+        <div className="mx-auto mt-14 grid items-start gap-10 lg:grid-cols-2">
+          <div>
+            <h3 className="mb-3 font-heading text-sm font-semibold uppercase tracking-wide text-brand-muted">
+              Register it in one block
+            </h3>
+            <CodeBlock lines={mcpRegistration} />
+            <p className="mt-4 flex items-start gap-2.5 text-sm leading-relaxed text-brand-muted">
+              <CheckIcon className="mt-0.5 h-4 w-4 shrink-0 text-vapor-green" />
+              <span>
+                Two agent skills —{" "}
+                <code className="rounded bg-brand-deep/70 px-1.5 py-0.5 font-mono text-xs text-brand-text">
+                  loregui
+                </code>{" "}
+                and{" "}
+                <code className="rounded bg-brand-deep/70 px-1.5 py-0.5 font-mono text-xs text-brand-text">
+                  lore
+                </code>{" "}
+                — let any agent self-onboard: install, configure and then drive
+                the server without hand-holding.
+              </span>
+            </p>
+          </div>
+
+          <ul className="grid gap-4" role="list">
+            {points.map((p) => (
+              <li key={p.title}>
+                <Card className="flex gap-4">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-brand-accent/30 bg-brand-accent/10">
+                    <p.icon className="h-5 w-5 text-brand-accent" />
+                  </div>
+                  <div>
+                    <h4 className="font-heading text-base font-semibold text-brand-text-bright">
+                      {p.title}
+                    </h4>
+                    <p className="mt-1 text-sm leading-relaxed text-brand-muted">
+                      {p.description}
+                    </p>
+                  </div>
+                </Card>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/website/src/components/Guide.tsx
+++ b/website/src/components/Guide.tsx
@@ -3,6 +3,7 @@ import { Container } from "@/components/ui/Container";
 import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { GradientText } from "@/components/ui/GradientText";
+import { CodeBlock } from "@/components/CodeBlock";
 import { AppWindow } from "@/components/mockups/AppWindow";
 
 type Shot = {
@@ -23,6 +24,10 @@ type GuideSectionData = {
   shots: Shot[];
   /** Lay shots out side by side (e.g. light vs dark theme). */
   sideBySide?: boolean;
+  /** Optional code snippet rendered below the body (e.g. MCP config). */
+  code?: string[];
+  /** Optional follow-up note rendered under the code snippet. */
+  note?: string;
 };
 
 const sections: GuideSectionData[] = [
@@ -200,6 +205,24 @@ const sections: GuideSectionData[] = [
     ],
     sideBySide: true,
   },
+  {
+    id: "agents-mcp",
+    step: "13",
+    heading: "Drive LoreGUI from AI agents (MCP)",
+    body: "LoreGUI is a toolkit, not just an app. The same in-process lore binding that powers the palette and panels also ships as an MCP server in the repo at lore-mcp/, exposing one tool per lore op — status, history, diff, branches, file-history and locks, plus commit, branch, stage and lock. Register it in your agent (Claude Code and friends) and it drives Epic’s lore VCS the way you drive the GUI. The loregui and lore agent skills let an agent self-onboard and configure it for you.",
+    shots: [],
+    code: [
+      '"lore": {',
+      '  "command": "/path/to/loregui/lore-mcp/venv/bin/python",',
+      '  "args": ["/path/to/loregui/lore-mcp/server.py"],',
+      '  "env": {',
+      '    "LORE_REPO": "/path/to/repo",',
+      '    "LORE_OFFLINE": "1"',
+      "  }",
+      "}",
+    ],
+    note: "One-time setup: build the JSON CLI with cargo build -p lorevm-cli, then create the lore-mcp/venv and install its requirements. The tool names and schemas are generated from the same command-palette manifests the GUI uses, so the agent and the app stay in lock-step.",
+  },
 ];
 
 function GuideShot({ shot }: { shot: Shot }) {
@@ -235,15 +258,29 @@ function GuideSection({ section }: { section: GuideSectionData }) {
         {section.body}
       </p>
 
-      <div
-        className={`mt-8 grid gap-6 ${
-          multi ? "lg:grid-cols-2" : "max-w-4xl"
-        }`}
-      >
-        {section.shots.map((shot) => (
-          <GuideShot key={shot.src} shot={shot} />
-        ))}
-      </div>
+      {section.code && (
+        <div className="mt-6 max-w-3xl">
+          <CodeBlock lines={section.code} />
+        </div>
+      )}
+
+      {section.note && (
+        <p className="mt-4 max-w-3xl text-sm leading-relaxed text-brand-muted">
+          {section.note}
+        </p>
+      )}
+
+      {section.shots.length > 0 && (
+        <div
+          className={`mt-8 grid gap-6 ${
+            multi ? "lg:grid-cols-2" : "max-w-4xl"
+          }`}
+        >
+          {section.shots.map((shot) => (
+            <GuideShot key={shot.src} shot={shot} />
+          ))}
+        </div>
+      )}
     </section>
   );
 }

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -11,6 +11,7 @@ const RELEASES_URL = "https://github.com/BiloxiStudios/loregui/releases";
 const navLinks = [
   { label: "Features", href: "/#features" },
   { label: "API", href: "/#api" },
+  { label: "For agents", href: "/#agents" },
   { label: "Screens", href: "/#screens" },
   { label: "Guide", href: "/guide" },
   { label: "Install", href: "/#install" },


### PR DESCRIPTION
Adds a ForAgents landing section + a guide section explaining the lore-mcp server (one tool per op from the palette manifests; read/metrics surface; loregui+lore skills for self-onboarding) with the MCP registration snippet. next build passes.