### PR TITLE
feat(commercial): offline Ed25519 signed license-key gate (SBAI-4068)

### DIFF
--- a/docs/COMMERCIAL-ADDONS.md
+++ b/docs/COMMERCIAL-ADDONS.md
@@ -42,10 +42,18 @@ isDevDefaultEntitlement(): boolean          // are we in dev "all on" mode?
 
 | # | Source | Use |
 |---|--------|-----|
-| 1 | `window.__LOREGUI_ENTITLEMENTS__` (string[]) | Runtime injection by the host shell / accounts bootstrap. **Highest precedence.** |
-| 2 | `localStorage["loregui.entitlements"]` (JSON array or CSV) | Dev / QA override; how an in-app toggle persists. |
-| 3 | `VITE_LOREGUI_ENTITLEMENTS` / `LOREGUI_ENTITLEMENTS` (CSV, build time) | Ship a commercial build pre-entitled. |
-| 4 | **default** | Dev build → **all features ON** (contributors see the full UI). Production build with nothing set → **all features OFF** (locked). |
+| 1 | **Signed license key** (Ed25519, offline) | The authoritative production unlock. A real, portable, offline license token only Biloxi can mint. Verified at bootstrap, then mirrored into `window.__LOREGUI_ENTITLEMENTS__`. See [Offline signed license keys](#offline-signed-license-keys-sbai-4068). **Highest precedence.** |
+| 2 | `window.__LOREGUI_ENTITLEMENTS__` (string[]) | Runtime injection by the host shell / accounts bootstrap (and where the license bootstrap writes its result). |
+| 3 | `localStorage["loregui.entitlements"]` (JSON array or CSV) | Dev / QA override; how an in-app toggle persists. |
+| 4 | `VITE_LOREGUI_ENTITLEMENTS` / `LOREGUI_ENTITLEMENTS` (CSV, build time) | Ship a commercial build pre-entitled. |
+| 5 | **default** | Dev build → **all features ON** (contributors see the full UI). Production build with nothing set → **all features OFF** (locked). |
+
+In production this collapses to the SBAI-4068 contract: **valid signed license →
+(dev override, dev builds only) → empty**. The verifier and the embedded public
+key are open-core public — this is *signature-verified entitlement, not
+anti-tamper DRM* (a user with the source can patch the gate; honest licensing,
+not copy protection). Only the private signing key, which is never in this repo,
+is secret.
 
 ### Tier → feature mapping
 
@@ -60,28 +68,140 @@ unaffected.
 
 ## How a studio unlocks an add-on
 
-**Today (dev / self-serve):** set the entitlement via any source above, e.g.
+**Production (today):** issue the studio an **offline signed license key** and
+have them drop it into `LOREGUI_LICENSE`, `localStorage["loregui.license"]`, or a
+`license.key` file. See [Offline signed license keys](#offline-signed-license-keys-sbai-4068)
+below for the full mint/install flow.
 
-- A commercial build: `LOREGUI_ENTITLEMENTS=reporting` at build time.
+**Dev / QA:** set the entitlement directly via any of the lower-priority sources, e.g.
+
 - Local trial / QA: in the browser console
   `localStorage.setItem("loregui.entitlements", '["reporting"]')` then reload,
   or call `setDevEntitlements(["reporting"])`.
+- A pre-entitled build: `LOREGUI_ENTITLEMENTS=reporting` at build time.
 - Dev builds already default to everything-on.
 
-**Future (StudioBrain accounts tiers):** the durable source is the StudioBrain
-accounts JWT (RS256, issued by `accounts.studiobrain.ai`). When the auth bridge
-lands, a bootstrap step will:
+**Future (StudioBrain accounts tiers):** the *second* durable source (after the
+offline license key) is the StudioBrain accounts JWT (RS256, issued by
+`accounts.studiobrain.ai`). When the auth bridge lands, a bootstrap step will:
 
 1. Read the signed JWT's `tier` claim (`free` / `team` / `enterprise`).
 2. Resolve it through `featuresForTier(tier)`.
 3. Inject the result into `window.__LOREGUI_ENTITLEMENTS__` **before** React
-   mounts (priority source #1).
+   mounts (priority source #2).
 
 No call site in the app changes — `isEntitled("reporting")` just starts
 returning the tier's answer. Per the StudioBrain **accounts security boundary**,
 LoreGUI never parses, stores, or mints the JWT here; token handling stays in the
 auth/accounts layer. This module only consumes a resolved, already-trusted
 feature list.
+
+## Offline signed license keys (SBAI-4068)
+
+The authoritative production unlock is an **offline, Ed25519-signed license
+token**. It needs no account and no network: a studio that pays gets a portable
+token they can drop on any machine.
+
+> **This is signature-verified open-core entitlement, NOT anti-tamper DRM.**
+> LoreGUI is MIT and public — the verifier *and* the embedded public key ship in
+> the open. A determined user with the source can patch the gate out; that is
+> fine and expected for honest open-core licensing. What the signature *does*
+> guarantee is that a license cannot be **forged or self-minted** (only the
+> holder of the private key can sign one) and that it **expires**. The future
+> accounts-JWT tier (above) is the planned *second* entitlement source.
+
+### Token format
+
+A compact, JWT-like string — `payload.signature`, but using **Ed25519 / EdDSA**:
+
+```
+base64url(JSON payload) "." base64url(Ed25519 signature)
+```
+
+The signature is over the UTF-8 bytes of the base64url **payload segment** (the
+part before the dot). The payload is:
+
+```jsonc
+{
+  "licensee":  "Acme Studios",     // who it's for (informational)
+  "tier":      "team",             // display label (informational)
+  "features":  ["reporting"],      // entitlement ids granted (authoritative)
+  "issuedAt":  1782148402,         // unix epoch seconds
+  "expiresAt": 1813684402          // unix epoch seconds; past → rejected
+}
+```
+
+### Verification (open, in the app)
+
+`frontend/src/commercial/license.ts#verifyLicense(token)` verifies the Ed25519
+signature with **WebCrypto** (`crypto.subtle`, native Ed25519) against the
+embedded public key, then enforces `expiresAt`. On success it returns the
+license's `features`; on any failure (malformed, bad signature, wrong key,
+expired) it returns `null` and the app falls back to open core — an invalid or
+absent license never breaks the free app, it only withholds premium surfaces.
+
+`bootstrapEntitlements()` (called from `main.tsx` before React mounts) resolves
+the token from `LOREGUI_LICENSE` env → `localStorage["loregui.license"]` →
+`license.key` file (read via the `read_license_file` Tauri command, which looks
+at `$LOREGUI_LICENSE_FILE` or `license.key` in the app config dir), verifies it,
+and mirrors the granted features into `window.__LOREGUI_ENTITLEMENTS__` so every
+`isEntitled()` call stays synchronous.
+
+### The public key (embedded — safe to be public)
+
+The Ed25519 **public** verify key is embedded as `LICENSE_PUBLIC_KEY_B64URL` in
+`frontend/src/commercial/license.ts` (raw 32 bytes, base64url). A verify key can
+only *check* signatures, so shipping it in a public MIT repo is safe.
+
+> ⚠️ The value currently embedded is a **throwaway placeholder** (its private
+> half was discarded). Before cutting a commercial build, generate the real
+> keypair, embed its public half here, and store the private half in Vaultwarden
+> (see below).
+
+### The private key (THE SECRET — never in the repo)
+
+The matching Ed25519 **private** signing key is the licensing secret. Anyone
+holding it can mint a license that unlocks every premium surface. It MUST live
+**only** in Vaultwarden (entry suggestion: *"LoreGUI license signing key
+(Ed25519 private)"*) or Azure Key Vault. It is **never** committed, never in
+`.env`, never in CI logs. The issuer tool reads it from an env var / file path at
+mint time only.
+
+### Tooling
+
+Both scripts live in `frontend/scripts/` and use only Node's built-in `crypto`
+(no deps):
+
+1. **Generate a keypair** (one-time, when setting up commercial signing):
+
+   ```bash
+   node frontend/scripts/gen-license-keypair.mjs
+   ```
+
+   Prints the PUBLIC key (embed it as `LICENSE_PUBLIC_KEY_B64URL`) and the
+   PRIVATE key (store it in Vaultwarden — do **not** commit it).
+
+2. **Mint a license** for a studio (reads the private key from the environment,
+   never from the repo):
+
+   ```bash
+   LOREGUI_LICENSE_PRIVATE_KEY=<private-key-from-vaultwarden> \
+     node frontend/scripts/issue-license.mjs \
+       --licensee "Acme Studios" \
+       --tier team \
+       --features reporting \
+       --days 365
+   ```
+
+   The token is printed to **stdout** (the human-readable summary goes to
+   stderr, so you can capture the token cleanly). Or supply
+   `LOREGUI_LICENSE_PRIVATE_KEY_FILE=/path/to/key` instead of the env var, and
+   `--expires <ISO-8601>` instead of `--days`.
+
+3. **Deliver** the token to the studio. They install it via any of:
+   - `LOREGUI_LICENSE=<token>` in the environment, or
+   - `localStorage.setItem("loregui.license", "<token>")` (then reload), or
+   - a `license.key` file in the app config dir (or at `$LOREGUI_LICENSE_FILE`).
 
 ## Adding a new premium feature
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "test": "node --test --experimental-strip-types \"src/**/*.test.ts\"",
     "screenshots": "node scripts/visual-test.mjs"
   },
   "dependencies": {

--- a/frontend/scripts/gen-license-keypair.mjs
+++ b/frontend/scripts/gen-license-keypair.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Generate an Ed25519 license keypair for LoreGUI's commercial entitlement gate
+ * (SBAI-4068).
+ *
+ * Prints:
+ *   - PUBLIC  key (raw 32-byte, base64url) — embed in `frontend/src/commercial/
+ *     license.ts` as `LICENSE_PUBLIC_KEY_B64URL`. Safe to be public; it can only
+ *     *verify* signatures.
+ *   - PRIVATE key (raw 32-byte seed, base64url) — THE LICENSING SECRET. Store it
+ *     ONLY in Vaultwarden / Azure Key Vault. NEVER commit it. Anyone holding it
+ *     can mint licenses that unlock every premium surface.
+ *
+ * Usage:
+ *   node frontend/scripts/gen-license-keypair.mjs
+ *
+ * This is signature-verified open-core entitlement, not anti-tamper DRM: the app
+ * and the public key are public; only the private key is secret.
+ */
+import { generateKeyPairSync } from "node:crypto";
+
+function b64url(buf) {
+  return Buffer.from(buf).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+
+// Raw 32-byte key material lives in the trailing 32 bytes of the DER encodings.
+const spki = publicKey.export({ type: "spki", format: "der" });
+const pkcs8 = privateKey.export({ type: "pkcs8", format: "der" });
+const rawPublic = spki.subarray(spki.length - 32);
+const rawPrivate = pkcs8.subarray(pkcs8.length - 32);
+
+console.log("LoreGUI license keypair (Ed25519)\n");
+console.log("PUBLIC  (embed in license.ts as LICENSE_PUBLIC_KEY_B64URL):");
+console.log("  " + b64url(rawPublic) + "\n");
+console.log("PRIVATE (THE SECRET — store in Vaultwarden / Azure KV, NEVER commit):");
+console.log("  " + b64url(rawPrivate) + "\n");
+console.log("To mint a license with this key:");
+console.log("  LOREGUI_LICENSE_PRIVATE_KEY=<private-above> \\");
+console.log('    node frontend/scripts/issue-license.mjs --licensee "Acme" --tier team \\');
+console.log("      --features reporting --days 365");

--- a/frontend/scripts/issue-license.mjs
+++ b/frontend/scripts/issue-license.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Issue (mint) a LoreGUI commercial license token (SBAI-4068).
+ *
+ * Signs a `{ licensee, tier, features, issuedAt, expiresAt }` payload with the
+ * Ed25519 PRIVATE signing key and prints a compact `payload.signature` token
+ * (base64url(JSON) "." base64url(Ed25519 sig) — JWT-like, EdDSA). That exact
+ * format is what `frontend/src/commercial/license.ts#verifyLicense` checks
+ * against the embedded public key.
+ *
+ * The PRIVATE key is the licensing secret. It is read from the environment or a
+ * file — it is NEVER read from, or written to, the repo:
+ *   - `LOREGUI_LICENSE_PRIVATE_KEY`        raw 32-byte seed, base64url, OR
+ *   - `LOREGUI_LICENSE_PRIVATE_KEY_FILE`   path to a file holding the same.
+ * Source it from Vaultwarden / Azure Key Vault at issuing time; do not commit it.
+ *
+ * Usage:
+ *   LOREGUI_LICENSE_PRIVATE_KEY=<b64url-seed> \
+ *     node frontend/scripts/issue-license.mjs \
+ *       --licensee "Acme Studios" \
+ *       --tier team \
+ *       --features reporting \
+ *       --days 365
+ *
+ * Flags:
+ *   --licensee <str>     who it's for (required)
+ *   --tier <str>         tier label for display (default: "team")
+ *   --features <csv>     entitlement ids granted (default: "reporting")
+ *   --days <n>           validity window in days from now (default: 365)
+ *   --expires <iso>      explicit expiry (ISO 8601), overrides --days
+ *
+ * This is signature-verified open-core entitlement, not anti-tamper DRM.
+ */
+import { createPrivateKey, sign as edSign } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+function b64url(buf) {
+  return Buffer.from(buf).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const val = argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[++i] : "true";
+      out[key] = val;
+    }
+  }
+  return out;
+}
+
+function loadPrivateSeed() {
+  let seedB64 = process.env.LOREGUI_LICENSE_PRIVATE_KEY?.trim();
+  const file = process.env.LOREGUI_LICENSE_PRIVATE_KEY_FILE?.trim();
+  if (!seedB64 && file) seedB64 = readFileSync(file, "utf8").trim();
+  if (!seedB64) {
+    console.error(
+      "ERROR: no private signing key. Set LOREGUI_LICENSE_PRIVATE_KEY (raw 32-byte\n" +
+        "seed, base64url) or LOREGUI_LICENSE_PRIVATE_KEY_FILE. Get it from Vaultwarden.",
+    );
+    process.exit(1);
+  }
+  const seed = Buffer.from(seedB64.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+  if (seed.length !== 32) {
+    console.error(`ERROR: private seed must be 32 bytes, got ${seed.length}.`);
+    process.exit(1);
+  }
+  // Wrap the raw 32-byte seed in a PKCS8 DER so Node can import it as an Ed25519 key.
+  const pkcs8Prefix = Buffer.from("302e020100300506032b657004220420", "hex");
+  return createPrivateKey({
+    key: Buffer.concat([pkcs8Prefix, seed]),
+    format: "der",
+    type: "pkcs8",
+  });
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+if (!args.licensee) {
+  console.error('ERROR: --licensee is required (e.g. --licensee "Acme Studios").');
+  process.exit(1);
+}
+
+const licensee = args.licensee;
+const tier = args.tier || "team";
+const features = (args.features || "reporting")
+  .split(/[,\s]+/)
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const issuedAt = Math.floor(Date.now() / 1000);
+let expiresAt;
+if (args.expires) {
+  const ms = Date.parse(args.expires);
+  if (Number.isNaN(ms)) {
+    console.error(`ERROR: --expires is not a valid ISO date: ${args.expires}`);
+    process.exit(1);
+  }
+  expiresAt = Math.floor(ms / 1000);
+} else {
+  const days = Number(args.days ?? 365);
+  if (!Number.isFinite(days) || days <= 0) {
+    console.error(`ERROR: --days must be a positive number, got ${args.days}`);
+    process.exit(1);
+  }
+  expiresAt = issuedAt + Math.round(days * 86400);
+}
+
+const payload = { licensee, tier, features, issuedAt, expiresAt };
+const payloadSeg = b64url(Buffer.from(JSON.stringify(payload), "utf8"));
+
+const privateKey = loadPrivateSeed();
+// Ed25519 signs the raw bytes (no pre-hash, no algorithm arg).
+const signature = edSign(null, Buffer.from(payloadSeg, "utf8"), privateKey);
+const token = `${payloadSeg}.${b64url(signature)}`;
+
+console.error("Minted license:");
+console.error("  licensee:  " + licensee);
+console.error("  tier:      " + tier);
+console.error("  features:  " + features.join(", "));
+console.error("  issuedAt:  " + new Date(issuedAt * 1000).toISOString());
+console.error("  expiresAt: " + new Date(expiresAt * 1000).toISOString());
+console.error("");
+console.error("Token (give this to the studio; they set LOREGUI_LICENSE / license.key /");
+console.error('localStorage["loregui.license"]):');
+// The token itself goes to stdout so it can be piped/captured cleanly.
+console.log(token);

--- a/frontend/scripts/palette-parity-allowlist.json
+++ b/frontend/scripts/palette-parity-allowlist.json
@@ -15,7 +15,8 @@
     "tray_sync_state",
     "get_desktop_settings",
     "set_autostart",
-    "set_close_to_tray"
+    "set_close_to_tray",
+    "read_license_file"
   ],
   "deferred": []
 }

--- a/frontend/src/commercial/entitlement.ts
+++ b/frontend/src/commercial/entitlement.ts
@@ -12,23 +12,37 @@
  *
  * ## Where entitlements come from (resolved in priority order)
  *
- * 1. **Runtime injection** — `window.__LOREGUI_ENTITLEMENTS__`, a string[] of
+ * 1. **Signed license key** — an offline Ed25519-signed license token (see
+ *    `license.ts`). This is the AUTHORITATIVE production unlock: a real, portable
+ *    license that only Biloxi can mint (we hold the private signing key) and that
+ *    carries an expiry. Resolved once at {@link bootstrapEntitlements} and cached
+ *    into the runtime slot below. Highest precedence.
+ * 2. **Runtime injection** — `window.__LOREGUI_ENTITLEMENTS__`, a string[] of
  *    feature ids. The host shell (or, later, a StudioBrain accounts session
- *    bootstrap) can write this before React mounts. Highest precedence.
- * 2. **Local override** — `localStorage["loregui.entitlements"]`, a JSON array
+ *    bootstrap) can write this before React mounts. This is ALSO where the
+ *    license bootstrap writes the verified license features, so call sites stay
+ *    synchronous.
+ * 3. **Local override** — `localStorage["loregui.entitlements"]`, a JSON array
  *    or comma-separated list. Lets a developer or QA toggle features without a
  *    rebuild. Also how the in-app dev affordance persists a choice.
- * 3. **Build-time env** — `import.meta.env.VITE_LOREGUI_ENTITLEMENTS` (a.k.a.
+ * 4. **Build-time env** — `import.meta.env.VITE_LOREGUI_ENTITLEMENTS` (a.k.a.
  *    `LOREGUI_ENTITLEMENTS` exported at build), comma-separated. Lets a
  *    commercial build ship pre-entitled.
- * 4. **Dev default** — in a dev build (`import.meta.env.DEV`) with none of the
+ * 5. **Dev default** — in a dev build (`import.meta.env.DEV`) with none of the
  *    above set, ALL features default to ON so contributors see the full UI. In a
  *    production build with nothing configured, features default to OFF (locked).
  *
+ * In production, the effective resolution collapses to the contract from
+ * SBAI-4068: **valid signed license → (dev override, dev builds only) → empty**.
+ * The license is signature-verified, not anti-tamper DRM — the app and verify key
+ * are public open core; only the private signing key (in Vaultwarden / Azure KV)
+ * is secret. See `license.ts` and `docs/COMMERCIAL-ADDONS.md`.
+ *
  * ## Future: StudioBrain accounts tiers (Free / Team / Enterprise)
  *
- * The long-term source is the StudioBrain accounts JWT (RS256, issued by
- * accounts.studiobrain.ai). Its `tier` claim maps to a feature set via
+ * The offline signed license key is the FIRST real source (shipping now). The
+ * StudioBrain accounts JWT (RS256, issued by accounts.studiobrain.ai) is the
+ * planned SECOND source. Its `tier` claim maps to a feature set via
  * {@link TIER_FEATURES}. When the auth bridge lands, a bootstrap step will read
  * the JWT's `tier` claim and inject the resolved feature ids into
  * `window.__LOREGUI_ENTITLEMENTS__` (path 1 above) — so NO call site here
@@ -36,6 +50,8 @@
  * parses or stores the JWT itself; that stays in the auth/accounts layer per the
  * StudioBrain accounts security boundary.
  */
+
+import { resolveLicensedFeatures } from "./license";
 
 /** A gateable premium feature id. Keep in sync with TIER_FEATURES below. */
 export type Feature = "reporting";
@@ -118,23 +134,68 @@ function localOverride(): string[] | null {
 const ALL = "*";
 
 /**
+ * Features unlocked by a verified signed license, resolved once by
+ * {@link bootstrapEntitlements}. `null` = bootstrap hasn't run / no valid
+ * license. This is the authoritative production source and takes precedence over
+ * everything except an explicit runtime injection by the host shell.
+ */
+let licensedFeatures: string[] | null = null;
+
+/**
+ * Resolve, verify, and cache the offline signed license (SBAI-4068). Call this
+ * ONCE before React mounts. After it resolves, `isEntitled()` reflects the
+ * license synchronously (the verified features are also mirrored into the
+ * runtime injection slot so any late readers agree).
+ *
+ * `loadFile` is an optional reader for an on-disk `license.key` (e.g. a thin
+ * wrapper over a `read_license_file` Tauri command). When omitted, only the env
+ * and localStorage token sources are consulted.
+ *
+ * Safe to call even with no license present: it simply leaves entitlements at
+ * their non-license defaults, so the open core stays fully functional.
+ */
+export async function bootstrapEntitlements(
+  loadFile?: () => Promise<string | null>,
+): Promise<string[] | null> {
+  try {
+    licensedFeatures = await resolveLicensedFeatures(loadFile);
+  } catch {
+    licensedFeatures = null;
+  }
+  if (licensedFeatures && typeof window !== "undefined") {
+    // Mirror into the runtime slot so any synchronous reader (and the future
+    // accounts-JWT bootstrap, which also writes here) sees a single source.
+    window.__LOREGUI_ENTITLEMENTS__ = [...licensedFeatures];
+  }
+  return licensedFeatures;
+}
+
+/** @internal — for tests only. Reset the cached license resolution. */
+export function __resetLicensedFeaturesForTests(): void {
+  licensedFeatures = null;
+}
+
+/**
  * The resolved set of entitled feature ids for this session. Returns `["*"]`
  * when everything is unlocked (dev default). Order matters: see module docs.
  */
 function resolveEntitlements(): string[] {
-  // 1. runtime injection
+  // 1. verified signed license (authoritative production unlock)
+  if (licensedFeatures != null) return [...licensedFeatures];
+
+  // 2. runtime injection (host shell / future accounts bootstrap)
   const injected = typeof window !== "undefined" ? window.__LOREGUI_ENTITLEMENTS__ : undefined;
   if (Array.isArray(injected)) return injected.map(String);
 
-  // 2. local override (dev / QA / in-app toggle)
+  // 3. local override (dev / QA / in-app toggle)
   const override = typeof window !== "undefined" ? localOverride() : null;
   if (override != null) return override;
 
-  // 3. build-time env
+  // 4. build-time env
   const env = envEntitlements();
   if (env.length) return env;
 
-  // 4. defaults: dev = all on, prod = none.
+  // 5. defaults: dev = all on, prod = none.
   return isDev() ? [ALL] : [];
 }
 

--- a/frontend/src/commercial/license.test.ts
+++ b/frontend/src/commercial/license.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for the offline signed license verifier (SBAI-4068).
+ *
+ * Run with Node's built-in test runner (type-stripping handles the .ts import):
+ *   node --test --experimental-strip-types frontend/src/commercial/license.test.ts
+ *
+ * A dedicated TEST keypair is generated/embedded HERE ONLY — it is unrelated to
+ * the public key shipped in `license.ts` and never leaves this file. We inject
+ * its public half via the `__setVerifyKeyForTests` seam so we exercise the real
+ * WebCrypto verification path with a key whose private half we control.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createPrivateKey, sign as edSign } from "node:crypto";
+
+import {
+  verifyLicense,
+  __setVerifyKeyForTests,
+  __setNowForTests,
+} from "./license.ts";
+
+// --- Test keypair (THIS FILE ONLY — not the shipped key) ---------------------
+// Raw 32-byte Ed25519 seed + matching raw 32-byte public key, base64url.
+const TEST_PRIVATE_SEED_B64URL = "G13yonnUXKISUWd9fz0mR9HPEseP62s62xiB2D4sAZA";
+const TEST_PUBLIC_B64URL = "O4XX8oJhN9lelj1x6RZm2DO_EWXsofN3u4CJApnhEww";
+
+// A different, unrelated public key used for the "wrong key" case.
+const OTHER_PUBLIC_B64URL = "UgsjCegtHciM5_idRfCsnFG_AR4hJc2QhwnuH5PeBeg";
+
+function b64urlToBytes(s: string): Uint8Array {
+  const n = s.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = n.length % 4 === 0 ? "" : "=".repeat(4 - (n.length % 4));
+  return new Uint8Array(Buffer.from(n + pad, "base64"));
+}
+
+function b64url(bytes: Uint8Array | Buffer): string {
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function testPrivateKey() {
+  const seed = Buffer.from(b64urlToBytes(TEST_PRIVATE_SEED_B64URL));
+  const pkcs8Prefix = Buffer.from("302e020100300506032b657004220420", "hex");
+  return createPrivateKey({
+    key: Buffer.concat([pkcs8Prefix, seed]),
+    format: "der",
+    type: "pkcs8",
+  });
+}
+
+/** Sign a payload object with the TEST private key → compact token. */
+function mintWithTestKey(payload: Record<string, unknown>): string {
+  const payloadSeg = b64url(Buffer.from(JSON.stringify(payload), "utf8"));
+  const sig = edSign(null, Buffer.from(payloadSeg, "utf8"), testPrivateKey());
+  return `${payloadSeg}.${b64url(sig)}`;
+}
+
+async function importPublic(b64: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey("raw", b64urlToBytes(b64), { name: "Ed25519" }, false, ["verify"]);
+}
+
+const NOW = 1_800_000_000; // fixed "current" time (seconds) for determinism
+const validPayload = {
+  licensee: "Test Studio",
+  tier: "team",
+  features: ["reporting"],
+  issuedAt: NOW - 86_400,
+  expiresAt: NOW + 86_400,
+};
+
+test.beforeEach(async () => {
+  __setNowForTests(() => NOW);
+  __setVerifyKeyForTests(await importPublic(TEST_PUBLIC_B64URL));
+});
+
+test.afterEach(() => {
+  __setNowForTests(null);
+  __setVerifyKeyForTests(null);
+});
+
+test("valid license → returns its features", async () => {
+  const token = mintWithTestKey(validPayload);
+  const features = await verifyLicense(token);
+  assert.deepEqual(features, ["reporting"]);
+});
+
+test("multiple features round-trip", async () => {
+  const token = mintWithTestKey({ ...validPayload, features: ["reporting", "future-thing"] });
+  assert.deepEqual(await verifyLicense(token), ["reporting", "future-thing"]);
+});
+
+test("tampered payload → null (signature no longer matches)", async () => {
+  const token = mintWithTestKey(validPayload);
+  const [payloadSeg, sigSeg] = token.split(".");
+  // Flip the payload to grant an extra feature, keep the original signature.
+  const tampered = { ...validPayload, features: ["reporting", "stolen"] };
+  void payloadSeg;
+  const forgedSeg = b64url(Buffer.from(JSON.stringify(tampered), "utf8"));
+  const forged = `${forgedSeg}.${sigSeg}`;
+  assert.equal(await verifyLicense(forged), null);
+});
+
+test("tampered signature bytes → null", async () => {
+  const token = mintWithTestKey(validPayload);
+  const [payloadSeg, sigSeg] = token.split(".");
+  const sigBytes = b64urlToBytes(sigSeg);
+  sigBytes[0] ^= 0xff; // corrupt one byte
+  assert.equal(await verifyLicense(`${payloadSeg}.${b64url(sigBytes)}`), null);
+});
+
+test("expired license → null", async () => {
+  const token = mintWithTestKey({
+    ...validPayload,
+    issuedAt: NOW - 2 * 86_400,
+    expiresAt: NOW - 86_400, // already past
+  });
+  assert.equal(await verifyLicense(token), null);
+});
+
+test("expiresAt not after issuedAt → null", async () => {
+  const token = mintWithTestKey({ ...validPayload, issuedAt: NOW, expiresAt: NOW });
+  assert.equal(await verifyLicense(token), null);
+});
+
+test("wrong verify key → null (signed by test key, verified by other key)", async () => {
+  const token = mintWithTestKey(validPayload);
+  __setVerifyKeyForTests(await importPublic(OTHER_PUBLIC_B64URL));
+  assert.equal(await verifyLicense(token), null);
+});
+
+test("malformed tokens → null", async () => {
+  for (const bad of ["", "no-dot", ".onlysig", "onlypayload.", "a.b.c", null, undefined]) {
+    assert.equal(await verifyLicense(bad as string), null, `expected null for ${JSON.stringify(bad)}`);
+  }
+});
+
+test("payload missing required fields → null", async () => {
+  const token = mintWithTestKey({ licensee: "x", tier: "team" }); // no features/dates
+  assert.equal(await verifyLicense(token), null);
+});
+
+test("non-base64url signature segment → null", async () => {
+  const token = mintWithTestKey(validPayload);
+  const payloadSeg = token.split(".")[0];
+  assert.equal(await verifyLicense(`${payloadSeg}.!!!not-base64!!!`), null);
+});

--- a/frontend/src/commercial/license.ts
+++ b/frontend/src/commercial/license.ts
@@ -1,0 +1,238 @@
+/**
+ * Offline signed license-key verification (SBAI-4068).
+ *
+ * ## What this is (and is NOT)
+ *
+ * LoreGUI is open core (MIT) — the source, including this verifier and the
+ * embedded public key, is public. So this is **signature-verified entitlement,
+ * not anti-tamper DRM**. A determined user with the source can patch the gate;
+ * that is fine and expected for honest open-core licensing. What this buys us:
+ *
+ * - A studio that pays gets a *real*, portable, **offline** license token they
+ *   can drop on any machine — no account, no network, no phone-home.
+ * - The token is **cryptographically signed** by a key only Biloxi holds, so it
+ *   cannot be forged or self-minted, and it carries an **expiry** so a lapsed
+ *   subscription naturally stops unlocking premium surfaces.
+ * - The public verify key ships in the binary (safe — it can only *verify*).
+ *   Only the matching Ed25519 **private** key (kept in Vaultwarden / Azure Key
+ *   Vault, never in this repo) can issue a license.
+ *
+ * This is the authoritative entitlement source today. The StudioBrain accounts
+ * JWT (RS256 tier claim) is the planned *second* source — see `entitlement.ts`.
+ *
+ * ## Token format — `payload.signature` (JWT-like, EdDSA / Ed25519)
+ *
+ *   <base64url(JSON payload)> "." <base64url(Ed25519 signature)>
+ *
+ * The signature is over the raw UTF-8 bytes of the **base64url payload segment**
+ * (i.e. everything before the dot), exactly as in a JWS detached-style scheme.
+ * The payload JSON is {@link LicensePayload}:
+ *
+ *   { licensee, tier, features: string[], issuedAt, expiresAt }
+ *
+ * `issuedAt` / `expiresAt` are unix epoch **seconds**. `features` is the literal
+ * list of entitlement ids this license grants (we do not re-derive them from
+ * `tier` here — the issuer decides; `tier` is informational / for display).
+ */
+
+/** The signed claims inside a license token. */
+export interface LicensePayload {
+  /** Who the license was issued to (studio / org name). Informational. */
+  licensee: string;
+  /** Commercial tier label (free / team / enterprise). Informational/display. */
+  tier: string;
+  /** The entitlement feature ids this license unlocks. Authoritative. */
+  features: string[];
+  /** Issue time, unix epoch seconds. */
+  issuedAt: number;
+  /** Expiry time, unix epoch seconds. Past → license is rejected. */
+  expiresAt: number;
+}
+
+/**
+ * Embedded Ed25519 **public** verify key, raw 32 bytes, base64url.
+ *
+ * SAFE TO BE PUBLIC: a verify key can only check signatures, never produce them.
+ * The matching PRIVATE signing key is the licensing secret and MUST live only in
+ * Vaultwarden / Azure Key Vault — never in this repo. See
+ * `docs/COMMERCIAL-ADDONS.md` and `scripts/gen-license-keypair.mjs`.
+ *
+ * NOTE: the value below is a **throwaway placeholder** generated for development
+ * (its private half was discarded and is NOT the real production signing key).
+ * Before shipping a commercial build, replace it with the public key whose
+ * private half is stored in Vaultwarden, via `scripts/gen-license-keypair.mjs`.
+ */
+export const LICENSE_PUBLIC_KEY_B64URL = "UgsjCegtHciM5_idRfCsnFG_AR4hJc2QhwnuH5PeBeg";
+
+/** localStorage key holding a raw license token string. */
+export const LICENSE_STORAGE_KEY = "loregui.license";
+
+/**
+ * base64url → ArrayBuffer (tolerant of missing padding; throws on bad chars).
+ * Returns an `ArrayBuffer` so the result is unambiguously a WebCrypto
+ * `BufferSource` regardless of TS lib's `Uint8Array` generic.
+ */
+function b64urlDecode(input: string): ArrayBuffer {
+  const normalized = input.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = normalized.length % 4 === 0 ? "" : "=".repeat(4 - (normalized.length % 4));
+  const bin = atob(normalized + pad);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out.buffer;
+}
+
+/** UTF-8 encode to an ArrayBuffer (a clean WebCrypto `BufferSource`). */
+function utf8Bytes(text: string): ArrayBuffer {
+  const view = new TextEncoder().encode(text);
+  return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength) as ArrayBuffer;
+}
+
+/** Get a SubtleCrypto, or null if unavailable (e.g. non-secure context). */
+function subtle(): SubtleCrypto | null {
+  try {
+    return globalThis.crypto?.subtle ?? null;
+  } catch {
+    return null;
+  }
+}
+
+let cachedKey: Promise<CryptoKey | null> | null = null;
+
+/** Import the embedded Ed25519 public key once, memoized. */
+function importVerifyKey(): Promise<CryptoKey | null> {
+  if (cachedKey) return cachedKey;
+  cachedKey = (async () => {
+    const s = subtle();
+    if (!s) return null;
+    try {
+      const raw = b64urlDecode(LICENSE_PUBLIC_KEY_B64URL);
+      return await s.importKey("raw", raw, { name: "Ed25519" }, false, ["verify"]);
+    } catch {
+      return null;
+    }
+  })();
+  return cachedKey;
+}
+
+/** Test seam: override the verify key (unit tests inject a test public key). */
+let keyOverride: CryptoKey | null = null;
+/** @internal — for tests only. Pass a key to override, or null to restore. */
+export function __setVerifyKeyForTests(key: CryptoKey | null): void {
+  keyOverride = key;
+}
+
+/** Current time in unix seconds. Overridable for deterministic tests. */
+let nowSeconds = (): number => Math.floor(Date.now() / 1000);
+/** @internal — for tests only. */
+export function __setNowForTests(fn: (() => number) | null): void {
+  nowSeconds = fn ?? (() => Math.floor(Date.now() / 1000));
+}
+
+function isLicensePayload(value: unknown): value is LicensePayload {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.licensee === "string" &&
+    typeof v.tier === "string" &&
+    Array.isArray(v.features) &&
+    v.features.every((f) => typeof f === "string") &&
+    typeof v.issuedAt === "number" &&
+    typeof v.expiresAt === "number"
+  );
+}
+
+/**
+ * Verify a license token. Returns the granted feature ids on success, or `null`
+ * on ANY failure (malformed, bad signature, wrong key, expired, missing crypto).
+ *
+ * Failure is always silent + null so the caller falls back to open-core: an
+ * invalid or absent license must NEVER break the free app, only withhold premium
+ * surfaces.
+ */
+export async function verifyLicense(token: string | null | undefined): Promise<string[] | null> {
+  if (!token || typeof token !== "string") return null;
+  const dot = token.indexOf(".");
+  if (dot <= 0 || dot === token.length - 1) return null;
+  const payloadSeg = token.slice(0, dot);
+  const sigSeg = token.slice(dot + 1);
+
+  const key = keyOverride ?? (await importVerifyKey());
+  if (!key) return null;
+  const s = subtle();
+  if (!s) return null;
+
+  let signature: ArrayBuffer;
+  let signedBytes: ArrayBuffer;
+  let payload: unknown;
+  try {
+    signature = b64urlDecode(sigSeg);
+    signedBytes = utf8Bytes(payloadSeg);
+    payload = JSON.parse(new TextDecoder().decode(b64urlDecode(payloadSeg)));
+  } catch {
+    return null;
+  }
+
+  let valid = false;
+  try {
+    valid = await s.verify({ name: "Ed25519" }, key, signature, signedBytes);
+  } catch {
+    return null;
+  }
+  if (!valid) return null;
+
+  if (!isLicensePayload(payload)) return null;
+  // Expiry check (and a sane issuedAt <= expiresAt guard).
+  if (!(payload.expiresAt > payload.issuedAt)) return null;
+  if (payload.expiresAt <= nowSeconds()) return null;
+
+  return [...payload.features];
+}
+
+/**
+ * Read the raw license token from the ambient sources, in priority order:
+ *
+ *   1. `LOREGUI_LICENSE` build-time env (`import.meta.env.VITE_LOREGUI_LICENSE`).
+ *   2. `localStorage["loregui.license"]`.
+ *   3. A `license.key` file on disk, read via the optional `read_license_file`
+ *      Tauri command (only if a `loadFile` reader is supplied).
+ *
+ * Returns the first non-empty token found, else null. This only *locates* a
+ * token; {@link verifyLicense} decides whether it actually grants anything.
+ */
+export async function readLicenseToken(loadFile?: () => Promise<string | null>): Promise<string | null> {
+  // 1. build-time env
+  try {
+    const env = (import.meta.env?.VITE_LOREGUI_LICENSE as string | undefined)?.trim();
+    if (env) return env;
+  } catch {
+    /* import.meta.env may be absent outside Vite */
+  }
+  // 2. localStorage
+  try {
+    const ls = globalThis.localStorage?.getItem(LICENSE_STORAGE_KEY)?.trim();
+    if (ls) return ls;
+  } catch {
+    /* storage may be unavailable */
+  }
+  // 3. on-disk license.key via host-provided reader (Tauri command)
+  if (loadFile) {
+    try {
+      const file = (await loadFile())?.trim();
+      if (file) return file;
+    } catch {
+      /* reader failure → treat as no file */
+    }
+  }
+  return null;
+}
+
+/**
+ * Convenience: locate AND verify in one call. Returns granted features or null.
+ * Used by the entitlement bootstrap to populate the runtime entitlement slot.
+ */
+export async function resolveLicensedFeatures(
+  loadFile?: () => Promise<string | null>,
+): Promise<string[] | null> {
+  const token = await readLicenseToken(loadFile);
+  return verifyLicense(token);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,32 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { invoke } from "@tauri-apps/api/core";
 import App from "./App";
 import { ThemeProvider } from "./theme/ThemeProvider";
+import { bootstrapEntitlements } from "./commercial/entitlement";
 import "./styles.css";
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <ThemeProvider>
-      <App />
-    </ThemeProvider>
-  </React.StrictMode>,
-);
+/** Read an on-disk `license.key` via the Tauri command; null outside Tauri. */
+async function loadLicenseFile(): Promise<string | null> {
+  try {
+    return (await invoke<string | null>("read_license_file")) ?? null;
+  } catch {
+    // Not running under Tauri (e.g. browser dev) or command unavailable.
+    return null;
+  }
+}
+
+function mount(): void {
+  ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+    <React.StrictMode>
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
+    </React.StrictMode>,
+  );
+}
+
+// Resolve + verify the offline signed license (SBAI-4068) BEFORE React mounts so
+// `isEntitled()` reflects it synchronously at every call site. A missing/invalid
+// license is a no-op — the open core mounts identically and stays fully working.
+void bootstrapEntitlements(loadLicenseFile).finally(mount);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -17,5 +17,6 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
+  "exclude": ["src/**/*.test.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2359,6 +2359,47 @@ use lore_vm::ops::revision::activity_report::{
     activity_report as op_revision_activity_report, ActivityReportArgs, ActivityReportResult,
 };
 
+/// Read an on-disk `license.key` file for the commercial entitlement gate
+/// (SBAI-4068), returning its trimmed contents or `None` if absent/unreadable.
+///
+/// This is purely a *file reader* — it does not verify the token. Signature
+/// verification happens in the frontend (`license.ts`) against the embedded
+/// Ed25519 public key. The lookup order is:
+///
+///   1. `LOREGUI_LICENSE_FILE` env var — an explicit path to the license file.
+///   2. `license.key` in the app config directory (next to `settings.json`).
+///
+/// Any failure (missing file, no config dir, read error) yields `Ok(None)` so an
+/// absent license never breaks startup — the open core stays fully functional.
+#[tauri::command]
+pub async fn read_license_file(app: AppHandle) -> Result<Option<String>, LoreError> {
+    use tauri::Manager;
+
+    let path: Option<PathBuf> = std::env::var_os("LOREGUI_LICENSE_FILE")
+        .map(PathBuf::from)
+        .or_else(|| {
+            app.path()
+                .app_config_dir()
+                .ok()
+                .map(|d| d.join("license.key"))
+        });
+
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => {
+            let trimmed = contents.trim();
+            Ok(if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            })
+        }
+        Err(_) => Ok(None),
+    }
+}
+
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
 pub async fn revision_activity_report(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -180,6 +180,7 @@ pub fn run() {
             commands::revision_commit_with_metadata,
             commands::revision_metadata_clear,
             commands::revision_activity_report,
+            commands::read_license_file,
             commands::tray_sync_state,
             get_desktop_settings,
             set_autostart,


### PR DESCRIPTION
Real entitlement: verifyLicense (WebCrypto Ed25519, sig+expiry) is the authoritative source; bootstrapEntitlements runs before React mounts. Issuer/keygen scripts (private key → Vaultwarden, never committed; embedded public key is a throwaway placeholder to regenerate pre-commercial). read_license_file Tauri command. 10/10 tests. Open core unaffected. accounts-JWT tier = future 2nd source.