### PR TITLE
feat(relay): cross-network advertised-URL seam (premium impl in loregui-cloud) (SBAI-4072)

### DIFF
--- a/frontend/scripts/palette-parity-allowlist.json
+++ b/frontend/scripts/palette-parity-allowlist.json
@@ -17,7 +17,9 @@
     "set_autostart",
     "set_close_to_tray",
     "read_license_file",
-    "host_server_render_config"
+    "host_server_render_config",
+    "host_server_set_advertised_url",
+    "host_server_clear_advertised_url"
   ],
   "deferred": []
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -327,6 +327,14 @@ export interface HostStatus {
   url?: string;
   configPath?: string;
   storeDir?: string;
+  /**
+   * An externally-registered, publicly-reachable URL that supersedes {@link url}
+   * for display (SBAI-4072). Set by the proprietary cross-network *relay*
+   * overlay via {@link api.hostServerSetAdvertisedUrl}; absent in the open core.
+   * When present, the host UI shows this to clients instead of the loopback
+   * `url`. The open core knows nothing about how it is produced.
+   */
+  advertisedUrl?: string;
 }
 
 export const api = {
@@ -414,6 +422,23 @@ export const api = {
     invoke<string>("host_server_render_config", { opts }),
   hostServerStop: () => invoke<HostStatus>("host_server_stop"),
   hostServerStatus: () => invoke<HostStatus>("host_server_status"),
+
+  // --- advertised-URL seam for the cross-network relay overlay (SBAI-4072) ---
+  // Generic open-core hooks: a premium relay overlay opens a tunnel to the
+  // hosted loreserver and registers the resulting public URL here, which
+  // `hostServerStatus` then surfaces as `advertisedUrl`. The open core ships
+  // these wrappers but never calls them (no relay UI in core).
+  /**
+   * Register a publicly-reachable URL for the hosted server (SBAI-4072). A blank
+   * string clears it. Surfaced by `hostServerStatus` as `advertisedUrl` while
+   * the server is running. The core stores the string verbatim — it has no
+   * knowledge of tunnels/bore.
+   */
+  hostServerSetAdvertisedUrl: (url: string) =>
+    invoke<void>("host_server_set_advertised_url", { url }),
+  /** Clear any advertised-URL override (SBAI-4072). */
+  hostServerClearAdvertisedUrl: () =>
+    invoke<void>("host_server_clear_advertised_url"),
 
   // --- system tray live status (SBAI-4042) ---
   traySyncState: (snapshot: TraySnapshot) =>

--- a/frontend/src/commercial/entitlement.ts
+++ b/frontend/src/commercial/entitlement.ts
@@ -54,20 +54,22 @@
 import { resolveLicensedFeatures } from "./license";
 
 /** A gateable premium feature id. Keep in sync with TIER_FEATURES below. */
-export type Feature = "reporting";
+export type Feature = "reporting" | "relay";
 
 /** Commercial tiers, as issued in the StudioBrain accounts JWT `tier` claim. */
 export type Tier = "free" | "team" | "enterprise";
 
 /**
  * The feature set unlocked by each tier. Reporting & Insights (SBAI-4061) is a
- * Team-and-up add-on. Adjust here when packaging changes — call sites are
- * unaffected.
+ * Team-and-up add-on; the cross-network Relay (SBAI-4072) — host a lore server
+ * reachable across networks with no VPN, via the StudioBrain bore relay — is an
+ * Enterprise add-on (it consumes shared relay infrastructure). Adjust here when
+ * packaging changes — call sites are unaffected.
  */
 export const TIER_FEATURES: Record<Tier, readonly Feature[]> = {
   free: [],
   team: ["reporting"],
-  enterprise: ["reporting"],
+  enterprise: ["reporting", "relay"],
 };
 
 /** Resolve a tier name to its feature ids (unknown tier → no features). */

--- a/frontend/src/commercial/relay-registry.ts
+++ b/frontend/src/commercial/relay-registry.ts
@@ -1,0 +1,90 @@
+import type { ComponentType } from "react";
+import type { Feature } from "./entitlement";
+import type { HostStatus } from "../api";
+
+/**
+ * Cross-network relay seam — the open-core hook a premium overlay uses to add a
+ * "Make reachable across networks (relay)" control to the Host-a-server flow
+ * (SBAI-4072).
+ *
+ * LoreGUI is open core (MIT). It hosts a `loreserver` on `127.0.0.1` only
+ * (SBAI-4065) — reachable on the LAN at best. Making that server reachable
+ * across networks with NO VPN (via the StudioBrain *bore* relay) is a PREMIUM,
+ * PROPRIETARY capability that lives in the `loregui-cloud` overlay. To keep the
+ * open core free of any relay/tunnel logic while still letting a commercial
+ * build slot the control in, the core ships only this tiny registry plus the
+ * generic advertised-URL hooks on {@link api} (`hostServerSetAdvertisedUrl` /
+ * `hostServerClearAdvertisedUrl`).
+ *
+ * This mirrors {@link import("./premium-registry")} exactly, but for a control
+ * *embedded inside the host flow* rather than a standalone nav panel: the relay
+ * toggle only makes sense next to a running hosted server, so it renders within
+ * `ServiceSetup`, not the top-bar nav.
+ *
+ * The open core registers nothing here, so {@link getRelayControl} returns
+ * `null` and `ServiceSetup` renders zero relay UI. A commercial build's overlay
+ * entry imports the relay module, which calls {@link registerRelayControl} at
+ * import time. The control is still gated: `ServiceSetup` only mounts it when
+ * `isEntitled(control.feature)` (`"relay"`) is true, otherwise it shows a locked
+ * upsell affordance.
+ *
+ * Dependency-light (just React's `ComponentType` + the `Feature` id + the
+ * `HostStatus` shape) so the overlay can register synchronously at module load.
+ */
+
+/** Props the host flow passes to a registered relay control. */
+export interface RelayControlProps {
+  /**
+   * Live status of the hosted `loreserver`. The control reads `port` (the
+   * local QUIC/gRPC port to tunnel) and `running`; it must render inert /
+   * disabled when the server is not running.
+   */
+  status: HostStatus;
+  /**
+   * Ask the host flow to re-fetch `host_server_status` so a freshly-registered
+   * `advertisedUrl` (the public relay URL) is reflected in the UI. The control
+   * calls this after it opens or closes a tunnel.
+   */
+  onAdvertisedUrlChange: () => void;
+}
+
+/** A relay control contributed by a commercial overlay. */
+export interface RelayControl {
+  /** Stable id, e.g. "relay". */
+  id: string;
+  /** The entitlement feature this control is gated behind (e.g. "relay"). */
+  feature: Feature;
+  /** Short label for the locked-upsell affordance, e.g. "Cross-network relay". */
+  label: string;
+  /** The control component, mounted inside the host flow when entitled. */
+  component: ComponentType<RelayControlProps>;
+}
+
+/** At most one relay control; a re-register (HMR / double import) replaces it. */
+let registered: RelayControl | null = null;
+
+/**
+ * Register the cross-network relay control. Called at import time by the
+ * commercial overlay's relay module
+ * (`loregui-cloud/frontend-overlay/relay/index.ts`). Idempotent.
+ *
+ * No-op in the open core: nothing imports a module that calls this, so the
+ * registry stays empty and no relay UI renders.
+ */
+export function registerRelayControl(control: RelayControl): void {
+  registered = control;
+}
+
+/**
+ * The registered relay control, or `null` in the open core. `ServiceSetup`
+ * gates this by `isEntitled(control.feature)` to decide whether to mount it or
+ * show a locked upsell; an open-core build gets `null` and renders neither.
+ */
+export function getRelayControl(): RelayControl | null {
+  return registered;
+}
+
+/** @internal — for tests only. Clear the registry. */
+export function __resetRelayRegistryForTests(): void {
+  registered = null;
+}

--- a/frontend/src/onboarding/server/ServiceSetup.tsx
+++ b/frontend/src/onboarding/server/ServiceSetup.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { api } from "../../api";
 import type { HostAdvancedOptions, HostStatus } from "../../api";
 import AdvancedServerConfig from "./AdvancedServerConfig";
+import { isEntitled } from "../../commercial/entitlement";
+import { getRelayControl } from "../../commercial/relay-registry";
 
 type Step = "idle" | "starting" | "running" | "stopping" | "error";
 type Mode = "basic" | "expert";
@@ -40,6 +42,13 @@ export default function ServiceSetup({
   const [mode, setMode] = useState<Mode>("basic");
   const [bindHost, setBindHost] = useState("");
   const [advanced, setAdvanced] = useState<HostAdvancedOptions>({});
+
+  // Cross-network relay control (SBAI-4072). The open core registers nothing, so
+  // `relayControl` is null and no relay UI renders. A commercial build's overlay
+  // registers a control here; it is only mounted when the studio is entitled to
+  // the "relay" feature (otherwise a locked upsell shows).
+  const relayControl = useMemo(() => getRelayControl(), []);
+  const relayEntitled = relayControl ? isEntitled(relayControl.feature) : false;
 
   // "View generated config" preview state.
   const [previewOpen, setPreviewOpen] = useState(false);
@@ -139,16 +148,32 @@ export default function ServiceSetup({
     }
   }, [storeDir, buildOptions]);
 
-  const handleCopy = useCallback(async () => {
-    if (!status?.url) return;
+  // The URL we show clients: the relay's public `advertisedUrl` when a tunnel is
+  // open (SBAI-4072), otherwise the real loopback `url`. The relay overlay sets
+  // `advertisedUrl` through the core seam; with no relay it is always undefined.
+  const displayUrl = status?.advertisedUrl ?? status?.url ?? "";
+
+  // Re-fetch host status so a freshly-registered (or cleared) advertised URL is
+  // reflected. Passed to the relay control so it can refresh after open/stop.
+  const refreshStatus = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(status.url);
+      const s = await api.hostServerStatus();
+      if (s.running) setStatus(s);
+    } catch {
+      /* best-effort; ignore */
+    }
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    if (!displayUrl) return;
+    try {
+      await navigator.clipboard.writeText(displayUrl);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
       /* clipboard may be unavailable; ignore */
     }
-  }, [status]);
+  }, [displayUrl]);
 
   const editing = step === "idle" || step === "starting" || step === "error";
   const inputsDisabled = step === "starting";
@@ -295,9 +320,12 @@ export default function ServiceSetup({
             <span>Server is hosting</span>
           </div>
           <div className="onboarding-field">
-            <label htmlFor="host-url">Connection URL (give this to clients)</label>
+            <label htmlFor="host-url">
+              Connection URL (give this to clients)
+              {status.advertisedUrl ? " — reachable across networks" : ""}
+            </label>
             <div className="onboarding-url-row">
-              <input id="host-url" type="text" readOnly value={status.url ?? ""} />
+              <input id="host-url" type="text" readOnly value={displayUrl} />
               <button className="onboarding-button" onClick={() => void handleCopy()}>
                 {copied ? "Copied" : "Copy"}
               </button>
@@ -308,6 +336,25 @@ export default function ServiceSetup({
               open. Use <strong>Stop Hosting</strong> below to shut it down.
             </p>
           </div>
+
+          {/* Cross-network relay (SBAI-4072). Premium + proprietary: present
+              only when the loregui-cloud overlay registered a relay control. The
+              open core registers nothing, so this whole block is absent. */}
+          {relayControl &&
+            (relayEntitled ? (
+              <relayControl.component
+                status={status}
+                onAdvertisedUrlChange={() => void refreshStatus()}
+              />
+            ) : (
+              <div className="onboarding-field">
+                <p className="onboarding-field-hint">
+                  <strong>{relayControl.label}</strong> — make this server
+                  reachable across networks with no VPN. Premium add-on (locked).
+                </p>
+              </div>
+            ))}
+
           <button
             className="onboarding-button onboarding-button--danger"
             onClick={() => void handleStop()}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -38,6 +38,14 @@ pub struct AppState {
     pub(crate) storage_session: Mutex<StorageSession>,
     /// The `loreserver` process the "Host a server" flow launched, if any.
     pub(crate) hosted_server: Mutex<Option<crate::server_host::HostedServer>>,
+    /// An externally-supplied "advertised URL" override for the hosted server
+    /// (SBAI-4072). The open core hosts on `127.0.0.1` only; this slot lets an
+    /// external module (e.g. the proprietary cross-network *relay* overlay)
+    /// register a publicly-reachable URL that the host UI displays *instead of*
+    /// the loopback `url` — without the core knowing anything about how that URL
+    /// is produced (no tunnel/bore logic lives here). `None` = no override, so
+    /// the UI shows the real loopback URL. Cleared on stop.
+    pub(crate) advertised_url: Mutex<Option<String>>,
 }
 
 impl AppState {
@@ -2052,17 +2060,69 @@ pub fn host_server_render_config(opts: HostServerOptions) -> Result<String, Lore
 }
 
 /// Stop the hosted `loreserver` (kill + reap). Idempotent.
+///
+/// Also clears any externally-registered advertised-URL override (SBAI-4072):
+/// once the server is down, a stale public URL would point clients at nothing,
+/// and the relay overlay tears its own tunnel down on stop. The core owns this
+/// lifecycle invariant so the override can never outlive the server.
 #[tauri::command]
 pub fn host_server_stop(state: State<'_, AppState>) -> Result<HostStatus, LoreError> {
     let mut slot = state.hosted_server.lock().unwrap();
-    server_host::stop(&mut slot)
+    let status = server_host::stop(&mut slot)?;
+    *state.advertised_url.lock().unwrap() = None;
+    Ok(status)
 }
 
 /// Current hosted-server status (running? + URL/port/pid). Reaps if it died.
+///
+/// Overlays any externally-registered advertised URL (SBAI-4072) onto the
+/// returned status' `advertisedUrl` field. The real loopback `url` is always
+/// preserved; the override is purely additive display metadata. If the server is
+/// not running, no override is surfaced (and any stale one is dropped).
 #[tauri::command]
 pub fn host_server_status(state: State<'_, AppState>) -> Result<HostStatus, LoreError> {
     let mut slot = state.hosted_server.lock().unwrap();
-    Ok(server_host::status(&mut slot))
+    let status = server_host::status(&mut slot);
+    if !status.running {
+        // Server is down — a stale advertised URL is meaningless; drop it.
+        *state.advertised_url.lock().unwrap() = None;
+        return Ok(status);
+    }
+    let advertised = state.advertised_url.lock().unwrap().clone();
+    Ok(status.with_advertised_url(advertised.as_deref()))
+}
+
+/// Register an externally-supplied "advertised URL" for the hosted server
+/// (SBAI-4072) — the open-core seam that lets a premium cross-network *relay*
+/// overlay surface a publicly-reachable URL in the host UI.
+///
+/// This is deliberately generic: the core stores the string and echoes it back
+/// through [`host_server_status`]. It contains NO tunnel/bore/relay logic — how
+/// the URL is produced is entirely the caller's concern. A blank string clears
+/// the override (equivalent to [`host_server_clear_advertised_url`]). Setting it
+/// while no server is running is allowed but inert: `host_server_status` only
+/// surfaces the override while the server is up.
+#[tauri::command]
+pub fn host_server_set_advertised_url(
+    state: State<'_, AppState>,
+    url: String,
+) -> Result<(), LoreError> {
+    let trimmed = url.trim();
+    *state.advertised_url.lock().unwrap() = if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    };
+    Ok(())
+}
+
+/// Clear any externally-registered advertised-URL override (SBAI-4072). After
+/// this, `host_server_status` reports only the real loopback `url`. The relay
+/// overlay calls this when it tears its tunnel down.
+#[tauri::command]
+pub fn host_server_clear_advertised_url(state: State<'_, AppState>) -> Result<(), LoreError> {
+    *state.advertised_url.lock().unwrap() = None;
+    Ok(())
 }
 
 // --- auth logout + clear (ops-layer) ---

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -62,6 +62,7 @@ pub fn run() {
             subscriptions: Mutex::new(HashSet::new()),
             storage_session: Mutex::new(commands::StorageSession::default()),
             hosted_server: Mutex::new(None),
+            advertised_url: Mutex::new(None),
         })
         .invoke_handler(tauri::generate_handler![
             commands::open_repository,
@@ -166,6 +167,8 @@ pub fn run() {
             commands::host_server_render_config,
             commands::host_server_stop,
             commands::host_server_status,
+            commands::host_server_set_advertised_url,
+            commands::host_server_clear_advertised_url,
             commands::repository_info,
             commands::repository_release,
             commands::repository_config_get,

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -466,6 +466,14 @@ pub struct HostStatus {
     pub url: Option<String>,
     pub config_path: Option<String>,
     pub store_dir: Option<String>,
+    /// An externally-registered, publicly-reachable URL that supersedes [`url`]
+    /// for display (SBAI-4072). The open core never sets this; an external module
+    /// (the proprietary cross-network relay overlay) registers it via
+    /// `host_server_set_advertised_url`. When `Some`, the host UI shows this URL
+    /// to clients instead of the loopback `url`; when `None`, `url` stands.
+    ///
+    /// [`url`]: HostStatus::url
+    pub advertised_url: Option<String>,
 }
 
 impl HostStatus {
@@ -478,6 +486,7 @@ impl HostStatus {
             url: None,
             config_path: None,
             store_dir: None,
+            advertised_url: None,
         }
     }
 
@@ -490,7 +499,20 @@ impl HostStatus {
             url: Some(server.url.clone()),
             config_path: Some(server.config_path.to_string_lossy().into_owned()),
             store_dir: Some(server.store_dir.to_string_lossy().into_owned()),
+            advertised_url: None,
         }
+    }
+
+    /// Overlay an externally-registered advertised URL (SBAI-4072) onto this
+    /// status. Trims; a blank/`None` override clears the field. Returns `self`
+    /// for chaining from the status command. Does NOT touch the real loopback
+    /// `url`, so the core always retains the authoritative local address.
+    pub fn with_advertised_url(mut self, advertised: Option<&str>) -> Self {
+        self.advertised_url = advertised
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned);
+        self
     }
 }
 
@@ -1802,6 +1824,45 @@ mod tests {
         assert!(resolved.force_path_style);
         assert_eq!(resolved.fragments_table(), "my-bucket-fragments");
         assert_eq!(resolved.metadata_table(), "my-bucket-fragment-metadata");
+    }
+
+    #[test]
+    fn with_advertised_url_overlays_and_trims() {
+        // SBAI-4072: the advertised-URL override is additive display metadata —
+        // it never touches the real loopback `url`, and blanks clear it.
+        let base = HostStatus {
+            running: true,
+            pid: Some(1),
+            port: Some(41337),
+            http_port: Some(41339),
+            url: Some("lore://127.0.0.1:41337/repo".into()),
+            config_path: None,
+            store_dir: None,
+            advertised_url: None,
+        };
+
+        // A real public URL is overlaid; the loopback url is preserved.
+        let with = base
+            .clone()
+            .with_advertised_url(Some("  lore://relay.studiobrain.ai:24681/repo  "));
+        assert_eq!(
+            with.advertised_url.as_deref(),
+            Some("lore://relay.studiobrain.ai:24681/repo"),
+            "advertised URL is set + trimmed"
+        );
+        assert_eq!(
+            with.url.as_deref(),
+            Some("lore://127.0.0.1:41337/repo"),
+            "the authoritative loopback url is never mutated"
+        );
+
+        // Blank / None clears the override.
+        assert!(base
+            .clone()
+            .with_advertised_url(Some("   "))
+            .advertised_url
+            .is_none());
+        assert!(base.with_advertised_url(None).advertised_url.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Thin core seam for cross-network relay: AppState advertised_url + host_server_set/clear_advertised_url commands + relay-registry; ServiceSetup shows advertisedUrl when entitled, locked upsell otherwise. NO bore logic in core (that's loregui-cloud crates/loregui-relay + gated overlay). bore is TCP-only → relays gRPC; QUIC stays LAN (docs/RELAY.md). Core builds with zero relay UI. SBAI-4072.