### PR TITLE
spike(SBAI-4079): UE bridge — proven lorevm FFI cdylib + design doc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,6 +2789,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lorevm-ffi"
+version = "0.1.0"
+dependencies = [
+ "lore-vm",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/lore-vm", "crates/lorevm-cli", "src-tauri"]
+members = ["crates/lore-vm", "crates/lorevm-cli", "crates/lorevm-ffi", "src-tauri"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/lorevm-ffi/Cargo.toml
+++ b/crates/lorevm-ffi/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "lorevm-ffi"
+description = "SPIKE (SBAI-4079): minimal C-ABI cdylib over lore-vm, proving an Unreal Engine C++ plugin can drive lore in-process via FFI instead of shelling out to `lorevm --json`. Not a shipped artifact."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[lib]
+name = "lorevm_ffi"
+# cdylib → a loadable C library (.so / .dylib / .dll) the UE plugin links against.
+# rlib → so the in-tree Rust smoke test can call the extern "C" entry points.
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+lore-vm = { path = "../lore-vm" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/lorevm-ffi/src/lib.rs
+++ b/crates/lorevm-ffi/src/lib.rs
@@ -1,0 +1,230 @@
+//! `lorevm-ffi` — SPIKE (SBAI-4079).
+//!
+//! A minimal C-ABI surface over [`lore_vm`], proving that an Unreal Engine C++
+//! plugin (or any C/C++ host) can drive our lore binding **in-process** over a
+//! stable C ABI, instead of shelling out to the `lorevm --json` subprocess that
+//! `lore-mcp` uses today.
+//!
+//! This is a **feasibility proof, not a shipped artifact.** It exposes exactly
+//! one call entry point plus a matching free function, and wraps a *subset* of
+//! the same `lore_vm::ops` dispatch that `lorevm-cli/src/main.rs` exposes. The
+//! point is to validate the ABI shape, the JSON-in/JSON-out contract, the
+//! tokio-runtime-per-call lifetime, and the malloc/free ownership rules — NOT
+//! to be op-complete. A production bridge would factor the full dispatch match
+//! out of `lorevm-cli` into a shared `lore-vm` library fn and call it from both
+//! the CLI and here (see docs/ue-lorevm-bridge-spike.md).
+//!
+//! # ABI contract
+//!
+//! ```c
+//! // op_id  : "<domain>.<op>"  (e.g. "repository.status"), UTF-8, NUL-terminated
+//! // request: JSON object, UTF-8, NUL-terminated. Shape:
+//! //          { "dir": "<path>", "args": {..}, "in_memory": bool,
+//! //            "offline": bool, "identity": "<id>"|null }
+//! // returns: malloc'd, NUL-terminated UTF-8 JSON string the caller OWNS and
+//! //          MUST release with lorevm_ffi_string_free(). On success it is the
+//! //          op's typed result; on failure it is {"error":{"kind","message"}}.
+//! //          Returns NULL only on a NUL/invalid-UTF-8 op_id or request pointer.
+//! char* lorevm_ffi_call(const char* op_id, const char* request);
+//! void  lorevm_ffi_string_free(char* s);
+//! const char* lorevm_ffi_abi_version(void);  // static, do NOT free
+//! ```
+//!
+//! # Threading
+//!
+//! `lorevm_ffi_call` is self-contained: it builds a fresh multi-thread tokio
+//! runtime, runs the op to completion, and tears the runtime down before
+//! returning. It blocks the calling thread for the op's duration, so a UE host
+//! MUST call it from a background thread (e.g. an `AsyncTask`), never the game
+//! thread, for anything that can block on I/O or the network. A production
+//! bridge would hold one long-lived runtime + `LoreApi` behind an opaque handle
+//! rather than spinning a runtime per call; this spike keeps it stateless to
+//! stay minimal.
+
+use std::ffi::{c_char, CStr, CString};
+
+use lore_vm::api::LoreApi;
+use lore_vm::global::LoreGlobal;
+use lore_vm::ops;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+/// Bumped if the C ABI shape changes. Lets the UE plugin assert compatibility.
+const ABI_VERSION: &str = "lorevm-ffi/0\0";
+
+/// Deserialised `request` envelope.
+#[derive(Debug, Deserialize)]
+struct Request {
+    #[serde(default = "default_dir")]
+    dir: String,
+    #[serde(default = "empty_obj")]
+    args: Value,
+    #[serde(default)]
+    in_memory: bool,
+    #[serde(default)]
+    offline: bool,
+    #[serde(default)]
+    identity: Option<String>,
+}
+
+fn default_dir() -> String {
+    ".".to_string()
+}
+fn empty_obj() -> Value {
+    json!({})
+}
+
+/// Return the ABI version string (static, NUL-terminated, do NOT free).
+///
+/// # Safety
+/// The returned pointer is valid for the lifetime of the loaded library.
+#[no_mangle]
+pub extern "C" fn lorevm_ffi_abi_version() -> *const c_char {
+    ABI_VERSION.as_ptr() as *const c_char
+}
+
+/// Free a string previously returned by [`lorevm_ffi_call`].
+///
+/// # Safety
+/// `s` must be a pointer returned by [`lorevm_ffi_call`] (or NULL). Passing any
+/// other pointer, or freeing twice, is undefined behaviour.
+#[no_mangle]
+pub unsafe extern "C" fn lorevm_ffi_string_free(s: *mut c_char) {
+    if !s.is_null() {
+        // Reclaim the CString we leaked in `respond` and drop it.
+        drop(CString::from_raw(s));
+    }
+}
+
+/// Invoke `<domain>.<op>` with a JSON request; return a malloc'd JSON response.
+///
+/// See the module-level docs for the full ABI contract.
+///
+/// # Safety
+/// `op_id` and `request` must be valid, NUL-terminated, UTF-8 C strings (or the
+/// call returns NULL). The returned pointer must be released exactly once with
+/// [`lorevm_ffi_string_free`].
+#[no_mangle]
+pub unsafe extern "C" fn lorevm_ffi_call(
+    op_id: *const c_char,
+    request: *const c_char,
+) -> *mut c_char {
+    // ---- decode the two C strings ------------------------------------------
+    if op_id.is_null() || request.is_null() {
+        return std::ptr::null_mut();
+    }
+    let op_id = match CStr::from_ptr(op_id).to_str() {
+        Ok(s) => s.to_owned(),
+        Err(_) => return std::ptr::null_mut(),
+    };
+    let request_str = match CStr::from_ptr(request).to_str() {
+        Ok(s) => s.to_owned(),
+        Err(_) => return std::ptr::null_mut(),
+    };
+
+    // From here on, every failure is reported as JSON, never NULL.
+    let req: Request = match serde_json::from_str(&request_str) {
+        Ok(r) => r,
+        Err(e) => return respond(&error_json("ffi", &format!("invalid request JSON: {e}"))),
+    };
+
+    // ---- build a fresh runtime + API and run the op ------------------------
+    // Stateless per-call: minimal for a spike. A real bridge keeps these alive.
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => return respond(&error_json("ffi", &format!("failed to start runtime: {e}"))),
+    };
+
+    let response = runtime.block_on(async move {
+        let mut global = LoreGlobal::new(std::path::PathBuf::from(&req.dir))
+            .in_memory(req.in_memory)
+            .offline(req.offline);
+        if let Some(id) = &req.identity {
+            global = global.identity(id.clone());
+        }
+        let api = LoreApi::from_global(global);
+        dispatch(&op_id, &api, req.args).await
+    });
+
+    respond(&response)
+}
+
+/// Dispatch a `<domain>.<op>` id to the matching `lore_vm::ops` fn and return
+/// its result (or a structured error) as a JSON `Value`.
+///
+/// SPIKE SCOPE: this mirrors `lorevm-cli`'s dispatch but only wires a
+/// representative subset of ops — enough to prove a read op, a metrics op, and
+/// a mutating op all cross the ABI. The full op set is intentionally omitted;
+/// the production design factors the CLI's complete match into a shared fn.
+async fn dispatch(op_id: &str, api: &LoreApi, args: Value) -> Value {
+    macro_rules! op {
+        ($path:path, $args:ty) => {{
+            let parsed: $args = match serde_json::from_value(args.clone()) {
+                Ok(p) => p,
+                Err(e) => {
+                    return error_json(
+                        "ffi",
+                        &format!("could not parse args for `{op_id}`: {e}"),
+                    )
+                }
+            };
+            match $path(api, parsed).await {
+                Ok(result) => {
+                    serde_json::to_value(&result).unwrap_or_else(|e| {
+                        error_json("ffi", &format!("failed to serialise result: {e}"))
+                    })
+                }
+                Err(e) => {
+                    let v = serde_json::to_value(&e).unwrap_or_else(|_| {
+                        json!({ "kind": "client", "message": e.to_string() })
+                    });
+                    json!({ "error": v })
+                }
+            }
+        }};
+    }
+
+    match op_id {
+        "repository.status" => op!(
+            ops::repository::status::status,
+            ops::repository::status::RepositoryStatusArgs
+        ),
+        "repository.info" => op!(
+            ops::repository::info::info,
+            ops::repository::info::RepositoryInfoArgs
+        ),
+        "repository.create" => op!(
+            ops::repository::create::create,
+            ops::repository::create::CreateArgs
+        ),
+        "branch.list" => op!(ops::branch::list::list, ops::branch::list::BranchListArgs),
+        unknown => error_json(
+            "ffi",
+            &format!(
+                "unknown or unwired op `{unknown}` (spike wires a subset; \
+                 production bridge shares lorevm-cli's full dispatch)"
+            ),
+        ),
+    }
+}
+
+/// Build a `{"error":{"kind","message"}}` JSON value.
+fn error_json(kind: &str, message: &str) -> Value {
+    json!({ "error": { "kind": kind, "message": message } })
+}
+
+/// Serialise a JSON value to a malloc'd, NUL-terminated C string and hand
+/// ownership to the caller. Returns NULL only if the value somehow contains an
+/// interior NUL (it cannot for JSON text, but we stay defensive).
+fn respond(value: &Value) -> *mut c_char {
+    let text = serde_json::to_string(value).unwrap_or_else(|_| {
+        "{\"error\":{\"kind\":\"ffi\",\"message\":\"unserialisable response\"}}".to_string()
+    });
+    match CString::new(text) {
+        Ok(c) => c.into_raw(),
+        Err(_) => std::ptr::null_mut(),
+    }
+}

--- a/crates/lorevm-ffi/tests/smoke.rs
+++ b/crates/lorevm-ffi/tests/smoke.rs
@@ -1,0 +1,90 @@
+//! SPIKE smoke test (SBAI-4079).
+//!
+//! Calls the `extern "C"` entry points exactly as a C/C++ host (the UE plugin)
+//! would — passing C strings in and freeing the returned C string — to prove
+//! lore-vm can be driven over the C ABI. We drive a real in-memory lore engine
+//! (`in_memory + offline`, the same headless mode the integration harness uses)
+//! so the roundtrip exercises the actual ops layer, not a stub.
+
+use std::ffi::{c_char, CStr, CString};
+
+use lorevm_ffi::{lorevm_ffi_abi_version, lorevm_ffi_call, lorevm_ffi_string_free};
+use serde_json::Value;
+
+/// Call across the ABI the way C would, returning the parsed JSON response.
+fn call(op_id: &str, request: &Value) -> Value {
+    let op_c = CString::new(op_id).unwrap();
+    let req_c = CString::new(request.to_string()).unwrap();
+    // SAFETY: both pointers are valid NUL-terminated UTF-8 for the call's
+    // duration; we free the result exactly once below.
+    unsafe {
+        let out: *mut c_char = lorevm_ffi_call(op_c.as_ptr(), req_c.as_ptr());
+        assert!(!out.is_null(), "ffi call returned NULL for `{op_id}`");
+        let text = CStr::from_ptr(out).to_str().unwrap().to_owned();
+        lorevm_ffi_string_free(out);
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("non-JSON response `{text}`: {e}"))
+    }
+}
+
+#[test]
+fn abi_version_is_exposed() {
+    // SAFETY: returns a static NUL-terminated string we must NOT free.
+    let v = unsafe { CStr::from_ptr(lorevm_ffi_abi_version()) }
+        .to_str()
+        .unwrap();
+    assert!(v.starts_with("lorevm-ffi/"), "unexpected ABI version: {v}");
+}
+
+#[test]
+fn create_then_status_roundtrips_over_the_c_abi() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().to_string_lossy().to_string();
+    // In-memory mode keeps stores in a process-wide cache that persists across
+    // sequential library calls, so create-then-status round-trips with no server
+    // and no on-disk store — mirroring lore-vm's integration_roundtrip harness.
+    let repo_url = format!("lore://localhost/spike-{}", std::process::id());
+
+    // 1. Mutating op across the ABI: create an in-memory repo.
+    let created = call(
+        "repository.create",
+        &serde_json::json!({
+            "dir": dir,
+            "in_memory": true,
+            "offline": true,
+            "identity": "spike-ffi",
+            "args": { "repository_url": repo_url }
+        }),
+    );
+    assert!(
+        created.get("error").is_none(),
+        "repository.create errored over FFI: {created}"
+    );
+
+    // 2. Read op across the ABI against the same in-memory engine.
+    let status = call(
+        "repository.status",
+        &serde_json::json!({
+            "dir": dir,
+            "in_memory": true,
+            "offline": true,
+            "identity": "spike-ffi",
+            "args": {}
+        }),
+    );
+    assert!(
+        status.get("error").is_none(),
+        "repository.status errored over FFI: {status}"
+    );
+    // A successful status result is a JSON object (the typed RepoStatus shape).
+    assert!(status.is_object(), "status was not a JSON object: {status}");
+}
+
+#[test]
+fn unknown_op_returns_structured_error_not_null() {
+    let resp = call("nope.nope", &serde_json::json!({ "dir": ".", "args": {} }));
+    let kind = resp
+        .pointer("/error/kind")
+        .and_then(Value::as_str)
+        .expect("expected {error:{kind}} shape");
+    assert_eq!(kind, "ffi");
+}

--- a/docs/ue-lorevm-bridge-spike.md
+++ b/docs/ue-lorevm-bridge-spike.md
@@ -1,0 +1,319 @@
+# Spike: how a StudioBrain Unreal Engine C++ plugin should drive our lore binding
+
+**Ticket:** SBAI-4079 (spike — design + feasibility, no UE code, no full build)
+**Branch:** `spike/ue-lorevm-bridge`
+**Status:** complete. FFI feasibility proof builds and its smoke call passes.
+
+---
+
+## 1. Problem
+
+We want a StudioBrain Unreal Engine (UE) editor plugin that surfaces lore VCS
+state in the editor — most visibly **Content Browser status overlays** (per-asset
+checked-out / locked / modified / up-to-date badges) and a source-control panel
+— driving lore through **our** stack, not Epic's public `lore` CLI.
+
+A UE plugin is **C++**. Our lore binding is **Rust**:
+
+```
+crates/lore-vm        LoreApi + ops/<domain>/<op>.rs  — binds Epic's `lore` crate in-process,
+                      collects its events into typed serde results. The reusable core.
+crates/lorevm-cli     the `lorevm` binary: a thin JSON CLI over lore-vm's dispatch.
+                      `lorevm <domain>.<op> --dir <repo> --args '<json>'` → JSON on stdout.
+                      This is the subprocess surface `lore-mcp` already drives.
+```
+
+So the question is: **how does C++ reach lore-vm?** Two viable routes (both go
+through *our* stack, neither shells Epic's `lore` CLI):
+
+- **A — Shell `lorevm --json`** as a child process per op (reuses the exact
+  surface `lore-mcp` uses today).
+- **B — C-ABI FFI**: build lore-vm as a `cdylib` exposing `extern "C"` entry
+  points, link it into the UE plugin, call in-process (no subprocess).
+
+This doc assesses both for the UE use case, proves B is feasible with a minimal
+crate, and recommends an architecture.
+
+---
+
+## 2. The surface a bridge must expose
+
+Whichever route we pick, the bridge wraps the **same dispatch** that
+`lorevm-cli/src/main.rs` already implements:
+
+- Build a `LoreApi` from a `LoreGlobal` (working dir + `in_memory` / `offline` /
+  `identity` / `force` / `max_connections`).
+- Map a `"<domain>.<op>"` string to the matching `lore_vm::ops::…` async fn.
+- Deserialize a JSON args object into that op's `Args` struct (snake_case serde
+  keys, all `#[serde(default)]`).
+- `await` the op, serialize its typed `Result` to JSON, or return the structured
+  `LoreError` as `{"error":{"kind","message"}}`.
+
+The op set today (30 ops across `repository`, `revision`, `branch`, `auth`,
+`file`, `lock`) is exactly what a UE plugin needs: `repository.status`,
+`lock.file_status` / `lock.file_query` (overlay state), `file.stage` /
+`file.unstage` / `lock.file_acquire` / `lock.file_release` (check-out / -in),
+`revision.commit` / `branch.*` (submit / streams).
+
+**Key structural fact for this spike:** that dispatch `match` lives **only in the
+CLI binary** (`main.rs`), not in `lore-vm` as a library fn. So any second driver
+(FFI, or a future in-process host) today has to *re-type* the match. The clean
+production fix is to **lift the dispatch into `lore-vm` as a public
+`dispatch(op_id, &LoreApi, args_json) -> serde_json::Value` fn** and have both
+`lorevm-cli` and the FFI crate call it. The spike crate deliberately re-types a
+small subset rather than refactor the CLI, to stay minimal and non-invasive — but
+the recommendation below assumes that one-time refactor.
+
+---
+
+## 3. Option A — shell `lorevm --json` from UE
+
+UE spawns the `lorevm` binary per op (UE has `FPlatformProcess` /
+`FMonitoredProcess`), writes flags + `--args '<json>'`, reads JSON from stdout,
+parses it (UE ships `FJsonSerializer`).
+
+**Pros**
+- **Zero new code in our repo.** `lorevm` already exists and is the proven
+  `lore-mcp` surface. The bridge is entirely on the UE side.
+- **Process isolation.** A panic / crash / memory blow-up in lore or its QUIC
+  stack takes down a child process, not the UE editor. For a pre-1.0 dependency
+  (`lore` is `0.8.4-nightly`, pinned by exact rev) this is real safety.
+- **Trivial threading story.** Run the subprocess on a UE background thread;
+  marshal the parsed result back to the game thread. No shared runtime, no
+  re-entrancy, no FFI lifetime rules.
+- **Process-per-op = no shared mutable state** to corrupt across calls.
+- **Cross-platform "for free."** Ship a `lorevm.exe` / `lorevm` per platform;
+  UE's process API is already cross-platform. No per-platform linking config.
+
+**Cons**
+- **Per-call latency floor.** Each op pays **process spawn + a fresh
+  `#[tokio::main(multi_thread)]` runtime spin-up + engine open + teardown.**
+  That's milliseconds-to-tens-of-ms of fixed overhead *before* any work. The
+  Content Browser refreshes overlays for *many* assets and re-queries on
+  navigation/focus; spawning a process per asset (or even per refresh tick)
+  is the wrong cost curve.
+- **No warm state.** Every call re-opens the repo and re-creates the engine.
+  Nothing is cached between calls; a status sweep can't reuse a warm handle.
+- **Throughput ceiling.** Batching helps (one `lorevm` call returning many
+  assets' status), but you're still bounded by spawn cost and stdout parsing,
+  and you can't stream incremental updates — it's one-shot request/response.
+- **Binary distribution.** The plugin must locate/ship a `lorevm` binary,
+  version-match it, and survive AV/Gatekeeper/quarantine on the child exe
+  (Windows Defender slow-write + macOS notarization both bite child binaries).
+- **Harder structured errors / progress.** Long-running networked ops
+  (`repository.clone`, `branch.push`, `revision.sync`) are opaque until the
+  process exits — no progress events, only a final blob.
+
+**Effort:** very low (UE-side only). **Risk:** low. **Fit for hot path:** poor.
+
+---
+
+## 4. Option B — C-ABI FFI (`cdylib`)
+
+Build lore-vm/dispatch as a `cdylib` exposing `extern "C"` entry points; the UE
+plugin links the resulting `.dll` / `.dylib` / `.so` and calls in-process.
+
+Minimal proven ABI (see `crates/lorevm-ffi` — this spike):
+
+```c
+// op_id  : "<domain>.<op>", UTF-8, NUL-terminated
+// request: JSON { "dir", "args", "in_memory", "offline", "identity" }, NUL-terminated
+// returns: malloc'd NUL-terminated JSON; caller owns it, frees via the free fn.
+//          success → op result; failure → {"error":{"kind","message"}}.
+char*       lorevm_ffi_call(const char* op_id, const char* request);
+void        lorevm_ffi_string_free(char* s);
+const char* lorevm_ffi_abi_version(void);   // static; do NOT free
+```
+
+**Pros**
+- **No per-call process/runtime cost.** A production version holds **one
+  long-lived tokio runtime + a warm `LoreApi`** behind an opaque handle, so a
+  status query is "enter runtime, run op, return" — microseconds of overhead,
+  not a process spawn. This is the right curve for **high-frequency overlay
+  refresh**.
+- **Warm state & caching become possible.** A handle can keep the repo open,
+  cache lock/status results, and serve the Content Browser's many per-asset
+  queries from one engine instance. Can add a batched `status_many` entry point.
+- **Streaming / progress is reachable.** With a handle + callback (or a
+  poll-a-channel entry point), long ops (`clone`/`push`/`sync`) can report
+  progress to the editor UI instead of blocking opaquely.
+- **One artifact, tighter coupling.** No child-binary discovery/versioning; the
+  `.dll`/`.dylib` ships inside the plugin's `Binaries/` like any other UE
+  third-party lib. ABI version fn lets the plugin assert compatibility.
+
+**Cons**
+- **Shared address space = shared fate.** A panic or memory error in lore or its
+  QUIC/TLS stack can take down the **UE editor**, not just a child process. We
+  must `catch_unwind` at every `extern "C"` boundary (a Rust panic unwinding
+  across the C ABI is UB) and treat the pre-1.0 `lore` dep with care.
+- **Threading discipline is on us.** UE is game-thread-sensitive. The call
+  **blocks** for the op's duration, so it must run on a UE background thread
+  (`AsyncTask` / `FRunnable`), never the game thread, then marshal results back.
+  A warm shared runtime also means the entry points must be `Send`-safe and
+  re-entrancy-aware (lore-vm's `LoreApi` is `Clone` and cheap, which helps).
+- **Memory ownership rules.** Strings cross the ABI malloc'd by Rust and **must**
+  be freed by the matching Rust free fn (not C `free`) — the spike enforces this
+  with `CString::into_raw` / `from_raw`. Get this wrong → leak or heap corruption.
+- **Cross-platform build/link config.** Need a `cdylib` per platform (Win MSVC
+  `.dll` + import lib, macOS `.dylib`, plus codesigning/notarization), wired into
+  UE's `*.Build.cs` as a third-party module. More moving parts than shipping a
+  binary, though all standard UE third-party-lib practice.
+- **The dispatch must be shared, not duplicated.** Worth doing the §2 refactor so
+  CLI and FFI can't drift.
+
+**Effort:** moderate (one-time ABI + the §2 dispatch lift + per-platform build).
+**Risk:** moderate (in-process fate-sharing, ownership, threading). **Fit for hot
+path:** excellent.
+
+---
+
+## 5. Feasibility proof for Option B (this spike)
+
+Added `crates/lorevm-ffi` — a minimal `cdylib` that wraps lore-vm's dispatch
+behind the C ABI above. It wires a representative subset of ops (`repository.create`,
+`repository.status`, `repository.info`, `branch.list`) — enough to prove a
+mutating op, a read op, and a metrics op all cross the boundary cleanly. It is
+clearly marked **SPIKE / not a shipped artifact**.
+
+**Build:** `cargo build -p lorevm-ffi` → produces `liblorevm_ffi.so` (and would
+produce `.dll` / `.dylib` on Win/Mac). The three `extern "C"` symbols
+(`lorevm_ffi_call`, `lorevm_ffi_string_free`, `lorevm_ffi_abi_version`) are
+exported (verified with `nm -D`).
+
+**Smoke test** (`crates/lorevm-ffi/tests/smoke.rs`) calls the symbols exactly as
+C would — `CString` in, parse + `lorevm_ffi_string_free` the returned C string:
+
+| test | result |
+|------|--------|
+| `abi_version_is_exposed` | pass — static ABI string readable across ABI |
+| `create_then_status_roundtrips_over_the_c_abi` | **pass** — real in-memory engine: `repository.create` then `repository.status`, both driven over the C ABI, no server |
+| `unknown_op_returns_structured_error_not_null` | pass — errors come back as `{"error":{"kind":"ffi",…}}`, never NULL |
+
+**Conclusion: Option B is feasible.** lore-vm can be driven over a stable C ABI
+with JSON in/out and clean malloc/free ownership. The same `LoreApi` + `ops`
+layer the CLI and Tauri app use works unchanged in-process from C.
+
+> Spike shortcuts (intentional, must change for production): a fresh tokio
+> runtime is built **per call** (a real bridge holds one long-lived runtime +
+> warm `LoreApi` behind an opaque handle); ops are re-typed instead of calling a
+> shared `lore_vm::dispatch`; no `catch_unwind` panic guard yet. None of these
+> affect the feasibility result — they're the gap between "proven" and "shipped."
+
+---
+
+## 6. Recommendation — **hybrid, FFI-first for the hot path**
+
+Use **both routes against the same dispatch**, picked by call shape:
+
+- **FFI (Option B) for the hot path / interactive state:** Content Browser
+  overlay refresh, the source-control panel's live status, lock/checkout state —
+  anything queried often or per-asset. Warm handle + one runtime + (later) a
+  batched `status_many` and progress callbacks. This is where A's per-call spawn
+  cost is unacceptable and B's warm-state model wins.
+
+- **Shell (Option A) for one-shot, low-frequency, or risky ops:** initial
+  `repository.clone`, `branch.push`, occasional `revision.commit` submits —
+  operations where process isolation (crash containment for the pre-1.0 lore
+  networking stack) is worth more than the spawn cost, and where one-shot
+  request/response is fine.
+
+**Why hybrid rather than pure B:** the overlay refresh path genuinely needs
+in-process latency, but the networked ops are exactly where in-process
+fate-sharing with a nightly QUIC stack is scariest. Splitting by call shape gets
+the latency where it matters and keeps the editor crash-isolated from the
+riskiest ops. If the team wants one mechanism, go **B everywhere** with a robust
+`catch_unwind` guard — but start the overlay path on B regardless.
+
+**Prerequisite for either FFI direction:** do the §2 refactor — lift the dispatch
+`match` out of `lorevm-cli/src/main.rs` into a public
+`lore_vm::dispatch(op_id, &LoreApi, args) -> Value`. Then `lorevm-cli`, the FFI
+`cdylib`, and the Tauri commands all share one dispatch and cannot drift.
+
+---
+
+## 7. StudioBrain UE plugin architecture sketch
+
+```
+┌─────────────────────────── Unreal Editor (C++) ───────────────────────────┐
+│                                                                            │
+│  StudioBrain DAM / entity layer  (UE plugin, C++/Slate)                    │
+│   • Content Browser overlays, asset → lore-path mapping, entity metadata,  │
+│     StudioBrain auth/identity surfaced to the user                         │
+│        │ asks "what's the VCS state of these assets?" / "check out"        │
+│        ▼                                                                    │
+│  ISourceControlProvider impl  ── thin VCS adapter ──────────────┐          │
+│   (FStudioBrainSourceControlProvider, modeled on BenVlodgi's    │          │
+│    MIT UnrealSourceControl scaffolding: Provider + Operations +  │          │
+│    Worker per op + State cache)                                  │          │
+│        │ translates UE SCC ops → "<domain>.<op>" + JSON args     │          │
+│        ▼                                                          │          │
+│  ┌──── Bridge (chosen mechanism) ───────────────────────────┐   │          │
+│  │  HOT PATH  → lorevm-ffi cdylib  (in-process C ABI)        │   │          │
+│  │              warm handle: 1 runtime + 1 LoreApi           │   │          │
+│  │  ONE-SHOT  → spawn `lorevm --json`  (process isolation)   │   │          │
+│  └──────────────────────────────────────────────────────────┘   │          │
+└───────────────────────────────────│──────────────────────────────┘          │
+                                     ▼  (both call the SAME shared dispatch)
+        crates/lore-vm  ──  lore_vm::dispatch → LoreApi + ops/<domain>/<op>
+                                     ▼
+                          Epic's `lore` crate (in-process), pinned by rev
+```
+
+**Layering, top to bottom:**
+
+1. **StudioBrain DAM / entity layer (plugin-owned).** Where StudioBrain's own
+   value sits: mapping UE assets ↔ lore paths ↔ StudioBrain entities, overlay
+   rendering, identity. Knows nothing about the bridge mechanism — it only talks
+   to the SCC provider.
+2. **Thin VCS adapter — `ISourceControlProvider`.** Implement UE's source-control
+   interface so the editor's *native* Content Browser overlays, "Check Out",
+   "Submit", "Revert" etc. light up. **Reference BenVlodgi's MIT
+   `UnrealSourceControl` scaffolding** for the Provider / per-op Worker / State
+   cache shape — but our Workers call our bridge, not git/p4. This adapter is the
+   only layer that knows lore op ids + JSON arg shapes; keep it thin.
+3. **Bridge.** FFI handle (hot path) + subprocess (one-shot), per §6. Both
+   serialize the same `"<domain>.<op>" + {args}` contract.
+4. **Shared dispatch → lore-vm.** The single `lore_vm::dispatch` (post-refactor),
+   identical to what the CLI and Tauri app drive.
+
+**Re-targeting Epic's official provider later.** Epic is building a first-party
+lore source-control provider for UE. Because steps 1–2 are isolated behind
+`ISourceControlProvider` and a thin adapter, swapping to Epic's provider later is
+a **provider-registration change**, not a rewrite: StudioBrain's DAM/entity layer
+keeps talking to `ISourceControlProvider`; we drop our adapter and register
+Epic's (or keep ours where StudioBrain needs richer DAM-aware behavior than
+Epic's exposes). Keeping the adapter thin and op-id/JSON-shaped is what preserves
+this exit.
+
+---
+
+## 8. Shared bridge — the VS Code extension reuses the SAME lorevm
+
+The planned **VS Code extension** reuses the **same `lorevm` JSON surface via
+shell (Option A), no FFI.** VS Code extensions are Node/TypeScript and already
+spawn child processes idiomatically (`child_process`), and the extension's needs
+are one-shot/command-driven, not per-asset hot-path — so the subprocess cost is a
+non-issue there. It shells `lorevm <domain>.<op> --args '<json>'` exactly like
+`lore-mcp` does.
+
+**Implication:** the JSON `"<domain>.<op>" + {args}` → typed-result contract is
+**shared bridge work across three consumers** — `lore-mcp`, the VS Code
+extension, and the UE plugin's one-shot path — all over shell, plus the UE hot
+path over FFI. The §2 dispatch refactor (one `lore_vm::dispatch`) is therefore
+high-leverage: it's the single seam every driver rides on. Get that contract and
+the op coverage right once, and every consumer benefits; the only UE-specific net
+new work is the `cdylib` ABI + the `ISourceControlProvider` adapter.
+
+---
+
+## 9. Verification (this spike)
+
+- `cargo build -p lorevm-ffi` → `liblorevm_ffi.so` produced; `extern "C"` symbols
+  exported.
+- `cargo test -p lorevm-ffi` → 3/3 smoke tests pass, including a real in-memory
+  create→status roundtrip over the C ABI.
+- `cargo fmt --all --check` → clean.
+- `cargo check` over the workspace → clean (no existing crate touched beyond the
+  one-line `members` addition).
+
+No UE code, no full build, no push — design + feasibility only, per the ticket.


### PR DESCRIPTION
De-risks the StudioBrain UE plugin: hybrid FFI-first (warm LoreApi cdylib for hot-path overlays/locks) + shell lorevm for one-shot ops. Adds crates/lorevm-ffi (minimal, marked SPIKE) — 3 extern C symbols, smoke 3/3 incl. a real create→status roundtrip over the C ABI. + docs/ue-lorevm-bridge-spike.md. Recommends lifting dispatch into lore_vm::dispatch as the shared seam (follow-up ticket).