### PR TITLE
fix(storage): honest backends — Local + S3-compatible (one aws mode), wire S3 host config

### DIFF
--- a/docs/domains/storage.md
+++ b/docs/domains/storage.md
@@ -16,9 +16,33 @@ obliterate upload`.
   `AppState.storage_session`.
 - **Partition** = 32-hex namespace. **Zero partition is rejected** — use a non-zero
   one (`ONBOARDING_PARTITION = "0…01"`).
-- **Backends:** `local` (packfiles path) | `s3`/`minio`/`garage` (endpoint, bucket,
-  region, access key, secret). Separate **mutable KV store** for branch pointers.
-  `StorageBackendConfig` (see `api.ts`) carries all fields.
+- **Backends (lore has exactly two):** `local` (filesystem store) and `s3`
+  (S3-compatible object store — lore's `aws` store mode). **AWS S3, MinIO, Garage,
+  Ceph/RGW, Backblaze B2, … are all the same `s3` backend**, differing only by
+  endpoint URL and whether path-style addressing is required — so the picker
+  offers them as non-binding *presets*, not separate backends. The `s3` fields are
+  endpoint, bucket, region, access key, secret. Separate **mutable KV store** for
+  branch pointers. `StorageBackendConfig` (see `api.ts`) carries all fields.
+- **Hosting with S3 (`server_host.rs`):** the picker's choice drives the hosted
+  `loreserver` config. `local` → `[immutable_store.local]` + `[mutable_store.local]`.
+  `s3` → `immutable_store.mode = "aws"` + `[plugins.aws.immutable_store]` (S3 keys:
+  `s3_bucket`/`s3_endpoint_url`/`s3_region`/`s3_force_path_style`, plus
+  auto-ensured DynamoDB `*_fragments`/`*_fragment-metadata` tables — lore's `aws`
+  immutable store pairs S3 payloads with DynamoDB metadata; there is no S3-only
+  variant). The **mutable store stays local** (lore's `aws` mutable store needs a
+  dedicated DynamoDB table the wizard doesn't provision). Credentials are NOT
+  written into the TOML — they're exported to the server process as
+  `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` (lore resolves them
+  via the standard AWS credential chain).
+- **Advanced / enterprise store modes (deferred — not wired by the wizard):** lore
+  also supports a `composite` immutable store (local cache tier + durable `aws`/S3
+  tier with a `ReplicationMode` of read/write/read_write), a `replicated`
+  server-to-server store (QUIC + mTLS), and `aws`-mode (DynamoDB) **mutable** + a
+  DynamoDB **lock** store at scale. These need extra inputs (replica peers,
+  DynamoDB tables/region, replication certs) the first-run host wizard doesn't
+  collect. To add them: extend `ResolvedConfig` + `render_config_toml` in
+  `server_host.rs` with new variants (the local/aws split is already structured
+  for it).
 - **Shared store:** `create(path)` → store path; `info`; `set_use_automatically`.
   Host setup creates a shared store before repositories.
 - **FFI gotcha:** `LoreBytes` is a borrowed view; build put items by direct struct

--- a/frontend/src/StoragePanel.tsx
+++ b/frontend/src/StoragePanel.tsx
@@ -66,7 +66,7 @@ export default function StoragePanel({ onClose }: { onClose: () => void }) {
   const backendLabel = config
     ? config.kind === "local"
       ? `Local · ${config.path || "(default path)"}`
-      : `${config.kind.toUpperCase()} · ${config.endpoint || "(no endpoint)"}${
+      : `S3-compatible · ${config.endpoint || "(no endpoint)"}${
           config.bucket ? ` / ${config.bucket}` : ""
         }`
     : null;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -40,11 +40,19 @@ export interface Revision {
 }
 
 /// Storage backend configuration captured by the server-setup onboarding wizard.
+///
+/// lore has exactly two real store backends: a `local` filesystem store and an
+/// `s3` (S3-compatible object store, lore's `aws` mode). AWS S3, MinIO, Garage,
+/// Ceph/RGW, Backblaze B2, etc. are all the *same* `s3` backend differing only
+/// by endpoint URL — they are surfaced as non-binding presets, not separate
+/// `kind`s. (lore also has advanced composite/replicated immutable stores and a
+/// DynamoDB lock/mutable store at scale; those are enterprise modes not exposed
+/// by this wizard yet — see `docs/domains/storage.md`.)
 export interface StorageBackendConfig {
-  kind: "local" | "s3" | "minio" | "garage";
+  kind: "local" | "s3";
   /** local packfiles path (kind === "local") */
   path?: string;
-  /** object-storage connection (kind !== "local") */
+  /** S3-compatible object-storage connection (kind === "s3") */
   endpoint?: string;
   bucket?: string;
   region?: string;
@@ -81,6 +89,33 @@ export interface HostServerOptions {
   repositoryName?: string;
   /** Reserved hook for a future authed mode. Local host flow is no-auth. */
   auth?: boolean;
+  /**
+   * Optional S3-compatible object-storage backing for the hosted server's
+   * immutable store (lore's `aws` mode). When omitted, the server uses a local
+   * filesystem store under `storeDir`. The mutable (branch-pointer) store stays
+   * local in both cases — lore's `aws` mutable store requires DynamoDB, which
+   * this wizard does not provision.
+   */
+  s3?: HostS3Options;
+}
+
+/// S3-compatible object-storage options for a hosted server's immutable store.
+export interface HostS3Options {
+  /** S3 endpoint URL. Empty/omitted = real AWS S3 (no custom endpoint). */
+  endpoint?: string;
+  /** Bucket name (required). */
+  bucket: string;
+  /** Region (e.g. "us-east-1"). Required by most S3 providers. */
+  region?: string;
+  /** Access key id. Passed to the server as AWS_ACCESS_KEY_ID. */
+  accessKeyId?: string;
+  /** Secret access key. Passed to the server as AWS_SECRET_ACCESS_KEY. */
+  secretAccessKey?: string;
+  /**
+   * Force path-style addressing (`endpoint/bucket/key` rather than
+   * `bucket.endpoint/key`). Required by MinIO/Garage and most non-AWS providers.
+   */
+  forcePathStyle?: boolean;
 }
 
 /// Status of the hosted `loreserver` process.
@@ -158,6 +193,15 @@ export const api = {
       port: opts.port ?? null,
       repositoryName: opts.repositoryName ?? null,
       auth: opts.auth ?? false,
+      // S3-compatible immutable store (lore `aws` mode) when a bucket is given;
+      // otherwise the server uses a local filesystem store under storeDir.
+      s3Bucket: opts.s3?.bucket ?? null,
+      s3Endpoint: opts.s3?.endpoint ?? null,
+      s3Region: opts.s3?.region ?? null,
+      s3AccessKeyId: opts.s3?.accessKeyId ?? null,
+      s3SecretAccessKey: opts.s3?.secretAccessKey ?? null,
+      s3ForcePathStyle: opts.s3?.forcePathStyle ?? null,
+      s3DynamodbEndpoint: null,
     }),
   hostServerStop: () => invoke<HostStatus>("host_server_stop"),
   hostServerStatus: () => invoke<HostStatus>("host_server_status"),

--- a/frontend/src/onboarding/server/BackendPicker.tsx
+++ b/frontend/src/onboarding/server/BackendPicker.tsx
@@ -1,13 +1,60 @@
 import { useCallback, useState } from "react";
 import { api, type StorageBackendConfig } from "../../api";
 
-type BackendKind = "local" | "s3" | "minio" | "garage";
+// lore has exactly two real store backends:
+//   - "local": a filesystem store (packfiles on disk).
+//   - "s3": an S3-compatible object store (lore's `aws` store mode).
+// AWS S3, MinIO, Garage, Ceph/RGW, Backblaze B2, etc. are all the SAME `s3`
+// backend — they differ only by endpoint URL (and whether path-style addressing
+// is required). They are offered below as non-binding *presets* that prefill the
+// endpoint placeholder, never as separate backends.
+type BackendKind = "local" | "s3";
 type Step = "idle" | "connecting" | "success" | "error";
+
+/** Non-binding endpoint presets for common S3-compatible providers. */
+interface S3Preset {
+  id: string;
+  label: string;
+  /** Placeholder shown in the endpoint field; the user can type any endpoint. */
+  endpointHint: string;
+  /** Hint copy shown under the preset row. */
+  note: string;
+}
+
+const S3_PRESETS: S3Preset[] = [
+  {
+    id: "aws",
+    label: "AWS S3",
+    endpointHint: "https://s3.us-east-1.amazonaws.com",
+    note: "Amazon's managed object storage. Leave the endpoint blank to use the default AWS S3 endpoint for your region.",
+  },
+  {
+    id: "minio",
+    label: "MinIO",
+    endpointHint: "https://minio.example.com:9000",
+    note: "Self-hosted S3-compatible server. Path-style addressing is enabled automatically.",
+  },
+  {
+    id: "garage",
+    label: "Garage",
+    endpointHint: "http://garage.example.com:3900",
+    note: "Lightweight self-hosted S3-compatible storage. Path-style addressing is enabled automatically.",
+  },
+  {
+    id: "other",
+    label: "Other S3-compatible",
+    endpointHint: "https://object-store.example.com",
+    note: "Any S3-compatible provider (Ceph/RGW, Backblaze B2, Wasabi, …). Enter its endpoint URL.",
+  },
+];
+
+/** Presets that need path-style addressing (everything except real AWS S3). */
+const PATH_STYLE_PRESETS = new Set(["minio", "garage", "other"]);
 
 interface FormState {
   // local
   path: string;
-  // object storage
+  // object storage (s3)
   endpoint: string;
   bucket: string;
   region: string;
@@ -27,10 +74,6 @@ const EMPTY_FORM: FormState = {
   mutableStore: "",
 };
 
-function isObjectStorage(kind: BackendKind): boolean {
-  return kind !== "local";
-}
-
 interface BackendPickerProps {
   /**
    * Called with the validated config once the backend opens successfully.
@@ -42,9 +85,13 @@ interface BackendPickerProps {
 
 export default function BackendPicker({ onConfigured }: BackendPickerProps = {}) {
   const [kind, setKind] = useState<BackendKind>("local");
+  const [presetId, setPresetId] = useState<string>(S3_PRESETS[0].id);
   const [form, setForm] = useState<FormState>({ ...EMPTY_FORM });
   const [step, setStep] = useState<Step>("idle");
   const [error, setError] = useState<string | null>(null);
+
+  const preset =
+    S3_PRESETS.find((p) => p.id === presetId) ?? S3_PRESETS[0];
 
   const updateField = useCallback(
     (field: keyof FormState) =>
@@ -58,7 +105,7 @@ export default function BackendPicker({ onConfigured }: BackendPickerProps = {})
     if (kind === "local") {
       return form.path.trim().length > 0;
     }
-    // object storage: endpoint + bucket required
+    // S3-compatible object storage: endpoint + bucket required.
     return (
       form.endpoint.trim().length > 0 && form.bucket.trim().length > 0
     );
@@ -73,7 +120,7 @@ export default function BackendPicker({ onConfigured }: BackendPickerProps = {})
       };
     }
     return {
-      kind,
+      kind: "s3",
       endpoint: form.endpoint.trim() || undefined,
       bucket: form.bucket.trim() || undefined,
       region: form.region.trim() || undefined,
@@ -109,11 +156,14 @@ export default function BackendPicker({ onConfigured }: BackendPickerProps = {})
     <div className="onboarding-card">
       <h2>Choose Storage Backend</h2>
       <p className="onboarding-description">
-        Pick where your Lore data will be stored. Local packfiles are simplest
-        for single-user setups. Object storage (S3, MinIO, Garage) scales to teams.
+        Pick where your Lore data is stored. A <strong>local</strong> filesystem
+        store is simplest for a single machine.{" "}
+        <strong>S3-compatible object storage</strong> scales to teams and works
+        with any S3 provider — AWS S3, MinIO, Garage, and others are the same
+        backend, differing only by endpoint URL.
       </p>
 
-      {/* Backend type selector */}
+      {/* Backend type selector — two honest options. */}
       {step !== "success" && (
         <div className="onboarding-radio-group">
           <label
@@ -129,9 +179,9 @@ export default function BackendPicker({ onConfigured }: BackendPickerProps = {})
               onChange={() => setKind("local")}
               disabled={step === "connecting"}
             />
-            <span className="onboarding-radio-label">Local Packfiles</span>
+            <span className="onboarding-radio-label">Local filesystem</span>
             <span className="onboarding-radio-desc">
-              Store data in local directories. Simple, no external services needed.
+              Store data in a local directory. Simplest — no external services.
             </span>
           </label>
 
@@ -148,54 +198,23 @@ export default function BackendPicker({ onConfigured }: BackendPickerProps = {})
               onChange={() => setKind("s3")}
               disabled={step === "connecting"}
             />
-            <span className="onboarding-radio-label">Amazon S3</span>
-            <span className="onboarding-radio-desc">
-              Managed object storage on AWS.
+            <span className="onboarding-radio-label">
+              S3-compatible object storage
             </span>
-          </label>
-
-          <label
-            className={`onboarding-radio ${
-              kind === "minio" ? "onboarding-radio--selected" : ""
-            }`}
-          >
-            <input
-              type="radio"
-              name="backend-kind"
-              value="minio"
-              checked={kind === "minio"}
-              onChange={() => setKind("minio")}
-              disabled={step === "connecting"}
-            />
-            <span className="onboarding-radio-label">MinIO</span>
             <span className="onboarding-radio-desc">
-              Self-hosted S3-compatible object storage.
-            </span>
-          </label>
-
-          <label
-            className={`onboarding-radio ${
-              kind === "garage" ? "onboarding-radio--selected" : ""
-            }`}
-          >
-            <input
-              type="radio"
-              name="backend-kind"
-              value="garage"
-              checked={kind === "garage"}
-              onChange={() => setKind("garage")}
-              disabled={step === "connecting"}
-            />
-            <span className="onboarding-radio-label">Garage</span>
-            <span className="onboarding-radio-desc">
-              Lightweight S3-compatible storage for self-hosting.
+              One backend, any S3 provider (AWS S3, MinIO, Garage, …). Scales to
+              teams.
             </span>
           </label>
         </div>
       )}
 
       {/* Error display */}
-      {error && <div className="error">{error}</div>}
+      {error && (
+        <div className="error" role="alert">
+          {error}
+        </div>
+      )}
 
       {/* Local form fields */}
       {kind === "local" && step !== "success" && (
@@ -212,19 +231,33 @@ export default function BackendPicker({ onConfigured }: BackendPickerProps = {})
         </div>
       )}
 
-      {/* Object storage form fields */}
-      {isObjectStorage(kind) && step !== "success" && (
+      {/* S3-compatible object storage form fields */}
+      {kind === "s3" && step !== "success" && (
         <>
+          {/* Provider presets — non-binding endpoint hints. */}
+          <div className="onboarding-field">
+            <label htmlFor="backend-preset">Provider preset (optional)</label>
+            <select
+              id="backend-preset"
+              value={presetId}
+              onChange={(e) => setPresetId(e.target.value)}
+              disabled={step === "connecting"}
+            >
+              {S3_PRESETS.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+            <span className="onboarding-field-hint">{preset.note}</span>
+          </div>
+
           <div className="onboarding-field">
             <label htmlFor="backend-endpoint">Endpoint URL</label>
             <input
               id="backend-endpoint"
               type="text"
-              placeholder={
-                kind === "s3"
-                  ? "https://s3.amazonaws.com"
-                  : "https://minio.example.com"
-              }
+              placeholder={preset.endpointHint}
               value={form.endpoint}
               onChange={updateField("endpoint")}
               disabled={step === "connecting"}
@@ -246,7 +279,7 @@ export default function BackendPicker({ onConfigured }: BackendPickerProps = {})
             <input
               id="backend-region"
               type="text"
-              placeholder={kind === "s3" ? "us-east-1" : ""}
+              placeholder={presetId === "aws" ? "us-east-1" : ""}
               value={form.region}
               onChange={updateField("region")}
               disabled={step === "connecting"}
@@ -257,7 +290,7 @@ export default function BackendPicker({ onConfigured }: BackendPickerProps = {})
             <input
               id="backend-access-key"
               type="text"
-              placeholder="AKIA..."
+              placeholder="AKIA…"
               value={form.accessKeyId}
               onChange={updateField("accessKeyId")}
               disabled={step === "connecting"}
@@ -274,6 +307,11 @@ export default function BackendPicker({ onConfigured }: BackendPickerProps = {})
               disabled={step === "connecting"}
             />
           </div>
+          {PATH_STYLE_PRESETS.has(presetId) && (
+            <p className="onboarding-field-hint">
+              Path-style addressing will be used automatically for this provider.
+            </p>
+          )}
         </>
       )}
 
@@ -316,7 +354,9 @@ export default function BackendPicker({ onConfigured }: BackendPickerProps = {})
         <div className="onboarding-success">
           <span className="success-icon">&#10003;</span>
           <span>
-            Storage opened — {kind === "local" ? "Local" : kind} backend ready
+            Storage opened —{" "}
+            {kind === "local" ? "Local filesystem" : "S3-compatible"} backend
+            ready
           </span>
           <button className="onboarding-button" onClick={handleReset}>
             Back

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -369,6 +369,13 @@ h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; color: v
   color: var(--surface-base-text-secondary, var(--muted));
 }
 
+/* Inline help under a form field (e.g. S3 provider-preset hints). */
+.onboarding-field-hint {
+  font-size: 12px;
+  color: var(--surface-base-text-secondary, var(--muted));
+  margin: 0;
+}
+
 /* Checkbox ----------------------------------------------------------- */
 .onboarding-checkbox {
   display: flex;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1252,12 +1252,14 @@ pub async fn repository_create(
 // needs path/endpoint today); retained for forthcoming object-store wiring.
 #[allow(dead_code)]
 pub struct StorageBackendConfig {
-    /// "local" | "s3" | "minio" | "garage".
+    /// lore's two real store backends: "local" (filesystem) | "s3"
+    /// (S3-compatible object store — AWS S3 / MinIO / Garage / … are the same
+    /// backend, differing only by endpoint).
     pub kind: String,
     /// Local packfiles path (kind == "local").
     #[serde(default)]
     pub path: Option<String>,
-    /// Object-storage endpoint (kind != "local").
+    /// S3-compatible object-storage endpoint (kind == "s3").
     #[serde(default)]
     pub endpoint: Option<String>,
     #[serde(default)]
@@ -1965,7 +1967,7 @@ pub async fn service_stop(
 
 // --- host server (SBAI-4065): launch + manage a real loreserver ---
 
-use crate::server_host::{self, HostServerOptions, HostStatus};
+use crate::server_host::{self, HostServerOptions, HostStatus, S3StoreOptions};
 
 /// Launch a real `loreserver` process serving the host flow's local stores.
 ///
@@ -1978,24 +1980,51 @@ use crate::server_host::{self, HostServerOptions, HostStatus};
 /// passes a flat `Record<string,unknown>` straight to `invoke`. The typed
 /// `api.hostServerStart(opts)` wrapper spreads `HostServerOptions` onto these.
 ///
+/// When `s3_bucket` is supplied, the hosted server's **immutable** store is an
+/// S3-compatible object store (lore's `aws` mode); otherwise it is a local
+/// filesystem store under `store_dir`. The mutable (branch-pointer) store is
+/// always local — see [`server_host::S3StoreOptions`].
+///
 /// `server_host` is synchronous (it spawns + manages a `std::process::Child`).
 /// The work here is fast — write a config, resolve the binary, spawn — so we
 /// run it inline under the std `Mutex` (the guard is never held across an
 /// `await`). The slow one-time dev build of `loreserver` happens only on a
 /// developer machine with no bundled sidecar.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub fn host_server_start(
     state: State<'_, AppState>,
     store_dir: String,
     port: Option<u16>,
     repository_name: Option<String>,
     auth: Option<bool>,
+    s3_bucket: Option<String>,
+    s3_endpoint: Option<String>,
+    s3_region: Option<String>,
+    s3_access_key_id: Option<String>,
+    s3_secret_access_key: Option<String>,
+    s3_force_path_style: Option<bool>,
+    s3_dynamodb_endpoint: Option<String>,
 ) -> Result<HostStatus, LoreError> {
+    // An S3 backend is requested iff a (non-blank) bucket is supplied.
+    let s3 = s3_bucket
+        .filter(|b| !b.trim().is_empty())
+        .map(|bucket| S3StoreOptions {
+            endpoint: s3_endpoint,
+            bucket,
+            region: s3_region,
+            access_key_id: s3_access_key_id,
+            secret_access_key: s3_secret_access_key,
+            force_path_style: s3_force_path_style.unwrap_or(false),
+            dynamodb_endpoint: s3_dynamodb_endpoint,
+        });
+
     let opts = HostServerOptions {
         store_dir,
         port: port.filter(|p| *p != 0),
         repository_name: repository_name.filter(|n| !n.trim().is_empty()),
         auth: auth.unwrap_or(false),
+        s3,
     };
     let mut slot = state.hosted_server.lock().unwrap();
     server_host::start(&mut slot, &opts)

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -50,6 +50,62 @@ pub struct HostServerOptions {
     /// the local host flow is no-auth; accepted for forward-compat.
     #[serde(default)]
     pub auth: bool,
+    /// Optional S3-compatible object-storage backing for the **immutable** store
+    /// (lore's `aws` store mode). When `None`, the immutable store is a local
+    /// filesystem store under [`store_dir`](Self::store_dir).
+    ///
+    /// The **mutable** (branch-pointer) store stays local in both cases: lore's
+    /// `aws` mutable store is backed by DynamoDB, which the host wizard does not
+    /// provision. Pairing an S3 immutable store with a local mutable store is a
+    /// valid lore topology for a single-node host (cf. the upstream
+    /// `composite.local + aws.durable` recipe in `dev-local.toml`).
+    #[serde(default)]
+    pub s3: Option<S3StoreOptions>,
+}
+
+/// S3-compatible object-storage options for the hosted server's immutable store.
+///
+/// Mirrors lore's `[plugins.aws.immutable_store]` S3 keys (`s3_bucket`,
+/// `s3_endpoint_url`, `s3_region`, `s3_force_path_style`). The same shape works
+/// for AWS S3, MinIO, Garage, Ceph/RGW, Backblaze B2, etc. — they differ only by
+/// endpoint URL and whether path-style addressing is required.
+///
+/// Credentials are NOT written into the TOML: lore's AWS plugin resolves them
+/// through the standard AWS credential chain, so [`access_key_id`] /
+/// [`secret_access_key`] are exported to the spawned `loreserver` process as the
+/// `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment variables instead.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct S3StoreOptions {
+    /// S3 endpoint URL. Empty/`None` selects real AWS S3 (SDK default endpoint).
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    /// Bucket name. Required — an `aws`-mode immutable store needs a bucket.
+    pub bucket: String,
+    /// Region (e.g. `"us-east-1"`). Required by most S3 providers.
+    #[serde(default)]
+    pub region: Option<String>,
+    /// Access key id, exported as `AWS_ACCESS_KEY_ID` to the server process.
+    #[serde(default)]
+    pub access_key_id: Option<String>,
+    /// Secret access key, exported as `AWS_SECRET_ACCESS_KEY`.
+    #[serde(default)]
+    pub secret_access_key: Option<String>,
+    /// Force path-style addressing (`endpoint/bucket/key`). MinIO/Garage and most
+    /// non-AWS providers require this; real AWS S3 does not. Defaults to `false`.
+    #[serde(default)]
+    pub force_path_style: bool,
+    /// Optional DynamoDB-compatible endpoint URL for the immutable store's
+    /// fragment-association + metadata tables.
+    ///
+    /// lore's `aws` immutable store pairs S3 (fragment payloads) with DynamoDB
+    /// (fragment associations + metadata) — there is no S3-only immutable store.
+    /// When omitted, the AWS SDK resolves the real AWS DynamoDB service in the
+    /// chosen region (so S3-on-AWS + DynamoDB-on-AWS works out of the box).
+    /// Operators running a DynamoDB-compatible service (DynamoDB Local,
+    /// LocalStack, ScyllaDB Alternator, …) set this to that endpoint.
+    #[serde(default)]
+    pub dynamodb_endpoint: Option<String>,
 }
 
 /// A running hosted server plus the metadata the UI needs.
@@ -117,15 +173,54 @@ struct ResolvedConfig {
     cert_file: PathBuf,
     pkey_file: PathBuf,
     auth: bool,
+    /// When `Some`, the immutable store is emitted in lore's `aws` (S3) mode
+    /// instead of `local`. The mutable store is always local (see
+    /// [`S3StoreOptions`]).
+    s3: Option<ResolvedS3>,
+}
+
+/// Resolved S3 inputs for `[plugins.aws.immutable_store]` generation.
+#[derive(Debug, Clone)]
+struct ResolvedS3 {
+    endpoint: Option<String>,
+    bucket: String,
+    region: Option<String>,
+    access_key_id: Option<String>,
+    secret_access_key: Option<String>,
+    force_path_style: bool,
+    dynamodb_endpoint: Option<String>,
+}
+
+impl ResolvedS3 {
+    /// DynamoDB table names for the immutable store, derived from the bucket so a
+    /// single S3 backend is self-describing. lore auto-ensures these tables.
+    fn fragments_table(&self) -> String {
+        format!("{}-fragments", self.bucket)
+    }
+    fn metadata_table(&self) -> String {
+        format!("{}-fragment-metadata", self.bucket)
+    }
 }
 
 /// Render the `loreserver` config TOML from resolved inputs.
 ///
 /// Pure and deterministic so it can be unit-tested. Mirrors the spike's
 /// `local.toml`: localhost QUIC + gRPC on the same port number (TCP gRPC / UDP
-/// QUIC), HTTP on `port + 2`, local immutable + mutable stores under the chosen
-/// directory, the shipped test certs for QUIC, single-node topology, and —
-/// crucially — **no `[server.auth]` block** so the server runs auth-disabled.
+/// QUIC), HTTP on `port + 2`, the shipped test certs for QUIC, single-node
+/// topology, and — crucially — **no `[server.auth]` block** so the server runs
+/// auth-disabled.
+///
+/// The **immutable** store is one of lore's two real backends:
+///   - `local` (default): a filesystem store under the chosen directory.
+///   - `aws` (when [`ResolvedConfig::s3`] is set): an S3-compatible object store
+///     (AWS S3 / MinIO / Garage / Ceph-RGW / B2 / …, all the same backend) for
+///     fragment payloads, paired with DynamoDB for fragment associations +
+///     metadata (lore's `aws` immutable store has no S3-only variant).
+///
+/// The **mutable** (branch-pointer) store is always `local`: lore's `aws`
+/// mutable store needs a dedicated DynamoDB table the host wizard does not
+/// provision, and an S3-immutable + local-mutable single node is a valid lore
+/// topology (cf. upstream `composite.local + aws.durable`).
 fn render_config_toml(cfg: &ResolvedConfig) -> String {
     // Paths are emitted as TOML basic strings; escape backslashes (Windows) and
     // quotes so the file is valid regardless of the platform's path separators.
@@ -134,10 +229,18 @@ fn render_config_toml(cfg: &ResolvedConfig) -> String {
             .replace('\\', "\\\\")
             .replace('"', "\\\"")
     };
+    // Escape a plain string value for a TOML basic string.
+    let escs = |s: &str| -> String { s.replace('\\', "\\\\").replace('"', "\\\"") };
 
     let mut out = String::new();
     out.push_str("# Generated by LoreGUI \"Host a server\" (SBAI-4065). Do not edit by hand.\n");
-    out.push_str("# Single-node, loopback-only, local-store loreserver config.\n\n");
+    if cfg.s3.is_some() {
+        out.push_str(
+            "# Single-node, loopback-only loreserver: S3-compatible immutable store + local mutable store.\n\n",
+        );
+    } else {
+        out.push_str("# Single-node, loopback-only, local-store loreserver config.\n\n");
+    }
 
     out.push_str("[server.quic]\n");
     out.push_str(&format!("host = \"{BIND_HOST}\"\n"));
@@ -154,10 +257,52 @@ fn render_config_toml(cfg: &ResolvedConfig) -> String {
     out.push_str(&format!("host = \"{BIND_HOST}\"\n"));
     out.push_str(&format!("port = {}\n\n", cfg.http_port));
 
-    out.push_str("[immutable_store.local]\n");
-    out.push_str(&format!("path = \"{}\"\n", esc(&cfg.store_dir)));
-    out.push_str("[mutable_store.local]\n");
-    out.push_str(&format!("path = \"{}\"\n\n", esc(&cfg.store_dir)));
+    match &cfg.s3 {
+        // Local filesystem immutable + mutable stores (the default).
+        None => {
+            out.push_str("[immutable_store.local]\n");
+            out.push_str(&format!("path = \"{}\"\n", esc(&cfg.store_dir)));
+            out.push_str("[mutable_store.local]\n");
+            out.push_str(&format!("path = \"{}\"\n\n", esc(&cfg.store_dir)));
+        }
+        // S3-compatible (lore `aws` mode) immutable store; local mutable store.
+        Some(s3) => {
+            out.push_str("[immutable_store]\n");
+            out.push_str("mode = \"aws\"\n\n");
+
+            // Mutable (branch pointers) stays on local disk — see fn docs.
+            out.push_str("[mutable_store.local]\n");
+            out.push_str(&format!("path = \"{}\"\n\n", esc(&cfg.store_dir)));
+
+            // The aws immutable store plugin: S3 for payloads, DynamoDB for the
+            // fragment-association + metadata tables (auto-ensured at startup).
+            out.push_str("[plugins.aws.immutable_store]\n");
+            out.push_str(&format!("s3_bucket = \"{}\"\n", escs(&s3.bucket)));
+            if let Some(ep) = &s3.endpoint {
+                out.push_str(&format!("s3_endpoint_url = \"{}\"\n", escs(ep)));
+            }
+            if let Some(region) = &s3.region {
+                out.push_str(&format!("s3_region = \"{}\"\n", escs(region)));
+            }
+            out.push_str(&format!("s3_force_path_style = {}\n", s3.force_path_style));
+            out.push_str(&format!(
+                "dynamodb_fragments_table = \"{}\"\n",
+                escs(&s3.fragments_table())
+            ));
+            out.push_str(&format!(
+                "dynamodb_metadata_table = \"{}\"\n",
+                escs(&s3.metadata_table())
+            ));
+            if let Some(ddb) = &s3.dynamodb_endpoint {
+                out.push_str(&format!("dynamodb_endpoint_url = \"{}\"\n", escs(ddb)));
+            }
+            // DynamoDB shares the S3 region unless the user runs it elsewhere.
+            if let Some(region) = &s3.region {
+                out.push_str(&format!("dynamodb_region = \"{}\"\n", escs(region)));
+            }
+            out.push('\n');
+        }
+    }
 
     out.push_str("[telemetry.logger]\n");
     out.push_str("format = \"ansi\"\n\n");
@@ -171,6 +316,16 @@ fn render_config_toml(cfg: &ResolvedConfig) -> String {
     if cfg.auth {
         out.push_str("\n# NOTE: authed hosting is not yet implemented; running auth-disabled.\n");
     }
+
+    // FOLLOW-UP (advanced / enterprise lore store modes, deferred — see
+    // docs/domains/storage.md): lore also supports a `composite` immutable store
+    // (local cache tier + durable `aws`/S3 tier with a `ReplicationMode` of
+    // read/write/read_write), a `replicated` store (server-to-server QUIC), and
+    // an `aws` (DynamoDB) mutable + lock store at scale. They need extra inputs
+    // (replica peers, DynamoDB tables/region, mTLS replication certs) the
+    // first-run host wizard does not collect, so they are intentionally not
+    // emitted here. Add new `ResolvedConfig` variants + render branches to wire
+    // them when those flows land.
 
     out
 }
@@ -345,6 +500,36 @@ fn sidecar_candidate() -> Option<PathBuf> {
     Some(dir.join(bin_name))
 }
 
+/// Validate + normalise the wizard's S3 options into [`ResolvedS3`].
+///
+/// Trims string fields and treats blanks as absent. The bucket is required —
+/// an `aws`-mode immutable store cannot be created without one.
+fn resolve_s3(opts: &S3StoreOptions) -> Result<ResolvedS3, LoreError> {
+    let norm = |s: &Option<String>| -> Option<String> {
+        s.as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(str::to_owned)
+    };
+
+    let bucket = opts.bucket.trim();
+    if bucket.is_empty() {
+        return Err(LoreError::CommandFailed(
+            "an S3-compatible bucket name is required to host with object storage".into(),
+        ));
+    }
+
+    Ok(ResolvedS3 {
+        endpoint: norm(&opts.endpoint),
+        bucket: bucket.to_owned(),
+        region: norm(&opts.region),
+        access_key_id: norm(&opts.access_key_id),
+        secret_access_key: norm(&opts.secret_access_key),
+        force_path_style: opts.force_path_style,
+        dynamodb_endpoint: norm(&opts.dynamodb_endpoint),
+    })
+}
+
 /// Build the resolved config + write the config file, returning everything
 /// `spawn` needs. Stores live directly under `store_dir`; the config file goes
 /// into `store_dir/.loregui-host/local.toml` so a single store directory is
@@ -378,6 +563,8 @@ fn prepare(opts: &HostServerOptions) -> Result<(ResolvedConfig, PathBuf, String)
     let cert_file = test_data.join("test_cert.pem");
     let pkey_file = test_data.join("test_key.pem");
 
+    let s3 = opts.s3.as_ref().map(resolve_s3).transpose()?;
+
     let cfg = ResolvedConfig {
         port,
         http_port,
@@ -385,6 +572,7 @@ fn prepare(opts: &HostServerOptions) -> Result<(ResolvedConfig, PathBuf, String)
         cert_file,
         pkey_file,
         auth: opts.auth,
+        s3,
     };
 
     let config_dir = store_dir.join(".loregui-host");
@@ -443,17 +631,36 @@ pub fn start(
 
     // Boot exactly like the spike: LORE_CONFIG_PATH points at the dir holding
     // local.toml, LORE_ENV=local selects it. cwd = config dir.
-    let child = Command::new(&binary)
+    let mut command = Command::new(&binary);
+    command
         .env("LORE_CONFIG_PATH", &config_dir)
         .env("LORE_ENV", "local")
-        .current_dir(&config_dir)
-        .spawn()
-        .map_err(|e| {
-            LoreError::CommandFailed(format!(
-                "failed to launch loreserver ({}): {e}",
-                binary.display()
-            ))
-        })?;
+        .current_dir(&config_dir);
+
+    // For an S3-backed (aws-mode) immutable store, lore resolves credentials via
+    // the standard AWS credential chain — NOT from the TOML. Export the access
+    // key + region as env vars on the child so the chain picks them up. (When
+    // absent, the chain falls back to ambient AWS config / instance role, which
+    // is the right behaviour for a host already authenticated to AWS.)
+    if let Some(s3) = &cfg.s3 {
+        if let Some(id) = &s3.access_key_id {
+            command.env("AWS_ACCESS_KEY_ID", id);
+        }
+        if let Some(secret) = &s3.secret_access_key {
+            command.env("AWS_SECRET_ACCESS_KEY", secret);
+        }
+        if let Some(region) = &s3.region {
+            command.env("AWS_REGION", region);
+            command.env("AWS_DEFAULT_REGION", region);
+        }
+    }
+
+    let child = command.spawn().map_err(|e| {
+        LoreError::CommandFailed(format!(
+            "failed to launch loreserver ({}): {e}",
+            binary.display()
+        ))
+    })?;
 
     let server = HostedServer {
         pid: child.id(),
@@ -513,6 +720,19 @@ mod tests {
             cert_file: PathBuf::from("/certs/test_cert.pem"),
             pkey_file: PathBuf::from("/certs/test_key.pem"),
             auth,
+            s3: None,
+        }
+    }
+
+    fn sample_s3_cfg(store: &str, port: u16, s3: ResolvedS3) -> ResolvedConfig {
+        ResolvedConfig {
+            port,
+            http_port: port + 2,
+            store_dir: PathBuf::from(store),
+            cert_file: PathBuf::from("/certs/test_cert.pem"),
+            pkey_file: PathBuf::from("/certs/test_key.pem"),
+            auth: false,
+            s3: Some(s3),
         }
     }
 
@@ -552,6 +772,131 @@ mod tests {
         let toml = render_config_toml(&cfg);
         // Backslashes are doubled so the TOML basic string is valid.
         assert!(toml.contains(r#"path = "C:\\Users\\dev\\store""#));
+    }
+
+    #[test]
+    fn local_config_does_not_emit_aws_store() {
+        let toml = render_config_toml(&sample_cfg("/srv/store", 41337, false));
+        // The default (no S3) path stays fully local: no aws mode, no plugin.
+        assert!(!toml.contains("mode = \"aws\""));
+        assert!(!toml.contains("[plugins.aws"));
+        assert!(toml.contains("[immutable_store.local]"));
+    }
+
+    #[test]
+    fn s3_config_emits_aws_immutable_store_and_local_mutable_store() {
+        let s3 = ResolvedS3 {
+            endpoint: Some("https://s3.us-west-2.amazonaws.com".into()),
+            bucket: "lore-prod".into(),
+            region: Some("us-west-2".into()),
+            access_key_id: Some("AKIAEXAMPLE".into()),
+            secret_access_key: Some("supersecret".into()),
+            force_path_style: false,
+            dynamodb_endpoint: None,
+        };
+        let toml = render_config_toml(&sample_s3_cfg("/srv/store", 41337, s3));
+
+        // Immutable store is aws (S3) mode.
+        assert!(toml.contains("[immutable_store]"));
+        assert!(toml.contains("mode = \"aws\""));
+
+        // aws immutable plugin: S3 payloads + DynamoDB metadata (tables derived
+        // from the bucket and auto-ensured by lore).
+        assert!(toml.contains("[plugins.aws.immutable_store]"));
+        assert!(toml.contains("s3_bucket = \"lore-prod\""));
+        assert!(toml.contains("s3_endpoint_url = \"https://s3.us-west-2.amazonaws.com\""));
+        assert!(toml.contains("s3_region = \"us-west-2\""));
+        assert!(toml.contains("s3_force_path_style = false"));
+        assert!(toml.contains("dynamodb_fragments_table = \"lore-prod-fragments\""));
+        assert!(toml.contains("dynamodb_metadata_table = \"lore-prod-fragment-metadata\""));
+        assert!(toml.contains("dynamodb_region = \"us-west-2\""));
+
+        // Mutable (branch-pointer) store stays local — see render_config_toml docs.
+        assert!(toml.contains("[mutable_store.local]"));
+        assert!(toml.contains("path = \"/srv/store\""));
+        // ...and is NOT switched to aws.
+        assert!(!toml.contains("[mutable_store]\nmode"));
+
+        // Secrets are never written into the config TOML (they go via env vars).
+        assert!(!toml.contains("AKIAEXAMPLE"));
+        assert!(!toml.contains("supersecret"));
+    }
+
+    #[test]
+    fn s3_config_for_minio_garage_uses_path_style_and_custom_endpoint() {
+        // MinIO/Garage: custom endpoint + path-style + a DynamoDB-compatible
+        // endpoint for the metadata tables.
+        let s3 = ResolvedS3 {
+            endpoint: Some("http://127.0.0.1:9000".into()),
+            bucket: "lore".into(),
+            region: Some("garage".into()),
+            access_key_id: None,
+            secret_access_key: None,
+            force_path_style: true,
+            dynamodb_endpoint: Some("http://127.0.0.1:8000".into()),
+        };
+        let toml = render_config_toml(&sample_s3_cfg("/srv/store", 41337, s3));
+        assert!(toml.contains("s3_endpoint_url = \"http://127.0.0.1:9000\""));
+        assert!(toml.contains("s3_force_path_style = true"));
+        assert!(toml.contains("dynamodb_endpoint_url = \"http://127.0.0.1:8000\""));
+    }
+
+    #[test]
+    fn s3_config_omits_optional_keys_when_absent() {
+        // Real AWS S3 with ambient creds: no endpoint, no region, no path-style.
+        let s3 = ResolvedS3 {
+            endpoint: None,
+            bucket: "lore".into(),
+            region: None,
+            access_key_id: None,
+            secret_access_key: None,
+            force_path_style: false,
+            dynamodb_endpoint: None,
+        };
+        let toml = render_config_toml(&sample_s3_cfg("/srv/store", 41337, s3));
+        assert!(toml.contains("s3_bucket = \"lore\""));
+        // Optional keys are omitted entirely (SDK resolves defaults).
+        assert!(!toml.contains("s3_endpoint_url"));
+        assert!(!toml.contains("s3_region"));
+        assert!(!toml.contains("dynamodb_endpoint_url"));
+        assert!(!toml.contains("dynamodb_region"));
+        // Required DynamoDB table names are always present.
+        assert!(toml.contains("dynamodb_fragments_table = \"lore-fragments\""));
+        assert!(toml.contains("dynamodb_metadata_table = \"lore-fragment-metadata\""));
+    }
+
+    #[test]
+    fn resolve_s3_trims_blanks_and_requires_bucket() {
+        // Blank bucket → error.
+        let blank = S3StoreOptions {
+            endpoint: Some("  ".into()),
+            bucket: "   ".into(),
+            region: None,
+            access_key_id: None,
+            secret_access_key: None,
+            force_path_style: false,
+            dynamodb_endpoint: None,
+        };
+        assert!(resolve_s3(&blank).is_err());
+
+        // Blanks elsewhere normalise to None; bucket is trimmed.
+        let opts = S3StoreOptions {
+            endpoint: Some("  https://s3.example.com  ".into()),
+            bucket: "  my-bucket  ".into(),
+            region: Some("".into()),
+            access_key_id: Some("  key  ".into()),
+            secret_access_key: None,
+            force_path_style: true,
+            dynamodb_endpoint: None,
+        };
+        let resolved = resolve_s3(&opts).expect("valid");
+        assert_eq!(resolved.bucket, "my-bucket");
+        assert_eq!(resolved.endpoint.as_deref(), Some("https://s3.example.com"));
+        assert_eq!(resolved.region, None);
+        assert_eq!(resolved.access_key_id.as_deref(), Some("key"));
+        assert!(resolved.force_path_style);
+        assert_eq!(resolved.fragments_table(), "my-bucket-fragments");
+        assert_eq!(resolved.metadata_table(), "my-bucket-fragment-metadata");
     }
 
     #[test]
@@ -597,6 +942,7 @@ mod tests {
             port: Some(port),
             repository_name: Some("smoke".into()),
             auth: false,
+            s3: None,
         };
 
         let started = start(&mut slot, &opts).expect("start should spawn loreserver");


### PR DESCRIPTION
Collapses the misleading local/s3/minio/garage picker to Local + S3-compatible (provider presets prefill the endpoint only — S3/MinIO/Garage are one lore 'aws' mode). Wires server_host to emit the aws store config (S3 + DynamoDB metadata) with creds via env (not TOML). Confirmed lore's real modes (local/aws/composite/replicated). 10 server_host tests green. Composite/replicated/DynamoDB deferred.