### PR TITLE
feat(host): bundle loreserver as Tauri sidecar for shipped hosting (SBAI-4069)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # `triple` is the Rust target triple Tauri appends to each `externalBin`
+        # entry (SBAI-4069). The staged sidecar MUST be named
+        # `src-tauri/binaries/loreserver-<triple>[.exe]` or `tauri build` fails.
+        #   x86_64-unknown-linux-gnu  (ubuntu)
+        #   x86_64-pc-windows-msvc    (windows, + .exe)
+        #   aarch64-apple-darwin      (macos, Apple Silicon)
         include:
           - platform: windows-latest
+            triple: x86_64-pc-windows-msvc
+            sidecar_ext: ".exe"
           - platform: ubuntu-22.04
+            triple: x86_64-unknown-linux-gnu
+            sidecar_ext: ""
           - platform: macos-latest
+            triple: aarch64-apple-darwin
+            sidecar_ext: ""
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
@@ -96,6 +108,81 @@ jobs:
 
       - name: Install frontend deps
         run: npm --prefix frontend ci || npm --prefix frontend install
+
+      # --- loreserver sidecar (SBAI-4069) ------------------------------------
+      # Ship the real upstream `loreserver` as a Tauri `externalBin` so the
+      # packaged "Host a server" flow works without a dev checkout. This is the
+      # heavy upstream build (~1 GB from the pinned `lore` git checkout), so it
+      # ONLY runs on this release matrix — the windows-build PR gate must NOT
+      # bundle it. The built binary is cached, keyed on the pinned lore rev +
+      # target triple, so it is built once per rev per platform.
+      - name: Read pinned lore rev (sidecar cache key)
+        id: lorerev
+        shell: bash
+        run: |
+          REV="$(grep -oE 'rev = "[0-9a-f]{40}"' Cargo.toml | head -1 | grep -oE '[0-9a-f]{40}')"
+          if [ -z "$REV" ]; then
+            echo "FATAL: could not read pinned lore rev from Cargo.toml" >&2
+            exit 1
+          fi
+          echo "rev=$REV" >> "$GITHUB_OUTPUT"
+          echo "Pinned lore rev: $REV"
+
+      - name: Cache built loreserver sidecar
+        id: sidecar-cache
+        uses: actions/cache@v4
+        with:
+          path: src-tauri/binaries/loreserver-${{ matrix.triple }}${{ matrix.sidecar_ext }}
+          key: loreserver-${{ matrix.triple }}-${{ steps.lorerev.outputs.rev }}
+
+      # A separate cache for the heavy lore build's target dir, so even a cache
+      # miss on the binary (e.g. rev bump) doesn't recompile the whole world.
+      - name: Cache lore build (cargo + target)
+        if: steps.sidecar-cache.outputs.cache-hit != 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: loreserver-build-${{ matrix.triple }}-${{ steps.lorerev.outputs.rev }}
+          # The lore checkout lives in the cargo git cache, not the workspace;
+          # cache the cargo registry/git + that checkout's own target dir.
+          cache-all-crates: true
+
+      - name: Build + stage loreserver sidecar
+        if: steps.sidecar-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -e
+          # Populate the cargo git cache with the pinned lore checkout, then
+          # build the upstream server binary from it (exactly as the SBAI-4064
+          # spike script does).
+          cargo fetch
+          REV="${{ steps.lorerev.outputs.rev }}"
+          SHORT="${REV:0:7}"
+          CARGO_HOME_DIR="${CARGO_HOME:-$HOME/.cargo}"
+          LORE_CHECKOUT="$(find "$CARGO_HOME_DIR/git/checkouts" -maxdepth 2 -type d -name "$SHORT" 2>/dev/null | head -1)"
+          if [ -z "$LORE_CHECKOUT" ]; then
+            echo "FATAL: lore checkout for rev $SHORT not found under cargo git cache" >&2
+            exit 1
+          fi
+          echo "lore checkout: $LORE_CHECKOUT"
+          ( cd "$LORE_CHECKOUT" && cargo build --release -p lore-server --bin loreserver --target ${{ matrix.triple }} )
+          # `--target` puts the binary under target/<triple>/release/.
+          BIN="$LORE_CHECKOUT/target/${{ matrix.triple }}/release/loreserver${{ matrix.sidecar_ext }}"
+          if [ ! -f "$BIN" ]; then
+            echo "FATAL: built loreserver not found at $BIN" >&2
+            exit 1
+          fi
+          mkdir -p src-tauri/binaries
+          cp "$BIN" "src-tauri/binaries/loreserver-${{ matrix.triple }}${{ matrix.sidecar_ext }}"
+
+      - name: Verify staged sidecar exists
+        shell: bash
+        run: |
+          STAGED="src-tauri/binaries/loreserver-${{ matrix.triple }}${{ matrix.sidecar_ext }}"
+          if [ ! -f "$STAGED" ]; then
+            echo "FATAL: sidecar not staged at $STAGED — tauri build would fail" >&2
+            exit 1
+          fi
+          ls -la "$STAGED"
 
       - name: Build + publish (Tauri → installers → GitHub Release)
         uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -29,6 +29,14 @@ jobs:
       - name: Install frontend deps
         run: npm --prefix frontend ci || npm --prefix frontend install
 
+      # SBAI-4069: `tauri.conf.json` declares `externalBin: ["binaries/loreserver"]`,
+      # so `tauri build` REQUIRES a sidecar named with this target's triple to
+      # exist. The real `loreserver` is a ~1 GB upstream build that we
+      # deliberately do NOT run on the PR gate — release.yml builds + bundles the
+      # genuine binary. Here, `src-tauri/build.rs` auto-stages a tiny placeholder
+      # for the current triple so the bundler is satisfied and the gate keeps
+      # proving the installer/config still builds. The placeholder is never
+      # shipped; release.yml stages the real binary, which build.rs leaves intact.
       - name: Build (Tauri → NSIS + MSI)
         uses: tauri-apps/tauri-action@v0
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,13 @@ website/node_modules
 src-tauri/gen
 src-tauri/target
 
+# Tauri externalBin sidecars (SBAI-4069): the bundled `loreserver` is a heavy
+# (~1 GB) per-target build artifact staged by CI as
+# src-tauri/binaries/loreserver-<target-triple>[.exe] before `tauri build`.
+# Never commit the binaries; the directory's README is tracked, the rest ignored.
+src-tauri/binaries/*
+!src-tauri/binaries/README.md
+
 # Editor / OS
 .DS_Store
 *.swp

--- a/docs/host-server-sidecar.md
+++ b/docs/host-server-sidecar.md
@@ -1,0 +1,95 @@
+# Hosting a server in shipped builds — the `loreserver` sidecar (SBAI-4069)
+
+LoreGUI's **"Host a server"** flow (SBAI-4065, `src-tauri/src/server_host.rs`)
+spawns the real upstream **`loreserver`** binary (crate `lore-server`, bin
+`loreserver`). For this to work in a **packaged installer** — which has no
+`LOREVM_SERVER_BIN` env var and no pinned `lore` dev checkout to build from — the
+server is shipped as a **Tauri `externalBin` sidecar**.
+
+## How `loreserver` is resolved at runtime
+
+`server_host::resolve_server_binary` tries these sources **in order**:
+
+1. **Bundled sidecar (production path).** The `loreserver` / `loreserver.exe`
+   that Tauri ships next to the app executable. This is checked **first**, so a
+   shipped build never needs an env var or a dev checkout.
+2. **`LOREVM_SERVER_BIN` (dev / override).** Point this at a locally-built
+   `loreserver` and it takes over when no sidecar is bundled (the normal dev
+   case). A value that is set but doesn't point at a file is a **hard error**
+   (we don't silently ignore an explicit override). The SBAI-4064 spike used
+   this.
+3. **Dev-checkout build fallback.** Builds `loreserver` from the pinned upstream
+   `lore` git checkout (`cargo build -p lore-server --bin loreserver`) — slow,
+   dev-only, and never reached in a release build because the sidecar resolves
+   at step 1.
+
+The resolution order is unit-tested (`server_host::tests::resolution_*`) via the
+pure `resolve_production_binary` helper, so the sidecar-first priority can't
+regress.
+
+> **Note:** the bundled sidecar wins even when `LOREVM_SERVER_BIN` is also set.
+> To force a custom binary in a shipped build, you'd remove/replace the bundled
+> sidecar — but `LOREVM_SERVER_BIN` remains the supported override for **dev**,
+> where no sidecar is bundled.
+
+## How the sidecar is bundled
+
+`src-tauri/tauri.conf.json`:
+
+```jsonc
+"bundle": {
+  "externalBin": ["binaries/loreserver"]
+}
+```
+
+Tauri resolves an `externalBin` entry **at build time** by appending the build's
+**target triple** (and `.exe` on Windows) to the base name, so the file the
+bundler picks up is `src-tauri/binaries/loreserver-<target-triple>[.exe]`:
+
+| CI runner / platform          | Rust target triple           | Staged file name                          |
+| ----------------------------- | ---------------------------- | ----------------------------------------- |
+| Linux x86_64 (`ubuntu-22.04`) | `x86_64-unknown-linux-gnu`   | `loreserver-x86_64-unknown-linux-gnu`     |
+| Windows x86_64 (`windows`)    | `x86_64-pc-windows-msvc`     | `loreserver-x86_64-pc-windows-msvc.exe`   |
+| macOS Apple Silicon (`macos`) | `aarch64-apple-darwin`       | `loreserver-aarch64-apple-darwin`         |
+
+At runtime Tauri ships the matched binary next to the app under the **bare**
+name, which is exactly where step 1 above looks.
+
+The binaries are **not committed** (~1 GB build artifacts) — `.gitignore` ignores
+everything under `src-tauri/binaries/` except its `README.md`.
+
+## How CI stages the sidecar
+
+`.github/workflows/release.yml` (the release matrix only — **not** the
+`windows-build.yml` PR gate) builds the genuine `loreserver` for each target
+**before** `tauri build`:
+
+1. Read the pinned `lore` rev from `Cargo.toml` (used as the cache key).
+2. `actions/cache` the staged binary, keyed on `triple + lore rev` — built once
+   per rev per platform.
+3. On a cache miss: `cargo fetch` to populate the cargo git cache, locate the
+   unpacked lore checkout, then
+   `cargo build --release -p lore-server --bin loreserver --target <triple>`.
+   A `Swatinem/rust-cache` keyed on the same `triple + rev` keeps the heavy lore
+   build incremental across runs.
+4. Copy the result to `src-tauri/binaries/loreserver-<triple>[.exe]` and verify
+   it exists before invoking `tauri build`.
+
+The **PR gate** (`windows-build.yml`) deliberately does **not** run this ~1 GB
+build. Because the `externalBin` declaration makes the Tauri build script require
+*some* file at the staged path (even during plain `cargo check` / `cargo test` /
+`tauri dev`), `src-tauri/build.rs` auto-stages a tiny **placeholder** for the
+current target triple whenever no sidecar is present. The placeholder is a stub
+that exits non-zero if ever spawned — it only satisfies the bundler's existence
+check; it is git-ignored and never shipped. release.yml stages the real binary
+*before* `tauri build`, and `build.rs` leaves an already-present sidecar intact,
+so the genuine server is the one bundled in releases.
+
+### Dev convenience: the `build.rs` placeholder
+
+`cargo check`, `cargo test`, and `tauri dev` all run the Tauri build script,
+which validates `externalBin` paths. So that developers don't have to manually
+stage anything, `src-tauri/build.rs::ensure_sidecar_placeholder` writes a stub at
+`src-tauri/binaries/loreserver-<current-triple>[.exe]` if one isn't there. To run
+a **real** hosted server in dev, set `LOREVM_SERVER_BIN` (which overrides) or let
+`server_host`'s dev-checkout fallback build the genuine `loreserver`.

--- a/docs/live-server-client-spike.md
+++ b/docs/live-server-client-spike.md
@@ -162,9 +162,12 @@ calls (e.g. `repository.clone`, `branch.push` after a commit made in-process).
 
 ## Notes / limits
 
-- **Local-only.** Everything binds `127.0.0.1`. Not wired into CI: the
-  `loreserver` binary is built from the pinned upstream `lore` git checkout under
-  `~/.cargo/git/checkouts/lore-*/`, which CI runners don't have unpacked.
+- **Local-only.** Everything binds `127.0.0.1`. The dev path builds the
+  `loreserver` binary from the pinned upstream `lore` git checkout under
+  `~/.cargo/git/checkouts/lore-*/`. For **shipped builds** this binary is bundled
+  as a Tauri `externalBin` sidecar instead (SBAI-4069) — see
+  [`host-server-sidecar.md`](host-server-sidecar.md). `LOREVM_SERVER_BIN` still
+  overrides for dev.
 - First run builds `loreserver` (~1 GB debug binary, several minutes). Subsequent
   runs are incremental.
 - Server boot method that worked: the **stock `loreserver` binary + a TOML

--- a/src-tauri/binaries/README.md
+++ b/src-tauri/binaries/README.md
@@ -1,0 +1,40 @@
+# Tauri sidecar binaries (`externalBin`) — SBAI-4069
+
+This directory holds the **`loreserver`** sidecar that LoreGUI's "Host a server"
+flow spawns in shipped builds. `tauri.conf.json` declares it via
+`bundle.externalBin: ["binaries/loreserver"]`.
+
+## Naming (Tauri `externalBin` contract)
+
+Tauri resolves an `externalBin` entry at **build time** by appending the build's
+**target triple** (and `.exe` on Windows) to the base name. So for the entry
+`binaries/loreserver`, the bundler looks for a file named:
+
+| Platform (CI runner)        | Rust target triple             | Staged file name                                   |
+| --------------------------- | ------------------------------ | -------------------------------------------------- |
+| Linux x86_64 (`ubuntu`)     | `x86_64-unknown-linux-gnu`     | `loreserver-x86_64-unknown-linux-gnu`              |
+| Windows x86_64 (`windows`)  | `x86_64-pc-windows-msvc`       | `loreserver-x86_64-pc-windows-msvc.exe`            |
+| macOS Apple Silicon (`macos`)| `aarch64-apple-darwin`        | `loreserver-aarch64-apple-darwin`                  |
+
+At **runtime** Tauri ships the matched binary next to the app executable under
+the **bare** name (`loreserver` / `loreserver.exe`); LoreGUI's
+`server_host::resolve_server_binary` looks for it there first (the production
+path).
+
+## Why this directory is (mostly) empty in git
+
+The `loreserver` binary is a heavy (~1 GB debug / large release) artifact built
+from the pinned upstream `lore` checkout
+(`cargo build -p lore-server --bin loreserver`). It is **never committed**. CI's
+release workflow (`.github/workflows/release.yml`) builds it for each matrix
+target and stages it here as `loreserver-<target-triple>[.exe]` *before* running
+`tauri build`. `.gitignore` ignores everything here except this README.
+
+## Dev / override
+
+Local development does not need a staged sidecar: `src-tauri/build.rs`
+auto-writes a stub placeholder here for the current target triple so the Tauri
+build script is satisfied during `cargo check` / `cargo test` / `tauri dev`. To
+run a **real** hosted server in dev, set `LOREVM_SERVER_BIN` to a locally-built
+`loreserver` (which overrides), or let the dev-checkout fallback build it from
+the pinned `lore` rev. See `docs/host-server-sidecar.md`.

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,59 @@
+use std::path::PathBuf;
+
 fn main() {
+    ensure_sidecar_placeholder();
     tauri_build::build()
+}
+
+/// Ensure a `loreserver` sidecar exists for the current target triple so the
+/// Tauri build script (which validates every `externalBin` path) succeeds during
+/// plain `cargo check` / `cargo test` / `tauri dev`, where the real ~1 GB
+/// upstream `loreserver` is not staged (SBAI-4069).
+///
+/// If a sidecar is already present (e.g. CI's release job staged the genuine
+/// binary, or a developer dropped one in), it is left untouched. Otherwise a
+/// tiny **placeholder** is written so the build proceeds. The placeholder is
+/// NOT a working server — production resolution uses the real bundled sidecar
+/// (release.yml), and dev hosting uses `LOREVM_SERVER_BIN` or the dev-checkout
+/// build (see `src/server_host.rs`). The placeholder only satisfies the
+/// bundler's existence check; it is git-ignored and never shipped by intent.
+fn ensure_sidecar_placeholder() {
+    // Tauri exports the resolved target triple to build scripts.
+    let triple = match std::env::var("TARGET") {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+    let exe_suffix = if triple.contains("windows") {
+        ".exe"
+    } else {
+        ""
+    };
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.join("binaries");
+    let sidecar = dir.join(format!("loreserver-{triple}{exe_suffix}"));
+
+    println!("cargo:rerun-if-changed={}", sidecar.display());
+
+    if sidecar.exists() {
+        return;
+    }
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        println!("cargo:warning=could not create {}: {e}", dir.display());
+        return;
+    }
+    // A non-empty placeholder; make it executable on unix so a stray spawn fails
+    // loudly rather than with a confusing permission error.
+    if let Err(e) = std::fs::write(
+        &sidecar,
+        b"#!/bin/sh\necho 'loreserver placeholder (not a real server) - see docs/host-server-sidecar.md' >&2\nexit 1\n",
+    ) {
+        println!("cargo:warning=could not stage placeholder sidecar: {e}");
+        return;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&sidecar, std::fs::Permissions::from_mode(0o755));
+    }
 }

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -1134,38 +1134,88 @@ fn dirs_home() -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
-/// Resolve the `loreserver` binary, building it from the dev checkout if needed.
+/// Outcome of the cheap (no-build) resolution pass over the env override and the
+/// bundled sidecar. `FallBackToDevCheckout` means neither produced a binary, so
+/// the caller must drop to the (slow) dev-checkout build path.
+enum ResolveOutcome {
+    /// A binary was resolved directly (sidecar or a valid env override).
+    Found(PathBuf),
+    /// `LOREVM_SERVER_BIN` was set but does not point at a file — a hard error
+    /// (the operator asked for a specific binary; silently ignoring it would be
+    /// surprising).
+    EnvOverrideMissing(PathBuf),
+    /// Nothing resolved; the caller falls back to the dev checkout.
+    FallBackToDevCheckout,
+}
+
+/// Pure resolution of the **production** sources, in priority order, given the
+/// raw inputs and a file-existence predicate. Extracted from
+/// [`resolve_server_binary`] so the ordering is unit-testable without touching
+/// the real filesystem, env, or `current_exe()`.
 ///
-/// Order:
-///   1. `LOREVM_SERVER_BIN` env var (explicit override).
-///   2. A Tauri **sidecar** next to the current executable (`loreserver`
-///      / `loreserver.exe`) — present only once we bundle it as `externalBin`.
-///   3. DEV fallback: the pinned upstream checkout's
-///      `target/debug/loreserver`, built via `cargo build -p lore-server
-///      --bin loreserver` if absent (exactly as the spike script does).
+/// Priority (SBAI-4069):
+///   1. The bundled Tauri **sidecar** next to the running executable — the
+///      **production path**. Tauri ships `externalBin` entries as
+///      `<name>-<target-triple>[.exe]` but resolves them at runtime under the
+///      bare name (`loreserver` / `loreserver.exe`) next to the app binary, so a
+///      packaged installer finds the server here with no env/dev setup.
+///   2. `LOREVM_SERVER_BIN` env var — the **dev/override** path. Lets a developer
+///      point at a locally-built `loreserver` (and is what the SBAI-4064 spike
+///      used). A set-but-missing value is a hard error rather than a silent skip.
 ///
-/// FOLLOW-UP: production should ship `loreserver` as a Tauri sidecar
-/// (`externalBin` in `tauri.conf.json`) so step 3 is never reached in a
-/// release build. We intentionally do NOT add the ~1 GB debug binary to the
-/// bundle / CI now — it is resolved at runtime here instead.
-fn resolve_server_binary() -> Result<PathBuf, LoreError> {
-    // 1. explicit override
-    if let Some(p) = std::env::var_os("LOREVM_SERVER_BIN") {
-        let path = PathBuf::from(p);
-        if path.is_file() {
-            return Ok(path);
+/// If neither matches, returns [`ResolveOutcome::FallBackToDevCheckout`] so the
+/// caller can build from the pinned upstream checkout (dev-only).
+fn resolve_production_binary(
+    sidecar: Option<&Path>,
+    env_override: Option<&Path>,
+    is_file: &impl Fn(&Path) -> bool,
+) -> ResolveOutcome {
+    // 1. bundled sidecar (production)
+    if let Some(p) = sidecar {
+        if is_file(p) {
+            return ResolveOutcome::Found(p.to_path_buf());
         }
-        return Err(LoreError::CommandFailed(format!(
-            "LOREVM_SERVER_BIN={} is not a file",
-            path.display()
-        )));
     }
 
-    // 2. sidecar next to the running executable
-    if let Some(p) = sidecar_candidate() {
-        if p.is_file() {
-            return Ok(p);
+    // 2. explicit env override (dev)
+    if let Some(p) = env_override {
+        if is_file(p) {
+            return ResolveOutcome::Found(p.to_path_buf());
         }
+        return ResolveOutcome::EnvOverrideMissing(p.to_path_buf());
+    }
+
+    ResolveOutcome::FallBackToDevCheckout
+}
+
+/// Resolve the `loreserver` binary, building it from the dev checkout if needed.
+///
+/// Order (SBAI-4069):
+///   1. A Tauri **sidecar** next to the current executable (`loreserver`
+///      / `loreserver.exe`) — the **production path**, present once it is bundled
+///      as `externalBin` in `tauri.conf.json`. This is checked first so a
+///      packaged installer never needs env vars or a dev checkout.
+///   2. `LOREVM_SERVER_BIN` env var (explicit dev override). A set-but-missing
+///      value is a hard error.
+///   3. DEV fallback: the pinned upstream checkout's
+///      `target/debug/loreserver`, built via `cargo build -p lore-server
+///      --bin loreserver` if absent (exactly as the spike script does). Never
+///      reached in a release build because the sidecar resolves at step 1.
+fn resolve_server_binary() -> Result<PathBuf, LoreError> {
+    let sidecar = sidecar_candidate();
+    let env_override = std::env::var_os("LOREVM_SERVER_BIN").map(PathBuf::from);
+
+    match resolve_production_binary(sidecar.as_deref(), env_override.as_deref(), &|p: &Path| {
+        p.is_file()
+    }) {
+        ResolveOutcome::Found(path) => return Ok(path),
+        ResolveOutcome::EnvOverrideMissing(path) => {
+            return Err(LoreError::CommandFailed(format!(
+                "LOREVM_SERVER_BIN={} is not a file",
+                path.display()
+            )));
+        }
+        ResolveOutcome::FallBackToDevCheckout => {}
     }
 
     // 3. dev fallback: build from the pinned upstream checkout
@@ -2295,5 +2345,87 @@ mod tests {
             "status should report stopped after stop()"
         );
         let _ = std::fs::remove_dir_all(&store);
+    }
+
+    // ---- binary resolution order (SBAI-4069) -------------------------------
+
+    fn found(outcome: ResolveOutcome) -> PathBuf {
+        match outcome {
+            ResolveOutcome::Found(p) => p,
+            ResolveOutcome::EnvOverrideMissing(p) => {
+                panic!("expected Found, got EnvOverrideMissing({})", p.display())
+            }
+            ResolveOutcome::FallBackToDevCheckout => {
+                panic!("expected Found, got FallBackToDevCheckout")
+            }
+        }
+    }
+
+    #[test]
+    fn resolution_prefers_sidecar_over_env_override() {
+        // Both the bundled sidecar and the env override exist → the sidecar (the
+        // production path) wins, even when an override is also present.
+        let sidecar = PathBuf::from("/app/loreserver");
+        let env = PathBuf::from("/dev/loreserver");
+        let exists = |_p: &Path| true;
+        let resolved = found(resolve_production_binary(
+            Some(&sidecar),
+            Some(&env),
+            &exists,
+        ));
+        assert_eq!(resolved, sidecar);
+    }
+
+    #[test]
+    fn resolution_uses_env_override_when_no_sidecar() {
+        // No sidecar bundled (dev build) → a valid env override is used.
+        let env = PathBuf::from("/dev/loreserver");
+        let only_env = |p: &Path| p == env.as_path();
+        let resolved = found(resolve_production_binary(None, Some(&env), &only_env));
+        assert_eq!(resolved, env);
+
+        // A present-but-not-a-file sidecar is skipped, falling through to env.
+        let sidecar = PathBuf::from("/app/loreserver");
+        let resolved = found(resolve_production_binary(
+            Some(&sidecar),
+            Some(&env),
+            &only_env,
+        ));
+        assert_eq!(resolved, env);
+    }
+
+    #[test]
+    fn resolution_errors_when_env_override_missing() {
+        // Env override set but not a file, and no sidecar → hard error (surfaced
+        // by the caller), NOT a silent fall-through to the dev checkout.
+        let env = PathBuf::from("/dev/missing-loreserver");
+        let none_exist = |_p: &Path| false;
+        match resolve_production_binary(None, Some(&env), &none_exist) {
+            ResolveOutcome::EnvOverrideMissing(p) => assert_eq!(p, env),
+            other => panic!(
+                "expected EnvOverrideMissing, got {}",
+                match other {
+                    ResolveOutcome::Found(p) => format!("Found({})", p.display()),
+                    ResolveOutcome::FallBackToDevCheckout => "FallBackToDevCheckout".into(),
+                    ResolveOutcome::EnvOverrideMissing(_) => unreachable!(),
+                }
+            ),
+        }
+    }
+
+    #[test]
+    fn resolution_falls_back_to_dev_checkout_when_nothing_resolves() {
+        // No sidecar and no env override → caller builds from the dev checkout.
+        let none_exist = |_p: &Path| false;
+        assert!(matches!(
+            resolve_production_binary(None, None, &none_exist),
+            ResolveOutcome::FallBackToDevCheckout
+        ));
+        // A missing sidecar with no env override also falls back.
+        let sidecar = PathBuf::from("/app/loreserver");
+        assert!(matches!(
+            resolve_production_binary(Some(&sidecar), None, &none_exist),
+            ResolveOutcome::FallBackToDevCheckout
+        ));
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,6 +26,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "externalBin": ["binaries/loreserver"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
server_host resolves the bundled sidecar first (then LOREVM_SERVER_BIN dev override, then dev-checkout). tauri.conf externalBin: binaries/loreserver. release.yml builds loreserver per-platform (cached, release-matrix only — not the PR gate). build.rs stages a stub placeholder so dev/check/PR stay green without the ~1GB build. 25 server_host tests pass. Real-binary install path needs a full release run to confirm. SBAI-4069.