### PR TITLE
feat(desktop): unified system tray + autostart + close-to-tray (SBAI-4042/4043)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +413,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -992,7 +1009,16 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
 ]
 
 [[package]]
@@ -1001,7 +1027,18 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1012,7 +1049,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1145,7 +1182,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2074,6 +2111,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2721,6 +2771,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tokio",
  "tracing",
@@ -2834,6 +2885,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -3669,6 +3730,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3853,6 +3920,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4737,7 +4815,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4745,6 +4823,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "image",
  "jni",
  "libc",
  "log",
@@ -4787,7 +4866,7 @@ checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4855,6 +4934,20 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5500,7 +5593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -6388,6 +6481,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -6418,7 +6520,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/frontend/scripts/palette-parity-allowlist.json
+++ b/frontend/scripts/palette-parity-allowlist.json
@@ -11,7 +11,11 @@
     "create_branch",
     "branches",
     "create_repository",
-    "file_stage"
+    "file_stage",
+    "tray_sync_state",
+    "get_desktop_settings",
+    "set_autostart",
+    "set_close_to_tray"
   ],
   "deferred": []
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
 import OnboardingFlow from "./onboarding/OnboardingFlow";
 import ThemeEditor from "./theme/ThemeEditor";
+import SettingsPanel from "./SettingsPanel";
 import StoragePanel from "./StoragePanel";
 import RepositoryPanel from "./RepositoryPanel";
 import LocksPanel from "./LocksPanel";
@@ -33,6 +35,7 @@ import {
   revisionFindApi,
   revisionRevertLocalApi,
   revisionSyncApi,
+  lockFileReleaseApi,
   type Branch,
   type BranchInfoResult,
   type BranchMetadataEntry,
@@ -49,8 +52,15 @@ import {
   type RevisionFindEntry,
   type RevisionFindResult,
   type RevisionSyncResult,
+  type TrayStatusKind,
   type VerifyStateResult,
 } from "./api";
+
+const TRAY_ACTION_EVENT = "tray/action";
+
+interface TrayActionPayload {
+  action: string;
+}
 
 /** Extract a human-readable message from a thrown value (LoreError is
  * serialized as `{ kind, message }`; plain strings and Errors pass through). */
@@ -78,6 +88,8 @@ function useAsyncError() {
 }
 
 export default function App() {
+  const commitMessageRef = useRef<HTMLTextAreaElement | null>(null);
+  const toastId = useRef(0);
   const [repo, setRepo] = useState<string>("");
   const [onboarded, setOnboarded] = useState<boolean>(
     () => localStorage.getItem("loregui.onboarded") === "true",
@@ -94,11 +106,15 @@ export default function App() {
   // Commercial Reporting add-on (SBAI-4061 / SBAI-4068). The nav shows a locked
   // upsell entry when not entitled; the panel itself also re-checks defensively.
   const reportingEntitled = isEntitled("reporting");
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [status, setStatus] = useState<RepoStatus | null>(null);
   const [branches, setBranches] = useState<Branch[]>([]);
   const [history, setHistory] = useState<Revision[]>([]);
   const [message, setMessage] = useState("");
-  const { error, run } = useAsyncError();
+  const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null);
+  const [syncHasConflicts, setSyncHasConflicts] = useState(false);
+  const [toasts, setToasts] = useState<Array<{ id: number; text: string }>>([]);
+  const { error, run, setError } = useAsyncError();
 
   // --- branch info state ---
   const [branchInfoData, setBranchInfoData] = useState<BranchInfoResult | null>(null);
@@ -181,6 +197,128 @@ export default function App() {
 
   const staged = status?.changes.filter((c) => c.staged) ?? [];
   const unstaged = status?.changes.filter((c) => !c.staged) ?? [];
+
+  const pushToast = useCallback((text: string) => {
+    const id = toastId.current + 1;
+    toastId.current = id;
+    setToasts((existing) => [...existing, { id, text }]);
+    window.setTimeout(() => {
+      setToasts((existing) => existing.filter((toast) => toast.id !== id));
+    }, 3500);
+  }, []);
+
+  const trayStatus: TrayStatusKind = useMemo(() => {
+    if (syncLoading) return "syncing";
+    if (syncHasConflicts) return "conflict";
+    if ((status?.changes.length ?? 0) > 0) return "dirty";
+    return "clean";
+  }, [status?.changes.length, syncHasConflicts, syncLoading]);
+
+  useEffect(() => {
+    void api.traySyncState({
+      branch: status?.branch ?? "",
+      dirtyCount: status?.changes.length ?? 0,
+      status: trayStatus,
+    });
+  }, [status?.branch, status?.changes.length, trayStatus]);
+
+  const runSync = useCallback(async () => {
+    setSyncLoading(true);
+    setError(null);
+    try {
+      const result = await revisionSyncApi.sync();
+      setSyncData(result);
+      const hasConflicts = result.revisions.some(
+        (revision) => revision.has_conflicts,
+      );
+      setSyncHasConflicts(hasConflicts);
+      pushToast(hasConflicts ? "Sync finished with conflicts." : "Sync completed.");
+    } catch (e) {
+      const message = errText(e);
+      setError(message);
+      setSyncHasConflicts(false);
+      pushToast(`Sync failed: ${message}`);
+      throw e;
+    } finally {
+      setSyncLoading(false);
+    }
+    await refresh();
+  }, [pushToast, refresh, setError]);
+
+  const handleTrayAction = useCallback(
+    async (action: string) => {
+      if (action === "sync") {
+        void runSync().catch(() => {});
+        return;
+      }
+
+      if (action === "check-in") {
+        if (staged.length === 0) {
+          pushToast("Stage at least one file before checking in.");
+          return;
+        }
+        window.setTimeout(() => commitMessageRef.current?.focus(), 50);
+        return;
+      }
+
+      if (action === "release-lock") {
+        const path = selectedFilePath;
+        if (!path) {
+          setLocksPanelOpen(true);
+          pushToast("Choose a current file before releasing its lock.");
+          return;
+        }
+
+        try {
+          const user = await api.authUserInfo();
+          if (!user) {
+            setAccountPanelOpen(true);
+            pushToast("Sign in before releasing a lock.");
+            return;
+          }
+
+          const result = await lockFileReleaseApi.fileRelease(
+            [path],
+            status?.branch ?? "",
+            user.name || user.id,
+            user.id,
+          );
+          pushToast(
+            result.released.length > 0
+              ? `Released lock for ${path}.`
+              : `No lock found for ${path}.`,
+          );
+          await refresh();
+        } catch (e) {
+          const message = errText(e);
+          setError(message);
+          setLocksPanelOpen(true);
+          pushToast(`Release lock failed: ${message}`);
+        }
+        return;
+      }
+
+      if (action === "check-updates") {
+        pushToast("Update checks are not configured in this build yet.");
+      }
+    },
+    [pushToast, refresh, runSync, selectedFilePath, setError, staged.length, status?.branch],
+  );
+
+  useEffect(() => {
+    let unlisten: undefined | (() => void);
+    void (async () => {
+      unlisten = await listen<TrayActionPayload>(
+        TRAY_ACTION_EVENT,
+        ({ payload }) => {
+          void handleTrayAction(payload.action);
+        },
+      );
+    })();
+    return () => {
+      if (unlisten) void unlisten();
+    };
+  }, [handleTrayAction]);
 
   const fetchBranchInfo = useCallback(
     async (name: string) => {
@@ -357,6 +495,12 @@ export default function App() {
             Account
           </button>
           <button
+            onClick={() => setSettingsOpen(true)}
+            title="Desktop settings: start at login, close to tray"
+          >
+            Settings
+          </button>
+          <button
             onClick={() => setBranchesPanelOpen(true)}
             title="Branches: list, create, switch, info, protect, archive, reset, merge"
           >
@@ -402,18 +546,10 @@ export default function App() {
           >
             Dependencies
           </button>
-          <button disabled={syncLoading} onClick={() => {
-            setSyncLoading(true);
-            void run(async () => {
-              try {
-                const result = await revisionSyncApi.sync();
-                setSyncData(result);
-              } finally {
-                setSyncLoading(false);
-              }
-              await refresh();
-            });
-          }}>
+          <button
+            disabled={syncLoading}
+            onClick={() => void runSync().catch(() => {})}
+          >
             {syncLoading ? "Syncing..." : "Sync"}
           </button>
           <button onClick={() => void run(async () => { await api.push(); await refresh(); })}>
@@ -439,6 +575,39 @@ export default function App() {
       </header>
 
       {error && <div className="error">{error}</div>}
+
+      {toasts.length > 0 && (
+        <div
+          aria-live="polite"
+          style={{
+            position: "fixed",
+            top: 72,
+            right: 16,
+            zIndex: 1200,
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+            maxWidth: 320,
+          }}
+        >
+          {toasts.map((toast) => (
+            <div
+              key={toast.id}
+              style={{
+                background: "var(--surface-overlay-bg, var(--panel))",
+                color: "var(--surface-overlay-text, var(--text))",
+                border:
+                  "1px solid var(--surface-overlay-border, var(--border))",
+                boxShadow: "var(--shadow-md, 0 4px 16px rgba(0, 0, 0, 0.3))",
+                borderRadius: 8,
+                padding: "10px 12px",
+              }}
+            >
+              {toast.text}
+            </div>
+          ))}
+        </div>
+      )}
 
       {verifyLoading && <p className="verify-loading">Verifying repository state...</p>}
       {verifyData && !verifyLoading && (
@@ -755,6 +924,7 @@ export default function App() {
             items={staged}
             action="unstage"
             onAction={(paths) => void run(async () => { await api.unstage(paths); await refresh(); })}
+            onSelectPath={setSelectedFilePath}
             onFileInfo={(path) => void fetchFileInfo(path)}
             extraAction={{
               label: "unresolve",
@@ -770,6 +940,7 @@ export default function App() {
             items={unstaged}
             action="stage"
             onAction={(paths) => void run(async () => { await api.stage(paths); await refresh(); })}
+            onSelectPath={setSelectedFilePath}
             onFileInfo={(path) => void fetchFileInfo(path)}
             extraAction={{
               label: "obliterate",
@@ -819,6 +990,7 @@ export default function App() {
           )}
           <div className="commit">
             <textarea
+              ref={commitMessageRef}
               placeholder="Commit message"
               value={message}
               onChange={(e) => setMessage(e.target.value)}
@@ -1009,6 +1181,8 @@ export default function App() {
         <LocksPanel onClose={() => setLocksPanelOpen(false)} />
       )}
 
+      {settingsOpen && <SettingsPanel onClose={() => setSettingsOpen(false)} />}
+
       {accountPanelOpen && (
         <AccountPanel onClose={() => setAccountPanelOpen(false)} />
       )}
@@ -1037,6 +1211,7 @@ function Section({
   items,
   action,
   onAction,
+  onSelectPath,
   onFileInfo,
   extraAction,
 }: {
@@ -1044,6 +1219,7 @@ function Section({
   items: FileChange[];
   action: string;
   onAction: (paths: string[]) => void;
+  onSelectPath?: (path: string) => void;
   onFileInfo?: (path: string) => void;
   extraAction?: { label: string; onAction: (paths: string[]) => void };
 }) {
@@ -1061,13 +1237,46 @@ function Section({
         {items.map((c) => (
           <li key={c.path}>
             <span className={`kind ${c.kind}`}>{c.kind[0].toUpperCase()}</span>
-            <span className="path">{c.path}</span>
+            <button
+              className="path"
+              onClick={() => onSelectPath?.(c.path)}
+              style={{
+                background: "transparent",
+                border: "none",
+                color: "inherit",
+                cursor: "pointer",
+                padding: 0,
+                textAlign: "left",
+              }}
+            >
+              {c.path}
+            </button>
             {onFileInfo && (
-              <button className="info-btn" onClick={() => onFileInfo(c.path)}>info</button>
+              <button
+                className="info-btn"
+                onClick={() => {
+                  onSelectPath?.(c.path);
+                  onFileInfo(c.path);
+                }}
+              >
+                info
+              </button>
             )}
-            <button onClick={() => onAction([c.path])}>{action}</button>
+            <button
+              onClick={() => {
+                onSelectPath?.(c.path);
+                onAction([c.path]);
+              }}
+            >
+              {action}
+            </button>
             {extraAction && (
-              <button onClick={() => extraAction.onAction([c.path])}>
+              <button
+                onClick={() => {
+                  onSelectPath?.(c.path);
+                  extraAction.onAction([c.path]);
+                }}
+              >
                 {extraAction.label}
               </button>
             )}

--- a/frontend/src/SettingsPanel.tsx
+++ b/frontend/src/SettingsPanel.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useState } from "react";
+import { desktopSettingsApi } from "./api";
+
+interface Props {
+  onClose: () => void;
+}
+
+/**
+ * Desktop integration settings (SBAI-4043): start-at-login (autostart) and
+ * close-to-tray. Both toggles persist immediately and revert on failure.
+ * Rendered by the parent only when open, so it has no `open` prop of its own.
+ */
+export default function SettingsPanel({ onClose }: Props) {
+  const [autostart, setAutostart] = useState(false);
+  const [closeToTray, setCloseToTray] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState<string | null>(null);
+
+  const loadSettings = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const s = await desktopSettingsApi.get();
+      setAutostart(s.autostart_enabled);
+      setCloseToTray(s.close_to_tray);
+    } catch (e) {
+      setError(typeof e === "string" ? e : JSON.stringify(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadSettings();
+  }, [loadSettings]);
+
+  const handleAutostart = useCallback(async (val: boolean) => {
+    setSaving("autostart");
+    setError(null);
+    try {
+      await desktopSettingsApi.setAutostart(val);
+      setAutostart(val);
+    } catch (e) {
+      setError(typeof e === "string" ? e : JSON.stringify(e));
+      // Revert on failure.
+      setAutostart(!val);
+    } finally {
+      setSaving(null);
+    }
+  }, []);
+
+  const handleCloseToTray = useCallback(async (val: boolean) => {
+    setSaving("closeToTray");
+    setError(null);
+    try {
+      await desktopSettingsApi.setCloseToTray(val);
+      setCloseToTray(val);
+    } catch (e) {
+      setError(typeof e === "string" ? e : JSON.stringify(e));
+      // Revert on failure.
+      setCloseToTray(!val);
+    } finally {
+      setSaving(null);
+    }
+  }, []);
+
+  return (
+    <div className="settings-panel-overlay" onClick={onClose}>
+      <div className="settings-panel" onClick={(e) => e.stopPropagation()}>
+        <div className="settings-header">
+          <h2>Desktop Settings</h2>
+          <button
+            className="settings-close"
+            aria-label="Close settings"
+            onClick={onClose}
+          >
+            ✕
+          </button>
+        </div>
+
+        {error && <div className="error">{error}</div>}
+
+        {loading ? (
+          <p className="settings-loading">Loading settings…</p>
+        ) : (
+          <div className="settings-body">
+            <div className="settings-row">
+              <div className="settings-row-label">
+                <strong>Start LoreGUI at login</strong>
+                <p className="settings-row-desc">
+                  Automatically launch the application when you log in to your
+                  computer. It starts hidden in the system tray.
+                </p>
+              </div>
+              <div className="settings-row-action">
+                <label className="toggle">
+                  <input
+                    type="checkbox"
+                    checked={autostart}
+                    onChange={(e) => void handleAutostart(e.target.checked)}
+                    disabled={saving === "autostart"}
+                  />
+                  <span className="toggle-slider" />
+                </label>
+                {saving === "autostart" && (
+                  <span className="settings-saving">Saving…</span>
+                )}
+              </div>
+            </div>
+
+            <div className="settings-row">
+              <div className="settings-row-label">
+                <strong>Close to tray</strong>
+                <p className="settings-row-desc">
+                  When closing the window, hide to the system tray instead of
+                  quitting. Reopen anytime from the tray icon.
+                </p>
+              </div>
+              <div className="settings-row-action">
+                <label className="toggle">
+                  <input
+                    type="checkbox"
+                    checked={closeToTray}
+                    onChange={(e) => void handleCloseToTray(e.target.checked)}
+                    disabled={saving === "closeToTray"}
+                  />
+                  <span className="toggle-slider" />
+                </label>
+                {saving === "closeToTray" && (
+                  <span className="settings-saving">Saving…</span>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -63,6 +63,14 @@ export interface ServiceStopResult {
   log_messages: string[];
 }
 
+export type TrayStatusKind = "clean" | "dirty" | "syncing" | "conflict";
+
+export interface TraySnapshot {
+  branch: string;
+  dirtyCount: number;
+  status: TrayStatusKind;
+}
+
 /// Options for hosting a real `loreserver` from the GUI (SBAI-4065).
 export interface HostServerOptions {
   /** Store directory to serve — MUST be the host flow's shared-store path. */
@@ -153,6 +161,10 @@ export const api = {
     }),
   hostServerStop: () => invoke<HostStatus>("host_server_stop"),
   hostServerStatus: () => invoke<HostStatus>("host_server_status"),
+
+  // --- system tray live status (SBAI-4042) ---
+  traySyncState: (snapshot: TraySnapshot) =>
+    invoke<void>("tray_sync_state", { snapshot }),
 };
 
 // --- repository create (ops-layer) ---
@@ -1581,4 +1593,19 @@ export const revisionActivityReportApi = {
       dateTo,
       filePath,
     }),
+};
+
+// --- desktop settings (autostart + close-to-tray, SBAI-4043) ---
+
+export interface DesktopSettingsResult {
+  autostart_enabled: boolean;
+  close_to_tray: boolean;
+}
+
+export const desktopSettingsApi = {
+  get: () => invoke<DesktopSettingsResult>("get_desktop_settings"),
+  setAutostart: (enabled: boolean) =>
+    invoke<void>("set_autostart", { enabled }),
+  setCloseToTray: (enabled: boolean) =>
+    invoke<void>("set_close_to_tray", { enabled }),
 };

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -781,6 +781,168 @@ h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; color: v
   word-break: break-all;
 }
 
+/* --- Settings Panel (desktop integration, SBAI-4043) --- */
+.settings-panel-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--surface-overlay-shadow, rgba(0, 0, 0, 0.5));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+.settings-panel {
+  width: 100%;
+  max-width: 480px;
+  max-height: 80vh;
+  overflow-y: auto;
+  background: var(--surface-overlay-bg, var(--panel));
+  color: var(--surface-overlay-text, var(--text));
+  border: 1px solid var(--surface-overlay-border, var(--border));
+  border-radius: 8px;
+  box-shadow: var(--shadow-lg, 0 8px 32px rgba(0, 0, 0, 0.4));
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--surface-overlay-border, var(--border));
+}
+
+.settings-header h2 {
+  margin: 0;
+  font-size: 16px;
+  color: var(--surface-overlay-text, var(--text));
+}
+
+.settings-close {
+  background: none;
+  border: none;
+  color: var(--surface-overlay-text, var(--text));
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.settings-close:hover {
+  background: var(--surface-secondary-bg, var(--panel2));
+}
+
+.settings-body {
+  padding: 16px 18px;
+}
+
+.settings-loading {
+  padding: 20px;
+  text-align: center;
+  color: var(--surface-overlay-text-secondary, var(--muted));
+}
+
+.settings-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--surface-overlay-border, var(--border));
+}
+
+.settings-row:last-child {
+  border-bottom: none;
+}
+
+.settings-row-label {
+  flex: 1;
+}
+
+.settings-row-label strong {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 4px;
+  color: var(--surface-overlay-text, var(--text));
+}
+
+.settings-row-desc {
+  margin: 0;
+  font-size: 12px;
+  color: var(--surface-overlay-text-secondary, var(--muted));
+  line-height: 1.4;
+}
+
+.settings-row-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.settings-saving {
+  font-size: 11px;
+  color: var(--surface-overlay-text-secondary, var(--muted));
+}
+
+/* Toggle switch */
+.toggle {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+}
+
+.toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: var(--surface-secondary-bg, var(--border));
+  border: 1px solid var(--surface-overlay-border, var(--border));
+  border-radius: 24px;
+  transition: background 0.2s;
+}
+
+.toggle-slider::before {
+  content: "";
+  position: absolute;
+  height: 18px;
+  width: 18px;
+  left: 2px;
+  bottom: 2px;
+  background: var(--surface-base-text, var(--text));
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+.toggle input:checked + .toggle-slider {
+  background: var(--surface-primary-bg, var(--accent));
+  border-color: var(--surface-primary-border, var(--accent));
+}
+
+.toggle input:checked + .toggle-slider::before {
+  transform: translateX(20px);
+}
+
+.toggle input:focus-visible + .toggle-slider {
+  outline: 2px solid var(--surface-primary-bg, var(--accent));
+  outline-offset: 2px;
+}
+
+.toggle input:disabled + .toggle-slider {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .storage-danger h3 {
   color: var(--surface-error-text, var(--red));
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,8 +16,9 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-dialog = "2"
+tauri-plugin-autostart = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
-use tauri::State;
+use tauri::{AppHandle, State};
 
 use crate::operations::SubscriptionId;
 
@@ -1836,6 +1836,16 @@ pub async fn auth_user_info(state: State<'_, AppState>) -> Result<Option<UserInf
         id: u.user_id,
         name: u.display_name,
     }))
+}
+
+// --- tray sync_state ---
+
+/// Push the current repository status into the system tray (icon badge color,
+/// tooltip, and title). Called from the frontend whenever branch/dirty/sync
+/// state changes so the tray reflects live status.
+#[tauri::command]
+pub fn tray_sync_state(app: AppHandle, snapshot: crate::tray::TraySnapshot) -> Result<(), String> {
+    crate::tray::apply_snapshot(&app, &snapshot).map_err(|e| e.to_string())
 }
 
 // --- dependency add ---

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1,0 +1,67 @@
+//! Desktop integration commands: autostart at login and close-to-tray behavior.
+//!
+//! Exposes Tauri commands for the frontend to toggle "Start at login" and
+//! "Close to tray instead of quitting" preferences.
+
+use crate::settings::SettingsManager;
+use serde::Serialize;
+use tauri::State;
+use tauri_plugin_autostart::ManagerExt;
+
+/// Result returned when querying or changing desktop settings.
+#[derive(Debug, Clone, Serialize)]
+pub struct SettingsResult {
+    pub autostart_enabled: bool,
+    pub close_to_tray: bool,
+}
+
+/// Get the current desktop integration settings.
+#[tauri::command]
+pub fn get_desktop_settings(
+    settings: State<'_, SettingsManager>,
+) -> Result<SettingsResult, String> {
+    let s = settings.get();
+    Ok(SettingsResult {
+        autostart_enabled: s.autostart_enabled,
+        close_to_tray: s.close_to_tray,
+    })
+}
+
+/// Enable or disable autostart at login.
+///
+/// This delegates to `tauri-plugin-autostart` for the platform-specific
+/// registration (launchd plist on macOS, registry on Windows, .desktop on Linux).
+#[tauri::command]
+pub async fn set_autostart(
+    app_handle: tauri::AppHandle,
+    settings: State<'_, SettingsManager>,
+    enabled: bool,
+) -> Result<(), String> {
+    // Update the persisted setting.
+    settings.update(|s| s.autostart_enabled = enabled);
+
+    // Register or unregister with the autostart plugin.
+    if enabled {
+        app_handle
+            .autolaunch()
+            .enable()
+            .map_err(|e| format!("failed to enable autostart: {e}"))?;
+    } else {
+        app_handle
+            .autolaunch()
+            .disable()
+            .map_err(|e| format!("failed to disable autostart: {e}"))?;
+    }
+
+    Ok(())
+}
+
+/// Enable or disable "close to tray" behavior.
+#[tauri::command]
+pub fn set_close_to_tray(
+    settings: State<'_, SettingsManager>,
+    enabled: bool,
+) -> Result<(), String> {
+    settings.update(|s| s.close_to_tray = enabled);
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,13 +1,19 @@
 mod commands;
+mod desktop;
 mod operations;
 mod server_host;
+mod settings;
+mod tray;
 
 use commands::AppState;
+use desktop::{get_desktop_settings, set_autostart, set_close_to_tray};
 use operations::subscribe::subscribe_notifications;
 use operations::unsubscribe::unsubscribe_notifications;
+use settings::SettingsManager;
 use std::collections::HashSet;
 use std::sync::atomic::AtomicU64;
 use std::sync::Mutex;
+use tauri::Manager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -21,6 +27,35 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            Some(vec!["--hidden"]),
+        ))
+        .setup(|app| {
+            // Load persisted desktop settings (autostart, close-to-tray) from the
+            // app config directory.
+            let config_dir = app.path().app_config_dir().unwrap_or_else(|_| {
+                tracing::warn!("could not resolve app config dir, using fallback");
+                std::env::temp_dir().join("loregui")
+            });
+            app.manage(SettingsManager::new(config_dir));
+
+            // Install the single system tray (status icon + quick actions).
+            tray::install(app.handle())?;
+
+            Ok(())
+        })
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                let settings = window.state::<SettingsManager>();
+                if settings.get().close_to_tray {
+                    // Hide to tray instead of quitting.
+                    api.prevent_close();
+                    let _ = window.hide();
+                }
+                // Otherwise let the close proceed normally (app quits).
+            }
+        })
         .manage(AppState {
             working_dir: Mutex::new(initial_dir),
             subscription_counter: AtomicU64::new(0),
@@ -145,6 +180,10 @@ pub fn run() {
             commands::revision_commit_with_metadata,
             commands::revision_metadata_clear,
             commands::revision_activity_report,
+            commands::tray_sync_state,
+            get_desktop_settings,
+            set_autostart,
+            set_close_to_tray,
             subscribe_notifications,
             unsubscribe_notifications,
         ])

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,0 +1,61 @@
+//! Application settings persistence.
+//!
+//! Stores user preferences (autostart, close-to-tray) in a JSON file
+//! in the app's config directory.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+/// User-configurable application settings.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AppSettings {
+    /// Whether LoreGUI should start automatically at login.
+    #[serde(default)]
+    pub autostart_enabled: bool,
+    /// Whether closing the main window hides to tray instead of quitting.
+    #[serde(default)]
+    pub close_to_tray: bool,
+}
+
+/// Manages loading and saving app settings to disk.
+pub struct SettingsManager {
+    settings_path: PathBuf,
+    cache: Mutex<AppSettings>,
+}
+
+impl SettingsManager {
+    /// Create a new settings manager, loading from the config directory.
+    pub fn new(config_dir: PathBuf) -> Self {
+        let settings_path = config_dir.join("settings.json");
+        let cache = Mutex::new(Self::load_from_disk(&settings_path));
+        Self {
+            settings_path,
+            cache,
+        }
+    }
+
+    fn load_from_disk(path: &PathBuf) -> AppSettings {
+        match std::fs::read_to_string(path) {
+            Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+            Err(_) => AppSettings::default(),
+        }
+    }
+
+    /// Get the current settings.
+    pub fn get(&self) -> AppSettings {
+        self.cache.lock().unwrap().clone()
+    }
+
+    /// Save updated settings to disk.
+    pub fn update(&self, f: impl FnOnce(&mut AppSettings)) {
+        let mut settings = self.cache.lock().unwrap();
+        f(&mut settings);
+        if let Ok(json) = serde_json::to_string_pretty(&*settings) {
+            if let Some(parent) = self.settings_path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            let _ = std::fs::write(&self.settings_path, json);
+        }
+    }
+}

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,0 +1,303 @@
+use serde::{Deserialize, Serialize};
+use tauri::{
+    image::Image,
+    menu::{Menu, MenuItemBuilder, PredefinedMenuItem},
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
+    AppHandle, Emitter, Manager, Runtime,
+};
+
+pub const TRAY_ACTION_EVENT: &str = "tray/action";
+const TRAY_ID: &str = "loregui-tray";
+const TRAY_SEPARATOR: &str = " · ";
+const STATUS_DOT_OFFSET: i32 = 7;
+const STATUS_DOT_OUTER_RADIUS: i32 = 5;
+const STATUS_DOT_INNER_RADIUS: i32 = 4;
+const COLOR_STATUS_BORDER: [u8; 4] = [255, 255, 255, 255];
+const COLOR_STATUS_CLEAN: [u8; 4] = [73, 191, 115, 255];
+const COLOR_STATUS_DIRTY: [u8; 4] = [230, 168, 58, 255];
+const COLOR_STATUS_SYNCING: [u8; 4] = [84, 160, 255, 255];
+const COLOR_STATUS_CONFLICT: [u8; 4] = [230, 92, 92, 255];
+
+const TRAY_OPEN_ID: &str = "tray.open";
+const TRAY_SYNC_ID: &str = "tray.sync";
+const TRAY_CHECK_IN_ID: &str = "tray.check_in";
+const TRAY_RELEASE_LOCK_ID: &str = "tray.release_lock";
+const TRAY_CHECK_UPDATES_ID: &str = "tray.check_updates";
+const TRAY_QUIT_ID: &str = "tray.quit";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum TrayStatusKind {
+    #[default]
+    Clean,
+    Dirty,
+    Syncing,
+    Conflict,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TraySnapshot {
+    pub branch: String,
+    pub dirty_count: usize,
+    #[serde(default)]
+    pub status: TrayStatusKind,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrayActionPayload {
+    pub action: String,
+}
+
+pub fn install<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
+    let menu = build_menu(app)?;
+    let snapshot = TraySnapshot::default();
+    let tooltip = format_tooltip(&snapshot);
+    let title = format_title(&snapshot);
+    let icon = icon_for_status(snapshot.status)?;
+
+    TrayIconBuilder::with_id(TRAY_ID)
+        .menu(&menu)
+        .icon(icon)
+        .tooltip(tooltip)
+        .title(title)
+        .show_menu_on_left_click(false)
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            TRAY_OPEN_ID => {
+                let _ = show_main_window(app);
+            }
+            TRAY_SYNC_ID => {
+                let _ = emit_action(app, "sync");
+            }
+            TRAY_CHECK_IN_ID => {
+                let _ = show_main_window(app);
+                let _ = emit_action(app, "check-in");
+            }
+            TRAY_RELEASE_LOCK_ID => {
+                let _ = show_main_window(app);
+                let _ = emit_action(app, "release-lock");
+            }
+            TRAY_CHECK_UPDATES_ID => {
+                let _ = show_main_window(app);
+                let _ = emit_action(app, "check-updates");
+            }
+            TRAY_QUIT_ID => app.exit(0),
+            _ => {}
+        })
+        .on_tray_icon_event(|tray, event| {
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            } = event
+            {
+                let _ = toggle_main_window(tray.app_handle());
+            }
+        })
+        .build(app)?;
+
+    Ok(())
+}
+
+pub fn apply_snapshot<R: Runtime>(
+    app: &AppHandle<R>,
+    snapshot: &TraySnapshot,
+) -> tauri::Result<()> {
+    if let Some(tray) = app.tray_by_id(TRAY_ID) {
+        tray.set_icon(Some(icon_for_status(snapshot.status)?))?;
+        tray.set_tooltip(Some(format_tooltip(snapshot)))?;
+        tray.set_title(Some(format_title(snapshot)))?;
+    }
+    Ok(())
+}
+
+fn build_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
+    let menu = Menu::new(app)?;
+    let open = MenuItemBuilder::with_id(TRAY_OPEN_ID, "Open LoreGUI").build(app)?;
+    let sync = MenuItemBuilder::with_id(TRAY_SYNC_ID, "Sync").build(app)?;
+    let check_in = MenuItemBuilder::with_id(TRAY_CHECK_IN_ID, "Check in").build(app)?;
+    let release_lock = MenuItemBuilder::with_id(TRAY_RELEASE_LOCK_ID, "Release lock").build(app)?;
+    let check_updates =
+        MenuItemBuilder::with_id(TRAY_CHECK_UPDATES_ID, "Check for updates").build(app)?;
+    let quit = MenuItemBuilder::with_id(TRAY_QUIT_ID, "Quit").build(app)?;
+    let separator_a = PredefinedMenuItem::separator(app)?;
+    let separator_b = PredefinedMenuItem::separator(app)?;
+
+    menu.append_items(&[
+        &open,
+        &separator_a,
+        &sync,
+        &check_in,
+        &release_lock,
+        &separator_b,
+        &check_updates,
+        &quit,
+    ])?;
+
+    Ok(menu)
+}
+
+/// Show, unminimize, and focus the main window. Public so the close-to-tray
+/// handler and tray menu share one implementation.
+pub fn show_main_window<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        window.show()?;
+        window.set_focus()?;
+    }
+    Ok(())
+}
+
+fn toggle_main_window<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
+    if let Some(window) = app.get_webview_window("main") {
+        if window.is_visible()? {
+            window.hide()?;
+        } else {
+            show_main_window(app)?;
+        }
+    }
+    Ok(())
+}
+
+fn emit_action<R: Runtime>(app: &AppHandle<R>, action: &str) -> tauri::Result<()> {
+    app.emit(
+        TRAY_ACTION_EVENT,
+        TrayActionPayload {
+            action: action.to_string(),
+        },
+    )
+}
+
+fn format_title(snapshot: &TraySnapshot) -> String {
+    if snapshot.branch.trim().is_empty() {
+        return "LoreGUI".to_string();
+    }
+    format!(
+        "{}{}{} dirty",
+        snapshot.branch.trim(),
+        TRAY_SEPARATOR,
+        snapshot.dirty_count
+    )
+}
+
+fn format_tooltip(snapshot: &TraySnapshot) -> String {
+    if snapshot.branch.trim().is_empty() {
+        return format!("LoreGUI{}no repository open", TRAY_SEPARATOR);
+    }
+    format!(
+        "LoreGUI{}{}{}{} dirty{}{}",
+        TRAY_SEPARATOR,
+        snapshot.branch.trim(),
+        TRAY_SEPARATOR,
+        snapshot.dirty_count,
+        TRAY_SEPARATOR,
+        snapshot.status.label()
+    )
+}
+
+fn icon_for_status(status: TrayStatusKind) -> tauri::Result<Image<'static>> {
+    let base = Image::from_bytes(include_bytes!("../icons/32x32.png"))?.to_owned();
+    let width = base.width();
+    let height = base.height();
+    let mut rgba = base.rgba().to_vec();
+    let dot_x = width as i32 - STATUS_DOT_OFFSET;
+    let dot_y = height as i32 - STATUS_DOT_OFFSET;
+
+    draw_dot(
+        &mut rgba,
+        width as usize,
+        height as usize,
+        dot_x,
+        dot_y,
+        STATUS_DOT_OUTER_RADIUS,
+        COLOR_STATUS_BORDER,
+    );
+    draw_dot(
+        &mut rgba,
+        width as usize,
+        height as usize,
+        dot_x,
+        dot_y,
+        STATUS_DOT_INNER_RADIUS,
+        status.color(),
+    );
+
+    Ok(Image::new_owned(rgba, width, height))
+}
+
+fn draw_dot(
+    rgba: &mut [u8],
+    width: usize,
+    height: usize,
+    cx: i32,
+    cy: i32,
+    radius: i32,
+    color: [u8; 4],
+) {
+    let radius_sq = radius * radius;
+    for y in (cy - radius).max(0)..=(cy + radius).min(height as i32 - 1) {
+        for x in (cx - radius).max(0)..=(cx + radius).min(width as i32 - 1) {
+            let dx = x - cx;
+            let dy = y - cy;
+            if dx * dx + dy * dy > radius_sq {
+                continue;
+            }
+            let idx = ((y as usize * width) + x as usize) * 4;
+            rgba[idx..idx + 4].copy_from_slice(&color);
+        }
+    }
+}
+
+impl TrayStatusKind {
+    fn label(self) -> &'static str {
+        match self {
+            TrayStatusKind::Clean => "clean",
+            TrayStatusKind::Dirty => "dirty",
+            TrayStatusKind::Syncing => "syncing",
+            TrayStatusKind::Conflict => "conflict",
+        }
+    }
+
+    fn color(self) -> [u8; 4] {
+        match self {
+            TrayStatusKind::Clean => COLOR_STATUS_CLEAN,
+            TrayStatusKind::Dirty => COLOR_STATUS_DIRTY,
+            TrayStatusKind::Syncing => COLOR_STATUS_SYNCING,
+            TrayStatusKind::Conflict => COLOR_STATUS_CONFLICT,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_title, format_tooltip, TraySnapshot, TrayStatusKind};
+
+    #[test]
+    fn title_handles_empty_repository() {
+        assert_eq!(format_title(&TraySnapshot::default()), "LoreGUI");
+    }
+
+    #[test]
+    fn title_includes_branch_and_dirty_count() {
+        let snapshot = TraySnapshot {
+            branch: "main".into(),
+            dirty_count: 3,
+            status: TrayStatusKind::Dirty,
+        };
+        assert_eq!(format_title(&snapshot), "main · 3 dirty");
+    }
+
+    #[test]
+    fn tooltip_includes_status_label() {
+        let snapshot = TraySnapshot {
+            branch: "release".into(),
+            dirty_count: 1,
+            status: TrayStatusKind::Syncing,
+        };
+        assert_eq!(
+            format_tooltip(&snapshot),
+            "LoreGUI · release · 1 dirty · syncing"
+        );
+    }
+}


### PR DESCRIPTION
Reconciles #264 (tray) + #260 (autostart/minimize-to-tray): ONE tray.rs (status badge + quick actions) with autostart + close-to-tray built on it. Fixes #260's palette-parity (4 lifecycle commands allowlisted) + build-windows (single tray, fresh Cargo.lock, tauri-plugin-autostart). All gates + cargo build + tray tests green. Supersedes #264/#260.