### PR TITLE
SBAI-4082: Ship lorevm with the published VS Code extension

### DIFF
--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -8,3 +8,4 @@ tsconfig.json
 **/*.ts
 node_modules/**
 !out/**
+!bin/**

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -170,11 +170,12 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "npm run compile",
+    "vscode:prepublish": "npm run compile && npm run copy-lorevm",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "package": "vsce package",
-    "lint": "tsc -p ./ --noEmit"
+    "lint": "tsc -p ./ --noEmit",
+    "copy-lorevm": "node scripts/copy-lorevm.mjs"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/vscode-extension/scripts/copy-lorevm.mjs
+++ b/vscode-extension/scripts/copy-lorevm.mjs
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// copy-lorevm.mjs — pulls the lorevm binary into the extension's bin/ folder.
+// This is used during the `vscode:prepublish` step (via `npm run package`)
+// to bundle the binary for marketplace delivery.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(__dirname, '..', '..');
+const extRoot = path.join(__dirname, '..');
+
+const BIN_NAME = process.platform === 'win32' ? 'lorevm.exe' : 'lorevm';
+const binDir = path.join(extRoot, 'bin');
+
+if (!fs.existsSync(binDir)) {
+  fs.mkdirSync(binDir, { recursive: true });
+}
+
+// 1. If LOREVM_BIN is set, use it (CI override).
+if (process.env.LOREVM_BIN && fs.existsSync(process.env.LOREVM_BIN)) {
+  const dest = path.join(binDir, BIN_NAME);
+  console.log(`Copying override ${process.env.LOREVM_BIN} to ${dest}...`);
+  fs.copyFileSync(process.env.LOREVM_BIN, dest);
+  process.exit(0);
+}
+
+// 2. Otherwise search target/{release,debug} (local dev).
+const profiles = ['release', 'debug'];
+let copied = false;
+
+for (const profile of profiles) {
+  const src = path.join(root, 'target', profile, BIN_NAME);
+  if (fs.existsSync(src)) {
+    const dest = path.join(binDir, BIN_NAME);
+    console.log(`Copying ${src} to ${dest}...`);
+    fs.copyFileSync(src, dest);
+    copied = true;
+    break;
+  }
+}
+
+if (!copied) {
+  console.error(`Error: ${BIN_NAME} not found. Build it first: cargo build -p lorevm-cli`);
+  process.exit(1);
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -90,7 +90,7 @@ async function discoverRepositories(
 ): Promise<void> {
   const folders = vscode.workspace.workspaceFolders ?? [];
   for (const folder of folders) {
-    const client = makeClient(folder.uri.fsPath);
+    const client = makeClient(folder.uri.fsPath, context.extensionPath);
 
     // Activation gate: a folder is a lore repo iff `repository.status` succeeds.
     // (lorevm errors with a non-repo kind otherwise.) This doubles as the
@@ -117,7 +117,7 @@ async function discoverRepositories(
   }
 }
 
-function makeClient(repoDir: string): LorevmClient {
+function makeClient(repoDir: string, extensionPath: string): LorevmClient {
   const cfg = vscode.workspace.getConfiguration('lore');
   return new LorevmClient({
     repoDir,
@@ -125,6 +125,7 @@ function makeClient(repoDir: string): LorevmClient {
     offline: cfg.get<boolean>('offline', true),
     identity: cfg.get<string>('identity') || undefined,
     loreguiDirs: loreguiCandidateDirs(repoDir),
+    extensionPath,
   });
 }
 

--- a/vscode-extension/src/lorevmClient.ts
+++ b/vscode-extension/src/lorevmClient.ts
@@ -51,6 +51,8 @@ export interface LorevmClientOptions {
    * lore-mcp's LOREGUI_DIR fallback.
    */
   loreguiDirs?: string[];
+  /** Absolute path to the extension's installation root (context.extensionPath). */
+  extensionPath?: string;
   /** Per-invocation timeout in ms (default 120s, matching lore-mcp). */
   timeoutMs?: number;
 }
@@ -63,12 +65,14 @@ const BIN_NAME = process.platform === 'win32' ? 'lorevm.exe' : 'lorevm';
  *   2. LOREVM_BIN env var
  *   3. PATH
  *   4. <loreguiDir>/target/{release,debug}/lorevm for each candidate dir
+ *   5. Bundled binary inside the extension's `bin/` directory (delivery)
  *
  * Returns the resolved absolute path, or null if not found.
  */
 export function resolveLorevmBin(opts: {
   binPath?: string;
   loreguiDirs?: string[];
+  extensionPath?: string;
 }): string | null {
   const override = opts.binPath?.trim();
   if (override && fs.existsSync(override)) {
@@ -99,6 +103,14 @@ export function resolveLorevmBin(opts: {
         return cand;
       }
     }
+  }
+
+  // Bundled binary: the primary delivery method for marketplace users.
+  const bundled = opts.extensionPath
+    ? path.join(opts.extensionPath, 'bin', BIN_NAME)
+    : path.join(__dirname, '..', 'bin', BIN_NAME);
+  if (fs.existsSync(bundled)) {
+    return bundled;
   }
 
   return null;
@@ -141,6 +153,7 @@ export class LorevmClient {
     return resolveLorevmBin({
       binPath: this.opts.binPath,
       loreguiDirs: this.opts.loreguiDirs ? [...this.opts.loreguiDirs] : [],
+      extensionPath: this.opts.extensionPath,
     });
   }
 


### PR DESCRIPTION
Resolves SBAI-4082

## Summary
Implements binary delivery for the VS Code extension by bundling the `lorevm` binary inside the `.vsix` package.

## Changes
- **LorevmClient**: Added `extensionPath` to options and updated `resolveLorevmBin` to check `bin/lorevm` relative to the extension root.
- **Extension**: Passes `context.extensionPath` to the client on activation.
- **Packaging**: Added `scripts/copy-lorevm.mjs` to pull the binary from the monorepo's `target/` directory into `vscode-extension/bin/`.
- **Manifests**: Updated `package.json` to run the copy script during prepublish and `.vscodeignore` to allow the `bin/` folder.

## Verification
- Built `lorevm-cli` locally.
- Ran `npm run copy-lorevm` in `vscode-extension` and verified `bin/lorevm` exists.
- `cargo check -p lore-vm` and `cargo test -p lore-vm` are green.