### PR TITLE
feat(host): full server configuration GUI — every loreserver option (SBAI-4075)

### DIFF
--- a/docs/domains/storage.md
+++ b/docs/domains/storage.md
@@ -34,15 +34,27 @@ obliterate upload`.
   written into the TOML — they're exported to the server process as
   `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` (lore resolves them
   via the standard AWS credential chain).
-- **Advanced / enterprise store modes (deferred — not wired by the wizard):** lore
-  also supports a `composite` immutable store (local cache tier + durable `aws`/S3
-  tier with a `ReplicationMode` of read/write/read_write), a `replicated`
-  server-to-server store (QUIC + mTLS), and `aws`-mode (DynamoDB) **mutable** + a
-  DynamoDB **lock** store at scale. These need extra inputs (replica peers,
-  DynamoDB tables/region, replication certs) the first-run host wizard doesn't
-  collect. To add them: extend `ResolvedConfig` + `render_config_toml` in
-  `server_host.rs` with new variants (the local/aws split is already structured
-  for it).
+- **Full server configuration (Expert mode, SBAI-4075):** the host flow has a
+  **Basic ↔ Expert** toggle. Basic is port + store + S3 (unchanged, and still
+  renders the exact working local config). Expert (`AdvancedServerConfig.tsx`)
+  exposes every lore-server `Settings` option grouped into collapsible sections —
+  Network (bind host, QUIC, gRPC, HTTP), Storage (local-store flush/eviction/
+  capacity + lock-store mode), Topology & replication (`none`/`fixed`/
+  `rotating_id_fixed` + peers + the opt-in mTLS `quic_internal`/`replication`
+  endpoints), Telemetry, Runtime (Tokio), Notifications, Features, and Shutdown
+  timeouts. Each field shows its **lore default** as placeholder/help and is
+  **optional**: an omitted field falls through to lore's compiled-in default, so
+  `render_config_toml` (in `server_host.rs`) only emits non-default keys. A
+  **"View generated config"** button calls `host_server_render_config` to render
+  the TOML **without** writing to disk or starting a server, surfacing validation
+  errors (bad enum / out-of-range / required-when-mode) as a dry run.
+- **Still deferred (need plugin/nested config the wizard doesn't collect):** the
+  `composite` immutable store (local cache tier + durable `aws`/S3 tier with a
+  `ReplicationMode`), a full `replicated` store with replica peers + a replica
+  factory, `aws`-mode (DynamoDB) **mutable** + DynamoDB **lock** store, and the
+  `consul`/`composite` topology providers. To add them: extend `*Options` +
+  `render_config_toml` in `server_host.rs` (the section structure is already set
+  up for it).
 - **Shared store:** `create(path)` → store path; `info`; `set_use_automatically`.
   Host setup creates a shared store before repositories.
 - **FFI gotcha:** `LoreBytes` is a borrowed view; build put items by direct struct

--- a/frontend/scripts/palette-parity-allowlist.json
+++ b/frontend/scripts/palette-parity-allowlist.json
@@ -16,7 +16,8 @@
     "get_desktop_settings",
     "set_autostart",
     "set_close_to_tray",
-    "read_license_file"
+    "read_license_file",
+    "host_server_render_config"
   ],
   "deferred": []
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -79,7 +79,7 @@ export interface TraySnapshot {
   status: TrayStatusKind;
 }
 
-/// Options for hosting a real `loreserver` from the GUI (SBAI-4065).
+/// Options for hosting a real `loreserver` from the GUI (SBAI-4065 / SBAI-4075).
 export interface HostServerOptions {
   /** Store directory to serve — MUST be the host flow's shared-store path. */
   storeDir: string;
@@ -90,6 +90,12 @@ export interface HostServerOptions {
   /** Reserved hook for a future authed mode. Local host flow is no-auth. */
   auth?: boolean;
   /**
+   * Bind host for every endpoint. Defaults to `127.0.0.1` (loopback only).
+   * Set to `0.0.0.0` to expose the server on the LAN/WAN — a deliberate choice
+   * that makes firewalling + real certs the operator's responsibility.
+   */
+  bindHost?: string;
+  /**
    * Optional S3-compatible object-storage backing for the hosted server's
    * immutable store (lore's `aws` mode). When omitted, the server uses a local
    * filesystem store under `storeDir`. The mutable (branch-pointer) store stays
@@ -97,6 +103,193 @@ export interface HostServerOptions {
    * this wizard does not provision.
    */
   s3?: HostS3Options;
+  /**
+   * Expert-mode advanced configuration (SBAI-4075). Every section/field is
+   * optional; whatever is left unset falls through to lore's own compiled-in
+   * default, so omitting this whole bag reproduces the simple local config.
+   */
+  advanced?: HostAdvancedOptions;
+}
+
+/// QUIC transport tuning (`[server.quic]`). lore default shown in `()`.
+export interface HostQuicOptions {
+  /** Override the QUIC port (default: the server port). */
+  port?: number;
+  /** Require client certificates / mTLS (default: false). */
+  verifyClientCerts?: boolean;
+  /** Idle timeout in milliseconds (default: 30000). */
+  idleTimeout?: number;
+  /** Keep-alive interval in milliseconds (default: 500). */
+  keepAlive?: number;
+  /** Max concurrent bidirectional streams per connection (default: 8). */
+  maxBidiStreams?: number;
+  /** Number of QUIC listener tasks (default: 10). */
+  numListeners?: number;
+  /** Transport bandwidth cap in bits/second (default: 1073741824 = 1 Gbit/s). */
+  transportBitsPerSecond?: number;
+  /** Expected round-trip time in milliseconds (default: 100). */
+  transportRtt?: number;
+  /** Per-request handler timeout in seconds (default: 50). */
+  handlerTimeoutSeconds?: number;
+  /** Max inflight messages per connection (default: unbounded). */
+  connectionMessageLimit?: number;
+}
+
+/// gRPC endpoint tuning (`[server.grpc]`).
+export interface HostGrpcOptions {
+  /** Override the gRPC port (default: the server port). */
+  port?: number;
+  /** Require client certificates / mTLS (default: true). */
+  verifyClientCerts?: boolean;
+  /** HTTP/2 keepalive ping interval in seconds (default: unset). */
+  http2KeepaliveIntervalSeconds?: number;
+  /** HTTP/2 keepalive ping timeout in seconds (default: unset). */
+  http2KeepaliveTimeoutSeconds?: number;
+  /** Per-request handler timeout in seconds (default: 50). */
+  requestHandlerTimeoutSeconds?: number;
+}
+
+/// HTTP endpoint tuning (`[server.http]`).
+export interface HostHttpOptions {
+  /** Override the HTTP port (default: server port + 2). */
+  port?: number;
+  /** Max upload size in bytes (default: 10485760 = 10 MB). */
+  maxFileSize?: number;
+  /** Whole-request timeout in seconds (default: 300). */
+  requestTimeoutSeconds?: number;
+  /** Request-body read timeout in seconds (default: 3600). */
+  requestBodyTimeoutSeconds?: number;
+  /** Store-availability poll interval in seconds (default: 30). */
+  availableIntervalSeconds?: number;
+  /** Store-availability check timeout in seconds (default: 5). */
+  availableTimeoutSeconds?: number;
+  /** Run an active store health check (default: false). */
+  storeHealthCheck?: boolean;
+}
+
+/// Local filesystem store tuning.
+export interface HostLocalStoreOptions {
+  /** Flush interval in seconds (default: 10). */
+  flushDelaySeconds?: number;
+  /** Immutable-store compaction delay (default: unset). */
+  compactionDelay?: number;
+  /** Immutable-store eviction delay (default: unset). */
+  evictionDelay?: number;
+  /** Immutable-store max capacity in entries (default: unbounded). */
+  maxCapacity?: number;
+  /** Immutable-store max on-disk size in bytes (default: unbounded). */
+  maxSize?: number;
+}
+
+/// A topology peer.
+export interface HostPeerOption {
+  /** Peer address (host or IP). */
+  address: string;
+  /** Peer port. */
+  port: number;
+  /** "SameRegion" (default) or "OtherRegion". */
+  locality?: string;
+}
+
+/// Topology + replication (`[topology]`). Built-in providers only.
+export interface HostTopologyOptions {
+  /** "none" (single node, default), "fixed", or "rotating_id_fixed". */
+  provider?: string;
+  /** Peers for fixed / rotating_id_fixed providers. */
+  peers?: HostPeerOption[];
+  /** Rotation interval (seconds) — required for rotating_id_fixed. */
+  rotationIntervalSeconds?: number;
+}
+
+/// Telemetry (`[telemetry]`).
+export interface HostTelemetryOptions {
+  /** Logger format: "text" (default), "ansi", or "json". */
+  logFormat?: string;
+  /** Logger output: "stdout" (default), "stderr", or "file". */
+  logOutput?: string;
+  /** File path when logOutput is "file". */
+  logFile?: string;
+  /** Emit logs over OTLP (default: false). */
+  enableOtlp?: boolean;
+  /** Metrics export interval in milliseconds (default: 30000). */
+  metricsExportIntervalMillis?: number;
+  /** Metrics sample interval in milliseconds (default: 10000). */
+  metricsSampleIntervalMillis?: number;
+  /** Trace sample rate in [0.0, 1.0] (default: 0.05). */
+  traceSampleRate?: number;
+  /** Low-tier trace sample rate in [0.0, 1.0] (default: 0.001). */
+  traceSampleRateLowTier?: number;
+}
+
+/// Tokio runtime (`[tokio]`).
+export interface HostRuntimeOptions {
+  /** Worker (async) threads (default: number of CPU cores). */
+  workerThreads?: number;
+  /** Max blocking threads (default: 512). */
+  maxBlockingThreads?: number;
+  /** Idle blocking-thread keep-alive in seconds. */
+  threadKeepAliveSeconds?: number;
+}
+
+/// Notification backend (`[notification]`).
+export interface HostNotificationOptions {
+  /** "local" (default, in-process) or a plugin name. */
+  mode?: string;
+}
+
+/// Revision/history feature flags (`[feature]`).
+export interface HostFeatureOptions {
+  /** Revision-history step size (default: 100). */
+  historyStepSize?: number;
+  /** Persist revision_step_key skip pointers (default: true). */
+  revisionStepKeys?: boolean;
+  /** Persist the per-segment revision-list cache (default: true). */
+  revisionListCache?: boolean;
+  /** Max source-side changes for v1 3-way RevisionDiff (default: 100000). */
+  revisionDiffSourceCap?: number;
+  /** Parallel history-walk permits for diff3 (default: 24). */
+  revisionDiffHistoryWalkConcurrency?: number;
+}
+
+/// Graceful-shutdown timeouts (`[server]`).
+export interface HostTimeoutOptions {
+  /** Seconds to wait for connections to drain on shutdown (default: 5). */
+  connectionCloseTimeoutSeconds?: number;
+  /** Seconds to wait for the runtime to stop after draining (default: 25). */
+  runtimeShutdownTimeoutSeconds?: number;
+}
+
+/// An opt-in internal endpoint (quic_internal / replication). mTLS required.
+export interface HostInternalEndpointOptions {
+  /** Enable the endpoint (default: false). */
+  enabled?: boolean;
+  /** Bind port (default: 41340). */
+  port?: number;
+  /** mTLS certificate chain file. */
+  certChain?: string;
+  /** mTLS certificate file (required when enabled). */
+  certFile?: string;
+  /** mTLS private-key file (required when enabled). */
+  pkeyFile?: string;
+}
+
+/// The full Expert-mode configuration surface (SBAI-4075). One optional bag of
+/// optional sections; anything unset uses lore's compiled-in default.
+export interface HostAdvancedOptions {
+  quic?: HostQuicOptions;
+  grpc?: HostGrpcOptions;
+  http?: HostHttpOptions;
+  localStore?: HostLocalStoreOptions;
+  topology?: HostTopologyOptions;
+  telemetry?: HostTelemetryOptions;
+  runtime?: HostRuntimeOptions;
+  notification?: HostNotificationOptions;
+  features?: HostFeatureOptions;
+  timeouts?: HostTimeoutOptions;
+  quicInternal?: HostInternalEndpointOptions;
+  replicationEndpoint?: HostInternalEndpointOptions;
+  /** Lock-store mode (`[lock_store]`). Defaults to lore's "local". */
+  lockStoreMode?: string;
 }
 
 /// S3-compatible object-storage options for a hosted server's immutable store.
@@ -116,6 +309,12 @@ export interface HostS3Options {
    * `bucket.endpoint/key`). Required by MinIO/Garage and most non-AWS providers.
    */
   forcePathStyle?: boolean;
+  /**
+   * Optional DynamoDB-compatible endpoint URL for the immutable store's
+   * fragment-association + metadata tables. Omit to use real AWS DynamoDB in the
+   * chosen region; set it for DynamoDB Local / LocalStack / ScyllaDB Alternator.
+   */
+  dynamodbEndpoint?: string;
 }
 
 /// Status of the hosted `loreserver` process.
@@ -193,6 +392,7 @@ export const api = {
       port: opts.port ?? null,
       repositoryName: opts.repositoryName ?? null,
       auth: opts.auth ?? false,
+      bindHost: opts.bindHost ?? null,
       // S3-compatible immutable store (lore `aws` mode) when a bucket is given;
       // otherwise the server uses a local filesystem store under storeDir.
       s3Bucket: opts.s3?.bucket ?? null,
@@ -201,8 +401,17 @@ export const api = {
       s3AccessKeyId: opts.s3?.accessKeyId ?? null,
       s3SecretAccessKey: opts.s3?.secretAccessKey ?? null,
       s3ForcePathStyle: opts.s3?.forcePathStyle ?? null,
-      s3DynamodbEndpoint: null,
+      s3DynamodbEndpoint: opts.s3?.dynamodbEndpoint ?? null,
+      // Expert-mode advanced sections (SBAI-4075); omitted = lore defaults.
+      advanced: opts.advanced ?? null,
     }),
+  /**
+   * Render the loreserver config TOML for `opts` WITHOUT writing anything to
+   * disk or starting a server (SBAI-4075). Backs the host flow's "View
+   * generated config" preview; also surfaces validation errors as a rejection.
+   */
+  hostServerRenderConfig: (opts: HostServerOptions) =>
+    invoke<string>("host_server_render_config", { opts }),
   hostServerStop: () => invoke<HostStatus>("host_server_stop"),
   hostServerStatus: () => invoke<HostStatus>("host_server_status"),
 

--- a/frontend/src/onboarding/server/AdvancedServerConfig.tsx
+++ b/frontend/src/onboarding/server/AdvancedServerConfig.tsx
@@ -1,0 +1,1094 @@
+import { useCallback, useMemo, useState } from "react";
+import type {
+  HostAdvancedOptions,
+  HostPeerOption,
+  HostTopologyOptions,
+} from "../../api";
+
+/**
+ * Advanced ("Expert mode") server configuration surface for the host flow
+ * (SBAI-4075). Renders every lore-server option the wizard exposes, grouped into
+ * collapsible sections. Fully controlled: the parent owns the
+ * {@link HostAdvancedOptions} value (plus the shared bind host) and receives
+ * granular updates.
+ *
+ * Defaults handling mirrors the backend: every field is optional, an empty field
+ * means "use lore's compiled-in default", and the placeholder/help text shows
+ * exactly what that default is. So leaving the whole surface untouched produces
+ * the same minimal local config the simple first-run flow always did.
+ */
+
+export interface AdvancedServerConfigProps {
+  /** Current advanced config (controlled). */
+  value: HostAdvancedOptions;
+  /** Bind host for every endpoint (controlled, shared with Basic mode). */
+  bindHost: string;
+  /** Emit a new advanced config. */
+  onChange: (next: HostAdvancedOptions) => void;
+  /** Emit a new bind host. */
+  onBindHostChange: (next: string) => void;
+  /** Disable all inputs (e.g. while the server is starting). */
+  disabled?: boolean;
+  /** Per-section validation errors keyed by stable field id (see validate()). */
+  errors?: Record<string, string>;
+}
+
+/* ------------------------------------------------------------------ */
+/* Generic field building blocks                                      */
+/* ------------------------------------------------------------------ */
+
+interface NumFieldProps {
+  id: string;
+  label: string;
+  /** lore default, shown as placeholder + in help. */
+  placeholder: string;
+  help?: string;
+  value: number | undefined;
+  onChange: (v: number | undefined) => void;
+  disabled?: boolean;
+  min?: number;
+  max?: number;
+  step?: number;
+  error?: string;
+}
+
+function NumField({
+  id,
+  label,
+  placeholder,
+  help,
+  value,
+  onChange,
+  disabled,
+  min,
+  max,
+  step,
+  error,
+}: NumFieldProps) {
+  return (
+    <div
+      className={`onboarding-field${error ? " server-config-field--invalid" : ""}`}
+    >
+      <label htmlFor={id}>{label}</label>
+      <input
+        id={id}
+        type="number"
+        inputMode="numeric"
+        placeholder={placeholder}
+        value={value ?? ""}
+        min={min}
+        max={max}
+        step={step}
+        disabled={disabled}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={help ? `${id}-help` : undefined}
+        onChange={(e) => {
+          const raw = e.target.value.trim();
+          onChange(raw === "" ? undefined : Number(raw));
+        }}
+      />
+      {help && (
+        <p id={`${id}-help`} className="onboarding-field-hint">
+          {help}
+        </p>
+      )}
+      {error && <p className="server-config-field-error">{error}</p>}
+    </div>
+  );
+}
+
+interface TextFieldProps {
+  id: string;
+  label: string;
+  placeholder?: string;
+  help?: string;
+  value: string | undefined;
+  onChange: (v: string | undefined) => void;
+  disabled?: boolean;
+  error?: string;
+}
+
+function TextField({
+  id,
+  label,
+  placeholder,
+  help,
+  value,
+  onChange,
+  disabled,
+  error,
+}: TextFieldProps) {
+  return (
+    <div
+      className={`onboarding-field${error ? " server-config-field--invalid" : ""}`}
+    >
+      <label htmlFor={id}>{label}</label>
+      <input
+        id={id}
+        type="text"
+        placeholder={placeholder}
+        value={value ?? ""}
+        disabled={disabled}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={help ? `${id}-help` : undefined}
+        onChange={(e) => {
+          const raw = e.target.value;
+          onChange(raw === "" ? undefined : raw);
+        }}
+      />
+      {help && (
+        <p id={`${id}-help`} className="onboarding-field-hint">
+          {help}
+        </p>
+      )}
+      {error && <p className="server-config-field-error">{error}</p>}
+    </div>
+  );
+}
+
+interface SelectFieldProps {
+  id: string;
+  label: string;
+  help?: string;
+  value: string | undefined;
+  options: { value: string; label: string }[];
+  /** Label for the "use lore default" empty option. */
+  defaultLabel: string;
+  onChange: (v: string | undefined) => void;
+  disabled?: boolean;
+}
+
+function SelectField({
+  id,
+  label,
+  help,
+  value,
+  options,
+  defaultLabel,
+  onChange,
+  disabled,
+}: SelectFieldProps) {
+  return (
+    <div className="onboarding-field">
+      <label htmlFor={id}>{label}</label>
+      <select
+        id={id}
+        value={value ?? ""}
+        disabled={disabled}
+        aria-describedby={help ? `${id}-help` : undefined}
+        onChange={(e) => {
+          const raw = e.target.value;
+          onChange(raw === "" ? undefined : raw);
+        }}
+      >
+        <option value="">{defaultLabel}</option>
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      {help && (
+        <p id={`${id}-help`} className="onboarding-field-hint">
+          {help}
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface BoolFieldProps {
+  id: string;
+  label: string;
+  /** Shown next to the value selector to explain the lore default. */
+  help: string;
+  value: boolean | undefined;
+  onChange: (v: boolean | undefined) => void;
+  disabled?: boolean;
+}
+
+/**
+ * A tri-state boolean: "Default" (omit → lore default), "On", "Off". Using a
+ * select rather than a checkbox preserves the unset state, which matters because
+ * omitting a key means "use lore's default" (which may itself be true).
+ */
+function BoolField({ id, label, help, value, onChange, disabled }: BoolFieldProps) {
+  const sel = value === undefined ? "" : value ? "true" : "false";
+  return (
+    <div className="onboarding-field">
+      <label htmlFor={id}>{label}</label>
+      <select
+        id={id}
+        value={sel}
+        disabled={disabled}
+        aria-describedby={`${id}-help`}
+        onChange={(e) => {
+          const raw = e.target.value;
+          onChange(raw === "" ? undefined : raw === "true");
+        }}
+      >
+        <option value="">Default</option>
+        <option value="true">On</option>
+        <option value="false">Off</option>
+      </select>
+      <p id={`${id}-help`} className="onboarding-field-hint">
+        {help}
+      </p>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Collapsible section                                                */
+/* ------------------------------------------------------------------ */
+
+interface SectionProps {
+  id: string;
+  title: string;
+  /** A short summary shown on the right of the header (e.g. "default"). */
+  summary?: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}
+
+function Section({ id, title, summary, defaultOpen, children }: SectionProps) {
+  const [open, setOpen] = useState(Boolean(defaultOpen));
+  const bodyId = `${id}-body`;
+  return (
+    <div className="server-config-section">
+      <button
+        type="button"
+        className="server-config-section-toggle"
+        aria-expanded={open}
+        aria-controls={bodyId}
+        onClick={() => setOpen((o) => !o)}
+      >
+        <span className="server-config-section-caret" aria-hidden="true">
+          ▶
+        </span>
+        <span>{title}</span>
+        {summary && <span className="server-config-section-summary">{summary}</span>}
+      </button>
+      {open && (
+        <div id={bodyId} className="server-config-section-body">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Main component                                                     */
+/* ------------------------------------------------------------------ */
+
+export default function AdvancedServerConfig({
+  value,
+  bindHost,
+  onChange,
+  onBindHostChange,
+  disabled,
+  errors = {},
+}: AdvancedServerConfigProps) {
+  // Section-update helpers. Each returns an updater that merges a partial patch
+  // into the named section and drops the section entirely when it becomes empty,
+  // so an all-default config serializes to nothing.
+  const patchSection = useCallback(
+    <K extends keyof HostAdvancedOptions>(
+      key: K,
+      patch: Partial<NonNullable<HostAdvancedOptions[K]>>,
+    ) => {
+      const current = (value[key] ?? {}) as Record<string, unknown>;
+      const merged: Record<string, unknown> = { ...current, ...patch };
+      // Strip undefined / empty so we don't ship empty sub-objects.
+      for (const k of Object.keys(merged)) {
+        const v = merged[k];
+        if (v === undefined || v === "" || (Array.isArray(v) && v.length === 0)) {
+          delete merged[k];
+        }
+      }
+      const next: HostAdvancedOptions = { ...value };
+      if (Object.keys(merged).length === 0) {
+        delete next[key];
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        next[key] = merged as any;
+      }
+      onChange(next);
+    },
+    [value, onChange],
+  );
+
+  const quic = value.quic ?? {};
+  const grpc = value.grpc ?? {};
+  const http = value.http ?? {};
+  const localStore = value.localStore ?? {};
+  const telemetry = value.telemetry ?? {};
+  const runtime = value.runtime ?? {};
+  const features = value.features ?? {};
+  const timeouts = value.timeouts ?? {};
+  const quicInternal = value.quicInternal ?? {};
+  const replication = value.replicationEndpoint ?? {};
+  const topology = value.topology ?? {};
+  const notification = value.notification ?? {};
+
+  const topologyProvider = topology.provider ?? "none";
+  const peers = topology.peers ?? [];
+
+  const setTopology = useCallback(
+    (patch: Partial<HostTopologyOptions>) => {
+      const merged: HostTopologyOptions = { ...topology, ...patch };
+      // Normalise: provider "none"/empty with no peers → drop the whole section.
+      const prov = merged.provider ?? "none";
+      const next: HostAdvancedOptions = { ...value };
+      const isDefault =
+        (prov === "none" || prov === undefined) &&
+        (merged.peers ?? []).length === 0 &&
+        merged.rotationIntervalSeconds === undefined;
+      if (isDefault) {
+        delete next.topology;
+      } else {
+        next.topology = merged;
+      }
+      onChange(next);
+    },
+    [topology, value, onChange],
+  );
+
+  const updatePeer = useCallback(
+    (index: number, patch: Partial<HostPeerOption>) => {
+      const nextPeers = peers.map((p, i) => (i === index ? { ...p, ...patch } : p));
+      setTopology({ peers: nextPeers });
+    },
+    [peers, setTopology],
+  );
+
+  const addPeer = useCallback(() => {
+    setTopology({
+      peers: [...peers, { address: "", port: 41337, locality: "SameRegion" }],
+    });
+  }, [peers, setTopology]);
+
+  const removePeer = useCallback(
+    (index: number) => {
+      setTopology({ peers: peers.filter((_, i) => i !== index) });
+    },
+    [peers, setTopology],
+  );
+
+  // Per-section "is anything set?" summaries for the collapsed header.
+  const summary = useCallback(
+    (obj: object) =>
+      Object.values(obj).some(
+        (v) => v !== undefined && v !== "" && !(Array.isArray(v) && v.length === 0),
+      )
+        ? "customized"
+        : "default",
+    [],
+  );
+
+  const topologySummary = useMemo(
+    () => (topologyProvider === "none" ? "single node" : topologyProvider),
+    [topologyProvider],
+  );
+
+  return (
+    <div className="server-config-advanced">
+      {/* Network / QUIC / gRPC / HTTP -------------------------------- */}
+      <Section
+        id="sc-network"
+        title="Network: bind host, QUIC, gRPC, HTTP"
+        summary={summary({ bindHost: bindHost || undefined, ...quic, ...grpc, ...http })}
+      >
+        <TextField
+          id="sc-bind-host"
+          label="Bind host"
+          placeholder="127.0.0.1"
+          help="Address every endpoint binds to. Default 127.0.0.1 (loopback only). Use 0.0.0.0 to expose on the network — you then own firewalling and certs."
+          value={bindHost || undefined}
+          onChange={(v) => onBindHostChange(v ?? "")}
+          disabled={disabled}
+        />
+
+        <h3>QUIC transport</h3>
+        <div className="server-config-grid">
+          <BoolField
+            id="sc-quic-verify"
+            label="Verify client certs (mTLS)"
+            help="Default off — clients are verified by auth token, not a cert."
+            value={quic.verifyClientCerts}
+            onChange={(v) => patchSection("quic", { verifyClientCerts: v })}
+            disabled={disabled}
+          />
+          <NumField
+            id="sc-quic-idle"
+            label="Idle timeout (ms)"
+            placeholder="30000"
+            value={quic.idleTimeout}
+            onChange={(v) => patchSection("quic", { idleTimeout: v })}
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-quic-keepalive"
+            label="Keep-alive (ms)"
+            placeholder="500"
+            value={quic.keepAlive}
+            onChange={(v) => patchSection("quic", { keepAlive: v })}
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-quic-bidi"
+            label="Max bidi streams"
+            placeholder="8"
+            value={quic.maxBidiStreams}
+            onChange={(v) => patchSection("quic", { maxBidiStreams: v })}
+            disabled={disabled}
+            min={1}
+          />
+          <NumField
+            id="sc-quic-listeners"
+            label="Listeners"
+            placeholder="10"
+            value={quic.numListeners}
+            onChange={(v) => patchSection("quic", { numListeners: v })}
+            disabled={disabled}
+            min={1}
+            max={255}
+            error={errors["quic.numListeners"]}
+          />
+          <NumField
+            id="sc-quic-bps"
+            label="Bandwidth cap (bits/s)"
+            placeholder="1073741824"
+            help="1073741824 = 1 Gbit/s."
+            value={quic.transportBitsPerSecond}
+            onChange={(v) => patchSection("quic", { transportBitsPerSecond: v })}
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-quic-rtt"
+            label="Expected RTT (ms)"
+            placeholder="100"
+            value={quic.transportRtt}
+            onChange={(v) => patchSection("quic", { transportRtt: v })}
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-quic-handler"
+            label="Handler timeout (s)"
+            placeholder="50"
+            value={quic.handlerTimeoutSeconds}
+            onChange={(v) => patchSection("quic", { handlerTimeoutSeconds: v })}
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-quic-msglimit"
+            label="Connection msg limit"
+            placeholder="unbounded"
+            value={quic.connectionMessageLimit}
+            onChange={(v) => patchSection("quic", { connectionMessageLimit: v })}
+            disabled={disabled}
+            min={1}
+          />
+        </div>
+
+        <h3>gRPC</h3>
+        <div className="server-config-grid">
+          <BoolField
+            id="sc-grpc-verify"
+            label="Verify client certs (mTLS)"
+            help="Default on for the gRPC endpoint."
+            value={grpc.verifyClientCerts}
+            onChange={(v) => patchSection("grpc", { verifyClientCerts: v })}
+            disabled={disabled}
+          />
+          <NumField
+            id="sc-grpc-handler"
+            label="Handler timeout (s)"
+            placeholder="50"
+            value={grpc.requestHandlerTimeoutSeconds}
+            onChange={(v) =>
+              patchSection("grpc", { requestHandlerTimeoutSeconds: v })
+            }
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-grpc-ka-int"
+            label="HTTP/2 keepalive (s)"
+            placeholder="unset"
+            value={grpc.http2KeepaliveIntervalSeconds}
+            onChange={(v) =>
+              patchSection("grpc", { http2KeepaliveIntervalSeconds: v })
+            }
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-grpc-ka-to"
+            label="HTTP/2 keepalive timeout (s)"
+            placeholder="unset"
+            value={grpc.http2KeepaliveTimeoutSeconds}
+            onChange={(v) =>
+              patchSection("grpc", { http2KeepaliveTimeoutSeconds: v })
+            }
+            disabled={disabled}
+            min={0}
+          />
+        </div>
+
+        <h3>HTTP</h3>
+        <div className="server-config-grid">
+          <NumField
+            id="sc-http-maxfile"
+            label="Max file size (bytes)"
+            placeholder="10485760"
+            help="10485760 = 10 MB."
+            value={http.maxFileSize}
+            onChange={(v) => patchSection("http", { maxFileSize: v })}
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-http-reqto"
+            label="Request timeout (s)"
+            placeholder="300"
+            value={http.requestTimeoutSeconds}
+            onChange={(v) => patchSection("http", { requestTimeoutSeconds: v })}
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-http-bodyto"
+            label="Body timeout (s)"
+            placeholder="3600"
+            value={http.requestBodyTimeoutSeconds}
+            onChange={(v) =>
+              patchSection("http", { requestBodyTimeoutSeconds: v })
+            }
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-http-availint"
+            label="Availability interval (s)"
+            placeholder="30"
+            value={http.availableIntervalSeconds}
+            onChange={(v) =>
+              patchSection("http", { availableIntervalSeconds: v })
+            }
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-http-availto"
+            label="Availability timeout (s)"
+            placeholder="5"
+            value={http.availableTimeoutSeconds}
+            onChange={(v) =>
+              patchSection("http", { availableTimeoutSeconds: v })
+            }
+            disabled={disabled}
+            min={0}
+          />
+          <BoolField
+            id="sc-http-health"
+            label="Store health check"
+            help="Default off."
+            value={http.storeHealthCheck}
+            onChange={(v) => patchSection("http", { storeHealthCheck: v })}
+            disabled={disabled}
+          />
+        </div>
+      </Section>
+
+      {/* Storage ----------------------------------------------------- */}
+      <Section
+        id="sc-storage"
+        title="Storage: local store tuning & lock store"
+        summary={summary({ ...localStore, lockStoreMode: value.lockStoreMode })}
+      >
+        <p className="onboarding-field-hint">
+          These tune the local filesystem store. S3 (object storage) is set in
+          Basic mode. Compaction/eviction/capacity apply to a local immutable
+          store only.
+        </p>
+        <div className="server-config-grid">
+          <NumField
+            id="sc-store-flush"
+            label="Flush delay (s)"
+            placeholder="10"
+            value={localStore.flushDelaySeconds}
+            onChange={(v) => patchSection("localStore", { flushDelaySeconds: v })}
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-store-compact"
+            label="Compaction delay"
+            placeholder="unset"
+            value={localStore.compactionDelay}
+            onChange={(v) => patchSection("localStore", { compactionDelay: v })}
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-store-evict"
+            label="Eviction delay"
+            placeholder="unset"
+            value={localStore.evictionDelay}
+            onChange={(v) => patchSection("localStore", { evictionDelay: v })}
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-store-maxcap"
+            label="Max capacity (entries)"
+            placeholder="unbounded"
+            value={localStore.maxCapacity}
+            onChange={(v) => patchSection("localStore", { maxCapacity: v })}
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-store-maxsize"
+            label="Max size (bytes)"
+            placeholder="unbounded"
+            value={localStore.maxSize}
+            onChange={(v) => patchSection("localStore", { maxSize: v })}
+            disabled={disabled}
+            min={0}
+          />
+        </div>
+        <SelectField
+          id="sc-lock-mode"
+          label="Lock store mode"
+          help="Default: local (in-memory). Other modes need a matching plugin."
+          value={value.lockStoreMode}
+          defaultLabel="Default (local)"
+          options={[{ value: "local", label: "local (in-memory)" }]}
+          onChange={(v) => onChange({ ...value, lockStoreMode: v })}
+          disabled={disabled}
+        />
+      </Section>
+
+      {/* Topology & Replication ------------------------------------- */}
+      <Section
+        id="sc-topology"
+        title="Topology & replication"
+        summary={topologySummary}
+      >
+        <SelectField
+          id="sc-topo-provider"
+          label="Topology provider"
+          help="Default: none (single node). 'fixed' / 'rotating_id_fixed' need a peer list."
+          value={topologyProvider === "none" ? undefined : topologyProvider}
+          defaultLabel="None (single node)"
+          options={[
+            { value: "fixed", label: "Fixed peer list" },
+            { value: "rotating_id_fixed", label: "Fixed peers, rotating IDs" },
+          ]}
+          onChange={(v) => setTopology({ provider: v ?? "none" })}
+          disabled={disabled}
+        />
+
+        {topologyProvider === "rotating_id_fixed" && (
+          <NumField
+            id="sc-topo-rotation"
+            label="Rotation interval (s)"
+            placeholder="required"
+            help="Required for rotating_id_fixed: how often peer IDs rotate."
+            value={topology.rotationIntervalSeconds}
+            onChange={(v) => setTopology({ rotationIntervalSeconds: v })}
+            disabled={disabled}
+            min={1}
+            error={errors["topology.rotationIntervalSeconds"]}
+          />
+        )}
+
+        {topologyProvider !== "none" && (
+          <div className="server-config-peers">
+            <h3>Peers</h3>
+            {peers.length === 0 && (
+              <p className="onboarding-field-hint">
+                Add at least one peer for this provider.
+              </p>
+            )}
+            {peers.map((peer, i) => (
+              <div className="server-config-grid" key={i}>
+                <TextField
+                  id={`sc-peer-addr-${i}`}
+                  label={`Peer ${i + 1} address`}
+                  placeholder="10.0.0.2"
+                  value={peer.address || undefined}
+                  onChange={(v) => updatePeer(i, { address: v ?? "" })}
+                  disabled={disabled}
+                  error={errors[`topology.peers.${i}.address`]}
+                />
+                <NumField
+                  id={`sc-peer-port-${i}`}
+                  label="Port"
+                  placeholder="41337"
+                  value={peer.port}
+                  onChange={(v) => updatePeer(i, { port: v ?? 0 })}
+                  disabled={disabled}
+                  min={1}
+                  max={65535}
+                />
+                <SelectField
+                  id={`sc-peer-loc-${i}`}
+                  label="Locality"
+                  value={peer.locality}
+                  defaultLabel="SameRegion"
+                  options={[
+                    { value: "SameRegion", label: "SameRegion" },
+                    { value: "OtherRegion", label: "OtherRegion" },
+                  ]}
+                  onChange={(v) => updatePeer(i, { locality: v })}
+                  disabled={disabled}
+                />
+                <div className="onboarding-field">
+                  <label aria-hidden="true">&nbsp;</label>
+                  <button
+                    type="button"
+                    className="onboarding-button onboarding-button--danger"
+                    onClick={() => removePeer(i)}
+                    disabled={disabled}
+                  >
+                    Remove peer {i + 1}
+                  </button>
+                </div>
+              </div>
+            ))}
+            <button
+              type="button"
+              className="onboarding-button"
+              onClick={addPeer}
+              disabled={disabled}
+            >
+              Add peer
+            </button>
+          </div>
+        )}
+
+        <h3>Internal replication endpoints</h3>
+        <p className="onboarding-field-hint">
+          Opt-in, mTLS-only server-to-server endpoints (off by default).
+        </p>
+        {(
+          [
+            ["quicInternal", quicInternal, "QUIC internal"] as const,
+            ["replicationEndpoint", replication, "gRPC replication"] as const,
+          ] satisfies ReadonlyArray<
+            readonly [
+              "quicInternal" | "replicationEndpoint",
+              {
+                enabled?: boolean;
+                port?: number;
+                certFile?: string;
+                pkeyFile?: string;
+                certChain?: string;
+              },
+              string,
+            ]
+          >
+        ).map(([key, ep, title]) => (
+          <div key={key}>
+            <h3>{title}</h3>
+            <div className="server-config-grid">
+              <BoolField
+                id={`sc-${key}-enabled`}
+                label="Enabled"
+                help="Default off. Requires the cert + key below when on."
+                value={ep.enabled}
+                onChange={(v) => patchSection(key, { enabled: v })}
+                disabled={disabled}
+              />
+              <NumField
+                id={`sc-${key}-port`}
+                label="Port"
+                placeholder="41340"
+                value={ep.port}
+                onChange={(v) => patchSection(key, { port: v })}
+                disabled={disabled}
+                min={1}
+                max={65535}
+              />
+              <TextField
+                id={`sc-${key}-cert`}
+                label="mTLS cert file"
+                placeholder="/path/cert.pem"
+                value={ep.certFile}
+                onChange={(v) => patchSection(key, { certFile: v })}
+                disabled={disabled}
+                error={errors[`${key}.certFile`]}
+              />
+              <TextField
+                id={`sc-${key}-key`}
+                label="mTLS key file"
+                placeholder="/path/key.pem"
+                value={ep.pkeyFile}
+                onChange={(v) => patchSection(key, { pkeyFile: v })}
+                disabled={disabled}
+                error={errors[`${key}.pkeyFile`]}
+              />
+              <TextField
+                id={`sc-${key}-chain`}
+                label="CA chain (optional)"
+                placeholder="/path/ca.pem"
+                value={ep.certChain}
+                onChange={(v) => patchSection(key, { certChain: v })}
+                disabled={disabled}
+              />
+            </div>
+          </div>
+        ))}
+      </Section>
+
+      {/* Telemetry --------------------------------------------------- */}
+      <Section id="sc-telemetry" title="Telemetry" summary={summary(telemetry)}>
+        <div className="server-config-grid">
+          <SelectField
+            id="sc-tel-format"
+            label="Log format"
+            value={telemetry.logFormat}
+            defaultLabel="Default (text)"
+            options={[
+              { value: "text", label: "text" },
+              { value: "ansi", label: "ansi" },
+              { value: "json", label: "json" },
+            ]}
+            onChange={(v) => patchSection("telemetry", { logFormat: v })}
+            disabled={disabled}
+          />
+          <SelectField
+            id="sc-tel-output"
+            label="Log output"
+            value={telemetry.logOutput}
+            defaultLabel="Default (stdout)"
+            options={[
+              { value: "stdout", label: "stdout" },
+              { value: "stderr", label: "stderr" },
+              { value: "file", label: "file" },
+            ]}
+            onChange={(v) => patchSection("telemetry", { logOutput: v })}
+            disabled={disabled}
+          />
+          {telemetry.logOutput === "file" && (
+            <TextField
+              id="sc-tel-file"
+              label="Log file path"
+              placeholder="/var/log/lore-server.log"
+              value={telemetry.logFile}
+              onChange={(v) => patchSection("telemetry", { logFile: v })}
+              disabled={disabled}
+              error={errors["telemetry.logFile"]}
+            />
+          )}
+          <BoolField
+            id="sc-tel-otlp"
+            label="OTLP export"
+            help="Default off."
+            value={telemetry.enableOtlp}
+            onChange={(v) => patchSection("telemetry", { enableOtlp: v })}
+            disabled={disabled}
+          />
+          <NumField
+            id="sc-tel-mexp"
+            label="Metrics export (ms)"
+            placeholder="30000"
+            value={telemetry.metricsExportIntervalMillis}
+            onChange={(v) =>
+              patchSection("telemetry", { metricsExportIntervalMillis: v })
+            }
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-tel-msam"
+            label="Metrics sample (ms)"
+            placeholder="10000"
+            value={telemetry.metricsSampleIntervalMillis}
+            onChange={(v) =>
+              patchSection("telemetry", { metricsSampleIntervalMillis: v })
+            }
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-tel-trace"
+            label="Trace sample rate"
+            placeholder="0.05"
+            help="0.0–1.0."
+            value={telemetry.traceSampleRate}
+            onChange={(v) => patchSection("telemetry", { traceSampleRate: v })}
+            disabled={disabled}
+            min={0}
+            max={1}
+            step={0.01}
+            error={errors["telemetry.traceSampleRate"]}
+          />
+          <NumField
+            id="sc-tel-tracelow"
+            label="Trace rate (low tier)"
+            placeholder="0.001"
+            help="0.0–1.0."
+            value={telemetry.traceSampleRateLowTier}
+            onChange={(v) =>
+              patchSection("telemetry", { traceSampleRateLowTier: v })
+            }
+            disabled={disabled}
+            min={0}
+            max={1}
+            step={0.001}
+            error={errors["telemetry.traceSampleRateLowTier"]}
+          />
+        </div>
+      </Section>
+
+      {/* Runtime ----------------------------------------------------- */}
+      <Section id="sc-runtime" title="Runtime (Tokio)" summary={summary(runtime)}>
+        <div className="server-config-grid">
+          <NumField
+            id="sc-rt-worker"
+            label="Worker threads"
+            placeholder="CPU cores"
+            value={runtime.workerThreads}
+            onChange={(v) => patchSection("runtime", { workerThreads: v })}
+            disabled={disabled}
+            min={1}
+          />
+          <NumField
+            id="sc-rt-blocking"
+            label="Max blocking threads"
+            placeholder="512"
+            value={runtime.maxBlockingThreads}
+            onChange={(v) => patchSection("runtime", { maxBlockingThreads: v })}
+            disabled={disabled}
+            min={1}
+          />
+          <NumField
+            id="sc-rt-keepalive"
+            label="Thread keep-alive (s)"
+            placeholder="default"
+            value={runtime.threadKeepAliveSeconds}
+            onChange={(v) =>
+              patchSection("runtime", { threadKeepAliveSeconds: v })
+            }
+            disabled={disabled}
+            min={0}
+          />
+        </div>
+      </Section>
+
+      {/* Notifications ----------------------------------------------- */}
+      <Section
+        id="sc-notify"
+        title="Notifications"
+        summary={notification.mode ?? "default"}
+      >
+        <SelectField
+          id="sc-notify-mode"
+          label="Notification mode"
+          help="Default: local (in-process). Other modes need a matching plugin."
+          value={notification.mode}
+          defaultLabel="Default (local)"
+          options={[{ value: "local", label: "local (in-process)" }]}
+          onChange={(v) => patchSection("notification", { mode: v })}
+          disabled={disabled}
+        />
+      </Section>
+
+      {/* Features ---------------------------------------------------- */}
+      <Section id="sc-features" title="Features" summary={summary(features)}>
+        <div className="server-config-grid">
+          <NumField
+            id="sc-feat-step"
+            label="History step size"
+            placeholder="100"
+            help="Larger speeds up history lookups but the cached blob must fit the fragment threshold."
+            value={features.historyStepSize}
+            onChange={(v) => patchSection("features", { historyStepSize: v })}
+            disabled={disabled}
+            min={1}
+          />
+          <BoolField
+            id="sc-feat-stepkeys"
+            label="Revision step keys"
+            help="Default on. Skip-pointer acceleration for revision lists."
+            value={features.revisionStepKeys}
+            onChange={(v) => patchSection("features", { revisionStepKeys: v })}
+            disabled={disabled}
+          />
+          <BoolField
+            id="sc-feat-listcache"
+            label="Revision list cache"
+            help="Default on. Per-segment cache of revision items."
+            value={features.revisionListCache}
+            onChange={(v) => patchSection("features", { revisionListCache: v })}
+            disabled={disabled}
+          />
+          <NumField
+            id="sc-feat-diffcap"
+            label="Diff source cap"
+            placeholder="100000"
+            value={features.revisionDiffSourceCap}
+            onChange={(v) =>
+              patchSection("features", { revisionDiffSourceCap: v })
+            }
+            disabled={disabled}
+            min={1}
+          />
+          <NumField
+            id="sc-feat-diffwalk"
+            label="Diff history-walk concurrency"
+            placeholder="24"
+            value={features.revisionDiffHistoryWalkConcurrency}
+            onChange={(v) =>
+              patchSection("features", {
+                revisionDiffHistoryWalkConcurrency: v,
+              })
+            }
+            disabled={disabled}
+            min={1}
+          />
+        </div>
+      </Section>
+
+      {/* Timeouts ---------------------------------------------------- */}
+      <Section id="sc-timeouts" title="Shutdown timeouts" summary={summary(timeouts)}>
+        <div className="server-config-grid">
+          <NumField
+            id="sc-to-conn"
+            label="Connection close (s)"
+            placeholder="5"
+            help="Seconds to wait for connections to drain on shutdown."
+            value={timeouts.connectionCloseTimeoutSeconds}
+            onChange={(v) =>
+              patchSection("timeouts", { connectionCloseTimeoutSeconds: v })
+            }
+            disabled={disabled}
+            min={0}
+          />
+          <NumField
+            id="sc-to-runtime"
+            label="Runtime shutdown (s)"
+            placeholder="25"
+            help="Seconds to wait for the runtime to stop after draining."
+            value={timeouts.runtimeShutdownTimeoutSeconds}
+            onChange={(v) =>
+              patchSection("timeouts", { runtimeShutdownTimeoutSeconds: v })
+            }
+            disabled={disabled}
+            min={0}
+          />
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/frontend/src/onboarding/server/ServiceSetup.tsx
+++ b/frontend/src/onboarding/server/ServiceSetup.tsx
@@ -1,8 +1,10 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { api } from "../../api";
-import type { HostStatus } from "../../api";
+import type { HostAdvancedOptions, HostStatus } from "../../api";
+import AdvancedServerConfig from "./AdvancedServerConfig";
 
 type Step = "idle" | "starting" | "running" | "stopping" | "error";
+type Mode = "basic" | "expert";
 
 interface ServiceSetupProps {
   /**
@@ -15,12 +17,14 @@ interface ServiceSetupProps {
 }
 
 /**
- * Final host-flow step (SBAI-4065): launch a REAL `loreserver` over the store
- * the previous step created and show the `lore://` URL clients connect to.
+ * Final host-flow step (SBAI-4065 / SBAI-4075): launch a REAL `loreserver` over
+ * the store the previous step created and show the `lore://` URL clients connect
+ * to. A Basic ↔ Expert toggle reveals the full lore-server configuration surface
+ * (network, storage, topology, telemetry, runtime, notifications, features,
+ * timeouts) plus a "View generated config" TOML preview.
  *
- * This replaces the old `serviceStart` call, which mapped to an upstream stub
- * that hosted nothing. If the previous step's store path isn't available, the
- * user can enter one manually.
+ * Basic mode produces exactly the working local config it always did — every
+ * advanced field defaults to lore's own value when left untouched.
  */
 export default function ServiceSetup({
   storePath,
@@ -31,6 +35,17 @@ export default function ServiceSetup({
   const [status, setStatus] = useState<HostStatus | null>(null);
   const [storeDir, setStoreDir] = useState(storePath ?? "");
   const [copied, setCopied] = useState(false);
+
+  // Basic vs Expert configuration surface.
+  const [mode, setMode] = useState<Mode>("basic");
+  const [bindHost, setBindHost] = useState("");
+  const [advanced, setAdvanced] = useState<HostAdvancedOptions>({});
+
+  // "View generated config" preview state.
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [previewToml, setPreviewToml] = useState<string | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
 
   // Keep the store-dir field in sync if the previous step reports a path.
   useEffect(() => {
@@ -56,22 +71,40 @@ export default function ServiceSetup({
     };
   }, []);
 
+  /** Client-side validation, keyed by the same field ids the panel uses. */
+  const validationErrors = useMemo(
+    () => validateAdvanced(advanced),
+    [advanced],
+  );
+  const hasErrors = Object.keys(validationErrors).length > 0;
+
+  /** Build the full options object sent to start / preview. */
+  const buildOptions = useCallback(
+    () => ({
+      storeDir: storeDir.trim(),
+      repositoryName: repoName,
+      bindHost: mode === "expert" && bindHost.trim() ? bindHost.trim() : undefined,
+      advanced:
+        mode === "expert" && Object.keys(advanced).length > 0
+          ? advanced
+          : undefined,
+    }),
+    [storeDir, repoName, mode, bindHost, advanced],
+  );
+
   const handleStart = useCallback(async () => {
-    if (!storeDir.trim()) return;
+    if (!storeDir.trim() || hasErrors) return;
     try {
       setStep("starting");
       setError(null);
-      const s = await api.hostServerStart({
-        storeDir: storeDir.trim(),
-        repositoryName: repoName,
-      });
+      const s = await api.hostServerStart(buildOptions());
       setStatus(s);
       setStep("running");
     } catch (e) {
       setError(typeof e === "string" ? e : JSON.stringify(e));
       setStep("error");
     }
-  }, [storeDir, repoName]);
+  }, [storeDir, hasErrors, buildOptions]);
 
   const handleStop = useCallback(async () => {
     try {
@@ -86,6 +119,26 @@ export default function ServiceSetup({
     }
   }, []);
 
+  const handlePreview = useCallback(async () => {
+    if (!storeDir.trim()) {
+      setPreviewError("Enter a store directory first.");
+      setPreviewOpen(true);
+      return;
+    }
+    setPreviewOpen(true);
+    setPreviewLoading(true);
+    setPreviewError(null);
+    try {
+      const toml = await api.hostServerRenderConfig(buildOptions());
+      setPreviewToml(toml);
+    } catch (e) {
+      setPreviewError(typeof e === "string" ? e : JSON.stringify(e));
+      setPreviewToml(null);
+    } finally {
+      setPreviewLoading(false);
+    }
+  }, [storeDir, buildOptions]);
+
   const handleCopy = useCallback(async () => {
     if (!status?.url) return;
     try {
@@ -97,49 +150,136 @@ export default function ServiceSetup({
     }
   }, [status]);
 
+  const editing = step === "idle" || step === "starting" || step === "error";
+  const inputsDisabled = step === "starting";
+
   return (
     <div className="onboarding-card">
       <h2>Host Server</h2>
       <p className="onboarding-description">
         Start a Lore server over your store so other people can connect to it.
-        The server runs on this machine and listens on <code>127.0.0.1</code>.
-        Share the <code>lore://</code> URL below with your team to let them clone
-        and push.
+        The server runs on this machine and listens on <code>127.0.0.1</code> by
+        default. Share the <code>lore://</code> URL below with your team to let
+        them clone and push.
       </p>
 
       {error && <div className="error">{error}</div>}
 
-      {step !== "running" && step !== "stopping" && (
-        <div className="onboarding-field">
-          <label htmlFor="host-store-dir">Store directory to serve</label>
-          <input
-            id="host-store-dir"
-            type="text"
-            placeholder="/path/to/shared/store"
-            value={storeDir}
-            onChange={(e) => setStoreDir(e.target.value)}
-            disabled={step === "starting"}
-          />
-          <p className="onboarding-description">
-            Use the same shared-store path you created on the previous step.
-          </p>
-        </div>
-      )}
+      {editing && (
+        <>
+          <div
+            className="server-config-modes"
+            role="tablist"
+            aria-label="Configuration detail"
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={mode === "basic"}
+              className={`server-config-mode${
+                mode === "basic" ? " server-config-mode--active" : ""
+              }`}
+              onClick={() => setMode("basic")}
+              disabled={inputsDisabled}
+            >
+              Basic
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={mode === "expert"}
+              className={`server-config-mode${
+                mode === "expert" ? " server-config-mode--active" : ""
+              }`}
+              onClick={() => setMode("expert")}
+              disabled={inputsDisabled}
+            >
+              Expert
+            </button>
+          </div>
 
-      {step === "idle" && (
-        <button
-          className="onboarding-button onboarding-button--primary"
-          disabled={!storeDir.trim()}
-          onClick={() => void handleStart()}
-        >
-          Start Hosting
-        </button>
-      )}
+          <div className="onboarding-field">
+            <label htmlFor="host-store-dir">Store directory to serve</label>
+            <input
+              id="host-store-dir"
+              type="text"
+              placeholder="/path/to/shared/store"
+              value={storeDir}
+              onChange={(e) => setStoreDir(e.target.value)}
+              disabled={inputsDisabled}
+            />
+            <p className="onboarding-field-hint">
+              Use the same shared-store path you created on the previous step.
+            </p>
+          </div>
 
-      {step === "starting" && (
-        <button className="onboarding-button onboarding-button--primary" disabled>
-          Starting&hellip;
-        </button>
+          {mode === "expert" && (
+            <AdvancedServerConfig
+              value={advanced}
+              bindHost={bindHost}
+              onChange={setAdvanced}
+              onBindHostChange={setBindHost}
+              disabled={inputsDisabled}
+              errors={validationErrors}
+            />
+          )}
+
+          <div className="server-config-actions">
+            <button
+              type="button"
+              className="onboarding-button"
+              onClick={() => void handlePreview()}
+              disabled={inputsDisabled}
+            >
+              View generated config
+            </button>
+
+            {step === "idle" || step === "error" ? (
+              <button
+                className="onboarding-button onboarding-button--primary"
+                disabled={!storeDir.trim() || hasErrors}
+                onClick={() => void handleStart()}
+              >
+                {step === "error" ? "Retry" : "Start Hosting"}
+              </button>
+            ) : (
+              <button
+                className="onboarding-button onboarding-button--primary"
+                disabled
+              >
+                Starting&hellip;
+              </button>
+            )}
+          </div>
+
+          {hasErrors && (
+            <p className="server-config-field-error">
+              Fix the highlighted fields before hosting.
+            </p>
+          )}
+
+          {previewOpen && (
+            <div className="server-config-preview">
+              <div className="onboarding-url-row">
+                <strong>Generated loreserver config (local.toml)</strong>
+                <button
+                  type="button"
+                  className="onboarding-button"
+                  onClick={() => setPreviewOpen(false)}
+                >
+                  Hide
+                </button>
+              </div>
+              {previewLoading && (
+                <p className="onboarding-field-hint">Rendering&hellip;</p>
+              )}
+              {previewError && <div className="error">{previewError}</div>}
+              {previewToml && !previewLoading && (
+                <pre aria-label="Generated config TOML">{previewToml}</pre>
+              )}
+            </div>
+          )}
+        </>
       )}
 
       {step === "stopping" && (
@@ -176,16 +316,68 @@ export default function ServiceSetup({
           </button>
         </div>
       )}
-
-      {step === "error" && (
-        <button
-          className="onboarding-button onboarding-button--primary"
-          disabled={!storeDir.trim()}
-          onClick={() => void handleStart()}
-        >
-          Retry
-        </button>
-      )}
     </div>
   );
+}
+
+/**
+ * Client-side validation mirroring the backend's `resolve_advanced` checks, so
+ * the user gets inline feedback before submitting. Returns a map of field id →
+ * message; the AdvancedServerConfig panel reads it to mark/explain bad fields.
+ */
+function validateAdvanced(adv: HostAdvancedOptions): Record<string, string> {
+  const errors: Record<string, string> = {};
+
+  const inRange = (v: number | undefined) =>
+    v === undefined || (v >= 0 && v <= 1);
+  if (!inRange(adv.telemetry?.traceSampleRate)) {
+    errors["telemetry.traceSampleRate"] = "Must be between 0.0 and 1.0.";
+  }
+  if (!inRange(adv.telemetry?.traceSampleRateLowTier)) {
+    errors["telemetry.traceSampleRateLowTier"] = "Must be between 0.0 and 1.0.";
+  }
+  if (
+    adv.telemetry?.logOutput === "file" &&
+    !adv.telemetry?.logFile?.trim()
+  ) {
+    errors["telemetry.logFile"] = "A file path is required for file output.";
+  }
+
+  const listeners = adv.quic?.numListeners;
+  if (listeners !== undefined && (listeners < 1 || listeners > 255)) {
+    errors["quic.numListeners"] = "Must be between 1 and 255.";
+  }
+
+  const topo = adv.topology;
+  if (topo && topo.provider && topo.provider !== "none") {
+    const peers = topo.peers ?? [];
+    peers.forEach((p, i) => {
+      if (!p.address.trim()) {
+        errors[`topology.peers.${i}.address`] = "Address is required.";
+      }
+    });
+    if (
+      topo.provider === "rotating_id_fixed" &&
+      topo.rotationIntervalSeconds === undefined
+    ) {
+      errors["topology.rotationIntervalSeconds"] =
+        "Rotation interval is required.";
+    }
+  }
+
+  for (const [key, ep] of [
+    ["quicInternal", adv.quicInternal],
+    ["replicationEndpoint", adv.replicationEndpoint],
+  ] as const) {
+    if (ep?.enabled) {
+      if (!ep.certFile?.trim()) {
+        errors[`${key}.certFile`] = "Required when the endpoint is enabled.";
+      }
+      if (!ep.pkeyFile?.trim()) {
+        errors[`${key}.pkeyFile`] = "Required when the endpoint is enabled.";
+      }
+    }
+  }
+
+  return errors;
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -972,3 +972,157 @@ h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; color: v
   font-size: 12px;
   color: var(--surface-overlay-text, var(--text));
 }
+
+/* ===================================================================== */
+/* Advanced server configuration (SBAI-4075)                             */
+/* Expert-mode host flow: Basic↔Expert toggle, collapsible sections,     */
+/* per-field help, and a "View generated config" TOML preview.           */
+/* All themeable via --surface-* tokens; never hardcode colors.          */
+/* ===================================================================== */
+
+/* Basic | Expert segmented toggle */
+.server-config-modes {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  margin-bottom: 16px;
+  border-radius: 8px;
+  background: var(--surface-base-bg, var(--bg));
+  border: 1px solid var(--surface-base-border, var(--border));
+}
+
+.server-config-mode {
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--surface-base-text-secondary, var(--muted));
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+}
+
+.server-config-mode:hover:not(.server-config-mode--active) {
+  color: var(--surface-base-text, var(--text));
+}
+
+.server-config-mode--active {
+  background: var(--surface-primary-bg, var(--accent));
+  color: var(--surface-primary-text, #ffffff);
+  border-color: var(--surface-primary-border, var(--accent));
+}
+
+.server-config-mode:focus-visible {
+  outline: 2px solid var(--surface-primary-bg, var(--accent));
+  outline-offset: 2px;
+}
+
+/* Collapsible section (disclosure) */
+.server-config-section {
+  margin-bottom: 10px;
+  border: 1px solid var(--surface-base-border, var(--border));
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--surface-base-bg, var(--bg));
+}
+
+.server-config-section-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 12px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: left;
+  background: transparent;
+  border: none;
+  color: var(--surface-base-text, var(--text));
+  cursor: pointer;
+}
+
+.server-config-section-toggle:hover {
+  background: var(--surface-base-hover, transparent);
+}
+
+.server-config-section-toggle:focus-visible {
+  outline: 2px solid var(--surface-primary-bg, var(--accent));
+  outline-offset: -2px;
+}
+
+.server-config-section-caret {
+  display: inline-block;
+  font-size: 10px;
+  color: var(--surface-base-text-secondary, var(--muted));
+  transition: transform 0.15s ease;
+}
+
+.server-config-section-toggle[aria-expanded="true"] .server-config-section-caret {
+  transform: rotate(90deg);
+}
+
+.server-config-section-summary {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--surface-base-text-secondary, var(--muted));
+}
+
+.server-config-section-body {
+  padding: 4px 14px 8px;
+  border-top: 1px solid var(--surface-base-border, var(--border));
+}
+
+/* A two-column grid for compact numeric fields inside a section */
+.server-config-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 4px 16px;
+}
+
+/* Inline validation error under a field */
+.server-config-field-error {
+  font-size: 12px;
+  color: var(--surface-error-text, var(--red));
+  margin: 2px 0 0;
+}
+
+.server-config-field--invalid input,
+.server-config-field--invalid select {
+  border-color: var(--surface-error-border, var(--red)) !important;
+}
+
+/* "View generated config" TOML preview */
+.server-config-preview {
+  margin-top: 12px;
+}
+
+.server-config-preview pre {
+  max-height: 320px;
+  overflow: auto;
+  margin: 8px 0 0;
+  padding: 12px;
+  border-radius: 8px;
+  font-family:
+    ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre;
+  background: var(--surface-overlay-bg, var(--panel2));
+  color: var(--surface-overlay-text, var(--text));
+  border: 1px solid var(--surface-overlay-border, var(--border));
+}
+
+.server-config-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.server-config-peers {
+  margin-top: 4px;
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1967,7 +1967,9 @@ pub async fn service_stop(
 
 // --- host server (SBAI-4065): launch + manage a real loreserver ---
 
-use crate::server_host::{self, HostServerOptions, HostStatus, S3StoreOptions};
+use crate::server_host::{
+    self, HostAdvancedOptions, HostServerOptions, HostStatus, S3StoreOptions,
+};
 
 /// Launch a real `loreserver` process serving the host flow's local stores.
 ///
@@ -1998,6 +2000,7 @@ pub fn host_server_start(
     port: Option<u16>,
     repository_name: Option<String>,
     auth: Option<bool>,
+    bind_host: Option<String>,
     s3_bucket: Option<String>,
     s3_endpoint: Option<String>,
     s3_region: Option<String>,
@@ -2005,6 +2008,7 @@ pub fn host_server_start(
     s3_secret_access_key: Option<String>,
     s3_force_path_style: Option<bool>,
     s3_dynamodb_endpoint: Option<String>,
+    advanced: Option<HostAdvancedOptions>,
 ) -> Result<HostStatus, LoreError> {
     // An S3 backend is requested iff a (non-blank) bucket is supplied.
     let s3 = s3_bucket
@@ -2024,10 +2028,27 @@ pub fn host_server_start(
         port: port.filter(|p| *p != 0),
         repository_name: repository_name.filter(|n| !n.trim().is_empty()),
         auth: auth.unwrap_or(false),
+        bind_host: bind_host.filter(|h| !h.trim().is_empty()),
         s3,
+        // The flat palette-driven `host_server_start` omits `advanced` (basic
+        // surface only). The host UI's Expert mode sends the full advanced bag
+        // (SBAI-4075); whatever is unset falls through to lore's own defaults.
+        advanced,
     };
     let mut slot = state.hosted_server.lock().unwrap();
     server_host::start(&mut slot, &opts)
+}
+
+/// Render the `loreserver` config TOML for the given options **without** writing
+/// anything to disk or starting a server (SBAI-4075). Backs the host flow's
+/// "View generated config" affordance. Accepts the full advanced-config bag as a
+/// single typed `opts` object (unlike `host_server_start`'s flat args, the
+/// preview is only ever driven from the host UI, not the command palette, so a
+/// nested object is the cleaner surface). Returns the generated TOML string, or
+/// a validation error (bad enum / out-of-range / required-when-mode).
+#[tauri::command]
+pub fn host_server_render_config(opts: HostServerOptions) -> Result<String, LoreError> {
+    server_host::render_config(&opts)
 }
 
 /// Stop the hosted `loreserver` (kill + reap). Idempotent.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,6 +163,7 @@ pub fn run() {
             commands::service_start,
             commands::service_stop,
             commands::host_server_start,
+            commands::host_server_render_config,
             commands::host_server_stop,
             commands::host_server_status,
             commands::repository_info,

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -30,7 +30,23 @@ pub const DEFAULT_PORT: u16 = 41337;
 const BIND_HOST: &str = "127.0.0.1";
 
 /// Inputs from the frontend "Host a server" flow.
-#[derive(Debug, Clone, Deserialize)]
+///
+/// # Defaults handling (SBAI-4075)
+///
+/// Every advanced section is **optional** and every field within it is
+/// `Option<_>`. The renderer ([`render_config_toml`]) only emits a key when the
+/// user supplied an explicit, non-default value, so:
+///
+/// - An all-`None` [`HostServerOptions`] (the simple first-run case) renders the
+///   exact same minimal local config it always did — lore fills in every other
+///   field from its own compiled-in `default.toml`.
+/// - A field the user leaves blank is **omitted**, which means "use lore's
+///   default" rather than "force lore's default" — the two are equivalent
+///   because lore's `default.toml` is the base layer of its config stack.
+///
+/// The lore default for each field is documented inline (and surfaced to the UI
+/// as placeholder/help text) so the operator always knows what omitting it does.
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HostServerOptions {
     /// Directory that backs the immutable + mutable stores. This MUST be the
@@ -50,6 +66,12 @@ pub struct HostServerOptions {
     /// the local host flow is no-auth; accepted for forward-compat.
     #[serde(default)]
     pub auth: bool,
+    /// Bind host for every endpoint (QUIC/gRPC/HTTP). Defaults to
+    /// [`BIND_HOST`] (`127.0.0.1`) — loopback only. Set to `0.0.0.0` to expose
+    /// the server on the LAN/WAN (a deliberate choice: firewalling + real certs
+    /// become the operator's responsibility).
+    #[serde(default)]
+    pub bind_host: Option<String>,
     /// Optional S3-compatible object-storage backing for the **immutable** store
     /// (lore's `aws` store mode). When `None`, the immutable store is a local
     /// filesystem store under [`store_dir`](Self::store_dir).
@@ -61,6 +83,313 @@ pub struct HostServerOptions {
     /// `composite.local + aws.durable` recipe in `dev-local.toml`).
     #[serde(default)]
     pub s3: Option<S3StoreOptions>,
+
+    /// All advanced (Expert-mode) sections in one bag (SBAI-4075). `None` (the
+    /// simple first-run case) means "use lore's defaults for everything", and
+    /// renders the original minimal local config exactly.
+    #[serde(default)]
+    pub advanced: Option<HostAdvancedOptions>,
+}
+
+/// The full Expert-mode configuration surface (SBAI-4075): one optional bag of
+/// optional sections. Carried as a single nested object so both the typed start
+/// call and the `host_server_render_config` preview send it whole, while the
+/// flat palette-driven `host_server_start` simply omits it.
+///
+/// Every field is `Option`/empty; whatever is left unset falls through to lore's
+/// own compiled-in default, so a `Default` value adds nothing to the config.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostAdvancedOptions {
+    /// QUIC transport tuning ([`server.quic`]).
+    #[serde(default)]
+    pub quic: Option<QuicOptions>,
+    /// gRPC endpoint tuning ([`server.grpc`]).
+    #[serde(default)]
+    pub grpc: Option<GrpcOptions>,
+    /// HTTP endpoint tuning ([`server.http`]).
+    #[serde(default)]
+    pub http: Option<HttpOptions>,
+    /// Local-store tuning (flush/eviction/capacity) for the filesystem stores.
+    #[serde(default)]
+    pub local_store: Option<LocalStoreOptions>,
+    /// Single-node fixed/rotating peer topology + replication ([`topology`]).
+    #[serde(default)]
+    pub topology: Option<TopologyOptions>,
+    /// Telemetry: logger / metrics / traces ([`telemetry`]).
+    #[serde(default)]
+    pub telemetry: Option<TelemetryOptions>,
+    /// Tokio runtime threads ([`tokio`]).
+    #[serde(default)]
+    pub runtime: Option<RuntimeOptions>,
+    /// Notification backend mode ([`notification`]).
+    #[serde(default)]
+    pub notification: Option<NotificationOptions>,
+    /// Revision/history feature flags ([`feature`]).
+    #[serde(default)]
+    pub features: Option<FeatureOptions>,
+    /// Graceful-shutdown timeouts ([`server`]).
+    #[serde(default)]
+    pub timeouts: Option<TimeoutOptions>,
+    /// `quic_internal` mTLS replication endpoint ([`server.quic_internal`]).
+    #[serde(default)]
+    pub quic_internal: Option<InternalEndpointOptions>,
+    /// `replication` gRPC endpoint ([`server.replication`]).
+    #[serde(default)]
+    pub replication_endpoint: Option<InternalEndpointOptions>,
+    /// Lock-store mode ([`lock_store`]). Defaults to lore's `local`.
+    #[serde(default)]
+    pub lock_store_mode: Option<String>,
+}
+
+/// QUIC transport options. Mirrors lore's `[server.quic]`. Every field is
+/// `Option`; omitting a field falls through to lore's compiled-in default
+/// (shown in parentheses).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuicOptions {
+    /// Override the QUIC port (default: the resolved server port).
+    #[serde(default)]
+    pub port: Option<u16>,
+    /// Require client certificates / mTLS (lore default: `false`).
+    #[serde(default)]
+    pub verify_client_certs: Option<bool>,
+    /// Idle timeout in milliseconds (lore default: `30000`).
+    #[serde(default)]
+    pub idle_timeout: Option<u64>,
+    /// Keep-alive interval in milliseconds (lore default: `500`).
+    #[serde(default)]
+    pub keep_alive: Option<u64>,
+    /// Max concurrent bidirectional streams per connection (lore default: `8`).
+    #[serde(default)]
+    pub max_bidi_streams: Option<u64>,
+    /// Number of QUIC listener tasks (lore default: `10`).
+    #[serde(default)]
+    pub num_listeners: Option<u8>,
+    /// Transport bandwidth cap in bits/second (lore default: `1073741824`, 1 Gbit/s).
+    #[serde(default)]
+    pub transport_bits_per_second: Option<u64>,
+    /// Expected round-trip time in milliseconds (lore default: `100`).
+    #[serde(default)]
+    pub transport_rtt: Option<u64>,
+    /// Per-request handler timeout in seconds (lore default: `50`).
+    #[serde(default)]
+    pub handler_timeout_seconds: Option<u64>,
+    /// Max inflight messages per connection (lore default: unset/unbounded).
+    #[serde(default)]
+    pub connection_message_limit: Option<u64>,
+}
+
+/// gRPC endpoint options. Mirrors lore's `[server.grpc]`.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GrpcOptions {
+    /// Override the gRPC port (default: the resolved server port).
+    #[serde(default)]
+    pub port: Option<u16>,
+    /// Require client certificates / mTLS (lore default: `true`).
+    #[serde(default)]
+    pub verify_client_certs: Option<bool>,
+    /// HTTP/2 keepalive ping interval in seconds (lore default: unset).
+    #[serde(default)]
+    pub http2_keepalive_interval_seconds: Option<u64>,
+    /// HTTP/2 keepalive ping timeout in seconds (lore default: unset).
+    #[serde(default)]
+    pub http2_keepalive_timeout_seconds: Option<u64>,
+    /// Per-request handler timeout in seconds (lore default: `50`).
+    #[serde(default)]
+    pub request_handler_timeout_seconds: Option<u64>,
+}
+
+/// HTTP endpoint options. Mirrors lore's `[server.http]`.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HttpOptions {
+    /// Override the HTTP port (default: server port + 2).
+    #[serde(default)]
+    pub port: Option<u16>,
+    /// Max upload size in bytes (lore default: `10485760`, 10 MB).
+    #[serde(default)]
+    pub max_file_size: Option<u64>,
+    /// Whole-request timeout in seconds (lore default: `300`).
+    #[serde(default)]
+    pub request_timeout_seconds: Option<u64>,
+    /// Request-body read timeout in seconds (lore default: `3600`).
+    #[serde(default)]
+    pub request_body_timeout_seconds: Option<u64>,
+    /// Store-availability poll interval in seconds (lore default: `30`).
+    #[serde(default)]
+    pub available_interval_seconds: Option<u64>,
+    /// Store-availability check timeout in seconds (lore default: `5`).
+    #[serde(default)]
+    pub available_timeout_seconds: Option<u64>,
+    /// Run an active store health check (lore default: `false`).
+    #[serde(default)]
+    pub store_health_check: Option<bool>,
+}
+
+/// Local filesystem store tuning. Applies to whichever stores are local
+/// (immutable + mutable in the default case, mutable-only in the S3 case).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalStoreOptions {
+    /// Flush interval in seconds (lore default: `10`).
+    #[serde(default)]
+    pub flush_delay_seconds: Option<u16>,
+    /// Immutable-store compaction delay (lore default: unset).
+    #[serde(default)]
+    pub compaction_delay: Option<u64>,
+    /// Immutable-store eviction delay (lore default: unset).
+    #[serde(default)]
+    pub eviction_delay: Option<u64>,
+    /// Immutable-store max capacity in entries (lore default: unset/unbounded).
+    #[serde(default)]
+    pub max_capacity: Option<u64>,
+    /// Immutable-store max on-disk size in bytes (lore default: unset/unbounded).
+    #[serde(default)]
+    pub max_size: Option<u64>,
+}
+
+/// Single-node topology + replication options. The wizard supports lore's
+/// built-in `none` / `fixed` / `rotating_id_fixed` providers (no external
+/// plugin needed). `consul` and `composite` need plugin or nested config the
+/// wizard does not collect and are intentionally not exposed here.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TopologyOptions {
+    /// `none` (single node, default), `fixed`, or `rotating_id_fixed`.
+    #[serde(default)]
+    pub provider: Option<String>,
+    /// Peers for `fixed` / `rotating_id_fixed`.
+    #[serde(default)]
+    pub peers: Vec<PeerOption>,
+    /// Rotation interval (seconds) — required when provider is
+    /// `rotating_id_fixed`.
+    #[serde(default)]
+    pub rotation_interval_seconds: Option<u64>,
+}
+
+/// A topology peer ([`topology.fixed.peers`] / `rotating_id_fixed.peers`).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PeerOption {
+    /// Peer address (host or IP).
+    pub address: String,
+    /// Peer port.
+    pub port: u16,
+    /// `SameRegion` or `OtherRegion` (lore's `Locality`).
+    #[serde(default)]
+    pub locality: Option<String>,
+}
+
+/// Telemetry options ([`telemetry`]).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TelemetryOptions {
+    /// Logger output format: `text` (lore default), `ansi`, or `json`.
+    #[serde(default)]
+    pub log_format: Option<String>,
+    /// Logger output: `stdout` (lore default), `stderr`, or `file`.
+    #[serde(default)]
+    pub log_output: Option<String>,
+    /// File path when `log_output` is `file`.
+    #[serde(default)]
+    pub log_file: Option<String>,
+    /// Emit logs over OTLP (lore default: `false`).
+    #[serde(default)]
+    pub enable_otlp: Option<bool>,
+    /// Metrics export interval in milliseconds (lore default: `30000`).
+    #[serde(default)]
+    pub metrics_export_interval_millis: Option<u64>,
+    /// Metrics sample interval in milliseconds (lore default: `10000`).
+    #[serde(default)]
+    pub metrics_sample_interval_millis: Option<u64>,
+    /// Trace sample rate in `[0.0, 1.0]` (lore default: `0.05`).
+    #[serde(default)]
+    pub trace_sample_rate: Option<f64>,
+    /// Low-tier trace sample rate in `[0.0, 1.0]` (lore default: `0.001`).
+    #[serde(default)]
+    pub trace_sample_rate_low_tier: Option<f64>,
+}
+
+/// Tokio runtime options ([`tokio`]).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeOptions {
+    /// Worker (async) threads (lore default: unset = number of CPU cores).
+    #[serde(default)]
+    pub worker_threads: Option<usize>,
+    /// Max blocking threads (lore default: `512`).
+    #[serde(default)]
+    pub max_blocking_threads: Option<usize>,
+    /// Idle blocking-thread keep-alive in seconds (lore default varies).
+    #[serde(default)]
+    pub thread_keep_alive_seconds: Option<u64>,
+}
+
+/// Notification backend options ([`notification`]).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotificationOptions {
+    /// Notification mode: `local` (lore default, in-process) or a plugin name.
+    #[serde(default)]
+    pub mode: Option<String>,
+}
+
+/// Revision/history feature-flag options ([`feature`]).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeatureOptions {
+    /// Revision-history step size (lore default: `100`). Must stay small enough
+    /// that the cached blob fits the fragment threshold.
+    #[serde(default)]
+    pub history_step_size: Option<u64>,
+    /// Persist `revision_step_key` skip pointers (lore default: `true`).
+    #[serde(default)]
+    pub revision_step_keys: Option<bool>,
+    /// Persist the per-segment revision-list cache (lore default: `true`).
+    #[serde(default)]
+    pub revision_list_cache: Option<bool>,
+    /// Max source-side changes for v1 3-way RevisionDiff (lore default: `100000`).
+    #[serde(default)]
+    pub revision_diff_source_cap: Option<u64>,
+    /// Parallel history-walk permits for diff3 (lore default: `24`).
+    #[serde(default)]
+    pub revision_diff_history_walk_concurrency: Option<u64>,
+}
+
+/// Graceful-shutdown timeout options ([`server`]).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TimeoutOptions {
+    /// Seconds to wait for connections to drain on shutdown (lore default: `5`).
+    #[serde(default)]
+    pub connection_close_timeout_seconds: Option<u16>,
+    /// Seconds to wait for the runtime to stop after draining (lore default: `25`).
+    #[serde(default)]
+    pub runtime_shutdown_timeout_seconds: Option<u16>,
+}
+
+/// Options for the internal `quic_internal` / `replication` endpoints. These
+/// are opt-in (`enabled = false` by lore default) and require mTLS certs.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InternalEndpointOptions {
+    /// Enable the endpoint (lore default: `false`).
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    /// Bind port (lore default: `41340`).
+    #[serde(default)]
+    pub port: Option<u16>,
+    /// mTLS certificate chain file.
+    #[serde(default)]
+    pub cert_chain: Option<String>,
+    /// mTLS certificate file (required when `enabled`).
+    #[serde(default)]
+    pub cert_file: Option<String>,
+    /// mTLS private-key file (required when `enabled`).
+    #[serde(default)]
+    pub pkey_file: Option<String>,
 }
 
 /// S3-compatible object-storage options for the hosted server's immutable store.
@@ -167,6 +496,8 @@ impl HostStatus {
 
 /// Resolved, fully-qualified inputs for config generation.
 struct ResolvedConfig {
+    /// Bind host for every endpoint. Defaults to [`BIND_HOST`].
+    bind_host: String,
     port: u16,
     http_port: u16,
     store_dir: PathBuf,
@@ -177,6 +508,29 @@ struct ResolvedConfig {
     /// instead of `local`. The mutable store is always local (see
     /// [`S3StoreOptions`]).
     s3: Option<ResolvedS3>,
+    /// Validated advanced sections (SBAI-4075). Each is rendered only when the
+    /// user supplied an explicit, non-default value. The whole bag defaults to
+    /// all-`None`, reproducing the original minimal local config exactly.
+    adv: AdvancedConfig,
+}
+
+/// Validated advanced-config sections carried through to the renderer.
+/// All-`Default` (every field `None`/empty) renders nothing extra.
+#[derive(Debug, Clone, Default)]
+struct AdvancedConfig {
+    quic: Option<QuicOptions>,
+    grpc: Option<GrpcOptions>,
+    http: Option<HttpOptions>,
+    local_store: Option<LocalStoreOptions>,
+    topology: Option<TopologyOptions>,
+    telemetry: Option<TelemetryOptions>,
+    runtime: Option<RuntimeOptions>,
+    notification: Option<NotificationOptions>,
+    features: Option<FeatureOptions>,
+    timeouts: Option<TimeoutOptions>,
+    quic_internal: Option<InternalEndpointOptions>,
+    replication_endpoint: Option<InternalEndpointOptions>,
+    lock_store_mode: Option<String>,
 }
 
 /// Resolved S3 inputs for `[plugins.aws.immutable_store]` generation.
@@ -232,38 +586,183 @@ fn render_config_toml(cfg: &ResolvedConfig) -> String {
     // Escape a plain string value for a TOML basic string.
     let escs = |s: &str| -> String { s.replace('\\', "\\\\").replace('"', "\\\"") };
 
+    // Escape a quoted host value (also used for the bind host).
+    let host = escs(&cfg.bind_host);
+    let adv = &cfg.adv;
+
     let mut out = String::new();
-    out.push_str("# Generated by LoreGUI \"Host a server\" (SBAI-4065). Do not edit by hand.\n");
+    out.push_str(
+        "# Generated by LoreGUI \"Host a server\" (SBAI-4065/SBAI-4075). Do not edit by hand.\n",
+    );
+    out.push_str("# Only non-default values are emitted; every omitted key falls back to lore's\n");
+    out.push_str("# own compiled-in default (config/default.toml).\n");
     if cfg.s3.is_some() {
-        out.push_str(
-            "# Single-node, loopback-only loreserver: S3-compatible immutable store + local mutable store.\n\n",
-        );
+        out.push_str("# loreserver: S3-compatible immutable store + local mutable store.\n\n");
     } else {
         out.push_str("# Single-node, loopback-only, local-store loreserver config.\n\n");
     }
 
+    // -- QUIC (public endpoint) --
     out.push_str("[server.quic]\n");
-    out.push_str(&format!("host = \"{BIND_HOST}\"\n"));
-    out.push_str(&format!("port = {}\n", cfg.port));
+    out.push_str(&format!("host = \"{host}\"\n"));
+    out.push_str(&format!(
+        "port = {}\n",
+        adv.quic.as_ref().and_then(|q| q.port).unwrap_or(cfg.port)
+    ));
+    if let Some(q) = &adv.quic {
+        if let Some(v) = q.verify_client_certs {
+            out.push_str(&format!("verify_client_certs = {v}\n"));
+        }
+        if let Some(v) = q.idle_timeout {
+            out.push_str(&format!("idle_timeout = {v}\n"));
+        }
+        if let Some(v) = q.keep_alive {
+            out.push_str(&format!("keep_alive = {v}\n"));
+        }
+        if let Some(v) = q.max_bidi_streams {
+            out.push_str(&format!("max_bidi_streams = {v}\n"));
+        }
+        if let Some(v) = q.num_listeners {
+            out.push_str(&format!("num_listeners = {v}\n"));
+        }
+        if let Some(v) = q.transport_bits_per_second {
+            out.push_str(&format!("transport_bits_per_second = {v}\n"));
+        }
+        if let Some(v) = q.transport_rtt {
+            out.push_str(&format!("transport_rtt = {v}\n"));
+        }
+        if let Some(v) = q.handler_timeout_seconds {
+            out.push_str(&format!("handler_timeout_seconds = {v}\n"));
+        }
+        if let Some(v) = q.connection_message_limit {
+            out.push_str(&format!("connection_message_limit = {v}\n"));
+        }
+    }
     out.push_str("[server.quic.certificate]\n");
     out.push_str(&format!("cert_file = \"{}\"\n", esc(&cfg.cert_file)));
     out.push_str(&format!("pkey_file = \"{}\"\n\n", esc(&cfg.pkey_file)));
 
+    // -- gRPC --
     out.push_str("[server.grpc]\n");
-    out.push_str(&format!("host = \"{BIND_HOST}\"\n"));
-    out.push_str(&format!("port = {}\n\n", cfg.port));
+    out.push_str(&format!("host = \"{host}\"\n"));
+    out.push_str(&format!(
+        "port = {}\n",
+        adv.grpc.as_ref().and_then(|g| g.port).unwrap_or(cfg.port)
+    ));
+    if let Some(g) = &adv.grpc {
+        if let Some(v) = g.verify_client_certs {
+            out.push_str(&format!("verify_client_certs = {v}\n"));
+        }
+        if let Some(v) = g.http2_keepalive_interval_seconds {
+            out.push_str(&format!("http2_keepalive_interval_seconds = {v}\n"));
+        }
+        if let Some(v) = g.http2_keepalive_timeout_seconds {
+            out.push_str(&format!("http2_keepalive_timeout_seconds = {v}\n"));
+        }
+        if let Some(v) = g.request_handler_timeout_seconds {
+            out.push_str(&format!("request_handler_timeout_seconds = {v}\n"));
+        }
+    }
+    out.push('\n');
 
+    // -- HTTP --
     out.push_str("[server.http]\n");
-    out.push_str(&format!("host = \"{BIND_HOST}\"\n"));
-    out.push_str(&format!("port = {}\n\n", cfg.http_port));
+    out.push_str(&format!("host = \"{host}\"\n"));
+    out.push_str(&format!(
+        "port = {}\n",
+        adv.http
+            .as_ref()
+            .and_then(|h| h.port)
+            .unwrap_or(cfg.http_port)
+    ));
+    if let Some(h) = &adv.http {
+        if let Some(v) = h.max_file_size {
+            out.push_str(&format!("max_file_size = {v}\n"));
+        }
+        if let Some(v) = h.request_timeout_seconds {
+            out.push_str(&format!("request_timeout_seconds = {v}\n"));
+        }
+        if let Some(v) = h.request_body_timeout_seconds {
+            out.push_str(&format!("request_body_timeout_seconds = {v}\n"));
+        }
+        if let Some(v) = h.available_interval_seconds {
+            out.push_str(&format!("available_interval_seconds = {v}\n"));
+        }
+        if let Some(v) = h.available_timeout_seconds {
+            out.push_str(&format!("available_timeout_seconds = {v}\n"));
+        }
+        if let Some(v) = h.store_health_check {
+            out.push_str(&format!("store_health_check = {v}\n"));
+        }
+    }
+    out.push('\n');
+
+    // -- Internal endpoints (quic_internal / replication), opt-in + mTLS --
+    render_internal_endpoint(&mut out, "server.quic_internal", &adv.quic_internal, &escs);
+    render_internal_endpoint(
+        &mut out,
+        "server.replication",
+        &adv.replication_endpoint,
+        &escs,
+    );
+
+    // -- Graceful-shutdown timeouts --
+    if let Some(t) = &adv.timeouts {
+        let mut wrote = false;
+        if let Some(v) = t.connection_close_timeout_seconds {
+            if !wrote {
+                out.push_str("[server]\n");
+                wrote = true;
+            }
+            out.push_str(&format!("connection_close_timeout_seconds = {v}\n"));
+        }
+        if let Some(v) = t.runtime_shutdown_timeout_seconds {
+            if !wrote {
+                out.push_str("[server]\n");
+                wrote = true;
+            }
+            out.push_str(&format!("runtime_shutdown_timeout_seconds = {v}\n"));
+        }
+        if wrote {
+            out.push('\n');
+        }
+    }
+
+    // -- Stores --
+    let local_path = esc(&cfg.store_dir);
+    let render_local_extras =
+        |out: &mut String, ls: &Option<LocalStoreOptions>, immutable: bool| {
+            if let Some(ls) = ls {
+                if let Some(v) = ls.flush_delay_seconds {
+                    out.push_str(&format!("flush_delay_seconds = {v}\n"));
+                }
+                if immutable {
+                    if let Some(v) = ls.compaction_delay {
+                        out.push_str(&format!("compaction_delay = {v}\n"));
+                    }
+                    if let Some(v) = ls.eviction_delay {
+                        out.push_str(&format!("eviction_delay = {v}\n"));
+                    }
+                    if let Some(v) = ls.max_capacity {
+                        out.push_str(&format!("max_capacity = {v}\n"));
+                    }
+                    if let Some(v) = ls.max_size {
+                        out.push_str(&format!("max_size = {v}\n"));
+                    }
+                }
+            }
+        };
 
     match &cfg.s3 {
         // Local filesystem immutable + mutable stores (the default).
         None => {
             out.push_str("[immutable_store.local]\n");
-            out.push_str(&format!("path = \"{}\"\n", esc(&cfg.store_dir)));
+            out.push_str(&format!("path = \"{local_path}\"\n"));
+            render_local_extras(&mut out, &adv.local_store, true);
             out.push_str("[mutable_store.local]\n");
-            out.push_str(&format!("path = \"{}\"\n\n", esc(&cfg.store_dir)));
+            out.push_str(&format!("path = \"{local_path}\"\n"));
+            render_local_extras(&mut out, &adv.local_store, false);
+            out.push('\n');
         }
         // S3-compatible (lore `aws` mode) immutable store; local mutable store.
         Some(s3) => {
@@ -272,7 +771,9 @@ fn render_config_toml(cfg: &ResolvedConfig) -> String {
 
             // Mutable (branch pointers) stays on local disk — see fn docs.
             out.push_str("[mutable_store.local]\n");
-            out.push_str(&format!("path = \"{}\"\n\n", esc(&cfg.store_dir)));
+            out.push_str(&format!("path = \"{local_path}\"\n"));
+            render_local_extras(&mut out, &adv.local_store, false);
+            out.push('\n');
 
             // The aws immutable store plugin: S3 for payloads, DynamoDB for the
             // fragment-association + metadata tables (auto-ensured at startup).
@@ -304,11 +805,124 @@ fn render_config_toml(cfg: &ResolvedConfig) -> String {
         }
     }
 
-    out.push_str("[telemetry.logger]\n");
-    out.push_str("format = \"ansi\"\n\n");
+    // -- Lock store mode (lore default: local) --
+    if let Some(mode) = &adv.lock_store_mode {
+        out.push_str("[lock_store]\n");
+        out.push_str(&format!("mode = \"{}\"\n\n", escs(mode)));
+    }
 
-    out.push_str("[topology]\n");
-    out.push_str("provider = \"none\"\n");
+    // -- Telemetry --
+    // The default (no override) keeps the original `format = "ansi"` line so the
+    // simple first-run config is byte-for-byte what it always was.
+    match &adv.telemetry {
+        None => {
+            out.push_str("[telemetry.logger]\n");
+            out.push_str("format = \"ansi\"\n\n");
+        }
+        Some(t) => {
+            out.push_str("[telemetry.logger]\n");
+            out.push_str(&format!(
+                "format = \"{}\"\n",
+                t.log_format.as_deref().unwrap_or("ansi")
+            ));
+            match t.log_output.as_deref() {
+                Some("file") => {
+                    let path = t.log_file.as_deref().unwrap_or("lore-server.log");
+                    out.push_str(&format!("output = {{ file = \"{}\" }}\n", escs(path)));
+                }
+                Some(other @ ("stdout" | "stderr")) => {
+                    out.push_str(&format!("output = \"{other}\"\n"));
+                }
+                _ => {}
+            }
+            if let Some(v) = t.enable_otlp {
+                out.push_str(&format!("enable_otlp = {v}\n"));
+            }
+            out.push('\n');
+            if t.metrics_export_interval_millis.is_some()
+                || t.metrics_sample_interval_millis.is_some()
+            {
+                out.push_str("[telemetry.metrics]\n");
+                if let Some(v) = t.metrics_export_interval_millis {
+                    out.push_str(&format!("export_interval_millis = {v}\n"));
+                }
+                if let Some(v) = t.metrics_sample_interval_millis {
+                    out.push_str(&format!("sample_interval_millis = {v}\n"));
+                }
+                out.push('\n');
+            }
+            if t.trace_sample_rate.is_some() || t.trace_sample_rate_low_tier.is_some() {
+                out.push_str("[telemetry.traces]\n");
+                if let Some(v) = t.trace_sample_rate {
+                    out.push_str(&format!("sample_rate = {v}\n"));
+                }
+                if let Some(v) = t.trace_sample_rate_low_tier {
+                    out.push_str(&format!("sample_rate_low_tier = {v}\n"));
+                }
+                out.push('\n');
+            }
+        }
+    }
+
+    // -- Tokio runtime --
+    if let Some(r) = &adv.runtime {
+        if r.worker_threads.is_some()
+            || r.max_blocking_threads.is_some()
+            || r.thread_keep_alive_seconds.is_some()
+        {
+            out.push_str("[tokio]\n");
+            if let Some(v) = r.worker_threads {
+                out.push_str(&format!("worker_threads = {v}\n"));
+            }
+            if let Some(v) = r.max_blocking_threads {
+                out.push_str(&format!("max_blocking_threads = {v}\n"));
+            }
+            if let Some(v) = r.thread_keep_alive_seconds {
+                out.push_str(&format!("thread_keep_alive_seconds = {v}\n"));
+            }
+            out.push('\n');
+        }
+    }
+
+    // -- Notification --
+    if let Some(n) = &adv.notification {
+        if let Some(mode) = &n.mode {
+            out.push_str("[notification]\n");
+            out.push_str(&format!("mode = \"{}\"\n\n", escs(mode)));
+        }
+    }
+
+    // -- Feature flags --
+    if let Some(f) = &adv.features {
+        let any = f.history_step_size.is_some()
+            || f.revision_step_keys.is_some()
+            || f.revision_list_cache.is_some()
+            || f.revision_diff_source_cap.is_some()
+            || f.revision_diff_history_walk_concurrency.is_some();
+        if any {
+            out.push_str("[feature]\n");
+            if let Some(v) = f.history_step_size {
+                out.push_str(&format!("history_step_size = {v}\n"));
+            }
+            if let Some(v) = f.revision_step_keys {
+                out.push_str(&format!("revision_step_keys = {v}\n"));
+            }
+            if let Some(v) = f.revision_list_cache {
+                out.push_str(&format!("revision_list_cache = {v}\n"));
+            }
+            if let Some(v) = f.revision_diff_source_cap {
+                out.push_str(&format!("revision_diff_source_cap = {v}\n"));
+            }
+            if let Some(v) = f.revision_diff_history_walk_concurrency {
+                out.push_str(&format!("revision_diff_history_walk_concurrency = {v}\n"));
+            }
+            out.push('\n');
+        }
+    }
+
+    // -- Topology --
+    // Default (no override) is single-node `provider = "none"`, preserved exactly.
+    render_topology(&mut out, &adv.topology, &escs);
 
     // Auth hook: a future authed mode would append a `[server.auth]` block here.
     // The no-auth local host flow deliberately omits it (server logs
@@ -320,14 +934,97 @@ fn render_config_toml(cfg: &ResolvedConfig) -> String {
     // FOLLOW-UP (advanced / enterprise lore store modes, deferred — see
     // docs/domains/storage.md): lore also supports a `composite` immutable store
     // (local cache tier + durable `aws`/S3 tier with a `ReplicationMode` of
-    // read/write/read_write), a `replicated` store (server-to-server QUIC), and
-    // an `aws` (DynamoDB) mutable + lock store at scale. They need extra inputs
-    // (replica peers, DynamoDB tables/region, mTLS replication certs) the
-    // first-run host wizard does not collect, so they are intentionally not
-    // emitted here. Add new `ResolvedConfig` variants + render branches to wire
-    // them when those flows land.
+    // read/write/read_write), a full `replicated` store (server-to-server QUIC
+    // with replica peers + a replica factory), an `aws` (DynamoDB) mutable +
+    // lock store at scale, and `consul`/`composite` topology providers. They
+    // need plugin config / nested inputs the host wizard does not collect, so
+    // they are intentionally not emitted here. Add new `*Options` + render
+    // branches to wire them when those flows land.
 
     out
+}
+
+/// Render an opt-in internal endpoint (`quic_internal` / `replication`). These
+/// default to `enabled = false`, so nothing is emitted unless the user supplied
+/// at least one explicit value. mTLS certs are nested under `<section>.certificate`.
+fn render_internal_endpoint(
+    out: &mut String,
+    section: &str,
+    opts: &Option<InternalEndpointOptions>,
+    escs: &impl Fn(&str) -> String,
+) {
+    let Some(o) = opts else { return };
+    let any = o.enabled.is_some()
+        || o.port.is_some()
+        || o.cert_chain.is_some()
+        || o.cert_file.is_some()
+        || o.pkey_file.is_some();
+    if !any {
+        return;
+    }
+    out.push_str(&format!("[{section}]\n"));
+    if let Some(v) = o.enabled {
+        out.push_str(&format!("enabled = {v}\n"));
+    }
+    if let Some(v) = o.port {
+        out.push_str(&format!("port = {v}\n"));
+    }
+    if o.cert_chain.is_some() || o.cert_file.is_some() || o.pkey_file.is_some() {
+        out.push_str(&format!("[{section}.certificate]\n"));
+        if let Some(v) = &o.cert_chain {
+            out.push_str(&format!("cert_chain = \"{}\"\n", escs(v)));
+        }
+        if let Some(v) = &o.cert_file {
+            out.push_str(&format!("cert_file = \"{}\"\n", escs(v)));
+        }
+        if let Some(v) = &o.pkey_file {
+            out.push_str(&format!("pkey_file = \"{}\"\n", escs(v)));
+        }
+    }
+    out.push('\n');
+}
+
+/// Render the `[topology]` section. Defaults to single-node `provider = "none"`.
+fn render_topology(
+    out: &mut String,
+    opts: &Option<TopologyOptions>,
+    escs: &impl Fn(&str) -> String,
+) {
+    let provider = opts
+        .as_ref()
+        .and_then(|t| t.provider.as_deref())
+        .filter(|p| !p.trim().is_empty())
+        .unwrap_or("none");
+    out.push_str("[topology]\n");
+    out.push_str(&format!("provider = \"{provider}\"\n"));
+
+    let Some(t) = opts else { return };
+    if provider == "none" {
+        return;
+    }
+    // rotating_id_fixed needs a rotation interval alongside the peer list.
+    let section = if provider == "rotating_id_fixed" {
+        "topology.rotating_id_fixed"
+    } else {
+        "topology.fixed"
+    };
+    if provider == "rotating_id_fixed" {
+        if let Some(v) = t.rotation_interval_seconds {
+            out.push_str(&format!("\n[{section}]\n"));
+            out.push_str(&format!("rotation_interval_seconds = {v}\n"));
+        } else if !t.peers.is_empty() {
+            out.push_str(&format!("\n[{section}]\n"));
+        }
+    }
+    for p in &t.peers {
+        let locality = p.locality.as_deref().unwrap_or("SameRegion");
+        out.push_str(&format!(
+            "[[{section}.peers]]\naddress = \"{}\"\nport = {}\nlocality = \"{}\"\n",
+            escs(&p.address),
+            p.port,
+            escs(locality),
+        ));
+    }
 }
 
 /// The advertised connection URL. `lore://` (no trailing `s`) so clients skip
@@ -505,13 +1202,6 @@ fn sidecar_candidate() -> Option<PathBuf> {
 /// Trims string fields and treats blanks as absent. The bucket is required —
 /// an `aws`-mode immutable store cannot be created without one.
 fn resolve_s3(opts: &S3StoreOptions) -> Result<ResolvedS3, LoreError> {
-    let norm = |s: &Option<String>| -> Option<String> {
-        s.as_deref()
-            .map(str::trim)
-            .filter(|v| !v.is_empty())
-            .map(str::to_owned)
-    };
-
     let bucket = opts.bucket.trim();
     if bucket.is_empty() {
         return Err(LoreError::CommandFailed(
@@ -520,13 +1210,223 @@ fn resolve_s3(opts: &S3StoreOptions) -> Result<ResolvedS3, LoreError> {
     }
 
     Ok(ResolvedS3 {
-        endpoint: norm(&opts.endpoint),
+        endpoint: norm_str(&opts.endpoint),
         bucket: bucket.to_owned(),
-        region: norm(&opts.region),
-        access_key_id: norm(&opts.access_key_id),
-        secret_access_key: norm(&opts.secret_access_key),
+        region: norm_str(&opts.region),
+        access_key_id: norm_str(&opts.access_key_id),
+        secret_access_key: norm_str(&opts.secret_access_key),
         force_path_style: opts.force_path_style,
-        dynamodb_endpoint: norm(&opts.dynamodb_endpoint),
+        dynamodb_endpoint: norm_str(&opts.dynamodb_endpoint),
+    })
+}
+
+/// Trim a `String`; treat blank as `None`.
+fn norm_str(s: &Option<String>) -> Option<String> {
+    s.as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(str::to_owned)
+}
+
+/// Validate + normalise the advanced sections (SBAI-4075). Returns an
+/// [`AdvancedConfig`] carrying only the user-supplied, sane values; everything
+/// else stays `None` so lore's own defaults apply. Surfaces actionable errors
+/// for out-of-range / required-when-mode mistakes the wizard's client-side
+/// validation should already prevent (defence in depth).
+fn resolve_advanced(opts: &HostServerOptions) -> Result<AdvancedConfig, LoreError> {
+    let err = |m: String| LoreError::CommandFailed(m);
+
+    // No Expert-mode bag → nothing extra; lore defaults apply everywhere.
+    let Some(adv) = opts.advanced.as_ref() else {
+        return Ok(AdvancedConfig::default());
+    };
+
+    // Telemetry: enum + range checks.
+    if let Some(t) = &adv.telemetry {
+        if let Some(f) = &t.log_format {
+            if !matches!(f.as_str(), "text" | "ansi" | "json") {
+                return Err(err(format!(
+                    "telemetry log format must be text, ansi, or json (got {f:?})"
+                )));
+            }
+        }
+        if let Some(o) = &t.log_output {
+            if !matches!(o.as_str(), "stdout" | "stderr" | "file") {
+                return Err(err(format!(
+                    "telemetry log output must be stdout, stderr, or file (got {o:?})"
+                )));
+            }
+            if o == "file" && norm_str(&t.log_file).is_none() {
+                return Err(err(
+                    "a log file path is required when telemetry output is 'file'".into(),
+                ));
+            }
+        }
+        for (name, v) in [
+            ("trace sample rate", t.trace_sample_rate),
+            ("low-tier trace sample rate", t.trace_sample_rate_low_tier),
+        ] {
+            if let Some(v) = v {
+                if !(0.0..=1.0).contains(&v) {
+                    return Err(err(format!("{name} must be within [0.0, 1.0] (got {v})")));
+                }
+            }
+        }
+    }
+
+    // Topology: validate provider + required-when-mode + peers.
+    let topology = if let Some(t) = &adv.topology {
+        let provider = norm_str(&t.provider).unwrap_or_else(|| "none".into());
+        if !matches!(provider.as_str(), "none" | "fixed" | "rotating_id_fixed") {
+            return Err(err(format!(
+                "topology provider must be none, fixed, or rotating_id_fixed (got {provider:?})"
+            )));
+        }
+        let mut peers = Vec::new();
+        for p in &t.peers {
+            let address = p.address.trim();
+            if address.is_empty() {
+                return Err(err("every topology peer needs an address".into()));
+            }
+            if let Some(loc) = &p.locality {
+                if !matches!(loc.as_str(), "SameRegion" | "OtherRegion") {
+                    return Err(err(format!(
+                        "peer locality must be SameRegion or OtherRegion (got {loc:?})"
+                    )));
+                }
+            }
+            peers.push(PeerOption {
+                address: address.to_owned(),
+                port: p.port,
+                locality: norm_str(&p.locality),
+            });
+        }
+        if provider != "none" && peers.is_empty() {
+            return Err(err(format!(
+                "topology provider {provider:?} requires at least one peer"
+            )));
+        }
+        if provider == "rotating_id_fixed" && t.rotation_interval_seconds.is_none() {
+            return Err(err(
+                "rotating_id_fixed topology requires a rotation interval (seconds)".into(),
+            ));
+        }
+        Some(TopologyOptions {
+            provider: Some(provider),
+            peers,
+            rotation_interval_seconds: t.rotation_interval_seconds,
+        })
+    } else {
+        None
+    };
+
+    // Internal endpoints: when enabled, require the mTLS cert + key.
+    let resolve_internal = |o: &Option<InternalEndpointOptions>,
+                            name: &str|
+     -> Result<Option<InternalEndpointOptions>, LoreError> {
+        let Some(o) = o else { return Ok(None) };
+        let cert_file = norm_str(&o.cert_file);
+        let pkey_file = norm_str(&o.pkey_file);
+        if o.enabled == Some(true) && (cert_file.is_none() || pkey_file.is_none()) {
+            return Err(err(format!(
+                "the {name} endpoint requires an mTLS cert file and key when enabled"
+            )));
+        }
+        Ok(Some(InternalEndpointOptions {
+            enabled: o.enabled,
+            port: o.port,
+            cert_chain: norm_str(&o.cert_chain),
+            cert_file,
+            pkey_file,
+        }))
+    };
+
+    Ok(AdvancedConfig {
+        quic: adv.quic.clone(),
+        grpc: adv.grpc.clone(),
+        http: adv.http.clone(),
+        local_store: adv.local_store.clone(),
+        topology,
+        telemetry: adv.telemetry.as_ref().map(|t| TelemetryOptions {
+            log_format: norm_str(&t.log_format),
+            log_output: norm_str(&t.log_output),
+            log_file: norm_str(&t.log_file),
+            ..t.clone()
+        }),
+        runtime: adv.runtime.clone(),
+        notification: adv.notification.as_ref().map(|n| NotificationOptions {
+            mode: norm_str(&n.mode),
+        }),
+        features: adv.features.clone(),
+        timeouts: adv.timeouts.clone(),
+        quic_internal: resolve_internal(&adv.quic_internal, "quic_internal")?,
+        replication_endpoint: resolve_internal(&adv.replication_endpoint, "replication")?,
+        lock_store_mode: norm_str(&adv.lock_store_mode),
+    })
+}
+
+/// Resolve every input into a [`ResolvedConfig`] without touching the
+/// filesystem store dir or writing the config file. Used by both [`prepare`]
+/// (which then writes the file) and the "view config" preview command, so a
+/// preview never spawns a server or mutates disk.
+///
+/// `cert_file` / `pkey_file` are the shipped self-signed QUIC test certs from
+/// the pinned lore checkout. When the checkout isn't present yet (no build has
+/// fetched the dep), `allow_missing_certs` lets the preview fall back to clearly
+/// labelled placeholder paths instead of erroring.
+fn resolve_config(
+    opts: &HostServerOptions,
+    allow_missing_certs: bool,
+) -> Result<ResolvedConfig, LoreError> {
+    if opts.store_dir.trim().is_empty() {
+        return Err(LoreError::CommandFailed(
+            "store directory is required to host a server".into(),
+        ));
+    }
+    let store_dir = PathBuf::from(opts.store_dir.trim());
+
+    let port = match opts.port {
+        Some(p) if p != 0 => p,
+        _ => DEFAULT_PORT,
+    };
+    let http_port = port.wrapping_add(2);
+
+    let (cert_file, pkey_file) = match lore_checkout() {
+        Ok(checkout) => {
+            let test_data = checkout
+                .join("lore-server")
+                .join("src")
+                .join("protocol")
+                .join("test_data");
+            (
+                test_data.join("test_cert.pem"),
+                test_data.join("test_key.pem"),
+            )
+        }
+        Err(e) if allow_missing_certs => {
+            tracing::debug!("lore checkout unavailable for cert paths in preview: {e}");
+            (
+                PathBuf::from("<lore test_cert.pem>"),
+                PathBuf::from("<lore test_key.pem>"),
+            )
+        }
+        Err(e) => return Err(e),
+    };
+
+    let bind_host = norm_str(&opts.bind_host).unwrap_or_else(|| BIND_HOST.to_owned());
+    let s3 = opts.s3.as_ref().map(resolve_s3).transpose()?;
+    let adv = resolve_advanced(opts)?;
+
+    Ok(ResolvedConfig {
+        bind_host,
+        port,
+        http_port,
+        store_dir,
+        cert_file,
+        pkey_file,
+        auth: opts.auth,
+        s3,
+        adv,
     })
 }
 
@@ -535,45 +1435,14 @@ fn resolve_s3(opts: &S3StoreOptions) -> Result<ResolvedS3, LoreError> {
 /// into `store_dir/.loregui-host/local.toml` so a single store directory is
 /// fully self-describing.
 fn prepare(opts: &HostServerOptions) -> Result<(ResolvedConfig, PathBuf, String), LoreError> {
-    let store_dir = PathBuf::from(opts.store_dir.trim());
-    if store_dir.as_os_str().is_empty() {
-        return Err(LoreError::CommandFailed(
-            "store directory is required to host a server".into(),
-        ));
-    }
+    let cfg = resolve_config(opts, false)?;
+    let store_dir = cfg.store_dir.clone();
     std::fs::create_dir_all(&store_dir).map_err(|e| {
         LoreError::CommandFailed(format!(
             "could not create store dir {}: {e}",
             store_dir.display()
         ))
     })?;
-
-    let port = match opts.port {
-        Some(p) if p != 0 => p,
-        _ => DEFAULT_PORT,
-    };
-    let http_port = port.wrapping_add(2);
-
-    let checkout = lore_checkout()?;
-    let test_data = checkout
-        .join("lore-server")
-        .join("src")
-        .join("protocol")
-        .join("test_data");
-    let cert_file = test_data.join("test_cert.pem");
-    let pkey_file = test_data.join("test_key.pem");
-
-    let s3 = opts.s3.as_ref().map(resolve_s3).transpose()?;
-
-    let cfg = ResolvedConfig {
-        port,
-        http_port,
-        store_dir: store_dir.clone(),
-        cert_file,
-        pkey_file,
-        auth: opts.auth,
-        s3,
-    };
 
     let config_dir = store_dir.join(".loregui-host");
     std::fs::create_dir_all(&config_dir).map_err(|e| {
@@ -590,7 +1459,7 @@ fn prepare(opts: &HostServerOptions) -> Result<(ResolvedConfig, PathBuf, String)
         ))
     })?;
 
-    let url = advertise_url(port, opts.repository_name.as_deref());
+    let url = advertise_url(cfg.port, opts.repository_name.as_deref());
     Ok((cfg, config_path, url))
 }
 
@@ -707,6 +1576,20 @@ pub fn status(slot: &mut Option<HostedServer>) -> HostStatus {
     }
 }
 
+/// Render the `loreserver` config TOML for the given options **without** writing
+/// anything to disk or starting a server (SBAI-4075). Backs the host flow's
+/// "View generated config" affordance so an operator can review exactly what
+/// will be written before committing. Validation errors (bad enum, out-of-range
+/// number, required-when-mode) surface here too, so the preview doubles as a
+/// dry-run check.
+pub fn render_config(opts: &HostServerOptions) -> Result<String, LoreError> {
+    // `allow_missing_certs = true`: a preview should work even before the lore
+    // dependency has been fetched/built, so fall back to labelled placeholder
+    // cert paths rather than erroring.
+    let cfg = resolve_config(opts, true)?;
+    Ok(render_config_toml(&cfg))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -714,6 +1597,7 @@ mod tests {
 
     fn sample_cfg(store: &str, port: u16, auth: bool) -> ResolvedConfig {
         ResolvedConfig {
+            bind_host: BIND_HOST.to_owned(),
             port,
             http_port: port + 2,
             store_dir: PathBuf::from(store),
@@ -721,11 +1605,13 @@ mod tests {
             pkey_file: PathBuf::from("/certs/test_key.pem"),
             auth,
             s3: None,
+            adv: AdvancedConfig::default(),
         }
     }
 
     fn sample_s3_cfg(store: &str, port: u16, s3: ResolvedS3) -> ResolvedConfig {
         ResolvedConfig {
+            bind_host: BIND_HOST.to_owned(),
             port,
             http_port: port + 2,
             store_dir: PathBuf::from(store),
@@ -733,6 +1619,25 @@ mod tests {
             pkey_file: PathBuf::from("/certs/test_key.pem"),
             auth: false,
             s3: Some(s3),
+            adv: AdvancedConfig::default(),
+        }
+    }
+
+    /// A minimal [`HostServerOptions`] with only a store dir — the simple
+    /// first-run case. Every advanced section is `None`.
+    fn basic_opts(store: &str) -> HostServerOptions {
+        HostServerOptions {
+            store_dir: store.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    /// Options for `store` with the given Expert-mode advanced bag.
+    fn adv_opts(store: &str, advanced: HostAdvancedOptions) -> HostServerOptions {
+        HostServerOptions {
+            store_dir: store.to_owned(),
+            advanced: Some(advanced),
+            ..Default::default()
         }
     }
 
@@ -922,6 +1827,360 @@ mod tests {
         assert_eq!(parse_pinned_rev("rev = \"short\""), None);
     }
 
+    // === Advanced config (SBAI-4075) ===
+
+    /// The most important invariant: an all-default `HostServerOptions` (the
+    /// simple first-run case) must render the **exact same** local config the
+    /// flow always produced — same sections, same values, no advanced keys.
+    #[test]
+    fn defaults_render_the_original_local_config() {
+        // What `render_config` produces for a bare store dir...
+        let opts = basic_opts("/srv/store");
+        let adv = resolve_advanced(&opts).expect("no advanced options");
+        assert!(
+            matches!(
+                adv,
+                AdvancedConfig {
+                    quic: None,
+                    grpc: None,
+                    http: None,
+                    local_store: None,
+                    topology: None,
+                    telemetry: None,
+                    runtime: None,
+                    notification: None,
+                    features: None,
+                    timeouts: None,
+                    quic_internal: None,
+                    replication_endpoint: None,
+                    lock_store_mode: None
+                }
+            ),
+            "a bare options bag must resolve to a fully-empty AdvancedConfig"
+        );
+
+        let cfg = ResolvedConfig {
+            bind_host: BIND_HOST.to_owned(),
+            port: DEFAULT_PORT,
+            http_port: DEFAULT_PORT + 2,
+            store_dir: PathBuf::from("/srv/store"),
+            cert_file: PathBuf::from("/certs/test_cert.pem"),
+            pkey_file: PathBuf::from("/certs/test_key.pem"),
+            auth: false,
+            s3: None,
+            adv,
+        };
+        let toml = render_config_toml(&cfg);
+
+        // The minimal config body, unchanged from the SBAI-4065 baseline: quic +
+        // certs, grpc, http, local stores, telemetry logger ansi, topology none.
+        // No advanced sections leak in when nothing was set.
+        assert!(toml.contains("[server.quic]\nhost = \"127.0.0.1\"\nport = 41337\n[server.quic.certificate]\ncert_file = \"/certs/test_cert.pem\"\npkey_file = \"/certs/test_key.pem\"\n"));
+        assert!(toml.contains("[server.grpc]\nhost = \"127.0.0.1\"\nport = 41337\n"));
+        assert!(toml.contains("[server.http]\nhost = \"127.0.0.1\"\nport = 41339\n"));
+        assert!(toml.contains("[immutable_store.local]\npath = \"/srv/store\"\n"));
+        assert!(toml.contains("[mutable_store.local]\npath = \"/srv/store\"\n"));
+        assert!(toml.contains("[telemetry.logger]\nformat = \"ansi\"\n"));
+        assert!(toml.contains("[topology]\nprovider = \"none\"\n"));
+        // No advanced sections.
+        assert!(!toml.contains("[server.quic_internal]"));
+        assert!(!toml.contains("[server.replication]"));
+        assert!(!toml.contains("[tokio]"));
+        assert!(!toml.contains("[feature]"));
+        assert!(!toml.contains("[notification]"));
+        assert!(!toml.contains("[lock_store]"));
+        assert!(!toml.contains("[telemetry.metrics]"));
+        // No per-endpoint tuning keys when unset.
+        assert!(!toml.contains("verify_client_certs"));
+        assert!(!toml.contains("idle_timeout"));
+        assert!(!toml.contains("max_file_size"));
+    }
+
+    #[test]
+    fn bind_host_override_applies_to_every_endpoint() {
+        let opts = HostServerOptions {
+            store_dir: "/srv/store".into(),
+            bind_host: Some("0.0.0.0".into()),
+            ..Default::default()
+        };
+        let cfg = resolve_config(&opts, true).expect("resolve");
+        let toml = render_config_toml(&cfg);
+        // All three endpoints bind the override; loopback no longer appears.
+        assert_eq!(toml.matches("host = \"0.0.0.0\"").count(), 3);
+        assert!(!toml.contains("host = \"127.0.0.1\""));
+    }
+
+    #[test]
+    fn quic_grpc_http_overrides_are_emitted() {
+        let opts = adv_opts(
+            "/srv/store",
+            HostAdvancedOptions {
+                quic: Some(QuicOptions {
+                    verify_client_certs: Some(true),
+                    idle_timeout: Some(60_000),
+                    num_listeners: Some(4),
+                    handler_timeout_seconds: Some(30),
+                    ..Default::default()
+                }),
+                grpc: Some(GrpcOptions {
+                    request_handler_timeout_seconds: Some(45),
+                    http2_keepalive_interval_seconds: Some(20),
+                    ..Default::default()
+                }),
+                http: Some(HttpOptions {
+                    max_file_size: Some(20_971_520),
+                    store_health_check: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+        let toml = render_config(&opts).expect("render");
+        assert!(toml.contains("[server.quic]"));
+        assert!(toml.contains("verify_client_certs = true"));
+        assert!(toml.contains("idle_timeout = 60000"));
+        assert!(toml.contains("num_listeners = 4"));
+        assert!(toml.contains("handler_timeout_seconds = 30"));
+        assert!(toml.contains("request_handler_timeout_seconds = 45"));
+        assert!(toml.contains("http2_keepalive_interval_seconds = 20"));
+        assert!(toml.contains("max_file_size = 20971520"));
+        assert!(toml.contains("store_health_check = true"));
+    }
+
+    #[test]
+    fn telemetry_runtime_notification_feature_sections_render() {
+        let opts = adv_opts(
+            "/srv/store",
+            HostAdvancedOptions {
+                telemetry: Some(TelemetryOptions {
+                    log_format: Some("json".into()),
+                    log_output: Some("file".into()),
+                    log_file: Some("/var/log/lore.log".into()),
+                    enable_otlp: Some(true),
+                    metrics_export_interval_millis: Some(15_000),
+                    trace_sample_rate: Some(0.5),
+                    ..Default::default()
+                }),
+                runtime: Some(RuntimeOptions {
+                    worker_threads: Some(8),
+                    max_blocking_threads: Some(256),
+                    ..Default::default()
+                }),
+                notification: Some(NotificationOptions {
+                    mode: Some("local".into()),
+                }),
+                features: Some(FeatureOptions {
+                    history_step_size: Some(50),
+                    revision_step_keys: Some(false),
+                    ..Default::default()
+                }),
+                timeouts: Some(TimeoutOptions {
+                    connection_close_timeout_seconds: Some(10),
+                    runtime_shutdown_timeout_seconds: Some(40),
+                }),
+                lock_store_mode: Some("local".into()),
+                ..Default::default()
+            },
+        );
+        let toml = render_config(&opts).expect("render");
+        // telemetry
+        assert!(toml.contains("[telemetry.logger]\nformat = \"json\""));
+        assert!(toml.contains("output = { file = \"/var/log/lore.log\" }"));
+        assert!(toml.contains("enable_otlp = true"));
+        assert!(toml.contains("[telemetry.metrics]\nexport_interval_millis = 15000"));
+        assert!(toml.contains("[telemetry.traces]\nsample_rate = 0.5"));
+        // runtime
+        assert!(toml.contains("[tokio]\nworker_threads = 8\nmax_blocking_threads = 256"));
+        // notification + lock store + timeouts + feature
+        assert!(toml.contains("[notification]\nmode = \"local\""));
+        assert!(toml.contains("[lock_store]\nmode = \"local\""));
+        assert!(toml.contains("connection_close_timeout_seconds = 10"));
+        assert!(toml.contains("runtime_shutdown_timeout_seconds = 40"));
+        assert!(toml.contains("[feature]\nhistory_step_size = 50\nrevision_step_keys = false"));
+    }
+
+    #[test]
+    fn fixed_topology_renders_peers() {
+        let opts = adv_opts(
+            "/srv/store",
+            HostAdvancedOptions {
+                topology: Some(TopologyOptions {
+                    provider: Some("fixed".into()),
+                    peers: vec![
+                        PeerOption {
+                            address: "10.0.0.1".into(),
+                            port: 41337,
+                            locality: Some("SameRegion".into()),
+                        },
+                        PeerOption {
+                            address: "10.0.0.2".into(),
+                            port: 41337,
+                            locality: Some("OtherRegion".into()),
+                        },
+                    ],
+                    rotation_interval_seconds: None,
+                }),
+                ..Default::default()
+            },
+        );
+        let toml = render_config(&opts).expect("render");
+        assert!(toml.contains("[topology]\nprovider = \"fixed\""));
+        assert!(toml.contains("[[topology.fixed.peers]]\naddress = \"10.0.0.1\"\nport = 41337\nlocality = \"SameRegion\""));
+        assert!(toml.contains("address = \"10.0.0.2\""));
+        assert!(toml.contains("locality = \"OtherRegion\""));
+    }
+
+    #[test]
+    fn rotating_topology_requires_interval() {
+        let mut opts = adv_opts(
+            "/srv/store",
+            HostAdvancedOptions {
+                topology: Some(TopologyOptions {
+                    provider: Some("rotating_id_fixed".into()),
+                    peers: vec![PeerOption {
+                        address: "10.0.0.1".into(),
+                        port: 41337,
+                        locality: None,
+                    }],
+                    rotation_interval_seconds: None,
+                }),
+                ..Default::default()
+            },
+        );
+        // Missing interval → error.
+        assert!(render_config(&opts).is_err());
+        // With interval → renders the rotating section + peer.
+        opts.advanced
+            .as_mut()
+            .unwrap()
+            .topology
+            .as_mut()
+            .unwrap()
+            .rotation_interval_seconds = Some(3600);
+        let toml = render_config(&opts).expect("render");
+        assert!(toml.contains("provider = \"rotating_id_fixed\""));
+        assert!(toml.contains("[topology.rotating_id_fixed]\nrotation_interval_seconds = 3600"));
+        assert!(toml.contains("[[topology.rotating_id_fixed.peers]]"));
+    }
+
+    #[test]
+    fn internal_endpoint_requires_certs_when_enabled() {
+        // enabled but no certs → error.
+        let bad = adv_opts(
+            "/srv/store",
+            HostAdvancedOptions {
+                quic_internal: Some(InternalEndpointOptions {
+                    enabled: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+        assert!(render_config(&bad).is_err());
+
+        // enabled with certs → renders the section + nested certificate table.
+        let ok = adv_opts(
+            "/srv/store",
+            HostAdvancedOptions {
+                replication_endpoint: Some(InternalEndpointOptions {
+                    enabled: Some(true),
+                    port: Some(41340),
+                    cert_file: Some("/c/cert.pem".into()),
+                    pkey_file: Some("/c/key.pem".into()),
+                    cert_chain: None,
+                }),
+                ..Default::default()
+            },
+        );
+        let toml = render_config(&ok).expect("render");
+        assert!(toml.contains("[server.replication]\nenabled = true\nport = 41340"));
+        assert!(toml.contains("[server.replication.certificate]\ncert_file = \"/c/cert.pem\"\npkey_file = \"/c/key.pem\""));
+    }
+
+    #[test]
+    fn validation_rejects_bad_enums_and_ranges() {
+        let bad_format = adv_opts(
+            "/s",
+            HostAdvancedOptions {
+                telemetry: Some(TelemetryOptions {
+                    log_format: Some("yaml".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+        assert!(render_config(&bad_format).is_err());
+
+        let bad_rate = adv_opts(
+            "/s",
+            HostAdvancedOptions {
+                telemetry: Some(TelemetryOptions {
+                    trace_sample_rate: Some(1.5),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+        assert!(render_config(&bad_rate).is_err());
+
+        let bad_provider = adv_opts(
+            "/s",
+            HostAdvancedOptions {
+                topology: Some(TopologyOptions {
+                    provider: Some("consul".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+        assert!(render_config(&bad_provider).is_err());
+    }
+
+    #[test]
+    fn render_config_preview_does_not_require_store_dir_on_disk() {
+        // A non-existent path must still render (preview writes nothing to disk).
+        let opts = basic_opts("/nonexistent/preview/only/store");
+        let toml = render_config(&opts).expect("preview should render");
+        assert!(toml.contains("provider = \"none\""));
+        // Empty store dir is still rejected.
+        let empty = basic_opts("   ");
+        assert!(render_config(&empty).is_err());
+    }
+
+    #[test]
+    fn s3_advanced_keeps_local_mutable_tuning() {
+        // S3 immutable + local-store flush override only touches the mutable
+        // local store; immutable-only keys (compaction etc.) are not emitted.
+        let opts = HostServerOptions {
+            store_dir: "/srv/store".into(),
+            s3: Some(S3StoreOptions {
+                endpoint: None,
+                bucket: "lore".into(),
+                region: Some("us-east-1".into()),
+                access_key_id: None,
+                secret_access_key: None,
+                force_path_style: false,
+                dynamodb_endpoint: None,
+            }),
+            advanced: Some(HostAdvancedOptions {
+                local_store: Some(LocalStoreOptions {
+                    flush_delay_seconds: Some(20),
+                    compaction_delay: Some(99),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let toml = render_config(&opts).expect("render");
+        assert!(toml.contains("mode = \"aws\""));
+        assert!(toml.contains("[mutable_store.local]"));
+        assert!(toml.contains("flush_delay_seconds = 20"));
+        // compaction_delay is immutable-only; the immutable store is aws here, so
+        // it must NOT appear.
+        assert!(!toml.contains("compaction_delay"));
+    }
+
     /// Live smoke test (LOCAL-ONLY, ignored by default): actually spawn a real
     /// `loreserver` via `start()` and prove it boots + binds its gRPC/QUIC port,
     /// then `stop()` reaps it. Launches the upstream server binary (resolved from
@@ -941,8 +2200,7 @@ mod tests {
             store_dir: store.to_string_lossy().into_owned(),
             port: Some(port),
             repository_name: Some("smoke".into()),
-            auth: false,
-            s3: None,
+            ..Default::default()
         };
 
         let started = start(&mut slot, &opts).expect("start should spawn loreserver");


### PR DESCRIPTION
Basic↔Expert host config: Network/QUIC/gRPC/HTTP, Storage tuning + lock-store, Topology+replication+mTLS, Telemetry, Runtime, Notifications, Features, Timeouts — all from lore Settings. Only-non-default emission (defaults == original local config, tested). host_server_render_config preview (no disk/no boot). 20 tests green; real-config smoke boots verified. Composite/replicated/DynamoDB/consul deferred (nested plugin config). SBAI-4075.