### PR TITLE
feat: live lore server↔client round trip — script + CLI networked ops + docs (SBAI-4064)

### DIFF
--- a/crates/lore-vm/examples/live_server_client.rs
+++ b/crates/lore-vm/examples/live_server_client.rs
@@ -1,0 +1,226 @@
+//! Live networked server↔client round-trip harness (SBAI-4064 spike).
+//!
+//! This is the genuine networked path that the CI-gated
+//! `tests/e2e_lifecycle.rs::multi_repo_shared_store_sync_observes_remote_commit`
+//! test deliberately stands in for with a *shared on-disk store* (because CI has
+//! no live server). Here we drive the REAL loop against a running `loreserver`
+//! QUIC/gRPC process:
+//!
+//!   client A:  repository::create  (lore://host/<repo>)
+//!              → write file → file::stage → revision::commit
+//!              → branch::push          (uploads revision to the server OVER THE WIRE)
+//!   client B:  repository::clone (lore://host/<repo>)   (pulls OVER THE WIRE)
+//!              → assert the file + revision authored by A are present
+//!
+//! Client B has its OWN local store in a separate temp dir and never touches
+//! A's store, so B observing A's revision proves a real network round trip
+//! through the server, not a shared-local-store shortcut.
+//!
+//! Run via `scripts/live-server-client.sh`, which boots the server first. To run
+//! by hand against an already-running server:
+//!
+//! ```sh
+//! cargo run -p lore-vm --example live_server_client -- \
+//!     lore://127.0.0.1:41337/spikerepo /tmp/clientA /tmp/clientB
+//! ```
+//!
+//! Args: <repo_url> <client_a_dir> <client_b_dir>
+//!
+//! Exit 0 on a fully-verified round trip; non-zero with a diagnostic otherwise.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use lore_vm::api::LoreApi;
+use lore_vm::global::LoreGlobal;
+use lore_vm::ops;
+
+/// An ONLINE api (offline=false) so push/clone actually hit the server. The
+/// identity flows through as the revision author and the connection identity;
+/// against a no-auth dev server any non-empty value is accepted.
+fn online_api(dir: &Path, identity: &str) -> LoreApi {
+    let global = LoreGlobal::new(dir.to_path_buf())
+        .in_memory(false)
+        .offline(false)
+        .identity(identity);
+    LoreApi::from_global(global)
+}
+
+fn write_file(path: &Path, contents: &[u8]) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dirs");
+    }
+    std::fs::write(path, contents).expect("write file");
+}
+
+async fn run(repo_url: &str, dir_a: &Path, dir_b: &Path) -> Result<(), String> {
+    let alice = online_api(dir_a, "alice");
+
+    // ---- client A: create a repo tracking the remote URL --------------------
+    println!("[A] repository::create {repo_url}");
+    let created = ops::repository::create::create(
+        &alice,
+        ops::repository::create::CreateArgs {
+            repository_url: repo_url.to_string(),
+            description: "live-server spike repo".into(),
+            id: String::new(),
+            use_shared_store: false,
+            shared_store_path: String::new(),
+        },
+    )
+    .await
+    .map_err(|e| format!("A repository::create failed: {e}"))?;
+    println!("[A] created repo id={} name={}", created.id, created.name);
+
+    // ---- client A: write + stage + commit (one process keeps staged state) --
+    let file_path = dir_a.join("hello.txt");
+    const CONTENT: &[u8] = b"hello from the live spike\nround trip test\n";
+    write_file(&file_path, CONTENT);
+
+    println!("[A] file::stage hello.txt");
+    let staged = ops::file::stage::stage(
+        &alice,
+        ops::file::stage::FileStageArgs {
+            paths: vec![file_path.to_string_lossy().into_owned()],
+            case_change: ops::file::stage::CaseChange::Error,
+            scan: true,
+        },
+    )
+    .await
+    .map_err(|e| format!("A file::stage failed: {e}"))?;
+    if !staged.files.iter().any(|f| f.path.ends_with("hello.txt")) {
+        return Err(format!("A stage did not report hello.txt: {staged:?}"));
+    }
+
+    println!("[A] revision::commit");
+    let commit = ops::revision::commit::commit(
+        &alice,
+        ops::revision::commit::CommitArgs {
+            message: "initial commit from alice".into(),
+        },
+    )
+    .await
+    .map_err(|e| format!("A revision::commit failed: {e}"))?;
+    if commit.revision.is_empty() {
+        return Err(format!("A commit returned empty revision: {commit:?}"));
+    }
+    let pushed_rev = commit.revision.clone();
+    println!("[A] committed revision {pushed_rev}");
+
+    // ---- client A: push to the server OVER THE WIRE -------------------------
+    println!("[A] branch::push  → {repo_url}");
+    let push = ops::branch::push::push(
+        &alice,
+        ops::branch::push::BranchPushArgs {
+            branch: String::new(),
+            fast_forward_merge: false,
+        },
+    )
+    .await
+    .map_err(|e| format!("A branch::push failed (server not reachable / auth?): {e}"))?;
+    println!(
+        "[A] pushed branch={} local_rev={} remote_rev={} already_pushed={}",
+        push.branch_name, push.local_revision, push.remote_revision, push.already_pushed
+    );
+
+    // ---- client B: clone the SAME URL into a fresh dir OVER THE WIRE --------
+    let bob = online_api(dir_b, "bob");
+    println!("[B] repository::clone {repo_url}  (separate local store)");
+    let cloned = ops::repository::clone::clone(
+        &bob,
+        ops::repository::clone::CloneArgs {
+            repository_url: repo_url.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .map_err(|e| format!("B repository::clone failed: {e}"))?;
+    println!(
+        "[B] cloned repo={} branch={} revision={} path={}",
+        cloned.repository, cloned.branch, cloned.revision, cloned.path
+    );
+
+    // ---- PROOF: B sees A's revision + file content, pulled over the wire ----
+    if cloned.revision != pushed_rev {
+        return Err(format!(
+            "B cloned revision {} != pushed revision {pushed_rev}",
+            cloned.revision
+        ));
+    }
+
+    let cloned_file = dir_b.join("hello.txt");
+    if !cloned_file.exists() {
+        return Err(format!(
+            "B working tree missing hello.txt after clone (path {})",
+            cloned_file.display()
+        ));
+    }
+    let got = std::fs::read(&cloned_file).map_err(|e| format!("read cloned file: {e}"))?;
+    if got != CONTENT {
+        return Err(format!(
+            "B file content mismatch: got {:?}",
+            String::from_utf8_lossy(&got)
+        ));
+    }
+
+    // The cloned revision's author/message must match A's commit — proves the
+    // revision metadata (not just bytes) crossed the network.
+    let info = ops::revision::info::info(
+        &bob,
+        ops::revision::info::RevisionInfoArgs {
+            revision: pushed_rev.clone(),
+            delta: true,
+            metadata: true,
+        },
+    )
+    .await
+    .map_err(|e| format!("B revision::info failed: {e}"))?;
+    if info.author() != Some("alice") {
+        return Err(format!("B saw author {:?}, expected alice", info.author()));
+    }
+    if info.message() != Some("initial commit from alice") {
+        return Err(format!("B saw message {:?}", info.message()));
+    }
+
+    println!();
+    println!("ROUND TRIP VERIFIED:");
+    println!("  revision {pushed_rev} authored by alice");
+    println!(
+        "  pushed from {} → cloned into {}",
+        dir_a.display(),
+        dir_b.display()
+    );
+    println!("  file hello.txt content matches, over the network via {repo_url}");
+    Ok(())
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> ExitCode {
+    let mut args = std::env::args().skip(1);
+    let repo_url = match args.next() {
+        Some(u) => u,
+        None => {
+            eprintln!(
+                "usage: live_server_client <repo_url> <client_a_dir> <client_b_dir>\n\
+                 e.g.   live_server_client lore://127.0.0.1:41337/spikerepo /tmp/A /tmp/B"
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+    let dir_a = PathBuf::from(
+        args.next()
+            .unwrap_or_else(|| "/tmp/lore-spike/clientA".into()),
+    );
+    let dir_b = PathBuf::from(
+        args.next()
+            .unwrap_or_else(|| "/tmp/lore-spike/clientB".into()),
+    );
+
+    match run(&repo_url, &dir_a, &dir_b).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("\nSPIKE FAILED: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/lorevm-cli/src/main.rs
+++ b/crates/lorevm-cli/src/main.rs
@@ -162,15 +162,19 @@ const SUPPORTED_OPS: &[&str] = &[
     "repository.info",
     "repository.list",
     "repository.create",
+    "repository.clone",
     "revision.history",
     "revision.diff",
     "revision.info",
     "revision.find",
     "revision.commit",
+    "revision.sync",
     "branch.list",
     "branch.info",
     "branch.create",
     "branch.switch",
+    "branch.push",
+    "auth.login_with_token",
     "file.stage",
     "file.unstage",
     "file.info",
@@ -240,6 +244,12 @@ async fn dispatch(cli: &Cli, api: &LoreApi) -> Result<(), CliError> {
             ops::repository::create::create,
             ops::repository::create::CreateArgs
         ),
+        // Networked: connects to a remote lore server over QUIC/gRPC and clones
+        // into `--dir`. Added for the live-server spike (SBAI-4064).
+        "repository.clone" => op!(
+            ops::repository::clone::clone,
+            ops::repository::clone::CloneArgs
+        ),
 
         // ---- revision -------------------------------------------------------
         "revision.history" => op!(
@@ -262,6 +272,12 @@ async fn dispatch(cli: &Cli, api: &LoreApi) -> Result<(), CliError> {
             ops::revision::commit::commit,
             ops::revision::commit::CommitArgs
         ),
+        // Networked: pulls the latest revision for the current branch from the
+        // remote and syncs the working tree. Added for the live-server spike.
+        "revision.sync" => op!(
+            ops::revision::sync::sync,
+            ops::revision::sync::RevisionSyncArgs
+        ),
 
         // ---- branch ---------------------------------------------------------
         "branch.list" => op!(ops::branch::list::list, ops::branch::list::BranchListArgs),
@@ -273,6 +289,17 @@ async fn dispatch(cli: &Cli, api: &LoreApi) -> Result<(), CliError> {
         "branch.switch" => op!(
             ops::branch::switch::switch,
             ops::branch::switch::BranchSwitchArgs
+        ),
+        // Networked: pushes the current/specified branch and its revisions to
+        // the remote. Added for the live-server spike (SBAI-4064).
+        "branch.push" => op!(ops::branch::push::push, ops::branch::push::BranchPushArgs),
+
+        // ---- auth -----------------------------------------------------------
+        // Non-interactive token login. Against a no-auth dev server this is a
+        // no-op, but it exercises the credential path. Added for the spike.
+        "auth.login_with_token" => op!(
+            ops::auth::login_with_token::login_with_token,
+            ops::auth::login_with_token::LoginWithTokenArgs
         ),
 
         // ---- file -----------------------------------------------------------

--- a/docs/live-server-client-spike.md
+++ b/docs/live-server-client-spike.md
@@ -1,0 +1,176 @@
+# Live lore server ↔ client round trip (SBAI-4064 spike)
+
+**Verdict: YES — LoreGUI can host a real lore server and connect a real client to
+it today, locally, with no external infrastructure.** The full
+`connect → create → commit → push → clone → verify` loop runs end-to-end over a
+genuine QUIC/gRPC network round trip.
+
+This documents the spike that proved it, the exact server-boot + cert + auth
+setup that worked, and how to re-run it.
+
+## TL;DR — run it
+
+```sh
+scripts/live-server-client.sh
+```
+
+That script: builds the upstream `loreserver` binary (from the pinned `lore` git
+checkout) and the `lore-vm` client example, writes a localhost-only server
+config, boots the server on `127.0.0.1`, runs the client loop, prints a verified
+round trip, then stops the server and removes its temp dirs. Exit 0 = verified.
+
+Env knobs: `LORE_PORT` (default `41337`), `KEEP_TMP=1` to keep the temp dir +
+server log for inspection.
+
+Sample output:
+
+```
+==> starting loreserver on 127.0.0.1:43337 (gRPC+QUIC), http 43339
+==> waiting for server to listen. — up (tcp+udp 43337)
+[A] repository::create lore://127.0.0.1:43337/spikerepo-3217086
+[A] file::stage hello.txt
+[A] revision::commit
+[A] committed revision 8db01cc7…
+[A] branch::push  → lore://127.0.0.1:43337/spikerepo-3217086
+[A] pushed branch=main local_rev=8db01cc7… already_pushed=false
+[B] repository::clone lore://127.0.0.1:43337/spikerepo-3217086  (separate local store)
+[B] cloned repo=… branch=main revision=8db01cc7…
+ROUND TRIP VERIFIED:
+  revision 8db01cc7… authored by alice
+  file hello.txt content matches, over the network
+RESULT: SUCCESS — live networked round trip verified.
+```
+
+## What this is the proof of
+
+The CI-gated test
+`crates/lore-vm/tests/e2e_lifecycle.rs::multi_repo_shared_store_sync_observes_remote_commit`
+deliberately uses a **shared on-disk store** (two repos, one store, `offline=1`,
+no server) as a stand-in for the networked path, because CI has no live server.
+Its own doc comment names the gap:
+
+> The genuine networked path (a QUIC `lore` server + `repository::clone` of a
+> `lore://host/repo` URL + token auth + `branch::push`) requires TLS material and
+> a live server … `branch::push` itself fails offline with `NoRemote`.
+
+This spike closes that gap. Client B here has its **own separate local store**
+and clones **from the server**, so B seeing A's revision/file/author proves a
+real network round trip — not a shared-local-store shortcut.
+
+## How the server boots (the setup that worked)
+
+The server is the upstream **`loreserver`** binary (crate `lore-server`, bin
+`loreserver`), which is just `server_main(ServerConfig::default())`. It is fully
+config-driven via layered TOML (`lore-server/src/settings.rs`):
+
+- built-in `config/default.toml` (baked in) → optional on-disk
+  `default.toml`/`<env>.toml`/`local.toml` from `LORE_CONFIG_PATH` → `LORE__*`
+  env vars.
+
+The spike writes a `local.toml` (loaded via `LORE_ENV=local`) that is the minimal
+single-node, no-infra, no-auth configuration:
+
+```toml
+[server.quic]            # QUIC storage service
+host = "127.0.0.1"
+port = 41337
+[server.quic.certificate]
+cert_file = "<lore checkout>/lore-server/src/protocol/test_data/test_cert.pem"
+pkey_file = "<lore checkout>/lore-server/src/protocol/test_data/test_key.pem"
+
+[server.grpc]            # gRPC revision/repository/lock/branch services
+host = "127.0.0.1"
+port = 41337             # same port number; gRPC is TCP, QUIC is UDP
+
+[server.http]
+host = "127.0.0.1"
+port = 41339
+
+[immutable_store.local]  # local filesystem stores — NO S3/MinIO/DynamoDB needed
+path = "<tmp>/store"
+[mutable_store.local]
+path = "<tmp>/store"
+
+[topology]
+provider = "none"        # single-node, no Consul
+```
+
+Boot:
+
+```sh
+LORE_CONFIG_PATH=<tmp>/config LORE_ENV=local loreserver
+```
+
+It comes up listening on **TCP 127.0.0.1:41337** (gRPC), **UDP 127.0.0.1:41337**
+(QUIC), **TCP 127.0.0.1:41339** (HTTP). No external services required.
+
+### Certs
+
+The shipped test fixtures live at
+`lore-server/src/protocol/test_data/{test_cert,test_key,test_ca}.pem` (plus
+client/untrusted variants). The QUIC server just needs `test_cert.pem` +
+`test_key.pem`.
+
+### Auth — the key enabler
+
+There is **no `[server.auth]` block**, so the server's JWT verifier is `None`
+(`lore-server/src/server.rs` ~line 1713) and the gRPC server logs
+`Auth: disabled`. No token, JWK, or login is required. This is the documented
+dev/no-auth path — the server only enforces JWT when an `auth.jwk` is configured.
+
+### Client trust (why no CA wiring is needed)
+
+The client connects with a **`lore://`** URL (no trailing `s`). In
+`lore-transport/src/quic/client.rs`, a scheme **not** ending in `s` sets
+`validate_server_certificate = false`, which installs
+`SkipServerVerification` — the client does **not** validate the server cert.
+So the shipped self-signed test cert works with zero client-side trust setup.
+(`lores://` would require the test CA in the client root store.)
+
+## How the client loop runs
+
+The client is a small example, `crates/lore-vm/examples/live_server_client.rs`,
+that drives the existing `lore-vm` op bindings **in one process** (important —
+staged state lives in the engine session and does not persist across separate
+processes). It runs ONLINE (`offline=false`) so push/clone hit the server:
+
+1. `repository::create` `lore://host/<repo>` in client-A's dir (local store).
+2. write `hello.txt` → `file::stage` (absolute path + `scan=true`) →
+   `revision::commit`.
+3. `branch::push` — uploads the revision to the server over the wire.
+4. `repository::clone` the same URL into client-B's separate dir.
+5. assert B's cloned revision hash == A's pushed hash, file bytes match, and the
+   revision author/message (`alice` / "initial commit from alice") match.
+
+`identity` ("alice"/"bob") flows through as the connection identity and revision
+author; against the no-auth server any non-empty value is accepted.
+
+## Driving the same loop from the CLI
+
+The spike also wired the three networked ops into the `lorevm` JSON CLI
+(`crates/lorevm-cli`): `repository.clone`, `branch.push`, `revision.sync`, plus
+`auth.login_with_token`. These were previously implemented in `lore-vm/src/ops/`
+but not dispatchable from the CLI.
+
+⚠️ The CLI runs **one op per process**, and lore's staged state is per-engine-session
+and is *not* flushed to disk for the next process — so a `file.stage` in one
+`lorevm` invocation is invisible to a `revision.commit` in the next (observed:
+`status` shows `revision_staged: ""` and commit fails with "Nothing staged").
+The multi-step author side (stage→commit) therefore must run in a single process
+(hence the Rust example). The CLI ops are still useful for single-shot networked
+calls (e.g. `repository.clone`, `branch.push` after a commit made in-process).
+
+## Notes / limits
+
+- **Local-only.** Everything binds `127.0.0.1`. Not wired into CI: the
+  `loreserver` binary is built from the pinned upstream `lore` git checkout under
+  `~/.cargo/git/checkouts/lore-*/`, which CI runners don't have unpacked.
+- First run builds `loreserver` (~1 GB debug binary, several minutes). Subsequent
+  runs are incremental.
+- Server boot method that worked: the **stock `loreserver` binary + a TOML
+  config**, *not* a custom Rust harness linking `QuinnServer` directly (that
+  would also require implementing a `StreamHandlerFactory` and wiring stores by
+  hand). Note `lore::service::start` (the lore-vm `service.start` op) is an
+  upstream **stub** that returns 1 — it does not launch a server, so it can't be
+  used to host.
+```

--- a/scripts/live-server-client.sh
+++ b/scripts/live-server-client.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# =============================================================================
+# live-server-client.sh — SBAI-4064 spike
+#
+# Boots a REAL lore QUIC/gRPC server (upstream `loreserver`) on localhost with
+# local in-process stores, the shipped test certs, and NO auth, then drives the
+# full networked client loop end-to-end:
+#
+#     connect → create → commit → push  (client A)  →  clone → verify (client B)
+#
+# Client B clones from the SERVER into its own separate store, so a successful
+# verify proves a genuine network round trip (not a shared-local-store shortcut).
+#
+# LOCAL-ONLY. Binds 127.0.0.1 exclusively. Not wired into CI — the lore server
+# is built from the pinned upstream `lore` git checkout, which CI does not have.
+#
+# Usage:   scripts/live-server-client.sh
+# Env:     LORE_PORT (default 41337)   KEEP_TMP=1 to leave temp dirs for inspection
+# =============================================================================
+set -euo pipefail
+
+PORT="${LORE_PORT:-41337}"
+HTTP_PORT=$((PORT + 2))
+REPO_NAME="spikerepo-$$"
+REPO_URL="lore://127.0.0.1:${PORT}/${REPO_NAME}"
+SPIKE_DIR="$(mktemp -d /tmp/lore-spike.XXXXXX)"
+SERVER_LOG="${SPIKE_DIR}/server.log"
+SERVER_PID=""
+
+# ---- locate the pinned upstream lore checkout (for the loreserver binary) ---
+# loregui pins `lore` by rev in Cargo.toml; cargo unpacks it under the git cache.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LORE_REV="$(grep -oE 'rev = "[0-9a-f]{40}"' "${REPO_ROOT}/Cargo.toml" | head -1 | grep -oE '[0-9a-f]{40}')"
+if [[ -z "${LORE_REV}" ]]; then
+  echo "FATAL: could not read pinned lore rev from Cargo.toml" >&2
+  exit 1
+fi
+SHORT_REV="${LORE_REV:0:7}"
+LORE_CHECKOUT="$(find "${CARGO_HOME:-$HOME/.cargo}/git/checkouts" -maxdepth 2 -type d -name "${SHORT_REV}" 2>/dev/null | head -1)"
+if [[ -z "${LORE_CHECKOUT}" ]]; then
+  echo "FATAL: lore checkout for rev ${SHORT_REV} not found under cargo git cache." >&2
+  echo "       Run a build that fetches the dep first (e.g. cargo fetch)." >&2
+  exit 1
+fi
+echo "lore checkout: ${LORE_CHECKOUT}"
+
+cleanup() {
+  if [[ -n "${SERVER_PID}" ]] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+    echo "stopping server (pid ${SERVER_PID})"
+    kill "${SERVER_PID}" 2>/dev/null || true
+    wait "${SERVER_PID}" 2>/dev/null || true
+  fi
+  if [[ "${KEEP_TMP:-0}" == "1" ]]; then
+    echo "KEEP_TMP=1 — leaving ${SPIKE_DIR} (server log: ${SERVER_LOG})"
+  else
+    rm -rf "${SPIKE_DIR}"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+# ---- 1. build the server binary + the client example -----------------------
+echo "==> building loreserver (upstream, from pinned checkout)"
+( cd "${LORE_CHECKOUT}" && cargo build -p lore-server --bin loreserver )
+LORESERVER="${LORE_CHECKOUT}/target/debug/loreserver"
+
+echo "==> building lore-vm live_server_client example"
+( cd "${REPO_ROOT}" && cargo build -p lore-vm --example live_server_client )
+# Resolve the example binary regardless of workspace target dir layout.
+EXAMPLE="$(find "${REPO_ROOT}/target/debug/examples" -maxdepth 1 -name live_server_client -type f 2>/dev/null | head -1)"
+if [[ -z "${EXAMPLE}" ]]; then
+  echo "FATAL: built example not found under target/debug/examples" >&2
+  exit 1
+fi
+
+# ---- 2. write a localhost-only server config --------------------------------
+# Single-node, local stores under SPIKE_DIR/store, shipped test certs for QUIC,
+# NO [server.auth] block → JWT verification disabled (auth: None).
+mkdir -p "${SPIKE_DIR}/config" "${SPIKE_DIR}/store"
+TEST_CERT="${LORE_CHECKOUT}/lore-server/src/protocol/test_data/test_cert.pem"
+TEST_KEY="${LORE_CHECKOUT}/lore-server/src/protocol/test_data/test_key.pem"
+cat > "${SPIKE_DIR}/config/local.toml" <<EOF
+[server.quic]
+host = "127.0.0.1"
+port = ${PORT}
+[server.quic.certificate]
+cert_file = "${TEST_CERT}"
+pkey_file = "${TEST_KEY}"
+
+[server.grpc]
+host = "127.0.0.1"
+port = ${PORT}
+
+[server.http]
+host = "127.0.0.1"
+port = ${HTTP_PORT}
+
+[immutable_store.local]
+path = "${SPIKE_DIR}/store"
+[mutable_store.local]
+path = "${SPIKE_DIR}/store"
+
+[telemetry.logger]
+format = "ansi"
+
+[topology]
+provider = "none"
+EOF
+
+# ---- 3. boot the server -----------------------------------------------------
+echo "==> starting loreserver on 127.0.0.1:${PORT} (gRPC+QUIC), http ${HTTP_PORT}"
+# `exec` so the subshell becomes the server process itself — then $! is the real
+# server pid and the EXIT trap can reliably reap it (no orphaned grandchild).
+( cd "${SPIKE_DIR}" && exec env LORE_CONFIG_PATH="${SPIKE_DIR}/config" LORE_ENV=local \
+    "${LORESERVER}" > "${SERVER_LOG}" 2>&1 ) &
+SERVER_PID=$!
+
+# wait for the gRPC + QUIC sockets to come up (or the process to die)
+echo -n "==> waiting for server to listen"
+for _ in $(seq 1 60); do
+  if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+    echo; echo "FATAL: server exited during startup. Log tail:" >&2
+    tail -30 "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  if ss -tln 2>/dev/null | grep -q "127.0.0.1:${PORT}" \
+     && ss -uln 2>/dev/null | grep -q "127.0.0.1:${PORT}"; then
+    echo " — up (tcp+udp ${PORT})"
+    break
+  fi
+  echo -n "."
+  sleep 0.5
+done
+
+# ---- 4. drive the networked client loop -------------------------------------
+echo "==> running client loop: ${REPO_URL}"
+CLIENT_A="${SPIKE_DIR}/clientA"
+CLIENT_B="${SPIKE_DIR}/clientB"
+mkdir -p "${CLIENT_A}" "${CLIENT_B}"
+
+set +e
+"${EXAMPLE}" "${REPO_URL}" "${CLIENT_A}" "${CLIENT_B}"
+RC=$?
+set -e
+
+echo
+if [[ ${RC} -eq 0 ]]; then
+  echo "RESULT: SUCCESS — live networked round trip verified."
+else
+  echo "RESULT: FAILURE (exit ${RC}). Server log tail:"
+  tail -40 "${SERVER_LOG}"
+fi
+exit ${RC}


### PR DESCRIPTION
Proves the real networked path: scripts/live-server-client.sh boots a minimal loreserver (localhost, local stores, no infra, test certs, auth disabled) + runs connect→create→commit→push→clone→verify over the wire. Wires the existing-but-unreachable networked ops (clone/push/sync/login_with_token) into the lorevm CLI; adds an example + docs. Local-dev only (loreserver builds from the ~1GB pinned checkout — not CI). Found: lore-vm service.start is an upstream stub (returns 1) — GUI host flow needs loreserver. SBAI-4064. All gates green.