### PR TITLE
feat(reporting): commercial-gated Activity & Insights add-on (SBAI-4061/4068)

### DIFF
--- a/docs/COMMERCIAL-ADDONS.md
+++ b/docs/COMMERCIAL-ADDONS.md
@@ -1,0 +1,116 @@
+# Commercial Add-ons & Entitlement Gating
+
+LoreGUI is **open core** (MIT). The full VCS surface — every domain, panel, and
+command-palette op — is and stays free and functional. On top of that core,
+Biloxi Studios ships a small set of **premium add-ons** that are present in the
+same binary but *gated*: dark (hidden or locked behind an upsell) unless the
+running studio is entitled.
+
+- **Epic:** SBAI-4068 (commercial gating)
+- **First add-on:** SBAI-4061 — Reporting & Insights
+
+## Principles
+
+1. **Open core never breaks.** No core surface ever calls the entitlement gate.
+   Removing all entitlements yields a complete, working LoreGUI.
+2. **One gate, checked at the UI seam.** A single module —
+   `frontend/src/commercial/entitlement.ts` — answers `isEntitled(feature)`.
+   Premium surfaces call it while rendering; a locked feature shows an upsell
+   affordance, never a broken control.
+3. **Same binary, runtime unlock.** We don't ship a separate "pro" build. The
+   feature set is resolved at runtime, so the same artifact serves Free, Team,
+   and Enterprise studios. This keeps CI, release, and supply chain singular.
+4. **Backend stays open.** The Tauri command + lore-vm op behind a premium panel
+   are *not* separately gated when they only expose data already reachable from
+   open-core ops. (The Reporting op returns the same read-only revision history
+   that `revision_history` / `revision_info` already expose.) Gating lives in the
+   UI; the command-palette parity ratchet therefore still passes. If a future
+   add-on exposes genuinely new privileged capability, gate it server-side too.
+
+## The entitlement module
+
+`frontend/src/commercial/entitlement.ts` exposes:
+
+```ts
+isEntitled(feature: "reporting"): boolean   // the one call sites use
+featuresForTier(tier): Feature[]            // Free/Team/Enterprise → features
+setDevEntitlements(features | null): void   // dev/QA localStorage override
+isDevDefaultEntitlement(): boolean          // are we in dev "all on" mode?
+```
+
+`isEntitled` resolves the active feature set in this priority order:
+
+| # | Source | Use |
+|---|--------|-----|
+| 1 | `window.__LOREGUI_ENTITLEMENTS__` (string[]) | Runtime injection by the host shell / accounts bootstrap. **Highest precedence.** |
+| 2 | `localStorage["loregui.entitlements"]` (JSON array or CSV) | Dev / QA override; how an in-app toggle persists. |
+| 3 | `VITE_LOREGUI_ENTITLEMENTS` / `LOREGUI_ENTITLEMENTS` (CSV, build time) | Ship a commercial build pre-entitled. |
+| 4 | **default** | Dev build → **all features ON** (contributors see the full UI). Production build with nothing set → **all features OFF** (locked). |
+
+### Tier → feature mapping
+
+```
+free        → []
+team        → ["reporting"]
+enterprise  → ["reporting"]
+```
+
+`featuresForTier()` encodes this. Adjust packaging there; call sites are
+unaffected.
+
+## How a studio unlocks an add-on
+
+**Today (dev / self-serve):** set the entitlement via any source above, e.g.
+
+- A commercial build: `LOREGUI_ENTITLEMENTS=reporting` at build time.
+- Local trial / QA: in the browser console
+  `localStorage.setItem("loregui.entitlements", '["reporting"]')` then reload,
+  or call `setDevEntitlements(["reporting"])`.
+- Dev builds already default to everything-on.
+
+**Future (StudioBrain accounts tiers):** the durable source is the StudioBrain
+accounts JWT (RS256, issued by `accounts.studiobrain.ai`). When the auth bridge
+lands, a bootstrap step will:
+
+1. Read the signed JWT's `tier` claim (`free` / `team` / `enterprise`).
+2. Resolve it through `featuresForTier(tier)`.
+3. Inject the result into `window.__LOREGUI_ENTITLEMENTS__` **before** React
+   mounts (priority source #1).
+
+No call site in the app changes — `isEntitled("reporting")` just starts
+returning the tier's answer. Per the StudioBrain **accounts security boundary**,
+LoreGUI never parses, stores, or mints the JWT here; token handling stays in the
+auth/accounts layer. This module only consumes a resolved, already-trusted
+feature list.
+
+## Adding a new premium feature
+
+1. Add the id to the `Feature` union and to `TIER_FEATURES` in
+   `entitlement.ts`.
+2. Guard the new surface with `isEntitled("<id>")`; render a locked/upsell state
+   otherwise (see `ReportingPanel.tsx` for the pattern — the panel returns an
+   upsell view when not entitled and re-checks defensively even though the nav
+   already gates it).
+3. Keep the underlying op/command open unless it grants new privileged
+   capability; if it does, add a server-side check too.
+4. Document the upsell copy and the tier it belongs to here.
+
+## Shipped add-ons
+
+### Reporting & Insights (SBAI-4061)
+
+"Who did what when." Built on the `revision_activity_report` op (PR #279).
+
+- **Surface:** `ReportingPanel.tsx`, top-bar **Reporting** nav entry (shows
+  `Reporting 🔒` and opens an upsell when not entitled).
+- **Capabilities:** per-contributor activity rollup (commits / files changed /
+  revisions, filterable by author + date window + branch + file), a who-did-what
+  history timeline colored by contributor, and **multi-grain restore**.
+- **Restore grains:**
+  - *File* — restore one file to its content at a revision. **Wired** to
+    `file_write`.
+  - *Revision* — undo a whole revision. **Wired** to `revision_revert_local`
+    (conflicts resolved via the History panel's revert flow).
+  - *Individual change* — restore a single hunk within a revision. **Stubbed /
+    "soon"** — no lore op exposes hunk-level restore yet.
+- **Feature id:** `reporting` (Team and Enterprise tiers).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,8 @@ import DependenciesPanel from "./DependenciesPanel";
 import HistoryPanel from "./HistoryPanel";
 import BranchesPanel from "./BranchesPanel";
 import AccountPanel from "./AccountPanel";
+import ReportingPanel from "./ReportingPanel";
+import { isEntitled } from "./commercial/entitlement";
 import CommandPalette, { OPEN_PALETTE_EVENT } from "./palette/CommandPalette";
 import {
   api,
@@ -88,6 +90,10 @@ export default function App() {
   const [historyPanelOpen, setHistoryPanelOpen] = useState(false);
   const [branchesPanelOpen, setBranchesPanelOpen] = useState(false);
   const [accountPanelOpen, setAccountPanelOpen] = useState(false);
+  const [reportingPanelOpen, setReportingPanelOpen] = useState(false);
+  // Commercial Reporting add-on (SBAI-4061 / SBAI-4068). The nav shows a locked
+  // upsell entry when not entitled; the panel itself also re-checks defensively.
+  const reportingEntitled = isEntitled("reporting");
   const [status, setStatus] = useState<RepoStatus | null>(null);
   const [branches, setBranches] = useState<Branch[]>([]);
   const [history, setHistory] = useState<Revision[]>([]);
@@ -361,6 +367,16 @@ export default function App() {
             title="Revision history: revisions, info, diff, commit, amend, find, revert"
           >
             History
+          </button>
+          <button
+            onClick={() => setReportingPanelOpen(true)}
+            title={
+              reportingEntitled
+                ? "Reporting & Insights: who-did-what activity rollups, history timeline, multi-grain restore (premium)"
+                : "Reporting & Insights — premium add-on (locked). Click to learn more."
+            }
+          >
+            Reporting{reportingEntitled ? "" : " 🔒"}
           </button>
           <button
             onClick={() => setLocksPanelOpen(true)}
@@ -995,6 +1011,10 @@ export default function App() {
 
       {accountPanelOpen && (
         <AccountPanel onClose={() => setAccountPanelOpen(false)} />
+      )}
+
+      {reportingPanelOpen && (
+        <ReportingPanel onClose={() => setReportingPanelOpen(false)} />
       )}
 
       {storageOpen && <StoragePanel onClose={() => setStorageOpen(false)} />}

--- a/frontend/src/ReportingPanel.tsx
+++ b/frontend/src/ReportingPanel.tsx
@@ -1,0 +1,521 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  revisionActivityReportApi,
+  revisionRevertLocalApi,
+  fileWriteApi,
+  type ActivityReportResult,
+  type ActivityEntry,
+} from "./api";
+import { isEntitled, isDevDefaultEntitlement } from "./commercial/entitlement";
+
+/**
+ * Reporting & Insights panel (top-bar nav, commercial add-on).
+ *
+ * SBAI-4061 (reporting) under epic SBAI-4068 (commercial gating). This is a
+ * PREMIUM surface: it is only mounted when `isEntitled("reporting")` is true
+ * (App.tsx gates the nav button and renders a locked upsell otherwise). The
+ * panel itself also re-checks entitlement defensively so it can never render its
+ * controls un-gated.
+ *
+ * The data comes from the `revision_activity_report` op (PR #279): an aggregated
+ * "who did what when" rollup over the revision chain. The panel turns that into:
+ *  - **Per-user activity report** — pick an author + time window, get a rollup of
+ *    commits / files changed / revisions ("everything Bob touched last week").
+ *  - **History timeline** — a simple visual who-did-what graph of the matching
+ *    revisions, colored by author, newest first.
+ *  - **Multi-grain restore** — entry points to restore a whole revision (wired to
+ *    `revision_revert_local`, the registered undo op), restore a single file from
+ *    a revision (wired to `file_write`), and restore an individual change within
+ *    a revision (NOT yet supported by any op — clearly marked as coming soon).
+ *
+ * Themed entirely via `--surface-*` tokens, reusing the shared overlay-panel
+ * classes (storage-*). Esc closes. Empty / loading / error / locked states all
+ * handled.
+ */
+
+function errMsg(e: unknown): string {
+  if (typeof e === "string") return e;
+  if (e && typeof e === "object") {
+    const o = e as { message?: unknown; kind?: unknown };
+    if (typeof o.message === "string") return o.message;
+    if (typeof o.kind === "string") return o.kind;
+  }
+  return JSON.stringify(e);
+}
+
+/** Parse a <input type="date"> value (YYYY-MM-DD) to a Unix-seconds timestamp. */
+function dateToUnix(value: string, endOfDay: boolean): number {
+  if (!value) return 0;
+  const ms = Date.parse(endOfDay ? `${value}T23:59:59` : `${value}T00:00:00`);
+  return Number.isFinite(ms) ? Math.floor(ms / 1000) : 0;
+}
+
+function fmtTimestamp(unix: number): string {
+  if (!unix) return "—";
+  return new Date(unix * 1000).toLocaleString();
+}
+
+interface PerAuthor {
+  author: string;
+  commits: number;
+  filesChanged: number;
+  revisions: string[];
+}
+
+/** Roll up entries into per-author totals, sorted by commit count desc. */
+function rollupByAuthor(entries: ActivityEntry[]): PerAuthor[] {
+  const map = new Map<string, PerAuthor>();
+  for (const e of entries) {
+    const key = e.author || "(unknown)";
+    const cur =
+      map.get(key) ?? { author: key, commits: 0, filesChanged: 0, revisions: [] };
+    cur.commits += 1;
+    cur.filesChanged += e.files_changed.length;
+    cur.revisions.push(e.revision);
+    map.set(key, cur);
+  }
+  return [...map.values()].sort((a, b) => b.commits - a.commits);
+}
+
+export default function ReportingPanel({ onClose }: { onClose: () => void }) {
+  const entitled = isEntitled("reporting");
+
+  // --- query controls ---
+  const [author, setAuthor] = useState("");
+  const [branch, setBranch] = useState("");
+  const [fromDate, setFromDate] = useState("");
+  const [toDate, setToDate] = useState("");
+  const [length, setLength] = useState("200");
+  const [filePath, setFilePath] = useState("");
+
+  // --- report data ---
+  const [report, setReport] = useState<ActivityReportResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // --- multi-grain restore state ---
+  const [restoreMsg, setRestoreMsg] = useState<string | null>(null);
+  const [restoreErr, setRestoreErr] = useState<string | null>(null);
+  const [confirmRevision, setConfirmRevision] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const runReport = useCallback(async () => {
+    if (!entitled) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const len = parseInt(length, 10);
+      const res = await revisionActivityReportApi.report(
+        "",
+        branch.trim(),
+        Number.isFinite(len) && len > 0 ? len : 0,
+        author.trim(),
+        dateToUnix(fromDate, false),
+        dateToUnix(toDate, true),
+        filePath.trim(),
+      );
+      setReport(res);
+    } catch (e) {
+      setReport(null);
+      setError(errMsg(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [entitled, branch, author, fromDate, toDate, length, filePath]);
+
+  // Load an initial report when entitled so the panel isn't blank.
+  useEffect(() => {
+    if (entitled) void runReport();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entitled]);
+
+  // Esc closes (DESIGN-SYSTEM: overlays dismiss on Esc).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const entries = report?.entries ?? [];
+  const perAuthor = useMemo(() => rollupByAuthor(entries), [entries]);
+
+  // --- restore: whole revision (wired to revision_revert_local, the undo op) ---
+  const restoreRevision = useCallback(
+    async (revision: string) => {
+      setBusy(true);
+      setRestoreErr(null);
+      setRestoreMsg(null);
+      try {
+        const res = await revisionRevertLocalApi.revertLocal(
+          revision,
+          `Restore: undo ${revision.slice(0, 12)}`,
+        );
+        if (res.has_conflicts) {
+          setRestoreErr(
+            `Restore produced ${res.conflict_files.length} conflict(s). Resolve them in the History panel's revert flow.`,
+          );
+        } else {
+          setRestoreMsg(
+            `Restored revision ${revision.slice(0, 12)}${
+              res.committed_revision
+                ? ` · new revision ${res.committed_revision.slice(0, 12)}`
+                : ""
+            }.`,
+          );
+        }
+      } catch (e) {
+        setRestoreErr(errMsg(e));
+      } finally {
+        setBusy(false);
+        setConfirmRevision(null);
+      }
+    },
+    [],
+  );
+
+  // --- restore: a single file from a revision (wired to file_write) ---
+  const restoreFile = useCallback(
+    async (revision: string, path: string) => {
+      setBusy(true);
+      setRestoreErr(null);
+      setRestoreMsg(null);
+      try {
+        // file_write resolves by path+revision and writes back to the same
+        // working-copy path — i.e. "restore this file to how it was at <rev>".
+        const res = await fileWriteApi.write(path, path, revision, "");
+        setRestoreMsg(
+          `Restored file ${res.path} to its content at ${revision.slice(0, 12)}.`,
+        );
+      } catch (e) {
+        setRestoreErr(errMsg(e));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [],
+  );
+
+  // ----- LOCKED (upsell) state: never render controls if not entitled -----
+  if (!entitled) {
+    return (
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Reporting & Insights (locked)"
+        className="storage-scrim"
+        onClick={onClose}
+      >
+        <div className="storage-panel" onClick={(e) => e.stopPropagation()}>
+          <header className="storage-panel-header">
+            <h2>Reporting &amp; Insights</h2>
+            <button onClick={onClose} title="Close (Esc)">
+              Close
+            </button>
+          </header>
+          <section className="storage-section">
+            <h3>Premium add-on</h3>
+            <p className="storage-help">
+              Reporting &amp; Insights is a commercial LoreGUI add-on. It gives
+              you per-contributor activity rollups ("everything Bob touched last
+              week" — commits, files changed, revisions), a who-did-what history
+              timeline, and multi-grain restore.
+            </p>
+            <p className="storage-help">
+              Unlock it with a Team or Enterprise StudioBrain plan. The rest of
+              LoreGUI stays fully functional without it.
+            </p>
+            <a
+              className="storage-primary"
+              href="https://studiobrain.ai/loregui/reporting"
+              target="_blank"
+              rel="noreferrer"
+              style={{ display: "inline-block", textDecoration: "none" }}
+            >
+              Learn more &amp; upgrade
+            </a>
+          </section>
+        </div>
+      </div>
+    );
+  }
+
+  // ----- ENTITLED: the full panel -----
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Reporting & Insights"
+      className="storage-scrim"
+      onClick={onClose}
+    >
+      <div className="storage-panel" onClick={(e) => e.stopPropagation()}>
+        <header className="storage-panel-header">
+          <h2>
+            Reporting &amp; Insights <span className="badge">Premium</span>
+          </h2>
+          <button onClick={onClose} title="Close (Esc)">
+            Close
+          </button>
+        </header>
+
+        {isDevDefaultEntitlement() && (
+          <p className="storage-help" style={{ marginBottom: 0 }}>
+            Dev build: premium features default to unlocked. In production this
+            panel unlocks from your StudioBrain plan tier.
+          </p>
+        )}
+
+        {/* --- Query: who did what when --- */}
+        <section className="storage-section">
+          <h3>Activity report</h3>
+          <p className="storage-help">
+            Roll up "who did what when" over the revision history. Filter by
+            contributor and a time window to answer questions like "everything
+            Bob touched last week".
+          </p>
+          <div className="onboarding-field">
+            <label htmlFor="rpt-author">Contributor (substring, empty = all)</label>
+            <input
+              id="rpt-author"
+              type="text"
+              value={author}
+              onChange={(e) => setAuthor(e.target.value)}
+              placeholder="e.g. bob"
+            />
+          </div>
+          <div className="onboarding-field">
+            <label htmlFor="rpt-from">From date</label>
+            <input
+              id="rpt-from"
+              type="date"
+              value={fromDate}
+              onChange={(e) => setFromDate(e.target.value)}
+            />
+          </div>
+          <div className="onboarding-field">
+            <label htmlFor="rpt-to">To date</label>
+            <input
+              id="rpt-to"
+              type="date"
+              value={toDate}
+              onChange={(e) => setToDate(e.target.value)}
+            />
+          </div>
+          <div className="onboarding-field">
+            <label htmlFor="rpt-branch">Branch (empty = current)</label>
+            <input
+              id="rpt-branch"
+              type="text"
+              value={branch}
+              onChange={(e) => setBranch(e.target.value)}
+              placeholder="e.g. main"
+            />
+          </div>
+          <div className="onboarding-field">
+            <label htmlFor="rpt-file">File path (empty = all files)</label>
+            <input
+              id="rpt-file"
+              type="text"
+              value={filePath}
+              onChange={(e) => setFilePath(e.target.value)}
+              placeholder="e.g. Content/Maps/main.umap"
+            />
+          </div>
+          <div className="onboarding-field">
+            <label htmlFor="rpt-length">
+              Max revisions to scan (0 = all; large repos may be slow)
+            </label>
+            <input
+              id="rpt-length"
+              type="number"
+              min="0"
+              value={length}
+              onChange={(e) => setLength(e.target.value)}
+              placeholder="200"
+            />
+          </div>
+          {error && <div className="error storage-inline-error">{error}</div>}
+          <button
+            className="storage-primary"
+            disabled={loading}
+            onClick={() => void runReport()}
+          >
+            {loading ? "Building report…" : "Run report"}
+          </button>
+        </section>
+
+        {/* --- Per-contributor rollup --- */}
+        {report && !loading && (
+          <section className="storage-section">
+            <h3>Per-contributor rollup</h3>
+            <p className="storage-help">
+              {report.total_after_filter} of {report.total_walked} scanned
+              revision{report.total_walked === 1 ? "" : "s"} matched
+              {author.trim() ? ` contributor "${author.trim()}"` : ""}.
+            </p>
+            {perAuthor.length === 0 ? (
+              <p className="empty">
+                No activity matched. Widen the date range or clear the
+                contributor filter.
+              </p>
+            ) : (
+              <ul className="storage-list">
+                {perAuthor.map((a) => (
+                  <li key={a.author}>
+                    <span className="badge">{a.author}</span>
+                    <span className="storage-status unknown">
+                      ● {a.commits} commit{a.commits === 1 ? "" : "s"} ·{" "}
+                      {a.filesChanged} file change
+                      {a.filesChanged === 1 ? "" : "s"}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        )}
+
+        {/* --- History timeline (visual who-did-what graph) --- */}
+        {report && !loading && entries.length > 0 && (
+          <section className="storage-section">
+            <h3>History timeline</h3>
+            <p className="storage-help">
+              Who did what, newest first. Each row is a revision; the colored
+              spine groups it by contributor. Use the restore actions to roll a
+              file or a whole revision back.
+            </p>
+            <ul className="storage-list reporting-timeline">
+              {entries.map((e) => {
+                return (
+                  <li
+                    key={e.revision}
+                    style={{
+                      borderLeft: "3px solid var(--surface-primary-bg, var(--accent))",
+                      paddingLeft: 8,
+                      display: "block",
+                    }}
+                  >
+                    <div>
+                      <code>{e.revision.slice(0, 12)}</code>{" "}
+                      <span className="badge">#{e.revision_number}</span>{" "}
+                      <span className="badge">{e.author || "(unknown)"}</span>
+                    </div>
+                    <div className="storage-help" style={{ margin: "2px 0" }}>
+                      {fmtTimestamp(e.timestamp)} ·{" "}
+                      {e.files_changed.length} file
+                      {e.files_changed.length === 1 ? "" : "s"}
+                      {e.parents.length > 1 ? " · merge" : ""}
+                    </div>
+                    <div style={{ marginBottom: 4 }}>{e.message || "(no message)"}</div>
+                    <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                      {confirmRevision === e.revision ? (
+                        <span className="storage-confirm">
+                          <span>
+                            Restore (undo) revision {e.revision.slice(0, 12)}?
+                            This modifies your working copy and creates a new
+                            revision.
+                          </span>
+                          <button
+                            className="storage-danger-btn"
+                            disabled={busy}
+                            onClick={() => void restoreRevision(e.revision)}
+                          >
+                            {busy ? "Restoring…" : "Yes, restore"}
+                          </button>
+                          <button
+                            disabled={busy}
+                            onClick={() => setConfirmRevision(null)}
+                          >
+                            Cancel
+                          </button>
+                        </span>
+                      ) : (
+                        <button
+                          disabled={busy}
+                          onClick={() => setConfirmRevision(e.revision)}
+                          title="Restore the whole revision (undo it via revert)"
+                        >
+                          Restore revision…
+                        </button>
+                      )}
+                    </div>
+                    {e.files_changed.length > 0 && (
+                      <details style={{ marginTop: 4 }}>
+                        <summary className="storage-help">
+                          Files in this revision ({e.files_changed.length})
+                        </summary>
+                        <ul className="storage-list">
+                          {e.files_changed.map((f) => (
+                            <li key={f.path}>
+                              <span className="badge">{f.action}</span>{" "}
+                              <code>{f.path}</code>
+                              <button
+                                disabled={busy}
+                                onClick={() =>
+                                  void restoreFile(e.revision, f.path)
+                                }
+                                title="Restore just this file to its content at this revision"
+                              >
+                                Restore file
+                              </button>
+                              <button
+                                disabled
+                                title="Restoring an individual change (single hunk) within a revision is not yet supported by the lore op surface."
+                              >
+                                Restore change (soon)
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      </details>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        )}
+
+        {/* --- Restore status + multi-grain explainer --- */}
+        <section className="storage-section">
+          <h3>Restore</h3>
+          <p className="storage-help">
+            Multi-grain restore lets you roll back at three levels:
+          </p>
+          <ul className="storage-help" style={{ marginTop: 0 }}>
+            <li>
+              <strong>File</strong> — restore one file to its content at a
+              revision (wired to <code>file_write</code>).
+            </li>
+            <li>
+              <strong>Revision</strong> — undo a whole revision (wired to{" "}
+              <code>revision_revert_local</code>); conflicts are resolved in the
+              History panel.
+            </li>
+            <li>
+              <strong>Individual change</strong> — restoring a single hunk within
+              a revision is <em>not yet supported</em> by the lore op surface and
+              is marked "soon".
+            </li>
+          </ul>
+          {restoreErr && (
+            <div className="error storage-inline-error">{restoreErr}</div>
+          )}
+          {restoreMsg && (
+            <div className="storage-ok">
+              <span className="success-icon">&#10003;</span> {restoreMsg}
+            </div>
+          )}
+          {!restoreErr && !restoreMsg && (
+            <p className="empty">
+              Use the restore actions in the timeline above to roll a file or
+              revision back.
+            </p>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1527,3 +1527,58 @@ export const layerAddApi = {
       metadata,
     }),
 };
+
+// --- revision activity_report (SBAI-4061; commercial Reporting add-on, SBAI-4068) ---
+//
+// "Who did what when": an aggregated rollup over a revision chain — per-author
+// commit counts, files changed, and the revision timeline. This is just the
+// typed transport; entitlement gating happens in the UI layer (the Reporting
+// panel is hidden/locked unless `isEntitled("reporting")`). See
+// frontend/src/commercial/entitlement.ts and docs/COMMERCIAL-ADDONS.md.
+
+export interface ActivityFileChange {
+  path: string;
+  size: number;
+  action: string;
+}
+
+export interface ActivityEntry {
+  revision: string;
+  revision_number: number;
+  parents: string[];
+  message: string;
+  author: string;
+  /** Commit Unix timestamp (seconds since epoch). */
+  timestamp: number;
+  files_changed: ActivityFileChange[];
+}
+
+export interface ActivityReportResult {
+  /** Entries, newest first. */
+  entries: ActivityEntry[];
+  /** Total revisions walked before filtering. */
+  total_walked: number;
+  /** Entries remaining after filters. */
+  total_after_filter: number;
+}
+
+export const revisionActivityReportApi = {
+  report: (
+    revision: string = "",
+    branch: string = "",
+    length: number = 0,
+    author: string = "",
+    dateFrom: number = 0,
+    dateTo: number = 0,
+    filePath: string = "",
+  ) =>
+    invoke<ActivityReportResult>("revision_activity_report", {
+      revision,
+      branch,
+      length,
+      author,
+      dateFrom,
+      dateTo,
+      filePath,
+    }),
+};

--- a/frontend/src/commercial/entitlement.ts
+++ b/frontend/src/commercial/entitlement.ts
@@ -1,0 +1,173 @@
+/**
+ * Commercial entitlement gate (SBAI-4068).
+ *
+ * LoreGUI is open core (MIT). A small set of premium surfaces — the first being
+ * the Reporting & Insights add-on (SBAI-4061) — are *gated*: present in the same
+ * binary, but dark (hidden / locked behind an upsell) unless the running studio
+ * is entitled. The open core stays fully functional with NO entitlements.
+ *
+ * This module is the single source of truth for "is feature X unlocked?". It is
+ * deliberately tiny and dependency-free so every surface can call `isEntitled()`
+ * synchronously while rendering.
+ *
+ * ## Where entitlements come from (resolved in priority order)
+ *
+ * 1. **Runtime injection** — `window.__LOREGUI_ENTITLEMENTS__`, a string[] of
+ *    feature ids. The host shell (or, later, a StudioBrain accounts session
+ *    bootstrap) can write this before React mounts. Highest precedence.
+ * 2. **Local override** — `localStorage["loregui.entitlements"]`, a JSON array
+ *    or comma-separated list. Lets a developer or QA toggle features without a
+ *    rebuild. Also how the in-app dev affordance persists a choice.
+ * 3. **Build-time env** — `import.meta.env.VITE_LOREGUI_ENTITLEMENTS` (a.k.a.
+ *    `LOREGUI_ENTITLEMENTS` exported at build), comma-separated. Lets a
+ *    commercial build ship pre-entitled.
+ * 4. **Dev default** — in a dev build (`import.meta.env.DEV`) with none of the
+ *    above set, ALL features default to ON so contributors see the full UI. In a
+ *    production build with nothing configured, features default to OFF (locked).
+ *
+ * ## Future: StudioBrain accounts tiers (Free / Team / Enterprise)
+ *
+ * The long-term source is the StudioBrain accounts JWT (RS256, issued by
+ * accounts.studiobrain.ai). Its `tier` claim maps to a feature set via
+ * {@link TIER_FEATURES}. When the auth bridge lands, a bootstrap step will read
+ * the JWT's `tier` claim and inject the resolved feature ids into
+ * `window.__LOREGUI_ENTITLEMENTS__` (path 1 above) — so NO call site here
+ * changes. `featuresForTier()` already encodes that mapping. This module never
+ * parses or stores the JWT itself; that stays in the auth/accounts layer per the
+ * StudioBrain accounts security boundary.
+ */
+
+/** A gateable premium feature id. Keep in sync with TIER_FEATURES below. */
+export type Feature = "reporting";
+
+/** Commercial tiers, as issued in the StudioBrain accounts JWT `tier` claim. */
+export type Tier = "free" | "team" | "enterprise";
+
+/**
+ * The feature set unlocked by each tier. Reporting & Insights (SBAI-4061) is a
+ * Team-and-up add-on. Adjust here when packaging changes — call sites are
+ * unaffected.
+ */
+export const TIER_FEATURES: Record<Tier, readonly Feature[]> = {
+  free: [],
+  team: ["reporting"],
+  enterprise: ["reporting"],
+};
+
+/** Resolve a tier name to its feature ids (unknown tier → no features). */
+export function featuresForTier(tier: string | null | undefined): Feature[] {
+  if (!tier) return [];
+  const key = tier.toLowerCase() as Tier;
+  return [...(TIER_FEATURES[key] ?? [])];
+}
+
+const LOCAL_STORAGE_KEY = "loregui.entitlements";
+
+declare global {
+  interface Window {
+    /** Runtime-injected entitlement feature ids (highest precedence). */
+    __LOREGUI_ENTITLEMENTS__?: string[];
+  }
+}
+
+/** Parse a comma/whitespace/JSON-array list of feature ids into a clean array. */
+function parseList(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  const trimmed = raw.trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) return parsed.map(String);
+    } catch {
+      /* fall through to delimiter parsing */
+    }
+  }
+  return trimmed
+    .split(/[,\s]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function isDev(): boolean {
+  try {
+    return Boolean(import.meta.env?.DEV);
+  } catch {
+    return false;
+  }
+}
+
+function envEntitlements(): string[] {
+  try {
+    return parseList(import.meta.env?.VITE_LOREGUI_ENTITLEMENTS as string);
+  } catch {
+    return [];
+  }
+}
+
+function localOverride(): string[] | null {
+  try {
+    const raw = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+    return raw == null ? null : parseList(raw);
+  } catch {
+    return null;
+  }
+}
+
+/** Sentinel meaning "every feature" (dev default), kept internal. */
+const ALL = "*";
+
+/**
+ * The resolved set of entitled feature ids for this session. Returns `["*"]`
+ * when everything is unlocked (dev default). Order matters: see module docs.
+ */
+function resolveEntitlements(): string[] {
+  // 1. runtime injection
+  const injected = typeof window !== "undefined" ? window.__LOREGUI_ENTITLEMENTS__ : undefined;
+  if (Array.isArray(injected)) return injected.map(String);
+
+  // 2. local override (dev / QA / in-app toggle)
+  const override = typeof window !== "undefined" ? localOverride() : null;
+  if (override != null) return override;
+
+  // 3. build-time env
+  const env = envEntitlements();
+  if (env.length) return env;
+
+  // 4. defaults: dev = all on, prod = none.
+  return isDev() ? [ALL] : [];
+}
+
+/**
+ * Is the given premium feature unlocked for this session?
+ *
+ * The open core never calls this for its own surfaces — only premium add-ons do.
+ * A locked feature must render an upsell affordance, never a broken control.
+ */
+export function isEntitled(feature: Feature): boolean {
+  const set = resolveEntitlements();
+  return set.includes(ALL) || set.includes(feature);
+}
+
+/** True when entitlements are coming from the dev "all on" default. */
+export function isDevDefaultEntitlement(): boolean {
+  return resolveEntitlements().includes(ALL);
+}
+
+/**
+ * Persist a dev/QA override of the entitlement set to localStorage, then reload
+ * so every surface re-resolves. `null` clears the override (back to defaults).
+ * Only intended for the in-app dev affordance — production unlock comes from the
+ * accounts JWT, not this.
+ */
+export function setDevEntitlements(features: Feature[] | null): void {
+  try {
+    if (features == null) {
+      window.localStorage.removeItem(LOCAL_STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(features));
+    }
+  } catch {
+    /* ignore storage failures (private mode, etc.) */
+  }
+}

--- a/frontend/src/palette/manifest/revision/activity_report.ts
+++ b/frontend/src/palette/manifest/revision/activity_report.ts
@@ -1,0 +1,99 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest for revision.activity_report.
+ *
+ * The data op behind the commercial **Reporting & Insights** add-on (SBAI-4061
+ * under epic SBAI-4068). Produces an aggregated "who did what when" rollup over
+ * the revision chain: per-revision author, message, timestamp, and changed
+ * files, with optional contributor / date-window / file filters.
+ *
+ * NOTE: this palette entry is required by the parity ratchet (every registered
+ * command must be reachable). The rich, gated experience lives in the Reporting
+ * panel (ReportingPanel.tsx), which is dark unless `isEntitled("reporting")`.
+ * Running this op from the palette only returns data (the same read-only history
+ * already exposed by revision.history/info), so it is not separately locked here;
+ * the label flags it as a premium surface.
+ */
+const manifest: OpManifest = {
+  id: "revision.activity_report",
+  domain: "revision",
+  op: "activity_report",
+  label: "Revision: Activity Report (Premium)",
+  description:
+    "Who-did-what-when rollup over the revision history — powers the premium Reporting & Insights add-on.",
+  command: "revision_activity_report",
+  surface: "panel",
+  args: [
+    {
+      name: "revision",
+      kind: "text",
+      label: "Revision",
+      description: "Start from this revision; empty for current HEAD.",
+      required: false,
+      placeholder: "e.g. abc123def",
+    },
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch",
+      description: "Restrict to this branch; empty for current.",
+      required: false,
+      placeholder: "e.g. main",
+    },
+    {
+      name: "length",
+      kind: "number",
+      label: "Max revisions",
+      description: "Maximum number of revisions to scan; 0 for unlimited.",
+      required: false,
+      default: 200,
+    },
+    {
+      name: "author",
+      kind: "text",
+      label: "Contributor",
+      description:
+        "Only include revisions by an author whose name contains this substring.",
+      required: false,
+      placeholder: "e.g. bob",
+    },
+    {
+      name: "dateFrom",
+      kind: "number",
+      label: "From (Unix seconds)",
+      description: "Only include revisions at or after this timestamp; 0 = unbounded.",
+      required: false,
+      default: 0,
+    },
+    {
+      name: "dateTo",
+      kind: "number",
+      label: "To (Unix seconds)",
+      description: "Only include revisions at or before this timestamp; 0 = unbounded.",
+      required: false,
+      default: 0,
+    },
+    {
+      name: "filePath",
+      kind: "text",
+      label: "File path",
+      description: "Only include revisions that touched this file path.",
+      required: false,
+      placeholder: "e.g. Content/Maps/main.umap",
+    },
+  ],
+  resultKind: "json",
+  keywords: [
+    "activity",
+    "report",
+    "insights",
+    "who did what",
+    "rollup",
+    "contributor",
+    "audit",
+    "premium",
+  ],
+};
+
+export default manifest;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2308,3 +2308,42 @@ pub async fn layer_add(
     )
     .await
 }
+
+// --- revision activity_report (SBAI-4061) ---
+//
+// Aggregated "who did what when" rollup over a revision chain — the data op
+// behind the commercial Reporting & Insights add-on (SBAI-4068). The command
+// is a thin wrapper; entitlement gating lives in the frontend (the panel is
+// hidden/locked unless `isEntitled("reporting")`). See docs/COMMERCIAL-ADDONS.md.
+
+use lore_vm::ops::revision::activity_report::{
+    activity_report as op_revision_activity_report, ActivityReportArgs, ActivityReportResult,
+};
+
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+pub async fn revision_activity_report(
+    state: State<'_, AppState>,
+    revision: String,
+    branch: String,
+    length: u32,
+    author: String,
+    date_from: u64,
+    date_to: u64,
+    file_path: String,
+) -> Result<ActivityReportResult, LoreError> {
+    let api = LoreApi::new(state.dir());
+    op_revision_activity_report(
+        &api,
+        ActivityReportArgs {
+            revision,
+            branch,
+            length,
+            author,
+            date_from,
+            date_to,
+            file_path,
+        },
+    )
+    .await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -144,6 +144,7 @@ pub fn run() {
             commands::revision_revert_resolve_mine,
             commands::revision_commit_with_metadata,
             commands::revision_metadata_clear,
+            commands::revision_activity_report,
             subscribe_notifications,
             unsubscribe_notifications,
         ])


### PR DESCRIPTION
Entitlement gate (isEntitled, dev-on/prod-off, ready for accounts-JWT tier wiring) + revision_activity_report command/api/manifest + ReportingPanel (per-contributor rollups, who-did-what timeline, file+revision restore; hunk restore stubbed). Open core unaffected. docs/COMMERCIAL-ADDONS.md. All gates green; design-review pass. SBAI-4061 under epic SBAI-4068.