### PR TITLE
SBAI-4070: Harden upstream-lore parity sync

### DIFF
--- a/.github/workflows/upstream-parity.yml
+++ b/.github/workflows/upstream-parity.yml
@@ -2,60 +2,140 @@ name: upstream-parity
 
 # Keep LoreGUI in parity with Epic's `lore`. On a schedule (and on demand), this
 # fetches the LATEST upstream `lore` source and diffs its op surface against our
-# `crates/lore-vm/src/ops` bindings. When upstream has added ops we don't bind
-# yet, it opens/updates a tracking issue — the "notice" that new functions need
-# to be built out (bound -> command -> palette entry) to restore full parity.
+# `crates/lore-vm/src/ops` bindings.
+#
+# Extensions (SBAI-4070):
+#   1. Detect/propose bumping pinned lore rev via PR.
+#   2. Detect signature drift (breaking changes) on bound ops.
+#   3. Auto-dispatch SBAI tickets per new/changed op.
+#   4. Canary E2E job against the new rev.
 on:
   schedule:
     - cron: "0 7 * * 1" # Mondays 07:00 UTC
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   issues: write
+  pull-requests: write
 
 jobs:
   detect:
     runs-on: ubuntu-latest
+    outputs:
+      rev_changed: ${{ steps.check.outputs.changed }}
+      old_rev: ${{ steps.pinned.outputs.rev }}
+      new_rev: ${{ steps.upstream.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Get pinned lore rev
+        id: pinned
+        run: |
+          REV=$(grep -oP 'lore = \{ git = "https://github.com/EpicGames/lore.git", rev = "\K[0-9a-f]+' Cargo.toml | head -1)
+          echo "rev=$REV" >> $GITHUB_OUTPUT
 
       - name: Fetch latest upstream lore
-        run: git clone --depth 1 https://github.com/EpicGames/lore.git /tmp/lore-head
-
-      - name: Diff upstream HEAD against our bindings
-        id: diff
+        id: upstream
         run: |
-          set +e
-          LORE_SRC=/tmp/lore-head node scripts/upstream-lore-parity.mjs --json > /tmp/parity.json
-          node -e '
-            const r = JSON.parse(require("fs").readFileSync("/tmp/parity.json","utf8"));
-            const fs = require("fs");
-            const out = process.env.GITHUB_OUTPUT;
-            fs.appendFileSync(out, `new_count=${r.newOps.length}\n`);
-            const body = r.newOps.length
-              ? "Upstream `lore` exposes ops we do not bind yet. Build each (lore-vm binding -> #[tauri::command] -> palette manifest entry) to restore parity:\n\n"
-                + r.newOps.map(o => `- [ ] \`${o}\``).join("\n")
-                + `\n\nUpstream ops: ${r.upstreamOpCount} - our bindings: ${r.ourOpCount}.`
-              : "";
-            fs.writeFileSync("/tmp/issue-body.md", body);
-          '
+          git clone --depth 1 https://github.com/EpicGames/lore.git /tmp/lore-head
+          SHA=$(git -C /tmp/lore-head rev-parse HEAD)
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
 
-      - name: Open/refresh tracking issue
-        if: steps.diff.outputs.new_count != '0'
+      - name: Check for rev change
+        id: check
+        run: |
+          if [ "${{ steps.pinned.outputs.rev }}" != "${{ steps.upstream.outputs.sha }}" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run parity check (with drift detection)
+        id: parity
+        run: |
+          LORE_SRC=/tmp/lore-head node scripts/upstream-lore-parity.mjs --head-src /tmp/lore-head/lore/src --json > /tmp/parity.json
+          # Show summary in logs
+          node scripts/upstream-lore-parity.mjs --head-src /tmp/lore-head/lore/src
+
+      - name: Create PR for rev bump
+        if: steps.check.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TITLE="Upstream lore parity: ${{ steps.diff.outputs.new_count }} new op(s) to build"
-          EXISTING=$(gh issue list --label upstream-parity --state open --json number --jq '.[0].number')
-          if [ -n "$EXISTING" ]; then
-            gh issue edit "$EXISTING" --title "$TITLE" --body-file /tmp/issue-body.md
-            gh issue comment "$EXISTING" --body "Re-detected on $(date -u +%F). See updated checklist."
-          else
-            gh issue create --title "$TITLE" --body-file /tmp/issue-body.md \
-              --label upstream-parity || \
-            gh issue create --title "$TITLE" --body-file /tmp/issue-body.md
-          fi
+          SHA=${{ steps.upstream.outputs.sha }}
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="update-lore-${SHA:0:12}"
+          git checkout -b "$BRANCH"
+          # Bump lore and its patched quinn-proto to the new rev
+          sed -i 's/\(git = "https:\/\/github.com\/EpicGames\/lore.git", rev = "\)[0-9a-f]\+"/\1'$SHA'"/g' Cargo.toml
+          cargo update -p lore
+          git add Cargo.toml Cargo.lock
+          git commit -m "SBAI-4070: bump lore to ${SHA:0:12}"
+          git push origin "$BRANCH"
+          gh pr create --title "Bump lore to ${SHA:0:12}" --body "Automated rev bump to latest upstream lore HEAD. Subtasks created for new/drifted ops."
+
+      - name: Dispatch BrainMon tickets
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node -e '
+            const r = JSON.parse(require("fs").readFileSync("/tmp/parity.json","utf8"));
+            const { execSync } = require("child_process");
+            
+            // Map domains to their primary Story keys for parent-linkage hint
+            const DOMAIN_STORIES = {
+              repository: "SBAI-4033",
+              file: "SBAI-4034",
+              revision: "SBAI-4036",
+              storage: "SBAI-4024",
+              auth: "SBAI-3841",
+            };
+
+            for (const op of r.newOps) {
+              const [domain] = op.id.split(".");
+              const title = `[Parity] Build op ${op.id}`;
+              const story = DOMAIN_STORIES[domain] || "SBAI-4024";
+              const body = `Upstream lore added op \`${op.id}\` (args: \`${op.sig.argsType}\`). Build binding -> command -> palette entry.\n\nParent Story: ${story}`;
+              
+              const existing = execSync(`gh issue list --search "${title}" --label upstream-parity --json number --jq ".[0].number"`, { encoding: "utf8" }).trim();
+              if (!existing) {
+                console.log(`Creating ticket for new op: ${op.id}`);
+                execSync(`gh issue create --title "${title}" --body "${body}" --label upstream-parity --label "${domain}"`);
+              }
+            }
+
+            for (const op of r.driftedOps) {
+              const [domain] = op.id.split(".");
+              const title = `[Parity] FIX signature drift in ${op.id}`;
+              const body = `Upstream lore changed signature of \`${op.id}\`.\n\nUpdate lore-vm binding to match upstream changes.`;
+              
+              const existing = execSync(`gh issue list --search "${title}" --label upstream-parity --json number --jq ".[0].number"`, { encoding: "utf8" }).trim();
+              if (!existing) {
+                console.log(`Creating ticket for drifted op: ${op.id}`);
+                execSync(`gh issue create --title "${title}" --body "${body}" --label upstream-parity --label drift --label "${domain}"`);
+              }
+            }
+          '
+
+  canary:
+    needs: detect
+    if: needs.detect.outputs.rev_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: System deps for lore build
+        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config
+      - name: Bump rev locally
+        run: |
+          sed -i 's/\(git = "https:\/\/github.com\/EpicGames\/lore.git", rev = "\)[0-9a-f]\+"/\1${{ needs.detect.outputs.new_rev }}"/g' Cargo.toml
+          cargo update -p lore
+      - name: Run integration tests (canary)
+        run: cargo test -p lore-vm --features integration-tests

--- a/scripts/upstream-lore-parity.mjs
+++ b/scripts/upstream-lore-parity.mjs
@@ -1,21 +1,16 @@
 #!/usr/bin/env node
 /**
- * Upstream lore API-parity detector.
+ * Upstream lore API-parity detector (Enhanced).
  *
  * Keeps LoreGUI in parity with Epic's `lore` crate: it enumerates the op surface
- * of the *pinned* upstream `lore` source (every `pub async fn` in `lore/src/`)
- * and diffs it against our `crates/lore-vm/src/ops/<domain>/<op>.rs` bindings.
+ * of the upstream `lore` source (every `pub async fn` in `lore/src/`) and diffs
+ * it against our `crates/lore-vm/src/ops/<domain>/<op>.rs` bindings.
  *
- *   - NEW upstream ops we don't bind yet  → candidates to build (the pipeline
- *     should file a subtask + an agent binds it, exposes it in the palette).
- *   - Bindings with no matching upstream fn → possibly removed/renamed upstream
- *     (our binding may be stale after a rev bump).
+ * It also supports comparing a "head" source (e.g. latest lore HEAD) against
+ * the "pinned" source (the version we currently use) to detect signature drift.
  *
  * Run on a schedule (and after any `lore` rev bump). Output is JSON on stdout
  * plus a human summary on stderr; pass `--json` for machine consumption.
- *
- * Heuristic by nature (upstream has internal helper fns; we have `*_local`
- * naming variants) — it produces a review list, not a hard gate.
  */
 import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -33,10 +28,7 @@ const UPSTREAM_IGNORE = new Set([
 ]);
 
 /**
- * Known-internal upstream ops by full `<domain>.<fn>` id. The `layer/` subdir
- * holds low-level impl fns (`add`/`list`/`remove`) that the public `layer.rs`
- * facade (`layer_add`/`layer_list`/…, which we DO bind) wraps — so they are not
- * separate ops. Add new entries here only with a justification.
+ * Known-internal upstream ops by full `<domain>.<fn>` id.
  */
 const KNOWN_INTERNAL_IDS = new Set([
   "layer.add",
@@ -45,9 +37,7 @@ const KNOWN_INTERNAL_IDS = new Set([
 ]);
 
 /**
- * Upstream modules that are internal plumbing, not part of the op API surface
- * we mirror (analytics, low-level call/remote RPC, logging, etc.). The diff is
- * scoped to the domains we actually bind.
+ * Upstream modules that are internal plumbing, not part of the op API surface.
  */
 const OP_DOMAINS = new Set([
   "auth",
@@ -67,24 +57,25 @@ const OP_DOMAINS = new Set([
 
 /** Read the pinned lore git rev from Cargo.lock. */
 function pinnedRev() {
-  const lock = readFileSync(join(repoRoot, "Cargo.lock"), "utf8");
+  const lockPath = join(repoRoot, "Cargo.lock");
+  if (!existsSync(lockPath)) return null;
+  const lock = readFileSync(lockPath, "utf8");
   const block = lock.split(/\n\[\[package\]\]/).find((b) =>
     /name = "lore"\n/.test(b),
   );
-  if (!block) throw new Error('no [[package]] name = "lore" in Cargo.lock');
+  if (!block) return null;
   const m = block.match(/source = ".*lore\.git\?rev=([0-9a-f]+)#/);
-  if (!m) throw new Error("could not parse lore rev from Cargo.lock source");
+  if (!m) return null;
   return m[1];
 }
 
-/** Locate the cargo git checkout for `rev` (cargo names the dir by 7-char rev). */
+/** Locate the cargo git checkout for `rev`. */
 function loreSrcDir(rev) {
   const envOverride = process.env.LORE_SRC;
   if (envOverride && existsSync(join(envOverride, "lore", "src"))) {
     return join(envOverride, "lore", "src");
   }
   const base = join(homedir(), ".cargo", "git", "checkouts");
-  const candidates = [];
   if (existsSync(base)) {
     for (const repo of readdirSync(base)) {
       if (!repo.startsWith("lore-")) continue;
@@ -92,23 +83,28 @@ function loreSrcDir(rev) {
       for (const short of readdirSync(repoDir)) {
         if (rev.startsWith(short) || short.startsWith(rev.slice(0, 7))) {
           const src = join(repoDir, short, "lore", "src");
-          if (existsSync(src)) candidates.push(src);
+          if (existsSync(src)) return src;
         }
       }
     }
   }
-  return candidates[0] ?? null;
+  return null;
 }
 
-/** Map a path under lore/src to its domain (first segment, sans `.rs`). */
+/** Map a path under lore/src to its domain. */
 function domainOf(relPath) {
   const seg = relPath.split("/")[0];
   return seg.endsWith(".rs") ? seg.slice(0, -3) : seg;
 }
 
-/** Enumerate upstream ops as a set of "<domain>.<fn>". */
-function upstreamOps(srcDir) {
-  const ops = new Set();
+/**
+ * Enumerate upstream ops and their signatures.
+ * Returns Map<id, { argsType, resultType, fields: { [name]: type } }>
+ */
+function collectSignatures(srcDir) {
+  const signatures = new Map();
+  const structs = new Map();
+
   const walk = (dir, rel) => {
     for (const name of readdirSync(dir)) {
       const p = join(dir, name);
@@ -118,23 +114,59 @@ function upstreamOps(srcDir) {
         const domain = domainOf(r);
         if (!OP_DOMAINS.has(domain)) continue;
         const src = readFileSync(p, "utf8");
-        for (const m of src.matchAll(/^pub async fn ([a-z_][a-z0-9_]*)\s*[(<]/gm)) {
-          const fn = m[1];
-          if (UPSTREAM_IGNORE.has(fn)) continue;
-          const id = `${domain}.${fn}`;
+
+        // Extract structs
+        const structRegex = /pub struct ([A-Za-z0-9_]+)\s*\{([\s\S]*?)\}/g;
+        const fieldRegex = /pub ([a-z_][a-z0-9_]*):\s*([A-Za-z0-9_<>, ]+)/g;
+        let sMatch;
+        while ((sMatch = structRegex.exec(src)) !== null) {
+          const sName = sMatch[1];
+          const sBody = sMatch[2];
+          const fields = new Map();
+          let fMatch;
+          while ((fMatch = fieldRegex.exec(sBody)) !== null) {
+            fields.set(fMatch[1], fMatch[2].trim());
+          }
+          structs.set(sName, fields);
+        }
+
+        // Extract fns
+        const fnRegex = /pub async fn ([a-z_][a-z0-9_]*)\s*\(([\s\S]*?)\)\s*(?:->\s*([^{]+))?\s*\{/g;
+        const argRegex = /args:\s*([A-Za-z0-9_]+)/;
+        let fMatch;
+        while ((fMatch = fnRegex.exec(src)) !== null) {
+          const fName = fMatch[1];
+          if (UPSTREAM_IGNORE.has(fName)) continue;
+          const fArgs = fMatch[2];
+          const fRet = (fMatch[3] || '()').trim();
+          const argMatch = argRegex.exec(fArgs);
+          const argsType = argMatch ? argMatch[1] : null;
+          const id = `${domain}.${fName}`;
           if (KNOWN_INTERNAL_IDS.has(id)) continue;
-          ops.add(id);
+          signatures.set(id, { argsType, resultType: fRet });
         }
       }
     }
   };
+
   walk(srcDir, "");
-  return ops;
+
+  // Link structs to fns
+  for (const [id, sig] of signatures) {
+    if (sig.argsType && structs.has(sig.argsType)) {
+      sig.fields = Object.fromEntries(structs.get(sig.argsType));
+    } else {
+      sig.fields = {};
+    }
+  }
+
+  return signatures;
 }
 
 /** Enumerate our bindings as a set of "<domain>.<op>". */
 function ourOps() {
   const ops = new Set();
+  if (!existsSync(opsDir)) return ops;
   for (const domain of readdirSync(opsDir)) {
     const dpath = join(opsDir, domain);
     if (!statSync(dpath).isDirectory()) continue;
@@ -147,43 +179,72 @@ function ourOps() {
   return ops;
 }
 
+const args = process.argv.slice(2);
+const headSrcPath = args.find((a, i) => a === "--head-src") ? args[args.indexOf("--head-src") + 1] : null;
+
 const rev = pinnedRev();
-const srcDir = loreSrcDir(rev);
-if (!srcDir) {
+const pinnedDir = loreSrcDir(rev);
+
+if (!pinnedDir) {
   console.error(
-    `Could not locate upstream lore source for rev ${rev.slice(0, 12)}.\n` +
-      `Run \`cargo fetch\` first, or set LORE_SRC=/path/to/lore-checkout.`,
+    `Could not locate pinned upstream lore source.\n` +
+    `Run \`cargo fetch\` first, or set LORE_SRC.`
   );
   process.exit(2);
 }
 
-const upstream = upstreamOps(srcDir);
+const pinnedSigs = collectSignatures(pinnedDir);
+const headSigs = headSrcPath ? collectSignatures(headSrcPath) : pinnedSigs;
 const ours = ourOps();
 
-// Compare by fn/op name within a domain. Upstream and our domain names line up
-// (repository, branch, revision, file, storage, auth, …). `*_local` variants and
-// deferred spike ops (cherry_pick/bisect) are reported but expected.
-const newOps = [...upstream].filter((o) => !ours.has(o)).sort();
-const orphanedBindings = [...ours].filter((o) => !upstream.has(o)).sort();
+const newOps = [];
+const driftedOps = [];
+const orphanedBindings = [];
+
+// Compare head vs ours
+for (const [id, sig] of headSigs) {
+  if (!ours.has(id)) {
+    newOps.push({ id, sig });
+  } else if (headSrcPath) {
+    // Check for drift against pinned
+    const pinnedSig = pinnedSigs.get(id);
+    if (pinnedSig && JSON.stringify(pinnedSig) !== JSON.stringify(sig)) {
+      driftedOps.push({ id, oldSig: pinnedSig, newSig: sig });
+    }
+  }
+}
+
+for (const id of ours) {
+  if (!headSigs.has(id)) {
+    orphanedBindings.push(id);
+  }
+}
 
 const report = {
   rev,
-  upstreamOpCount: upstream.size,
+  pinnedOpCount: pinnedSigs.size,
+  headOpCount: headSigs.size,
   ourOpCount: ours.size,
-  newOps, // upstream ops we don't bind yet → build these
-  orphanedBindings, // our bindings with no matching upstream fn → review
+  newOps: newOps.sort((a, b) => a.id.localeCompare(b.id)),
+  driftedOps: driftedOps.sort((a, b) => a.id.localeCompare(b.id)),
+  orphanedBindings: orphanedBindings.sort(),
 };
 
 if (process.argv.includes("--json")) {
   console.log(JSON.stringify(report, null, 2));
 } else {
-  console.error(`upstream lore parity @ ${rev.slice(0, 12)}`);
-  console.error(
-    `  upstream ops: ${upstream.size} · our bindings: ${ours.size}`,
-  );
+  console.error(`upstream lore parity @ ${rev?.slice(0, 12) || "unknown"}`);
+  console.error(`  pinned ops: ${pinnedSigs.size} · our bindings: ${ours.size}`);
+  if (headSrcPath) console.error(`  head ops: ${headSigs.size}`);
+
   console.error(`  NEW upstream ops not bound (${newOps.length}):`);
-  for (const o of newOps) console.error(`    + ${o}`);
+  for (const o of newOps) console.error(`    + ${o.id} (${o.sig.argsType})`);
+
+  console.error(`  DRIFTED ops signatures (${driftedOps.length}):`);
+  for (const o of driftedOps) console.error(`    ! ${o.id} (signature changed)`);
+
   console.error(`  bindings with no upstream match (${orphanedBindings.length}):`);
   for (const o of orphanedBindings) console.error(`    ? ${o}`);
+
   console.log(JSON.stringify(report));
 }


### PR DESCRIPTION
Resolves SBAI-4070

## Summary
Hardened the upstream-lore parity sync workflow to automate lore rev-bump proposals, signature drift detection, and BrainMon ticket dispatch.

## Changes
- **scripts/upstream-lore-parity.mjs**: Enhanced to extract full function signatures and struct fields from lore source. Added support for comparing two source directories (pinned vs head) to detect signature drift (breaking changes).
- **.github/workflows/upstream-parity.yml**: 
  - Now fetches lore HEAD SHA and compares with pinned rev in Cargo.toml.
  - Automatically creates a PR to bump the rev if it has changed.
  - Dispatches SBAI tickets (GitHub issues) for each new or drifted op detected, labeled by domain.
  - Added a canary integration test job that runs against the new rev to catch breakage early.

## Testing
- Verified the enhanced parity script locally against lore HEAD.
- Verified the Cargo.toml rev-bump logic (sed command).
- Verified the YAML workflow structure.