### PR TITLE
feat(lore-vm): shared lore_vm::dispatch seam + productionized FFI (SBAI-4081)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,34 @@ frontend/src/palette/ + panels/views      4. GUI — command palette (universal)
 - **Plans:** `docs/IMPLEMENTATION-PLAN.md` (full-parity), `docs/COMMAND-PALETTE-PLAN.md` (palette parity, Epic SBAI-3865), `docs/EXPERT-AGENTS.md` (this system, Epic SBAI-4024).
 - **CI gates:** `ci.yml` (`core-check` = fmt+clippy+test on lore-vm; `palette-parity` = GUI coverage ratchet), `integration.yml`, `windows-build.yml`. `main` is not branch-protected.
 
+## One binding, two consumption modes (NOT a contradiction)
+
+"Binds `lore` in-process, never shells out" is about **this GUI** — and it still
+holds. There are two distinct surfaces over the *same* in-process `lore-vm`
+binding; don't read them as conflicting:
+
+- **GUI / Tauri path (in-process, typed):** the app binds `lore-vm`'s ops as ~140
+  typed `#[tauri::command]`s (the four-layer pattern above). It calls the ops
+  in-process and **never shells out and never goes through FFI.** This is the
+  rule, unchanged.
+- **External-driver contract (`lorevm` CLI + `lorevm-ffi`):** the deliberate seam
+  for drivers that are *not* this GUI — `lore-mcp` and the planned VS Code
+  extension (shell `lorevm <domain>.<op> --args '<json>'`), and the Unreal Engine
+  plugin (link `lorevm-ffi`'s C ABI for the hot path). These are *supposed* to
+  shell / FFI in; that's their job.
+
+Both surfaces ride **one canonical dispatch**: `lore_vm::dispatch(&api, op_id,
+args) -> Result<Value, LoreError>` in `crates/lore-vm/src/dispatch.rs`, with
+`lore_vm::supported_ops()` listing the routable ids. `lorevm-cli` and
+`lorevm-ffi` both call it (no re-typed op match — SBAI-4081), so the CLI, the FFI
+bridge, and any future external driver cannot drift. The GUI's typed Tauri
+commands *could* also route through `dispatch` instead of binding each op
+directly, but that ~140-command refactor is **out of scope** — the GUI stays
+as-is for now; this is just a note, not a TODO.
+
+See `docs/ue-lorevm-bridge-spike.md` for the UE bridge design that motivated the
+shared seam.
+
 ## The coherence mandate (READ BEFORE ANY UI WORK)
 
 Exposing an op is **not** just adding a command-palette row. Every endpoint must

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,6 +2793,7 @@ name = "lorevm-ffi"
 version = "0.1.0"
 dependencies = [
  "lore-vm",
+ "lorevm-ffi",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/lore-vm/src/dispatch.rs
+++ b/crates/lore-vm/src/dispatch.rs
@@ -1,0 +1,316 @@
+//! Canonical op dispatch — the single `"<domain>.<op>"` → typed-op seam.
+//!
+//! This is the **one** place that maps a string op id to the matching
+//! [`crate::ops`] async fn. Every *external* driver of lore-vm rides this fn so
+//! they cannot drift:
+//!
+//! - `lorevm-cli` (the `lorevm` JSON CLI — the subprocess surface `lore-mcp` and
+//!   the planned VS Code extension shell) calls [`dispatch`] directly.
+//! - `lorevm-ffi` (the C-ABI `cdylib` the Unreal Engine plugin links) calls
+//!   [`dispatch`] behind its `extern "C"` boundary.
+//!
+//! The in-process **GUI/Tauri** path does **not** go through here — it binds the
+//! ops as ~140 typed `#[tauri::command]`s for richer per-arg typing. That is a
+//! deliberate second consumption mode of the *same* in-process binding, not a
+//! competing dispatch. See `CLAUDE.md` ("One binding, two consumption modes").
+//!
+//! ## Contract
+//!
+//! ```ignore
+//! let value = lore_vm::dispatch(&api, "repository.status", json!({})).await?;
+//! ```
+//!
+//! - `op_id` is `"<domain>.<op>"` (e.g. `"repository.status"`).
+//! - `args` is a JSON object deserialised straight into the op's `Args` struct
+//!   (snake_case serde keys; every field is `#[serde(default)]`, so `{}` / `null`
+//!   means "all defaults").
+//! - On success the op's typed `Result` is serialised back to a [`Value`].
+//! - On failure a structured [`LoreError`] is returned — bad args / unknown op
+//!   surface as [`LoreError::Parse`] so a caller can tell a dispatch-layer
+//!   failure from an op failure by `kind`.
+//!
+//! ## Adding an op
+//!
+//! Add one `op!` arm to the match below **and** one entry to [`SUPPORTED_OPS`].
+//! `cargo test -p lore-vm` asserts the two stay in lockstep.
+
+use serde_json::Value;
+
+use crate::api::LoreApi;
+use crate::error::LoreError;
+use crate::ops;
+
+/// Every op id [`dispatch`] understands, in a stable, human-scannable order.
+///
+/// `lorevm --list`, the FFI `supported_ops` surface, and the CLI usage text all
+/// read this through [`supported_ops`]. Keep it in sync with the match in
+/// [`dispatch`] — the unit tests enforce that every listed id dispatches and
+/// every dispatched id is listed.
+const SUPPORTED_OPS: &[&str] = &[
+    // ---- repository -----------------------------------------------------
+    "repository.status",
+    "repository.info",
+    "repository.list",
+    "repository.create",
+    "repository.clone",
+    // ---- revision -------------------------------------------------------
+    "revision.history",
+    "revision.diff",
+    "revision.info",
+    "revision.find",
+    "revision.commit",
+    "revision.sync",
+    // ---- branch ---------------------------------------------------------
+    "branch.list",
+    "branch.info",
+    "branch.create",
+    "branch.switch",
+    "branch.push",
+    // ---- auth -----------------------------------------------------------
+    "auth.login_with_token",
+    // ---- file -----------------------------------------------------------
+    "file.stage",
+    "file.unstage",
+    "file.info",
+    "file.history",
+    "file.diff",
+    // ---- lock -----------------------------------------------------------
+    "lock.file_query",
+    "lock.file_status",
+    "lock.file_acquire",
+    "lock.file_acquire_as_owner",
+    "lock.file_message_send",
+    "lock.file_release",
+];
+
+/// The set of `"<domain>.<op>"` ids [`dispatch`] can route.
+///
+/// Drivers expose this verbatim: `lorevm --list` prints it, and the FFI bridge
+/// re-exports it so a C host can enumerate the surface without hardcoding it.
+pub fn supported_ops() -> &'static [&'static str] {
+    SUPPORTED_OPS
+}
+
+/// Route `op_id` (`"<domain>.<op>"`) to its [`crate::ops`] fn.
+///
+/// Deserialises `args` into the op's `Args`, awaits the op against `api`, and
+/// serialises its typed `Result` back to a [`Value`]. See the module docs for
+/// the full contract. This is the canonical dispatch shared by every external
+/// driver (CLI, FFI).
+pub async fn dispatch(api: &LoreApi, op_id: &str, args: Value) -> Result<Value, LoreError> {
+    /// `op!(path::to::fn, ArgsType)` — bind one op: deserialise `args` into
+    /// `ArgsType`, await the op, serialise the typed result to JSON.
+    macro_rules! op {
+        ($path:path, $args:ty) => {{
+            let parsed: $args = serde_json::from_value(args).map_err(|e| {
+                LoreError::Parse(format!("could not parse args for `{op_id}`: {e}"))
+            })?;
+            let result = $path(api, parsed).await?;
+            serde_json::to_value(&result).map_err(|e| {
+                LoreError::Parse(format!("could not serialise result for `{op_id}`: {e}"))
+            })
+        }};
+    }
+
+    match op_id {
+        // ---- repository (read / metrics + create + clone) ---------------
+        "repository.status" => op!(
+            ops::repository::status::status,
+            ops::repository::status::RepositoryStatusArgs
+        ),
+        "repository.info" => op!(
+            ops::repository::info::info,
+            ops::repository::info::RepositoryInfoArgs
+        ),
+        "repository.list" => op!(ops::repository::list::list, ops::repository::list::ListArgs),
+        "repository.create" => op!(
+            ops::repository::create::create,
+            ops::repository::create::CreateArgs
+        ),
+        // Networked: connects to a remote lore server over QUIC/gRPC and clones
+        // into the working dir.
+        "repository.clone" => op!(
+            ops::repository::clone::clone,
+            ops::repository::clone::CloneArgs
+        ),
+
+        // ---- revision ---------------------------------------------------
+        "revision.history" => op!(
+            ops::revision::history::history,
+            ops::revision::history::RevisionHistoryArgs
+        ),
+        "revision.diff" => op!(
+            ops::revision::diff::diff,
+            ops::revision::diff::RevisionDiffArgs
+        ),
+        "revision.info" => op!(
+            ops::revision::info::info,
+            ops::revision::info::RevisionInfoArgs
+        ),
+        "revision.find" => op!(
+            ops::revision::find::find,
+            ops::revision::find::RevisionFindArgs
+        ),
+        "revision.commit" => op!(
+            ops::revision::commit::commit,
+            ops::revision::commit::CommitArgs
+        ),
+        // Networked: pulls the latest revision for the current branch from the
+        // remote and syncs the working tree.
+        "revision.sync" => op!(
+            ops::revision::sync::sync,
+            ops::revision::sync::RevisionSyncArgs
+        ),
+
+        // ---- branch -----------------------------------------------------
+        "branch.list" => op!(ops::branch::list::list, ops::branch::list::BranchListArgs),
+        "branch.info" => op!(ops::branch::info::info, ops::branch::info::BranchInfoArgs),
+        "branch.create" => op!(
+            ops::branch::create::create,
+            ops::branch::create::BranchCreateArgs
+        ),
+        "branch.switch" => op!(
+            ops::branch::switch::switch,
+            ops::branch::switch::BranchSwitchArgs
+        ),
+        // Networked: pushes the current/specified branch and its revisions to
+        // the remote.
+        "branch.push" => op!(ops::branch::push::push, ops::branch::push::BranchPushArgs),
+
+        // ---- auth -------------------------------------------------------
+        // Non-interactive token login. Against a no-auth dev server this is a
+        // no-op, but it exercises the credential path.
+        "auth.login_with_token" => op!(
+            ops::auth::login_with_token::login_with_token,
+            ops::auth::login_with_token::LoginWithTokenArgs
+        ),
+
+        // ---- file -------------------------------------------------------
+        "file.stage" => op!(ops::file::stage::stage, ops::file::stage::FileStageArgs),
+        "file.unstage" => op!(
+            ops::file::unstage::unstage,
+            ops::file::unstage::FileUnstageArgs
+        ),
+        "file.info" => op!(ops::file::info::info, ops::file::info::FileInfoArgs),
+        "file.history" => op!(
+            ops::file::history::history,
+            ops::file::history::FileHistoryArgs
+        ),
+        "file.diff" => op!(ops::file::diff::diff, ops::file::diff::DiffArgs),
+
+        // ---- lock -------------------------------------------------------
+        "lock.file_query" => op!(
+            ops::lock::file_query::file_query,
+            ops::lock::file_query::FileQueryArgs
+        ),
+        "lock.file_status" => op!(
+            ops::lock::file_status::file_status,
+            ops::lock::file_status::FileStatusArgs
+        ),
+        "lock.file_acquire" => op!(
+            ops::lock::file_acquire::file_acquire,
+            ops::lock::file_acquire::FileAcquireArgs
+        ),
+        "lock.file_acquire_as_owner" => op!(
+            ops::lock::file_acquire_as_owner::file_acquire_as_owner,
+            ops::lock::file_acquire_as_owner::FileAcquireAsOwnerArgs
+        ),
+        "lock.file_message_send" => op!(
+            ops::lock::file_message_send::file_message_send,
+            ops::lock::file_message_send::FileMessageSendArgs
+        ),
+        "lock.file_release" => op!(
+            ops::lock::file_release::file_release,
+            ops::lock::file_release::FileReleaseArgs
+        ),
+
+        unknown => Err(LoreError::Parse(format!(
+            "unknown op `{unknown}`; see lore_vm::supported_ops() for the dispatchable set"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashSet;
+
+    #[test]
+    fn supported_ops_has_no_duplicates() {
+        let set: HashSet<_> = supported_ops().iter().collect();
+        assert_eq!(
+            set.len(),
+            supported_ops().len(),
+            "supported_ops() contains duplicate ids"
+        );
+    }
+
+    /// `supported_ops()` and the match must stay in lockstep: no listed id may
+    /// fall through to the unknown-op arm. We probe routing with *bad* args
+    /// (`null`), which makes every routed op fail at deserialisation *before* it
+    /// ever touches the engine — so this never opens a repo or hits the network,
+    /// yet still distinguishes "routed but arg-parse failed" from the distinctive
+    /// "unknown op" message produced only by the fall-through arm.
+    #[tokio::test]
+    async fn every_supported_op_is_routed() {
+        let api = LoreApi::new(std::path::PathBuf::from("/nonexistent-lorevm-dispatch"));
+        for op in supported_ops() {
+            // `null` cannot deserialise into any op's Args struct, so a routed op
+            // returns Parse("could not parse args …"); only an *unrouted* id
+            // returns Parse("unknown op …").
+            if let Err(LoreError::Parse(msg)) = dispatch(&api, op, Value::Null).await {
+                assert!(
+                    !msg.starts_with("unknown op"),
+                    "listed op `{op}` is not routed by dispatch()"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_op_is_a_structured_parse_error() {
+        let api = LoreApi::new(std::path::PathBuf::from("."));
+        let err = dispatch(&api, "nope.nope", json!({}))
+            .await
+            .expect_err("unknown op must error");
+        match err {
+            LoreError::Parse(msg) => assert!(msg.contains("unknown op")),
+            other => panic!("expected Parse error, got {other:?}"),
+        }
+    }
+
+    /// A couple of real ops round-trip through dispatch against an in-memory
+    /// engine: a mutating op (`repository.create`) then a read op
+    /// (`repository.status`), both producing JSON objects, no server.
+    ///
+    /// Gated behind `integration-tests` (like `tests/integration_roundtrip.rs`)
+    /// so the fast default `cargo test -p lore-vm` never spins the real engine.
+    /// The FFI smoke test exercises the same create→status path over the C ABI.
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn ops_round_trip_through_dispatch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let api = LoreApi::from_global(
+            crate::global::LoreGlobal::new(tmp.path().to_path_buf())
+                .in_memory(true)
+                .offline(true)
+                .identity("dispatch-test"),
+        );
+        let repo_url = format!("lore://localhost/dispatch-{}", std::process::id());
+
+        let created = dispatch(
+            &api,
+            "repository.create",
+            json!({ "repository_url": repo_url }),
+        )
+        .await
+        .expect("repository.create should succeed in-memory");
+        assert!(created.is_object(), "create result was not an object");
+
+        let status = dispatch(&api, "repository.status", json!({}))
+            .await
+            .expect("repository.status should succeed after create");
+        assert!(status.is_object(), "status result was not an object");
+    }
+}

--- a/crates/lore-vm/src/lib.rs
+++ b/crates/lore-vm/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod api;
 pub mod backend;
 pub mod collect;
+pub mod dispatch;
 pub mod error;
 pub mod global;
 pub mod model;
@@ -30,5 +31,6 @@ pub mod client_backend;
 
 pub use api::LoreApi;
 pub use backend::{default_backend, LoreBackend};
+pub use dispatch::{dispatch, supported_ops};
 pub use error::{LoreError, Result};
 pub use model::{Branch, ChangeKind, FileChange, RepoStatus, Revision};

--- a/crates/lorevm-cli/src/main.rs
+++ b/crates/lorevm-cli/src/main.rs
@@ -3,11 +3,18 @@
 //! This is **not** the legacy upstream `lore` CLI. It links the `lore-vm` crate
 //! (which binds the upstream `lore` engine in-process via its `ops/` layer) and
 //! exposes a tiny, uniform JSON interface so an out-of-process driver — notably
-//! the `lore-mcp` MCP server — can invoke any supported op without knowing Rust:
+//! the `lore-mcp` MCP server and the planned VS Code extension — can invoke any
+//! supported op without knowing Rust:
 //!
 //! ```sh
 //! lorevm <domain>.<op> --dir <repo> --args '<json>'
 //! ```
+//!
+//! It is one of the deliberate **external-driver** consumers of the canonical
+//! [`lore_vm::dispatch`] seam (alongside `lorevm-ffi`). The CLI owns only
+//! argument parsing and JSON I/O; the actual `"<domain>.<op>"` → op routing lives
+//! once in `lore-vm` so the CLI, the FFI bridge, and any future driver cannot
+//! drift. See `CLAUDE.md` ("One binding, two consumption modes").
 //!
 //! Behaviour:
 //! - `--dir <path>` selects the repository working directory. Defaults to `.`.
@@ -22,18 +29,18 @@
 //!   exits 0.
 //! - On any error it prints `{"error": {...}}` to stdout and exits 1. The
 //!   `error` value is the structured [`lore_vm::LoreError`] (`{kind, message}`)
-//!   when the failure came from an op, or a `{kind:"cli", message}` shape for
-//!   argument/dispatch problems.
+//!   when the failure came from dispatch (op failure, bad args, unknown op), or
+//!   a `{kind:"cli", message}` shape for argument/usage problems caught before
+//!   dispatch.
 //!
-//! Adding an op is one line in the [`dispatch`] match — see the `op!` macro.
+//! Adding an op is a one-line arm in [`lore_vm::dispatch`] plus its entry in
+//! `lore_vm::supported_ops()` — nothing changes here.
 
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use lore_vm::api::LoreApi;
 use lore_vm::global::LoreGlobal;
-use lore_vm::ops;
-use serde::Serialize;
+use lore_vm::{dispatch, supported_ops, LoreApi};
 use serde_json::{json, Value};
 
 /// Parsed command line.
@@ -49,9 +56,10 @@ struct Cli {
     identity: Option<String>,
 }
 
-/// A small CLI-level error (bad usage / unknown op / bad JSON), kept distinct
-/// from a [`lore_vm::LoreError`] so the JSON `error.kind` tells callers which
-/// layer failed.
+/// A small CLI-level error (bad usage / bad JSON), kept distinct from a
+/// [`lore_vm::LoreError`] so the JSON `error.kind` tells callers which layer
+/// failed. Op-level failures, unknown ops, and bad args are reported by
+/// `dispatch` itself as a `LoreError`.
 #[derive(Debug)]
 struct CliError(String);
 
@@ -64,14 +72,6 @@ impl CliError {
 fn print_error_json(kind: &str, message: &str) {
     let body = json!({ "error": { "kind": kind, "message": message } });
     println!("{}", serde_json::to_string_pretty(&body).unwrap());
-}
-
-/// Print a successfully-typed op result as pretty JSON.
-fn print_ok<T: Serialize>(value: &T) -> Result<(), CliError> {
-    let v = serde_json::to_value(value)
-        .map_err(|e| CliError::new(format!("failed to serialise result: {e}")))?;
-    println!("{}", serde_json::to_string_pretty(&v).unwrap());
-    Ok(())
 }
 
 fn parse_cli() -> Result<Cli, CliError> {
@@ -151,42 +151,9 @@ fn usage() -> String {
          lorevm <domain>.<op> --dir <repo> [--args '<json>'] [--in-memory] [--offline] [--identity <id>]\n  \
          lorevm --list        # print every dispatchable op id (one per line)\n\n\
          Supported ops:\n  {}\n",
-        SUPPORTED_OPS.join("\n  ")
+        supported_ops().join("\n  ")
     )
 }
-
-/// The set of ops `dispatch` knows about. Keep in sync with the match below;
-/// the integration smoke test and `--list` both read this.
-const SUPPORTED_OPS: &[&str] = &[
-    "repository.status",
-    "repository.info",
-    "repository.list",
-    "repository.create",
-    "repository.clone",
-    "revision.history",
-    "revision.diff",
-    "revision.info",
-    "revision.find",
-    "revision.commit",
-    "revision.sync",
-    "branch.list",
-    "branch.info",
-    "branch.create",
-    "branch.switch",
-    "branch.push",
-    "auth.login_with_token",
-    "file.stage",
-    "file.unstage",
-    "file.info",
-    "file.history",
-    "file.diff",
-    "lock.file_query",
-    "lock.file_status",
-    "lock.file_acquire",
-    "lock.file_acquire_as_owner",
-    "lock.file_message_send",
-    "lock.file_release",
-];
 
 /// Build the headless [`LoreApi`] for `cli`.
 fn build_api(cli: &Cli) -> LoreApi {
@@ -197,156 +164,6 @@ fn build_api(cli: &Cli) -> LoreApi {
         global = global.identity(id.clone());
     }
     LoreApi::from_global(global)
-}
-
-/// Dispatch `<domain>.<op>` to the matching `lore_vm::ops` fn.
-///
-/// The `op!` macro deserialises `cli.args` into the op's `Args` type, awaits the
-/// op, and prints its typed `Result` as JSON. Adding a new op is one `op!` arm.
-async fn dispatch(cli: &Cli, api: &LoreApi) -> Result<(), CliError> {
-    /// `op!(id => path::to::fn, ArgsType)` — bind one op.
-    macro_rules! op {
-        ($path:path, $args:ty) => {{
-            let parsed: $args = serde_json::from_value(cli.args.clone()).map_err(|e| {
-                CliError::new(format!(
-                    "could not parse --args into {} for `{}`: {e}",
-                    stringify!($args),
-                    cli.op_id
-                ))
-            })?;
-            match $path(api, parsed).await {
-                Ok(result) => print_ok(&result),
-                Err(e) => {
-                    // Structured op error → {"error": {kind, message}}.
-                    let v = serde_json::to_value(&e).unwrap_or_else(|_| {
-                        json!({ "kind": "client", "message": e.to_string() })
-                    });
-                    println!(
-                        "{}",
-                        serde_json::to_string_pretty(&json!({ "error": v })).unwrap()
-                    );
-                    Err(CliError::new("__already_reported__"))
-                }
-            }
-        }};
-    }
-
-    match cli.op_id.as_str() {
-        // ---- repository (read / metrics + create) ---------------------------
-        "repository.status" => op!(
-            ops::repository::status::status,
-            ops::repository::status::RepositoryStatusArgs
-        ),
-        "repository.info" => op!(
-            ops::repository::info::info,
-            ops::repository::info::RepositoryInfoArgs
-        ),
-        "repository.list" => op!(ops::repository::list::list, ops::repository::list::ListArgs),
-        "repository.create" => op!(
-            ops::repository::create::create,
-            ops::repository::create::CreateArgs
-        ),
-        // Networked: connects to a remote lore server over QUIC/gRPC and clones
-        // into `--dir`. Added for the live-server spike (SBAI-4064).
-        "repository.clone" => op!(
-            ops::repository::clone::clone,
-            ops::repository::clone::CloneArgs
-        ),
-
-        // ---- revision -------------------------------------------------------
-        "revision.history" => op!(
-            ops::revision::history::history,
-            ops::revision::history::RevisionHistoryArgs
-        ),
-        "revision.diff" => op!(
-            ops::revision::diff::diff,
-            ops::revision::diff::RevisionDiffArgs
-        ),
-        "revision.info" => op!(
-            ops::revision::info::info,
-            ops::revision::info::RevisionInfoArgs
-        ),
-        "revision.find" => op!(
-            ops::revision::find::find,
-            ops::revision::find::RevisionFindArgs
-        ),
-        "revision.commit" => op!(
-            ops::revision::commit::commit,
-            ops::revision::commit::CommitArgs
-        ),
-        // Networked: pulls the latest revision for the current branch from the
-        // remote and syncs the working tree. Added for the live-server spike.
-        "revision.sync" => op!(
-            ops::revision::sync::sync,
-            ops::revision::sync::RevisionSyncArgs
-        ),
-
-        // ---- branch ---------------------------------------------------------
-        "branch.list" => op!(ops::branch::list::list, ops::branch::list::BranchListArgs),
-        "branch.info" => op!(ops::branch::info::info, ops::branch::info::BranchInfoArgs),
-        "branch.create" => op!(
-            ops::branch::create::create,
-            ops::branch::create::BranchCreateArgs
-        ),
-        "branch.switch" => op!(
-            ops::branch::switch::switch,
-            ops::branch::switch::BranchSwitchArgs
-        ),
-        // Networked: pushes the current/specified branch and its revisions to
-        // the remote. Added for the live-server spike (SBAI-4064).
-        "branch.push" => op!(ops::branch::push::push, ops::branch::push::BranchPushArgs),
-
-        // ---- auth -----------------------------------------------------------
-        // Non-interactive token login. Against a no-auth dev server this is a
-        // no-op, but it exercises the credential path. Added for the spike.
-        "auth.login_with_token" => op!(
-            ops::auth::login_with_token::login_with_token,
-            ops::auth::login_with_token::LoginWithTokenArgs
-        ),
-
-        // ---- file -----------------------------------------------------------
-        "file.stage" => op!(ops::file::stage::stage, ops::file::stage::FileStageArgs),
-        "file.unstage" => op!(
-            ops::file::unstage::unstage,
-            ops::file::unstage::FileUnstageArgs
-        ),
-        "file.info" => op!(ops::file::info::info, ops::file::info::FileInfoArgs),
-        "file.history" => op!(
-            ops::file::history::history,
-            ops::file::history::FileHistoryArgs
-        ),
-        "file.diff" => op!(ops::file::diff::diff, ops::file::diff::DiffArgs),
-
-        // ---- lock -----------------------------------------------------------
-        "lock.file_query" => op!(
-            ops::lock::file_query::file_query,
-            ops::lock::file_query::FileQueryArgs
-        ),
-        "lock.file_status" => op!(
-            ops::lock::file_status::file_status,
-            ops::lock::file_status::FileStatusArgs
-        ),
-        "lock.file_acquire" => op!(
-            ops::lock::file_acquire::file_acquire,
-            ops::lock::file_acquire::FileAcquireArgs
-        ),
-        "lock.file_acquire_as_owner" => op!(
-            ops::lock::file_acquire_as_owner::file_acquire_as_owner,
-            ops::lock::file_acquire_as_owner::FileAcquireAsOwnerArgs
-        ),
-        "lock.file_message_send" => op!(
-            ops::lock::file_message_send::file_message_send,
-            ops::lock::file_message_send::FileMessageSendArgs
-        ),
-        "lock.file_release" => op!(
-            ops::lock::file_release::file_release,
-            ops::lock::file_release::FileReleaseArgs
-        ),
-
-        unknown => Err(CliError::new(format!(
-            "unknown op `{unknown}`. Run `lorevm --list` to see supported ops."
-        ))),
-    }
 }
 
 #[tokio::main(flavor = "multi_thread")]
@@ -366,18 +183,28 @@ async fn main() -> ExitCode {
     };
 
     if cli.op_id == "__list__" {
-        for id in SUPPORTED_OPS {
+        for id in supported_ops() {
             println!("{id}");
         }
         return ExitCode::SUCCESS;
     }
 
     let api = build_api(&cli);
-    match dispatch(&cli, &api).await {
-        Ok(()) => ExitCode::SUCCESS,
-        Err(e) if e.0 == "__already_reported__" => ExitCode::FAILURE,
+    // The single shared seam: every external driver (this CLI, lorevm-ffi) routes
+    // `<domain>.<op>` through `lore_vm::dispatch`.
+    match dispatch(&api, &cli.op_id, cli.args).await {
+        Ok(value) => {
+            println!("{}", serde_json::to_string_pretty(&value).unwrap());
+            ExitCode::SUCCESS
+        }
         Err(e) => {
-            print_error_json("cli", &e.0);
+            // Structured op / dispatch error → {"error": {kind, message}}.
+            let v = serde_json::to_value(&e)
+                .unwrap_or_else(|_| json!({ "kind": "client", "message": e.to_string() }));
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&json!({ "error": v })).unwrap()
+            );
             ExitCode::FAILURE
         }
     }

--- a/crates/lorevm-ffi/Cargo.toml
+++ b/crates/lorevm-ffi/Cargo.toml
@@ -13,6 +13,12 @@ name = "lorevm_ffi"
 # rlib → so the in-tree Rust smoke test can call the extern "C" entry points.
 crate-type = ["cdylib", "rlib"]
 
+[features]
+# Compiles a magic `__ffi_panic_test__` op id into `run_call` that panics, so the
+# smoke test can prove the C-boundary `catch_unwind` guard turns a panic into a
+# JSON error rather than unwinding across the ABI. Never enabled in real builds.
+panic-test-hook = []
+
 [dependencies]
 lore-vm = { path = "../lore-vm" }
 serde = { workspace = true }
@@ -21,3 +27,5 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+# The smoke test exercises the panic guard via the magic op id above.
+lorevm-ffi = { path = ".", features = ["panic-test-hook"] }

--- a/crates/lorevm-ffi/src/lib.rs
+++ b/crates/lorevm-ffi/src/lib.rs
@@ -1,64 +1,99 @@
-//! `lorevm-ffi` — SPIKE (SBAI-4079).
+//! `lorevm-ffi` — the production C-ABI bridge over [`lore_vm`] (SBAI-4081).
 //!
-//! A minimal C-ABI surface over [`lore_vm`], proving that an Unreal Engine C++
-//! plugin (or any C/C++ host) can drive our lore binding **in-process** over a
-//! stable C ABI, instead of shelling out to the `lorevm --json` subprocess that
-//! `lore-mcp` uses today.
+//! A stable C ABI over our lore binding, so an Unreal Engine C++ plugin (or any
+//! C/C++ host) can drive lore **in-process** over FFI instead of shelling out to
+//! the `lorevm --json` subprocess that `lore-mcp` uses. It is one of the two
+//! deliberate **external-driver** consumers of the canonical
+//! [`lore_vm::dispatch`] seam (the other is the `lorevm` CLI). The GUI/Tauri app
+//! binds the same `lore-vm` ops **in-process** as typed commands and never goes
+//! through this bridge — see `CLAUDE.md` ("One binding, two consumption modes").
 //!
-//! This is a **feasibility proof, not a shipped artifact.** It exposes exactly
-//! one call entry point plus a matching free function, and wraps a *subset* of
-//! the same `lore_vm::ops` dispatch that `lorevm-cli/src/main.rs` exposes. The
-//! point is to validate the ABI shape, the JSON-in/JSON-out contract, the
-//! tokio-runtime-per-call lifetime, and the malloc/free ownership rules — NOT
-//! to be op-complete. A production bridge would factor the full dispatch match
-//! out of `lorevm-cli` into a shared `lore-vm` library fn and call it from both
-//! the CLI and here (see docs/ue-lorevm-bridge-spike.md).
+//! This crate no longer re-types any ops: every call routes through the single
+//! shared `lore_vm::dispatch`, so the FFI surface cannot drift from the CLI.
+//!
+//! # Design: a warm, long-lived handle
+//!
+//! The hot path (a UE Content Browser refreshing per-asset overlay state) calls
+//! often, so we do **not** spin a tokio runtime per call. Instead a host:
+//!
+//! 1. `lorevm_ffi_open(request_json)` once — builds **one** multi-thread tokio
+//!    runtime and **one** warm [`LoreApi`] for a working dir, returning an opaque
+//!    handle.
+//! 2. `lorevm_ffi_call(handle, op_id, args_json)` many times — reuses the warm
+//!    runtime + api; this is the cheap hot path.
+//! 3. `lorevm_ffi_close(handle)` once — tears down the runtime.
 //!
 //! # ABI contract
 //!
 //! ```c
-//! // op_id  : "<domain>.<op>"  (e.g. "repository.status"), UTF-8, NUL-terminated
-//! // request: JSON object, UTF-8, NUL-terminated. Shape:
-//! //          { "dir": "<path>", "args": {..}, "in_memory": bool,
-//! //            "offline": bool, "identity": "<id>"|null }
-//! // returns: malloc'd, NUL-terminated UTF-8 JSON string the caller OWNS and
-//! //          MUST release with lorevm_ffi_string_free(). On success it is the
-//! //          op's typed result; on failure it is {"error":{"kind","message"}}.
-//! //          Returns NULL only on a NUL/invalid-UTF-8 op_id or request pointer.
-//! char* lorevm_ffi_call(const char* op_id, const char* request);
-//! void  lorevm_ffi_string_free(char* s);
+//! typedef struct LorevmHandle LorevmHandle;
+//!
+//! // open: build a warm runtime + LoreApi for a repo.
+//! //   request: JSON { "dir": "<path>", "in_memory": bool, "offline": bool,
+//! //                   "identity": "<id>"|null }, UTF-8, NUL-terminated.
+//! //   returns: opaque handle, or NULL on a NUL/invalid-UTF-8 request or a
+//! //            runtime-build failure. Free with lorevm_ffi_close().
+//! LorevmHandle* lorevm_ffi_open(const char* request);
+//!
+//! // call: run one op on a warm handle. THE HOT PATH.
+//! //   op_id : "<domain>.<op>"  (e.g. "repository.status"), UTF-8, NUL-terminated.
+//! //   args  : JSON object deserialised into the op's Args, UTF-8, NUL-terminated.
+//! //   returns: malloc'd, NUL-terminated UTF-8 JSON the caller OWNS and MUST
+//! //            release with lorevm_ffi_string_free(). Success → the op's typed
+//! //            result; failure (op error, bad args, unknown op, or a caught
+//! //            panic) → {"error":{"kind","message"}}. NULL only on a
+//! //            NUL/invalid-UTF-8 handle/op_id/args pointer.
+//! char* lorevm_ffi_call(const LorevmHandle* handle, const char* op_id, const char* args);
+//!
+//! // close: tear down a handle from lorevm_ffi_open(). NULL-safe; never double-close.
+//! void lorevm_ffi_close(LorevmHandle* handle);
+//!
+//! void        lorevm_ffi_string_free(char* s);
 //! const char* lorevm_ffi_abi_version(void);  // static, do NOT free
 //! ```
 //!
-//! # Threading
+//! # Safety guarantees
 //!
-//! `lorevm_ffi_call` is self-contained: it builds a fresh multi-thread tokio
-//! runtime, runs the op to completion, and tears the runtime down before
-//! returning. It blocks the calling thread for the op's duration, so a UE host
-//! MUST call it from a background thread (e.g. an `AsyncTask`), never the game
-//! thread, for anything that can block on I/O or the network. A production
-//! bridge would hold one long-lived runtime + `LoreApi` behind an opaque handle
-//! rather than spinning a runtime per call; this spike keeps it stateless to
-//! stay minimal.
+//! - **No panic unwinds across the ABI.** Every `extern "C"` entry that runs Rust
+//!   logic wraps it in [`std::panic::catch_unwind`]; a panic in lore or its QUIC
+//!   stack becomes an `{"error":{"kind":"panic",…}}` JSON response (or NULL where
+//!   no response buffer can be returned), never UB.
+//! - **String ownership.** Strings cross the ABI malloc'd by Rust via
+//!   `CString::into_raw` and MUST be freed by [`lorevm_ffi_string_free`] (which
+//!   calls `CString::from_raw`), never by C `free`.
+//! - **Threading.** `lorevm_ffi_call` blocks the calling thread for the op's
+//!   duration (it `block_on`s the op on the handle's runtime). A UE host MUST call
+//!   it from a background thread, never the game thread. The handle is `Send` +
+//!   `Sync` and the warm `LoreApi` is cheap to clone, so concurrent calls on one
+//!   handle are sound (each enters the shared runtime).
 
 use std::ffi::{c_char, CStr, CString};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
-use lore_vm::api::LoreApi;
 use lore_vm::global::LoreGlobal;
-use lore_vm::ops;
+use lore_vm::LoreApi;
 use serde::Deserialize;
 use serde_json::{json, Value};
+use tokio::runtime::Runtime;
 
 /// Bumped if the C ABI shape changes. Lets the UE plugin assert compatibility.
-const ABI_VERSION: &str = "lorevm-ffi/0\0";
+/// `1` introduces the warm-handle API (open/call/close) over the spike's `0`.
+const ABI_VERSION: &str = "lorevm-ffi/1\0";
 
-/// Deserialised `request` envelope.
+/// A warm, long-lived bridge handle: one tokio runtime + one [`LoreApi`].
+///
+/// Opaque to C. Created by [`lorevm_ffi_open`], used by [`lorevm_ffi_call`],
+/// destroyed by [`lorevm_ffi_close`].
+pub struct LorevmHandle {
+    runtime: Runtime,
+    api: LoreApi,
+}
+
+/// Deserialised `lorevm_ffi_open` request: how to build the warm [`LoreApi`].
 #[derive(Debug, Deserialize)]
-struct Request {
+struct OpenRequest {
     #[serde(default = "default_dir")]
     dir: String,
-    #[serde(default = "empty_obj")]
-    args: Value,
     #[serde(default)]
     in_memory: bool,
     #[serde(default)]
@@ -69,9 +104,6 @@ struct Request {
 
 fn default_dir() -> String {
     ".".to_string()
-}
-fn empty_obj() -> Value {
-    json!({})
 }
 
 /// Return the ABI version string (static, NUL-terminated, do NOT free).
@@ -96,118 +128,155 @@ pub unsafe extern "C" fn lorevm_ffi_string_free(s: *mut c_char) {
     }
 }
 
-/// Invoke `<domain>.<op>` with a JSON request; return a malloc'd JSON response.
+/// Open a warm bridge handle: build one tokio runtime + one [`LoreApi`].
+///
+/// Call once per repo working dir, then drive many ops through
+/// [`lorevm_ffi_call`] on the returned handle, and finally [`lorevm_ffi_close`].
+///
+/// # Safety
+/// `request` must be a valid, NUL-terminated, UTF-8 C string (or this returns
+/// NULL). The returned handle must be freed exactly once with
+/// [`lorevm_ffi_close`].
+#[no_mangle]
+pub unsafe extern "C" fn lorevm_ffi_open(request: *const c_char) -> *mut LorevmHandle {
+    if request.is_null() {
+        return std::ptr::null_mut();
+    }
+    let request_str = match CStr::from_ptr(request).to_str() {
+        Ok(s) => s.to_owned(),
+        Err(_) => return std::ptr::null_mut(),
+    };
+
+    // A panic while building the runtime/api must not cross the ABI.
+    let built = catch_unwind(AssertUnwindSafe(|| build_handle(&request_str)));
+    match built {
+        Ok(Some(handle)) => Box::into_raw(Box::new(handle)),
+        // None: bad request JSON or runtime build failure. Ok(None) and a caught
+        // panic both surface as NULL — open has no response buffer to return an
+        // error through; the contract documents NULL as "could not open".
+        Ok(None) | Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Build a warm handle from an open-request JSON string. `None` on bad JSON or a
+/// runtime-build failure.
+fn build_handle(request_str: &str) -> Option<LorevmHandle> {
+    let req: OpenRequest = serde_json::from_str(request_str).ok()?;
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .ok()?;
+    let mut global = LoreGlobal::new(std::path::PathBuf::from(&req.dir))
+        .in_memory(req.in_memory)
+        .offline(req.offline);
+    if let Some(id) = &req.identity {
+        global = global.identity(id.clone());
+    }
+    let api = LoreApi::from_global(global);
+    Some(LorevmHandle { runtime, api })
+}
+
+/// Invoke `<domain>.<op>` with JSON args on a warm `handle`; return a malloc'd
+/// JSON response. **The hot path** — reuses the handle's runtime + warm api.
 ///
 /// See the module-level docs for the full ABI contract.
 ///
 /// # Safety
-/// `op_id` and `request` must be valid, NUL-terminated, UTF-8 C strings (or the
+/// `handle` must be a live pointer from [`lorevm_ffi_open`] (not yet closed).
+/// `op_id` and `args` must be valid, NUL-terminated, UTF-8 C strings (or the
 /// call returns NULL). The returned pointer must be released exactly once with
 /// [`lorevm_ffi_string_free`].
 #[no_mangle]
 pub unsafe extern "C" fn lorevm_ffi_call(
+    handle: *const LorevmHandle,
     op_id: *const c_char,
-    request: *const c_char,
+    args: *const c_char,
 ) -> *mut c_char {
-    // ---- decode the two C strings ------------------------------------------
-    if op_id.is_null() || request.is_null() {
+    // ---- decode the inputs -------------------------------------------------
+    if handle.is_null() || op_id.is_null() || args.is_null() {
         return std::ptr::null_mut();
     }
     let op_id = match CStr::from_ptr(op_id).to_str() {
         Ok(s) => s.to_owned(),
         Err(_) => return std::ptr::null_mut(),
     };
-    let request_str = match CStr::from_ptr(request).to_str() {
+    let args_str = match CStr::from_ptr(args).to_str() {
         Ok(s) => s.to_owned(),
         Err(_) => return std::ptr::null_mut(),
     };
+    let handle: &LorevmHandle = &*handle;
 
-    // From here on, every failure is reported as JSON, never NULL.
-    let req: Request = match serde_json::from_str(&request_str) {
-        Ok(r) => r,
-        Err(e) => return respond(&error_json("ffi", &format!("invalid request JSON: {e}"))),
-    };
-
-    // ---- build a fresh runtime + API and run the op ------------------------
-    // Stateless per-call: minimal for a spike. A real bridge keeps these alive.
-    let runtime = match tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(e) => return respond(&error_json("ffi", &format!("failed to start runtime: {e}"))),
-    };
-
-    let response = runtime.block_on(async move {
-        let mut global = LoreGlobal::new(std::path::PathBuf::from(&req.dir))
-            .in_memory(req.in_memory)
-            .offline(req.offline);
-        if let Some(id) = &req.identity {
-            global = global.identity(id.clone());
-        }
-        let api = LoreApi::from_global(global);
-        dispatch(&op_id, &api, req.args).await
-    });
+    // ---- run the op, guarded against panics --------------------------------
+    // From here every failure (bad args JSON, op error, unknown op, or a panic)
+    // is reported as a JSON value, never NULL. catch_unwind stops a Rust panic
+    // (e.g. from the pre-1.0 lore/QUIC stack) from unwinding across the C ABI.
+    let response = catch_unwind(AssertUnwindSafe(|| run_call(handle, &op_id, &args_str)))
+        .unwrap_or_else(|payload| error_json("panic", &panic_message(payload.as_ref())));
 
     respond(&response)
 }
 
-/// Dispatch a `<domain>.<op>` id to the matching `lore_vm::ops` fn and return
-/// its result (or a structured error) as a JSON `Value`.
-///
-/// SPIKE SCOPE: this mirrors `lorevm-cli`'s dispatch but only wires a
-/// representative subset of ops — enough to prove a read op, a metrics op, and
-/// a mutating op all cross the ABI. The full op set is intentionally omitted;
-/// the production design factors the CLI's complete match into a shared fn.
-async fn dispatch(op_id: &str, api: &LoreApi, args: Value) -> Value {
-    macro_rules! op {
-        ($path:path, $args:ty) => {{
-            let parsed: $args = match serde_json::from_value(args.clone()) {
-                Ok(p) => p,
-                Err(e) => {
-                    return error_json(
-                        "ffi",
-                        &format!("could not parse args for `{op_id}`: {e}"),
-                    )
-                }
-            };
-            match $path(api, parsed).await {
-                Ok(result) => {
-                    serde_json::to_value(&result).unwrap_or_else(|e| {
-                        error_json("ffi", &format!("failed to serialise result: {e}"))
-                    })
-                }
-                Err(e) => {
-                    let v = serde_json::to_value(&e).unwrap_or_else(|_| {
-                        json!({ "kind": "client", "message": e.to_string() })
-                    });
-                    json!({ "error": v })
-                }
-            }
-        }};
+/// Parse `args`, route through the canonical [`lore_vm::dispatch`] on the
+/// handle's warm runtime, and return the op's result (or a structured error) as
+/// a JSON `Value`.
+fn run_call(handle: &LorevmHandle, op_id: &str, args_str: &str) -> Value {
+    // Test-only hook: a magic op id that panics, so the smoke test can prove the
+    // `catch_unwind` guard in `lorevm_ffi_call` turns a panic into a JSON error
+    // instead of unwinding across the C ABI. Compiled out of normal builds.
+    #[cfg(feature = "panic-test-hook")]
+    if op_id == "__ffi_panic_test__" {
+        panic!("induced panic for FFI catch_unwind test");
     }
 
-    match op_id {
-        "repository.status" => op!(
-            ops::repository::status::status,
-            ops::repository::status::RepositoryStatusArgs
-        ),
-        "repository.info" => op!(
-            ops::repository::info::info,
-            ops::repository::info::RepositoryInfoArgs
-        ),
-        "repository.create" => op!(
-            ops::repository::create::create,
-            ops::repository::create::CreateArgs
-        ),
-        "branch.list" => op!(ops::branch::list::list, ops::branch::list::BranchListArgs),
-        unknown => error_json(
-            "ffi",
-            &format!(
-                "unknown or unwired op `{unknown}` (spike wires a subset; \
-                 production bridge shares lorevm-cli's full dispatch)"
-            ),
-        ),
+    let args: Value = match serde_json::from_str(args_str) {
+        Ok(v) => v,
+        Err(e) => return error_json("ffi", &format!("invalid args JSON: {e}")),
+    };
+
+    // Block on the handle's long-lived runtime — no per-call runtime spin-up.
+    let result = handle
+        .runtime
+        .block_on(lore_vm::dispatch(&handle.api, op_id, args));
+
+    match result {
+        Ok(value) => value,
+        Err(e) => {
+            // Structured LoreError → {"error":{kind,message}}.
+            let v = serde_json::to_value(&e)
+                .unwrap_or_else(|_| json!({ "kind": "client", "message": e.to_string() }));
+            json!({ "error": v })
+        }
+    }
+}
+
+/// Close a handle from [`lorevm_ffi_open`], tearing down its runtime.
+///
+/// NULL-safe. Must be called exactly once per successful `open`; never call it
+/// twice on the same handle.
+///
+/// # Safety
+/// `handle` must be a pointer returned by [`lorevm_ffi_open`] (or NULL) that has
+/// not already been closed.
+#[no_mangle]
+pub unsafe extern "C" fn lorevm_ffi_close(handle: *mut LorevmHandle) {
+    if handle.is_null() {
+        return;
+    }
+    // Reclaim the Box and drop it (and its runtime). Guard the drop: a panic in
+    // runtime teardown must not cross the ABI.
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        drop(Box::from_raw(handle));
+    }));
+}
+
+/// Best-effort extraction of a panic payload's message.
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "panic in lore-vm op (payload not a string)".to_string()
     }
 }
 

--- a/crates/lorevm-ffi/tests/smoke.rs
+++ b/crates/lorevm-ffi/tests/smoke.rs
@@ -1,24 +1,37 @@
-//! SPIKE smoke test (SBAI-4079).
+//! Smoke test for the production C-ABI bridge (SBAI-4081).
 //!
 //! Calls the `extern "C"` entry points exactly as a C/C++ host (the UE plugin)
-//! would — passing C strings in and freeing the returned C string — to prove
-//! lore-vm can be driven over the C ABI. We drive a real in-memory lore engine
-//! (`in_memory + offline`, the same headless mode the integration harness uses)
-//! so the roundtrip exercises the actual ops layer, not a stub.
+//! would — `CString` in, free the returned C string — to prove lore-vm can be
+//! driven over the C ABI through the warm-handle lifecycle. We drive a real
+//! in-memory lore engine (`in_memory + offline`, the same headless mode the
+//! integration harness uses), so the roundtrip exercises the real ops layer via
+//! `lore_vm::dispatch`, not a stub.
 
 use std::ffi::{c_char, CStr, CString};
 
-use lorevm_ffi::{lorevm_ffi_abi_version, lorevm_ffi_call, lorevm_ffi_string_free};
+use lorevm_ffi::{
+    lorevm_ffi_abi_version, lorevm_ffi_call, lorevm_ffi_close, lorevm_ffi_open,
+    lorevm_ffi_string_free, LorevmHandle,
+};
 use serde_json::Value;
 
-/// Call across the ABI the way C would, returning the parsed JSON response.
-fn call(op_id: &str, request: &Value) -> Value {
-    let op_c = CString::new(op_id).unwrap();
+/// Open a warm handle for a repo working dir. Caller closes it.
+fn open(request: &Value) -> *mut LorevmHandle {
     let req_c = CString::new(request.to_string()).unwrap();
-    // SAFETY: both pointers are valid NUL-terminated UTF-8 for the call's
-    // duration; we free the result exactly once below.
+    // SAFETY: a valid NUL-terminated UTF-8 request string.
+    let h = unsafe { lorevm_ffi_open(req_c.as_ptr()) };
+    assert!(!h.is_null(), "lorevm_ffi_open returned NULL for {request}");
+    h
+}
+
+/// Call one op on a warm handle, returning the parsed JSON response.
+fn call(handle: *const LorevmHandle, op_id: &str, args: &Value) -> Value {
+    let op_c = CString::new(op_id).unwrap();
+    let args_c = CString::new(args.to_string()).unwrap();
+    // SAFETY: handle is live; both string pointers are valid NUL-terminated
+    // UTF-8 for the call's duration; we free the result exactly once below.
     unsafe {
-        let out: *mut c_char = lorevm_ffi_call(op_c.as_ptr(), req_c.as_ptr());
+        let out: *mut c_char = lorevm_ffi_call(handle, op_c.as_ptr(), args_c.as_ptr());
         assert!(!out.is_null(), "ffi call returned NULL for `{op_id}`");
         let text = CStr::from_ptr(out).to_str().unwrap().to_owned();
         lorevm_ffi_string_free(out);
@@ -36,55 +49,88 @@ fn abi_version_is_exposed() {
 }
 
 #[test]
-fn create_then_status_roundtrips_over_the_c_abi() {
+fn warm_handle_create_then_status_then_status_roundtrips() {
     let tmp = tempfile::tempdir().unwrap();
     let dir = tmp.path().to_string_lossy().to_string();
     // In-memory mode keeps stores in a process-wide cache that persists across
-    // sequential library calls, so create-then-status round-trips with no server
-    // and no on-disk store — mirroring lore-vm's integration_roundtrip harness.
-    let repo_url = format!("lore://localhost/spike-{}", std::process::id());
+    // sequential calls on the SAME warm handle, so create-then-status round-trips
+    // with no server and no on-disk store — mirroring the integration harness.
+    let repo_url = format!("lore://localhost/ffi-{}", std::process::id());
 
-    // 1. Mutating op across the ABI: create an in-memory repo.
+    // 1. Open ONE warm handle (one runtime + one LoreApi).
+    let handle = open(&serde_json::json!({
+        "dir": dir,
+        "in_memory": true,
+        "offline": true,
+        "identity": "ffi-smoke",
+    }));
+
+    // 2. Mutating op across the ABI on the warm handle.
     let created = call(
+        handle,
         "repository.create",
-        &serde_json::json!({
-            "dir": dir,
-            "in_memory": true,
-            "offline": true,
-            "identity": "spike-ffi",
-            "args": { "repository_url": repo_url }
-        }),
+        &serde_json::json!({ "repository_url": repo_url }),
     );
     assert!(
         created.get("error").is_none(),
         "repository.create errored over FFI: {created}"
     );
 
-    // 2. Read op across the ABI against the same in-memory engine.
-    let status = call(
-        "repository.status",
-        &serde_json::json!({
-            "dir": dir,
-            "in_memory": true,
-            "offline": true,
-            "identity": "spike-ffi",
-            "args": {}
-        }),
-    );
+    // 3. Two read ops REUSING the same warm handle — the hot path. Both must hit
+    //    the same warm in-memory engine the create populated.
+    let status1 = call(handle, "repository.status", &serde_json::json!({}));
     assert!(
-        status.get("error").is_none(),
-        "repository.status errored over FFI: {status}"
+        status1.get("error").is_none() && status1.is_object(),
+        "first repository.status errored/!object over FFI: {status1}"
     );
-    // A successful status result is a JSON object (the typed RepoStatus shape).
-    assert!(status.is_object(), "status was not a JSON object: {status}");
+    let status2 = call(handle, "repository.status", &serde_json::json!({}));
+    assert!(
+        status2.get("error").is_none() && status2.is_object(),
+        "second repository.status errored/!object over FFI: {status2}"
+    );
+
+    // 4. Close the warm handle.
+    // SAFETY: handle came from lorevm_ffi_open and is closed exactly once.
+    unsafe { lorevm_ffi_close(handle) };
 }
 
 #[test]
 fn unknown_op_returns_structured_error_not_null() {
-    let resp = call("nope.nope", &serde_json::json!({ "dir": ".", "args": {} }));
+    let handle = open(&serde_json::json!({ "dir": ".", "offline": true }));
+    let resp = call(handle, "nope.nope", &serde_json::json!({}));
     let kind = resp
         .pointer("/error/kind")
         .and_then(Value::as_str)
         .expect("expected {error:{kind}} shape");
-    assert_eq!(kind, "ffi");
+    // Unknown ops are caught by lore_vm::dispatch and surface as a LoreError::Parse,
+    // whose serde tag is the variant name "Parse".
+    assert_eq!(kind, "Parse");
+    // SAFETY: closed exactly once.
+    unsafe { lorevm_ffi_close(handle) };
+}
+
+#[test]
+fn a_panic_in_an_op_becomes_a_json_error_not_a_crash() {
+    // The `panic-test-hook` feature (enabled for this dev build) compiles a magic
+    // op id that panics inside `run_call`. The `catch_unwind` guard in
+    // `lorevm_ffi_call` must turn that into an `{"error":{"kind":"panic"}}` JSON
+    // response instead of letting the panic unwind across the C ABI (UB).
+    let handle = open(&serde_json::json!({ "dir": ".", "offline": true }));
+    let resp = call(handle, "__ffi_panic_test__", &serde_json::json!({}));
+    let kind = resp
+        .pointer("/error/kind")
+        .and_then(Value::as_str)
+        .expect("expected {error:{kind}} shape after a guarded panic");
+    assert_eq!(
+        kind, "panic",
+        "panic was not converted to a JSON error: {resp}"
+    );
+    // SAFETY: closed exactly once.
+    unsafe { lorevm_ffi_close(handle) };
+}
+
+#[test]
+fn close_is_null_safe() {
+    // SAFETY: NULL is explicitly allowed and is a no-op.
+    unsafe { lorevm_ffi_close(std::ptr::null_mut()) };
 }

--- a/docs/ue-lorevm-bridge-spike.md
+++ b/docs/ue-lorevm-bridge-spike.md
@@ -4,6 +4,18 @@
 **Branch:** `spike/ue-lorevm-bridge`
 **Status:** complete. FFI feasibility proof builds and its smoke call passes.
 
+> **Update (SBAI-4081):** the two prerequisites this doc calls out — §2's "lift
+> the dispatch into `lore-vm`" and §5's spike shortcuts (per-call runtime,
+> re-typed ops, no `catch_unwind`) — are now **done**. The dispatch lives in
+> `crates/lore-vm/src/dispatch.rs` as `lore_vm::dispatch(&api, op_id, args)` +
+> `lore_vm::supported_ops()`; both `lorevm-cli` and `lorevm-ffi` call it (no
+> re-typed match). `crates/lorevm-ffi` is now the **production bridge**, not a
+> spike: a warm-handle API (`lorevm_ffi_open` → `lorevm_ffi_call` × N →
+> `lorevm_ffi_close`) holding one long-lived runtime + warm `LoreApi`, with a
+> `catch_unwind` guard at the C boundary. The "Cons / shortcuts" paragraphs below
+> are kept for the historical record of the spike; see the ABI block in
+> `crates/lorevm-ffi/src/lib.rs` for the current contract.
+
 ---
 
 ## 1. Problem


### PR DESCRIPTION
Canonical lore_vm::dispatch (28 ops) — lorevm-cli + lorevm-ffi both ride it (no re-typed drift). Warm-handle FFI (open/call/close, one runtime + warm LoreApi) + catch_unwind at the C boundary. CLAUDE.md clarifies in-process GUI vs external-driver (CLI/FFI) surfaces. 703+3+5 tests green.