### PR TITLE
feat(host): GUI 'Host a server' launches + manages a real loreserver (SBAI-4065)

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -63,6 +63,30 @@ export interface ServiceStopResult {
   log_messages: string[];
 }
 
+/// Options for hosting a real `loreserver` from the GUI (SBAI-4065).
+export interface HostServerOptions {
+  /** Store directory to serve — MUST be the host flow's shared-store path. */
+  storeDir: string;
+  /** QUIC/gRPC port. Defaults to 41337 when omitted. */
+  port?: number;
+  /** Repository name embedded in the advertised lore:// URL clients clone. */
+  repositoryName?: string;
+  /** Reserved hook for a future authed mode. Local host flow is no-auth. */
+  auth?: boolean;
+}
+
+/// Status of the hosted `loreserver` process.
+export interface HostStatus {
+  running: boolean;
+  pid?: number;
+  port?: number;
+  httpPort?: number;
+  /** The `lore://host:port/<repo>` URL clients connect to. */
+  url?: string;
+  configPath?: string;
+  storeDir?: string;
+}
+
 export const api = {
   currentRepository: () => invoke<string>("current_repository"),
   openRepository: (path: string) => invoke<void>("open_repository", { path }),
@@ -115,6 +139,20 @@ export const api = {
     invoke<void>("service_start", { installAutorun }),
   serviceStop: (all: boolean = false) =>
     invoke<ServiceStopResult>("service_stop", { all }),
+
+  // --- host a real loreserver (SBAI-4065) ---
+  // `serviceStart` maps to an upstream STUB that hosts nothing. These launch and
+  // manage the genuine standalone `loreserver` binary over the host flow's
+  // local stores. `hostServerStart` returns the lore:// URL to give to clients.
+  hostServerStart: (opts: HostServerOptions) =>
+    invoke<HostStatus>("host_server_start", {
+      storeDir: opts.storeDir,
+      port: opts.port ?? null,
+      repositoryName: opts.repositoryName ?? null,
+      auth: opts.auth ?? false,
+    }),
+  hostServerStop: () => invoke<HostStatus>("host_server_stop"),
+  hostServerStatus: () => invoke<HostStatus>("host_server_status"),
 };
 
 // --- repository create (ops-layer) ---

--- a/frontend/src/onboarding/OnboardingFlow.tsx
+++ b/frontend/src/onboarding/OnboardingFlow.tsx
@@ -6,7 +6,7 @@ import ClientConnect from "./ClientConnect";
 import ClientClone from "./ClientClone";
 import BackendPicker from "./server/BackendPicker";
 import ValidateConnectivity from "./server/ValidateConnectivity";
-import InitStore from "./server/InitStore";
+import InitStore, { type InitStoreResult } from "./server/InitStore";
 import ServiceSetup from "./server/ServiceSetup";
 
 interface OnboardingFlowProps {
@@ -21,7 +21,7 @@ const STEP_LABELS: Record<string, string> = {
   backend: "Storage backend",
   validate: "Validate connectivity",
   init: "Initialize server",
-  service: "Start service",
+  service: "Host server",
   connect: "Connect to server",
   clone: "Clone / open repository",
 };
@@ -39,6 +39,7 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
   const [stepIndex, setStepIndex] = useState(0);
   const [backendConfig, setBackendConfig] =
     useState<StorageBackendConfig | null>(null);
+  const [initResult, setInitResult] = useState<InitStoreResult | null>(null);
 
   const steps: readonly string[] =
     mode === "host" ? HOST_STEPS : mode === "client" ? CLIENT_STEPS : [];
@@ -95,10 +96,15 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
         );
         break;
       case "init":
-        content = <InitStore />;
+        content = <InitStore onInitialized={setInitResult} />;
         break;
       case "service":
-        content = <ServiceSetup />;
+        content = (
+          <ServiceSetup
+            storePath={initResult?.storePath}
+            repoName={initResult?.repoName}
+          />
+        );
         break;
     }
   }

--- a/frontend/src/onboarding/server/InitStore.tsx
+++ b/frontend/src/onboarding/server/InitStore.tsx
@@ -3,6 +3,22 @@ import { api } from "../../api";
 
 type Step = "store" | "repo" | "done" | "error";
 
+export interface InitStoreResult {
+  /** The shared-store directory created — this is what the host server serves. */
+  storePath: string;
+  /** The repository name created in that store. */
+  repoName: string;
+}
+
+interface InitStoreProps {
+  /**
+   * Reports the created store path + repo name up to the onboarding shell so the
+   * next step ("Host server") can serve exactly this store and advertise this
+   * repo in its lore:// URL.
+   */
+  onInitialized?: (result: InitStoreResult) => void;
+}
+
 /**
  * Onboarding component: initialize a shared store + repository.
  * Wired into the onboarding shell by the integration manager.
@@ -10,7 +26,7 @@ type Step = "store" | "repo" | "done" | "error";
  * Uses `api.sharedStoreCreate` to create the shared storage backend,
  * then `api.repositoryCreate` to create the first repository.
  */
-export default function InitStore() {
+export default function InitStore({ onInitialized }: InitStoreProps = {}) {
   const [storePath, setStorePath] = useState("");
   const [repoPath, setRepoPath] = useState("");
   const [repoName, setRepoName] = useState("");
@@ -44,13 +60,14 @@ export default function InitStore() {
       const id = await api.repositoryCreate(repoPath.trim(), repoName.trim());
       setRepoResult(id);
       setStep("done");
+      onInitialized?.({ storePath: storePath.trim(), repoName: repoName.trim() });
     } catch (e) {
       setError(typeof e === "string" ? e : JSON.stringify(e));
       setStep("error");
     } finally {
       setIsSubmitting(false);
     }
-  }, [repoPath, repoName]);
+  }, [repoPath, repoName, storePath, onInitialized]);
 
   const handleRetry = useCallback(() => {
     setError(null);

--- a/frontend/src/onboarding/server/ServiceSetup.tsx
+++ b/frontend/src/onboarding/server/ServiceSetup.tsx
@@ -1,58 +1,138 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { api } from "../../api";
+import type { HostStatus } from "../../api";
 
-type Step = "idle" | "starting" | "running" | "error";
+type Step = "idle" | "starting" | "running" | "stopping" | "error";
 
-export default function ServiceSetup() {
+interface ServiceSetupProps {
+  /**
+   * The store directory the previous step created. The hosted server serves
+   * exactly this store so the repository just created is actually reachable.
+   */
+  storePath?: string;
+  /** Repository name created in that store — advertised in the lore:// URL. */
+  repoName?: string;
+}
+
+/**
+ * Final host-flow step (SBAI-4065): launch a REAL `loreserver` over the store
+ * the previous step created and show the `lore://` URL clients connect to.
+ *
+ * This replaces the old `serviceStart` call, which mapped to an upstream stub
+ * that hosted nothing. If the previous step's store path isn't available, the
+ * user can enter one manually.
+ */
+export default function ServiceSetup({
+  storePath,
+  repoName,
+}: ServiceSetupProps = {}) {
   const [step, setStep] = useState<Step>("idle");
-  const [installAutorun, setInstallAutorun] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<HostStatus | null>(null);
+  const [storeDir, setStoreDir] = useState(storePath ?? "");
+  const [copied, setCopied] = useState(false);
+
+  // Keep the store-dir field in sync if the previous step reports a path.
+  useEffect(() => {
+    if (storePath) setStoreDir(storePath);
+  }, [storePath]);
+
+  // Reflect any already-running server (e.g. user navigated back and forth).
+  useEffect(() => {
+    let cancelled = false;
+    void api
+      .hostServerStatus()
+      .then((s) => {
+        if (!cancelled && s.running) {
+          setStatus(s);
+          setStep("running");
+        }
+      })
+      .catch(() => {
+        /* status is best-effort; ignore */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleStart = useCallback(async () => {
+    if (!storeDir.trim()) return;
     try {
       setStep("starting");
       setError(null);
-      await api.serviceStart(installAutorun);
+      const s = await api.hostServerStart({
+        storeDir: storeDir.trim(),
+        repositoryName: repoName,
+      });
+      setStatus(s);
       setStep("running");
     } catch (e) {
       setError(typeof e === "string" ? e : JSON.stringify(e));
       setStep("error");
     }
-  }, [installAutorun]);
+  }, [storeDir, repoName]);
 
-  const handleReset = useCallback(() => {
-    setStep("idle");
-    setError(null);
+  const handleStop = useCallback(async () => {
+    try {
+      setStep("stopping");
+      setError(null);
+      await api.hostServerStop();
+      setStatus(null);
+      setStep("idle");
+    } catch (e) {
+      setError(typeof e === "string" ? e : JSON.stringify(e));
+      setStep("error");
+    }
   }, []);
+
+  const handleCopy = useCallback(async () => {
+    if (!status?.url) return;
+    try {
+      await navigator.clipboard.writeText(status.url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard may be unavailable; ignore */
+    }
+  }, [status]);
 
   return (
     <div className="onboarding-card">
-      <h2>Start Lore Service</h2>
+      <h2>Host Server</h2>
       <p className="onboarding-description">
-        The Lore service handles repository synchronization and background operations.
-        Start the service now to continue setup.
+        Start a Lore server over your store so other people can connect to it.
+        The server runs on this machine and listens on <code>127.0.0.1</code>.
+        Share the <code>lore://</code> URL below with your team to let them clone
+        and push.
       </p>
 
-      {step !== "running" && (
-        <label className="onboarding-checkbox">
+      {error && <div className="error">{error}</div>}
+
+      {step !== "running" && step !== "stopping" && (
+        <div className="onboarding-field">
+          <label htmlFor="host-store-dir">Store directory to serve</label>
           <input
-            type="checkbox"
-            checked={installAutorun}
-            onChange={(e) => setInstallAutorun(e.target.checked)}
+            id="host-store-dir"
+            type="text"
+            placeholder="/path/to/shared/store"
+            value={storeDir}
+            onChange={(e) => setStoreDir(e.target.value)}
             disabled={step === "starting"}
           />
-          <span>Install as Windows service / autorun on login</span>
-        </label>
+          <p className="onboarding-description">
+            Use the same shared-store path you created on the previous step.
+          </p>
+        </div>
       )}
-
-      {error && <div className="error">{error}</div>}
 
       {step === "idle" && (
         <button
           className="onboarding-button onboarding-button--primary"
-          onClick={handleStart}
+          disabled={!storeDir.trim()}
+          onClick={() => void handleStart()}
         >
-          Start Service
+          Start Hosting
         </button>
       )}
 
@@ -62,12 +142,37 @@ export default function ServiceSetup() {
         </button>
       )}
 
-      {step === "running" && (
+      {step === "stopping" && (
+        <button className="onboarding-button" disabled>
+          Stopping&hellip;
+        </button>
+      )}
+
+      {step === "running" && status && (
         <div className="onboarding-success">
-          <span className="success-icon">&#10003;</span>
-          <span>Service is running</span>
-          <button className="onboarding-button" onClick={handleReset}>
-            Back
+          <div className="success-message">
+            <span className="success-icon">&#10003;</span>
+            <span>Server is hosting</span>
+          </div>
+          <div className="onboarding-field">
+            <label htmlFor="host-url">Connection URL (give this to clients)</label>
+            <div className="onboarding-url-row">
+              <input id="host-url" type="text" readOnly value={status.url ?? ""} />
+              <button className="onboarding-button" onClick={() => void handleCopy()}>
+                {copied ? "Copied" : "Copy"}
+              </button>
+            </div>
+            <p className="onboarding-description">
+              Clients run <strong>Connect to server</strong> with this URL, then
+              clone the repository. The server keeps running while LoreGUI is
+              open. Use <strong>Stop Hosting</strong> below to shut it down.
+            </p>
+          </div>
+          <button
+            className="onboarding-button onboarding-button--danger"
+            onClick={() => void handleStop()}
+          >
+            Stop Hosting
           </button>
         </div>
       )}
@@ -75,7 +180,8 @@ export default function ServiceSetup() {
       {step === "error" && (
         <button
           className="onboarding-button onboarding-button--primary"
-          onClick={handleStart}
+          disabled={!storeDir.trim()}
+          onClick={() => void handleStart()}
         >
           Retry
         </button>

--- a/frontend/src/palette/manifest/service/host_server_start.ts
+++ b/frontend/src/palette/manifest/service/host_server_start.ts
@@ -1,0 +1,50 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest entry for `host server: start` (SBAI-4065).
+ *
+ * Launches a real standalone `loreserver` process serving a local store over
+ * QUIC + gRPC on loopback, with auth disabled (the local host case). Returns the
+ * `lore://host:port/<repo>` URL that clients connect to. Unlike `service.start`
+ * (an upstream stub that hosts nothing), this actually hosts a server.
+ */
+const manifest: OpManifest = {
+  id: "service.host_server_start",
+  domain: "service",
+  op: "host_server_start",
+  label: "Host Server: Start",
+  description:
+    "Launch a real Lore server (loreserver) over a local store on 127.0.0.1. Returns the lore:// URL to give to clients.",
+  command: "host_server_start",
+  args: [
+    {
+      name: "storeDir",
+      kind: "text",
+      label: "Store directory",
+      description:
+        "Directory backing the served stores. Use the same shared-store path your repository was created in.",
+      required: true,
+      placeholder: "/path/to/shared/store",
+    },
+    {
+      name: "port",
+      kind: "number",
+      label: "Port",
+      description: "QUIC/gRPC port. HTTP is served on port + 2. Defaults to 41337.",
+      required: false,
+      placeholder: "41337",
+    },
+    {
+      name: "repositoryName",
+      kind: "text",
+      label: "Repository name",
+      description:
+        "Optional. Embedded in the advertised lore://host:port/<name> URL clients clone.",
+      required: false,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["host", "server", "loreserver", "serve", "start", "quic", "grpc"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/service/host_server_status.ts
+++ b/frontend/src/palette/manifest/service/host_server_status.ts
@@ -1,0 +1,23 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest entry for `host server: status` (SBAI-4065).
+ *
+ * Reports whether a hosted `loreserver` is running and, if so, its pid, port,
+ * and the `lore://host:port/<repo>` URL clients connect to. Reaps the process if
+ * it has exited so the status reflects reality.
+ */
+const manifest: OpManifest = {
+  id: "service.host_server_status",
+  domain: "service",
+  op: "host_server_status",
+  label: "Host Server: Status",
+  description:
+    "Show whether a hosted Lore server is running, with its pid, port, and lore:// URL.",
+  command: "host_server_status",
+  args: [],
+  resultKind: "json",
+  keywords: ["host", "server", "loreserver", "status", "running", "url"],
+};
+
+export default manifest;

--- a/frontend/src/palette/manifest/service/host_server_stop.ts
+++ b/frontend/src/palette/manifest/service/host_server_stop.ts
@@ -1,0 +1,21 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest entry for `host server: stop` (SBAI-4065).
+ *
+ * Stops the `loreserver` process launched by "Host Server: Start" (kill + reap).
+ * Idempotent — a no-op if nothing is hosting. Returns the (now stopped) status.
+ */
+const manifest: OpManifest = {
+  id: "service.host_server_stop",
+  domain: "service",
+  op: "host_server_stop",
+  label: "Host Server: Stop",
+  description: "Stop the hosted Lore server (loreserver) started from the GUI.",
+  command: "host_server_stop",
+  args: [],
+  resultKind: "json",
+  keywords: ["host", "server", "loreserver", "stop", "halt", "shutdown"],
+};
+
+export default manifest;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -298,6 +298,29 @@ h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; color: v
   background: var(--surface-primary-active, var(--accent));
 }
 
+/* Danger button (stop hosting) — themed via the error surface tokens. */
+.onboarding-button--danger {
+  background: var(--surface-error-bg, rgba(248, 81, 73, 0.12));
+  color: var(--surface-error-text, var(--red));
+  border-color: var(--surface-error-border, rgba(248, 81, 73, 0.4));
+}
+
+.onboarding-button--danger:hover:not(:disabled) {
+  border-color: var(--surface-error-text, var(--red));
+}
+
+/* URL + copy-button row for the host-server connection URL. */
+.onboarding-url-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.onboarding-url-row input {
+  flex: 1;
+  min-width: 0;
+}
+
 /* Radio group (storage backend picker) ------------------------------- */
 .onboarding-radio-group {
   display: flex;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -36,6 +36,8 @@ pub struct AppState {
     pub(crate) subscriptions: Mutex<HashSet<SubscriptionId>>,
     /// Storage session for the server-setup onboarding flow.
     pub(crate) storage_session: Mutex<StorageSession>,
+    /// The `loreserver` process the "Host a server" flow launched, if any.
+    pub(crate) hosted_server: Mutex<Option<crate::server_host::HostedServer>>,
 }
 
 impl AppState {
@@ -1919,6 +1921,10 @@ pub async fn revision_cherry_pick_restart(
 
 use lore_vm::ops::service::start::start as op_service_start;
 
+/// DEPRECATED for hosting: `lore::service::start` is an upstream **stub** that
+/// returns 1 and hosts no server. The real "Host a server" path is
+/// `host_server_start` (see `server_host.rs`, SBAI-4065). Kept registered so
+/// nothing that already calls it breaks, but do NOT use it to host.
 #[tauri::command]
 pub async fn service_start(
     state: State<'_, AppState>,
@@ -1945,6 +1951,58 @@ pub async fn service_stop(
     let api = LoreApi::new(state.dir());
     let result = op_service_stop(&api, ServiceStopArgs { all }).await?;
     Ok(result)
+}
+
+// --- host server (SBAI-4065): launch + manage a real loreserver ---
+
+use crate::server_host::{self, HostServerOptions, HostStatus};
+
+/// Launch a real `loreserver` process serving the host flow's local stores.
+///
+/// Idempotent: refuses (errors) if a server is already running — call
+/// `host_server_stop` first. Returns the status incl. the advertised
+/// `lore://host:port/<repo>` URL clients connect to.
+///
+/// Accepts flat fields (rather than a nested `opts` object) so the command is
+/// directly drivable from the command palette's generated form — the palette
+/// passes a flat `Record<string,unknown>` straight to `invoke`. The typed
+/// `api.hostServerStart(opts)` wrapper spreads `HostServerOptions` onto these.
+///
+/// `server_host` is synchronous (it spawns + manages a `std::process::Child`).
+/// The work here is fast — write a config, resolve the binary, spawn — so we
+/// run it inline under the std `Mutex` (the guard is never held across an
+/// `await`). The slow one-time dev build of `loreserver` happens only on a
+/// developer machine with no bundled sidecar.
+#[tauri::command]
+pub fn host_server_start(
+    state: State<'_, AppState>,
+    store_dir: String,
+    port: Option<u16>,
+    repository_name: Option<String>,
+    auth: Option<bool>,
+) -> Result<HostStatus, LoreError> {
+    let opts = HostServerOptions {
+        store_dir,
+        port: port.filter(|p| *p != 0),
+        repository_name: repository_name.filter(|n| !n.trim().is_empty()),
+        auth: auth.unwrap_or(false),
+    };
+    let mut slot = state.hosted_server.lock().unwrap();
+    server_host::start(&mut slot, &opts)
+}
+
+/// Stop the hosted `loreserver` (kill + reap). Idempotent.
+#[tauri::command]
+pub fn host_server_stop(state: State<'_, AppState>) -> Result<HostStatus, LoreError> {
+    let mut slot = state.hosted_server.lock().unwrap();
+    server_host::stop(&mut slot)
+}
+
+/// Current hosted-server status (running? + URL/port/pid). Reaps if it died.
+#[tauri::command]
+pub fn host_server_status(state: State<'_, AppState>) -> Result<HostStatus, LoreError> {
+    let mut slot = state.hosted_server.lock().unwrap();
+    Ok(server_host::status(&mut slot))
 }
 
 // --- auth logout + clear (ops-layer) ---

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod operations;
+mod server_host;
 
 use commands::AppState;
 use operations::subscribe::subscribe_notifications;
@@ -25,6 +26,7 @@ pub fn run() {
             subscription_counter: AtomicU64::new(0),
             subscriptions: Mutex::new(HashSet::new()),
             storage_session: Mutex::new(commands::StorageSession::default()),
+            hosted_server: Mutex::new(None),
         })
         .invoke_handler(tauri::generate_handler![
             commands::open_repository,
@@ -125,6 +127,9 @@ pub fn run() {
             commands::revision_cherry_pick_restart,
             commands::service_start,
             commands::service_stop,
+            commands::host_server_start,
+            commands::host_server_stop,
+            commands::host_server_status,
             commands::repository_info,
             commands::repository_release,
             commands::repository_config_get,

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -1,0 +1,579 @@
+//! Hosting a real `lore` server from the GUI (SBAI-4065).
+//!
+//! The onboarding "Host a server" flow used to call `service_start`, which maps
+//! to `lore::service::start` — an upstream **stub** that returns 1 and hosts
+//! nothing. The genuine server is the standalone upstream **`loreserver`**
+//! binary (crate `lore-server`, bin `loreserver`), driven entirely by a layered
+//! TOML config. The SBAI-4064 spike (`scripts/live-server-client.sh` +
+//! `docs/live-server-client-spike.md`) proved the exact recipe; this module
+//! productionises it: generate the config, resolve the binary, spawn it as a
+//! managed child, and expose start/stop/status.
+//!
+//! The server binds `127.0.0.1` only, serves the host flow's local immutable +
+//! mutable stores, ships the upstream self-signed test certs for QUIC, and runs
+//! with **auth disabled** (no `[server.auth]` block) for the local/no-auth case.
+//! An `auth` hook is kept on [`HostServerOptions`] for a future authed mode.
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+
+use lore_vm::LoreError;
+use serde::{Deserialize, Serialize};
+
+/// Default QUIC/gRPC port for a hosted server. The HTTP service is `port + 2`,
+/// matching the spike. 41337 is the spike default and is unprivileged.
+pub const DEFAULT_PORT: u16 = 41337;
+
+/// Bind host. We host on loopback only — exposing a `lore` server to a LAN/WAN
+/// is a deliberate, separate concern (firewalling, real certs, auth) and is not
+/// what the first-run "Host a server" flow does.
+const BIND_HOST: &str = "127.0.0.1";
+
+/// Inputs from the frontend "Host a server" flow.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostServerOptions {
+    /// Directory that backs the immutable + mutable stores. This MUST be the
+    /// same store the host flow's `shared_store` / `repository` create used, so
+    /// the repository the user just created is actually served.
+    pub store_dir: String,
+    /// QUIC/gRPC port. Defaults to [`DEFAULT_PORT`] when absent/zero.
+    #[serde(default)]
+    pub port: Option<u16>,
+    /// Repository name to embed in the advertised `lore://host:port/<name>` URL
+    /// so the success screen can show clients exactly what to clone. Optional —
+    /// when absent the URL is the bare `lore://host:port`.
+    #[serde(default)]
+    pub repository_name: Option<String>,
+    /// Reserved hook for a future authed mode. When `true` the generated config
+    /// would include a `[server.auth]` block (JWK/issuer). Not yet implemented —
+    /// the local host flow is no-auth; accepted for forward-compat.
+    #[serde(default)]
+    pub auth: bool,
+}
+
+/// A running hosted server plus the metadata the UI needs.
+pub struct HostedServer {
+    /// The managed child process. `None` only transiently during teardown.
+    child: Option<Child>,
+    /// OS process id of the server.
+    pub pid: u32,
+    /// QUIC/gRPC port.
+    pub port: u16,
+    /// HTTP port (`port + 2`).
+    pub http_port: u16,
+    /// Advertised `lore://host:port[/<repo>]` URL clients connect to.
+    pub url: String,
+    /// Path to the generated config file on disk.
+    pub config_path: PathBuf,
+    /// Store directory being served.
+    pub store_dir: PathBuf,
+}
+
+/// Serializable status returned to the frontend.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostStatus {
+    pub running: bool,
+    pub pid: Option<u32>,
+    pub port: Option<u16>,
+    pub http_port: Option<u16>,
+    pub url: Option<String>,
+    pub config_path: Option<String>,
+    pub store_dir: Option<String>,
+}
+
+impl HostStatus {
+    fn stopped() -> Self {
+        HostStatus {
+            running: false,
+            pid: None,
+            port: None,
+            http_port: None,
+            url: None,
+            config_path: None,
+            store_dir: None,
+        }
+    }
+
+    fn from(server: &HostedServer) -> Self {
+        HostStatus {
+            running: true,
+            pid: Some(server.pid),
+            port: Some(server.port),
+            http_port: Some(server.http_port),
+            url: Some(server.url.clone()),
+            config_path: Some(server.config_path.to_string_lossy().into_owned()),
+            store_dir: Some(server.store_dir.to_string_lossy().into_owned()),
+        }
+    }
+}
+
+/// Resolved, fully-qualified inputs for config generation.
+struct ResolvedConfig {
+    port: u16,
+    http_port: u16,
+    store_dir: PathBuf,
+    cert_file: PathBuf,
+    pkey_file: PathBuf,
+    auth: bool,
+}
+
+/// Render the `loreserver` config TOML from resolved inputs.
+///
+/// Pure and deterministic so it can be unit-tested. Mirrors the spike's
+/// `local.toml`: localhost QUIC + gRPC on the same port number (TCP gRPC / UDP
+/// QUIC), HTTP on `port + 2`, local immutable + mutable stores under the chosen
+/// directory, the shipped test certs for QUIC, single-node topology, and —
+/// crucially — **no `[server.auth]` block** so the server runs auth-disabled.
+fn render_config_toml(cfg: &ResolvedConfig) -> String {
+    // Paths are emitted as TOML basic strings; escape backslashes (Windows) and
+    // quotes so the file is valid regardless of the platform's path separators.
+    let esc = |p: &Path| -> String {
+        p.to_string_lossy()
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
+    };
+
+    let mut out = String::new();
+    out.push_str("# Generated by LoreGUI \"Host a server\" (SBAI-4065). Do not edit by hand.\n");
+    out.push_str("# Single-node, loopback-only, local-store loreserver config.\n\n");
+
+    out.push_str("[server.quic]\n");
+    out.push_str(&format!("host = \"{BIND_HOST}\"\n"));
+    out.push_str(&format!("port = {}\n", cfg.port));
+    out.push_str("[server.quic.certificate]\n");
+    out.push_str(&format!("cert_file = \"{}\"\n", esc(&cfg.cert_file)));
+    out.push_str(&format!("pkey_file = \"{}\"\n\n", esc(&cfg.pkey_file)));
+
+    out.push_str("[server.grpc]\n");
+    out.push_str(&format!("host = \"{BIND_HOST}\"\n"));
+    out.push_str(&format!("port = {}\n\n", cfg.port));
+
+    out.push_str("[server.http]\n");
+    out.push_str(&format!("host = \"{BIND_HOST}\"\n"));
+    out.push_str(&format!("port = {}\n\n", cfg.http_port));
+
+    out.push_str("[immutable_store.local]\n");
+    out.push_str(&format!("path = \"{}\"\n", esc(&cfg.store_dir)));
+    out.push_str("[mutable_store.local]\n");
+    out.push_str(&format!("path = \"{}\"\n\n", esc(&cfg.store_dir)));
+
+    out.push_str("[telemetry.logger]\n");
+    out.push_str("format = \"ansi\"\n\n");
+
+    out.push_str("[topology]\n");
+    out.push_str("provider = \"none\"\n");
+
+    // Auth hook: a future authed mode would append a `[server.auth]` block here.
+    // The no-auth local host flow deliberately omits it (server logs
+    // "Auth: disabled"). Keep the branch explicit so the intent is documented.
+    if cfg.auth {
+        out.push_str("\n# NOTE: authed hosting is not yet implemented; running auth-disabled.\n");
+    }
+
+    out
+}
+
+/// The advertised connection URL. `lore://` (no trailing `s`) so clients skip
+/// server-cert validation against the self-signed test cert (see spike).
+fn advertise_url(port: u16, repository_name: Option<&str>) -> String {
+    match repository_name.map(str::trim).filter(|n| !n.is_empty()) {
+        Some(name) => format!("lore://{BIND_HOST}:{port}/{name}"),
+        None => format!("lore://{BIND_HOST}:{port}"),
+    }
+}
+
+/// Locate the upstream `lore` git checkout cargo unpacked for the pinned rev.
+///
+/// `Cargo.toml` pins `lore` by 40-char rev; cargo unpacks it under
+/// `$CARGO_HOME/git/checkouts/lore-*/<short-rev>/`. We read the rev from the
+/// workspace `Cargo.toml` and find the matching short-rev dir — exactly as the
+/// spike script does.
+fn lore_checkout() -> Result<PathBuf, LoreError> {
+    // src-tauri/Cargo.toml is one level above this crate's manifest dir; the
+    // pinned rev lives in the *workspace* Cargo.toml at the repo root.
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest_dir.parent().ok_or_else(|| {
+        LoreError::CommandFailed("could not locate repo root from CARGO_MANIFEST_DIR".into())
+    })?;
+    let cargo_toml = repo_root.join("Cargo.toml");
+    let text = std::fs::read_to_string(&cargo_toml).map_err(|e| {
+        LoreError::CommandFailed(format!(
+            "could not read {} to find pinned lore rev: {e}",
+            cargo_toml.display()
+        ))
+    })?;
+    let rev = parse_pinned_rev(&text).ok_or_else(|| {
+        LoreError::CommandFailed("could not parse pinned lore rev from Cargo.toml".into())
+    })?;
+    let short = &rev[..7];
+
+    let cargo_home = std::env::var_os("CARGO_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs_home().map(|h| h.join(".cargo")))
+        .ok_or_else(|| LoreError::CommandFailed("could not resolve CARGO_HOME".into()))?;
+    let checkouts = cargo_home.join("git").join("checkouts");
+
+    // checkouts/lore-<hash>/<short-rev>/
+    let entries = std::fs::read_dir(&checkouts).map_err(|e| {
+        LoreError::CommandFailed(format!(
+            "lore git checkout not found under {}: {e} — run a build that fetches the dep first",
+            checkouts.display()
+        ))
+    })?;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with("lore-") {
+            let candidate = entry.path().join(short);
+            if candidate.is_dir() {
+                return Ok(candidate);
+            }
+        }
+    }
+    Err(LoreError::CommandFailed(format!(
+        "lore checkout for rev {short} not found under {} — run `cargo fetch` first",
+        checkouts.display()
+    )))
+}
+
+/// Extract the first 40-hex-char `rev = "..."` from a Cargo.toml string.
+fn parse_pinned_rev(cargo_toml: &str) -> Option<String> {
+    for line in cargo_toml.lines() {
+        if let Some(idx) = line.find("rev = \"") {
+            let rest = &line[idx + "rev = \"".len()..];
+            if let Some(end) = rest.find('"') {
+                let rev = &rest[..end];
+                if rev.len() == 40 && rev.bytes().all(|b| b.is_ascii_hexdigit()) {
+                    return Some(rev.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Best-effort home directory (avoids pulling in the `dirs` crate).
+fn dirs_home() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+/// Resolve the `loreserver` binary, building it from the dev checkout if needed.
+///
+/// Order:
+///   1. `LOREVM_SERVER_BIN` env var (explicit override).
+///   2. A Tauri **sidecar** next to the current executable (`loreserver`
+///      / `loreserver.exe`) — present only once we bundle it as `externalBin`.
+///   3. DEV fallback: the pinned upstream checkout's
+///      `target/debug/loreserver`, built via `cargo build -p lore-server
+///      --bin loreserver` if absent (exactly as the spike script does).
+///
+/// FOLLOW-UP: production should ship `loreserver` as a Tauri sidecar
+/// (`externalBin` in `tauri.conf.json`) so step 3 is never reached in a
+/// release build. We intentionally do NOT add the ~1 GB debug binary to the
+/// bundle / CI now — it is resolved at runtime here instead.
+fn resolve_server_binary() -> Result<PathBuf, LoreError> {
+    // 1. explicit override
+    if let Some(p) = std::env::var_os("LOREVM_SERVER_BIN") {
+        let path = PathBuf::from(p);
+        if path.is_file() {
+            return Ok(path);
+        }
+        return Err(LoreError::CommandFailed(format!(
+            "LOREVM_SERVER_BIN={} is not a file",
+            path.display()
+        )));
+    }
+
+    // 2. sidecar next to the running executable
+    if let Some(p) = sidecar_candidate() {
+        if p.is_file() {
+            return Ok(p);
+        }
+    }
+
+    // 3. dev fallback: build from the pinned upstream checkout
+    let checkout = lore_checkout()?;
+    let bin_name = if cfg!(windows) {
+        "loreserver.exe"
+    } else {
+        "loreserver"
+    };
+    let built = checkout.join("target").join("debug").join(bin_name);
+    if built.is_file() {
+        return Ok(built);
+    }
+
+    // Build it (first run is slow — several minutes, ~1 GB debug binary).
+    tracing::info!(
+        "loreserver not built; running `cargo build -p lore-server --bin loreserver` in {}",
+        checkout.display()
+    );
+    let status = Command::new("cargo")
+        .args(["build", "-p", "lore-server", "--bin", "loreserver"])
+        .current_dir(&checkout)
+        .status()
+        .map_err(|e| {
+            LoreError::CommandFailed(format!("failed to launch cargo to build loreserver: {e}"))
+        })?;
+    if !status.success() {
+        return Err(LoreError::CommandFailed(
+            "cargo build -p lore-server --bin loreserver failed".into(),
+        ));
+    }
+    if built.is_file() {
+        Ok(built)
+    } else {
+        Err(LoreError::CommandFailed(format!(
+            "built loreserver not found at {}",
+            built.display()
+        )))
+    }
+}
+
+/// Candidate sidecar path next to the current executable.
+fn sidecar_candidate() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let dir = exe.parent()?;
+    let bin_name = if cfg!(windows) {
+        "loreserver.exe"
+    } else {
+        "loreserver"
+    };
+    Some(dir.join(bin_name))
+}
+
+/// Build the resolved config + write the config file, returning everything
+/// `spawn` needs. Stores live directly under `store_dir`; the config file goes
+/// into `store_dir/.loregui-host/local.toml` so a single store directory is
+/// fully self-describing.
+fn prepare(opts: &HostServerOptions) -> Result<(ResolvedConfig, PathBuf, String), LoreError> {
+    let store_dir = PathBuf::from(opts.store_dir.trim());
+    if store_dir.as_os_str().is_empty() {
+        return Err(LoreError::CommandFailed(
+            "store directory is required to host a server".into(),
+        ));
+    }
+    std::fs::create_dir_all(&store_dir).map_err(|e| {
+        LoreError::CommandFailed(format!(
+            "could not create store dir {}: {e}",
+            store_dir.display()
+        ))
+    })?;
+
+    let port = match opts.port {
+        Some(p) if p != 0 => p,
+        _ => DEFAULT_PORT,
+    };
+    let http_port = port.wrapping_add(2);
+
+    let checkout = lore_checkout()?;
+    let test_data = checkout
+        .join("lore-server")
+        .join("src")
+        .join("protocol")
+        .join("test_data");
+    let cert_file = test_data.join("test_cert.pem");
+    let pkey_file = test_data.join("test_key.pem");
+
+    let cfg = ResolvedConfig {
+        port,
+        http_port,
+        store_dir: store_dir.clone(),
+        cert_file,
+        pkey_file,
+        auth: opts.auth,
+    };
+
+    let config_dir = store_dir.join(".loregui-host");
+    std::fs::create_dir_all(&config_dir).map_err(|e| {
+        LoreError::CommandFailed(format!(
+            "could not create config dir {}: {e}",
+            config_dir.display()
+        ))
+    })?;
+    let config_path = config_dir.join("local.toml");
+    std::fs::write(&config_path, render_config_toml(&cfg)).map_err(|e| {
+        LoreError::CommandFailed(format!(
+            "could not write config {}: {e}",
+            config_path.display()
+        ))
+    })?;
+
+    let url = advertise_url(port, opts.repository_name.as_deref());
+    Ok((cfg, config_path, url))
+}
+
+/// Start a hosted server for the given options. Idempotent: if a server is
+/// already running this returns an error rather than spawning a second one
+/// (call stop first, or read status).
+pub fn start(
+    slot: &mut Option<HostedServer>,
+    opts: &HostServerOptions,
+) -> Result<HostStatus, LoreError> {
+    if let Some(existing) = slot.as_mut() {
+        // Reap if it died out from under us; otherwise refuse.
+        match existing.child.as_mut().map(|c| c.try_wait()) {
+            Some(Ok(Some(_))) | None => {
+                // exited — fall through to (re)start
+                *slot = None;
+            }
+            Some(Ok(None)) => {
+                return Err(LoreError::CommandFailed(format!(
+                    "a hosted server is already running (pid {}, {})",
+                    existing.pid, existing.url
+                )));
+            }
+            Some(Err(e)) => {
+                return Err(LoreError::CommandFailed(format!(
+                    "could not check existing server state: {e}"
+                )));
+            }
+        }
+    }
+
+    let (cfg, config_path, url) = prepare(opts)?;
+    let binary = resolve_server_binary()?;
+    let config_dir = config_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    // Boot exactly like the spike: LORE_CONFIG_PATH points at the dir holding
+    // local.toml, LORE_ENV=local selects it. cwd = config dir.
+    let child = Command::new(&binary)
+        .env("LORE_CONFIG_PATH", &config_dir)
+        .env("LORE_ENV", "local")
+        .current_dir(&config_dir)
+        .spawn()
+        .map_err(|e| {
+            LoreError::CommandFailed(format!(
+                "failed to launch loreserver ({}): {e}",
+                binary.display()
+            ))
+        })?;
+
+    let server = HostedServer {
+        pid: child.id(),
+        child: Some(child),
+        port: cfg.port,
+        http_port: cfg.http_port,
+        url,
+        config_path,
+        store_dir: cfg.store_dir,
+    };
+    let status = HostStatus::from(&server);
+    *slot = Some(server);
+    Ok(status)
+}
+
+/// Stop the hosted server (kill + reap). Idempotent: a no-op if none running.
+pub fn stop(slot: &mut Option<HostedServer>) -> Result<HostStatus, LoreError> {
+    if let Some(mut server) = slot.take() {
+        if let Some(mut child) = server.child.take() {
+            // Best-effort: ignore "already exited" errors.
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+    Ok(HostStatus::stopped())
+}
+
+/// Current status. Reaps the child if it has exited so status reflects reality.
+pub fn status(slot: &mut Option<HostedServer>) -> HostStatus {
+    let exited = match slot.as_mut() {
+        Some(server) => match server.child.as_mut().map(|c| c.try_wait()) {
+            Some(Ok(Some(_))) | None => true,
+            Some(Ok(None)) => false,
+            Some(Err(_)) => false,
+        },
+        None => false,
+    };
+    if exited {
+        *slot = None;
+    }
+    match slot.as_ref() {
+        Some(server) => HostStatus::from(server),
+        None => HostStatus::stopped(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn sample_cfg(store: &str, port: u16, auth: bool) -> ResolvedConfig {
+        ResolvedConfig {
+            port,
+            http_port: port + 2,
+            store_dir: PathBuf::from(store),
+            cert_file: PathBuf::from("/certs/test_cert.pem"),
+            pkey_file: PathBuf::from("/certs/test_key.pem"),
+            auth,
+        }
+    }
+
+    #[test]
+    fn config_has_required_sections_and_values() {
+        let toml = render_config_toml(&sample_cfg("/srv/store", 41337, false));
+        // localhost binds
+        assert!(toml.contains("[server.quic]"));
+        assert!(toml.contains("[server.grpc]"));
+        assert!(toml.contains("[server.http]"));
+        assert!(toml.contains("host = \"127.0.0.1\""));
+        assert!(toml.contains("port = 41337"));
+        // http is port + 2
+        assert!(toml.contains("port = 41339"));
+        // local stores point at the chosen dir
+        assert!(toml.contains("[immutable_store.local]"));
+        assert!(toml.contains("[mutable_store.local]"));
+        assert!(toml.contains("path = \"/srv/store\""));
+        // certs
+        assert!(toml.contains("cert_file = \"/certs/test_cert.pem\""));
+        assert!(toml.contains("pkey_file = \"/certs/test_key.pem\""));
+        // single node
+        assert!(toml.contains("[topology]"));
+        assert!(toml.contains("provider = \"none\""));
+    }
+
+    #[test]
+    fn config_is_auth_disabled_by_default() {
+        let toml = render_config_toml(&sample_cfg("/srv/store", 41337, false));
+        // No [server.auth] block → server runs auth-disabled (the key enabler).
+        assert!(!toml.contains("[server.auth]"));
+    }
+
+    #[test]
+    fn config_escapes_windows_paths() {
+        let cfg = sample_cfg(r"C:\Users\dev\store", 50000, false);
+        let toml = render_config_toml(&cfg);
+        // Backslashes are doubled so the TOML basic string is valid.
+        assert!(toml.contains(r#"path = "C:\\Users\\dev\\store""#));
+    }
+
+    #[test]
+    fn advertise_url_with_and_without_repo() {
+        assert_eq!(
+            advertise_url(41337, Some("myrepo")),
+            "lore://127.0.0.1:41337/myrepo"
+        );
+        assert_eq!(advertise_url(41337, None), "lore://127.0.0.1:41337");
+        // blank/whitespace repo name → bare URL
+        assert_eq!(advertise_url(41337, Some("  ")), "lore://127.0.0.1:41337");
+    }
+
+    #[test]
+    fn parse_pinned_rev_finds_40_hex() {
+        let toml = r#"
+            lore = { git = "https://github.com/EpicGames/lore.git", rev = "65598412872a15685e1e8cd6d9d88425eedbc3c2" }
+        "#;
+        assert_eq!(
+            parse_pinned_rev(toml).as_deref(),
+            Some("65598412872a15685e1e8cd6d9d88425eedbc3c2")
+        );
+        assert_eq!(parse_pinned_rev("rev = \"short\""), None);
+    }
+}


### PR DESCRIPTION
Replaces the no-op service_start path: new server_host module generates the proven loreserver config + spawns/manages it as a child; host_server_start/stop/status commands wired into the onboarding host flow, which now displays the lore:// URL. Binary resolved at runtime (env→sidecar→dev-checkout); sidecar bundling is a follow-up. 5/5 unit tests, guards + build green. Resolves SBAI-4065.