### PR TITLE
feat(locks): check-in request messaging — tray notification + inbox (SBAI-4044)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,120 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +248,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -364,6 +484,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -609,6 +742,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1192,12 +1334,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -1228,6 +1397,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1396,6 +1586,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1847,6 +2050,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2774,6 +2983,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-autostart",
  "tauri-plugin-dialog",
+ "tauri-plugin-notification",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2815,6 +3025,20 @@ checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
 ]
 
 [[package]]
@@ -2982,6 +3206,20 @@ name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
 
 [[package]]
 name = "ntapi"
@@ -3357,6 +3595,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3380,6 +3628,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3517,6 +3771,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3530,7 +3795,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -3559,6 +3824,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3761,6 +4040,15 @@ dependencies = [
  "wasi",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5006,6 +5294,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5103,6 +5410,18 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]
@@ -5638,6 +5957,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -6646,6 +6976,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6739,4 +7130,44 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.118",
+ "winnow 1.0.3",
 ]

--- a/docs/lock-messaging-spike.md
+++ b/docs/lock-messaging-spike.md
@@ -1,0 +1,183 @@
+# Lock-coordination messaging — transport spike (SBAI-4044)
+
+**Goal:** let a user ask the current lock holder of a file to check it in /
+release, delivered to the holder's client as a **tray notification** ("X is
+asking you to check in `<file>`") plus an inbox entry with Release / Dismiss.
+
+This is a SPIKE + MVP. The crux is **transport**: how does a request reach
+*another user's* client? This document is the spike. The MVP that was built on
+top of its conclusion is summarised at the end.
+
+---
+
+## TL;DR — transport verdict
+
+| Layer | Can it carry an arbitrary user→user message? |
+|-------|----------------------------------------------|
+| lore **gRPC proto** (`lore.notification`) | **Yes** — `NotificationServiceClient::publish` + `Event::Other(ExtensionEvent { type, payload: Any })`. |
+| lore **high-level crate** (`lore::notification`, what lore-vm binds) | **No** — only `subscribe`/`unsubscribe`; no `publish`; `ExtensionEvent` is **dropped** before it becomes a `LoreEvent`. |
+| **Conclusion** | lore-vm (in-process, never shells out / never FFI) **cannot** send or receive arbitrary lock-request messages today. The capability exists one layer down in the protocol but is not surfaced by the crate API the GUI is allowed to bind. |
+
+So the cross-network delivery path requires either (a) upstream lore exposing
+`publish`/`ExtensionEvent` in its high-level crate, or (b) a small **server
+side-channel** (the relay, SBAI-4072 — premium). Neither is in scope for a
+core/MIT MVP. The MVP therefore delivers **locally** (same machine / same app
+state) and leaves a clearly-marked seam for the relay.
+
+---
+
+## 1. lore's `notification` domain — does it carry messages?
+
+### What the lore-vm binding exposes
+
+`crates/lore-vm/src/ops/notification/` has exactly two ops:
+
+- `subscribe.rs` → `lore::notification::subscribe(globals, LoreNotificationSubscribeArgs {}, cb)`
+- `unsubscribe.rs` → `lore::notification::unsubscribe(globals, LoreNotificationUnsubscribeArgs {}, cb)`
+
+Both arg structs are **empty** (`{}`). There is no `publish` op, and no way to
+attach a payload. Subscribe just opens a server→client push stream.
+
+### What the high-level `lore` crate exposes
+
+Pinned rev `65598412` (`Cargo.lock`), at
+`~/.cargo/git/checkouts/lore-*/6559841/lore/src/notification.rs`:
+
+```rust
+pub async fn subscribe(globals, LoreNotificationSubscribeArgs {}, callback) -> i32
+pub async fn unsubscribe(globals, LoreNotificationUnsubscribeArgs {}, callback) -> i32
+```
+
+That is the **entire** public surface. No `publish`. `grep -rn publish lore/src/`
+→ nothing.
+
+### What the subscribe stream actually delivers
+
+`lore-notification/src/client.rs` maps incoming server events to `LoreEvent`s:
+
+| proto `event::Event` variant | mapped to `LoreEvent` |
+|------------------------------|------------------------|
+| `BranchCreated`              | `NotificationBranchCreated` |
+| `BranchDeleted`              | `NotificationBranchDeleted` |
+| `BranchPushed`               | `NotificationBranchPushed` |
+| `ResourceLocked`             | `NotificationResourceLocked` |
+| `ResourceUnlocked`           | `NotificationResourceUnlocked` |
+| `Other(ExtensionEvent)`      | **dropped — `_ => {}`** |
+| `Obliterate`                 | dropped |
+
+So the channel only carries **lock/branch lifecycle events**, never an arbitrary
+message. A "user A asks user B to check in file F" event is not representable as
+any of the surfaced variants.
+
+### The capability that *does* exist (one layer down)
+
+`lore-proto/src/grpc/lore.notification.rs` is richer than the crate API admits:
+
+```rust
+pub struct ExtensionEvent {
+    pub r#type: String,                       // e.g. "org.lore.security.compliance"
+    pub payload: Option<prost_types::Any>,    // arbitrary
+}
+pub enum event::Event { Other(ExtensionEvent), BranchPushed(..), ResourceLocked(..), .. }
+
+impl NotificationServiceClient {
+    pub async fn subscribe(SubscribeRequest { repository }) -> Stream<Event>;
+    pub async fn publish(PublishRequest { event: Event }) -> ();   // <-- exists!
+}
+```
+
+`ExtensionEvent` is an explicit, namespaced, arbitrary-payload extension hook,
+and `publish` is a real RPC. A lock-request could be modelled as
+`ExtensionEvent { type: "games.studiobrain.lore.lock.request", payload }` and
+`publish`ed, then received by every subscriber and filtered by `type`.
+
+**But** to use it, lore-vm would have to either:
+- talk raw gRPC (`lore_transport` / `lore_proto`) — which violates the "bind the
+  high-level `lore` crate in-process, never shell, never FFI" rule in CLAUDE.md;
+  or
+- depend on upstream lore adding `lore::notification::publish` + an
+  `ExtensionEvent`/`Other` `LoreEvent` variant.
+
+Neither is available from the binding we are allowed to use. **The in-band path
+is blocked at the crate boundary.**
+
+> Upstream ask (file against EpicGames/lore, do NOT fork): surface
+> `notification::publish` and an `Other(ExtensionEvent)` → `LoreEvent` mapping in
+> the high-level crate. That single change would make the relay unnecessary for
+> same-server teams — the lock-request becomes a normal `ExtensionEvent` rode in
+> on the existing subscribe stream.
+
+---
+
+## 2. Server side-channel (the fallback)
+
+If lore won't carry the message in-band, the alternative is a tiny relay the
+clients both reach:
+
+- **Endpoint:** `POST /api/v1/lock-messages` (send) + a delivery stream/poll
+  (`GET /api/v1/lock-messages?since=…` or an SSE/WebSocket push) keyed by
+  recipient `to_user_id`.
+- **Store:** a small per-tenant table `lock_messages(id, repo, branch, path,
+  from_user, to_user, kind, note, created_at, state)`. Ephemeral; a request is
+  done once the holder releases or dismisses.
+- **Who hosts it:** the hosted lore server already in the loop, or the
+  StudioBrain cloud relay overlay (SBAI-4072). This is **premium** — cross-
+  network delivery is the paid extension; basic same-machine coordination stays
+  core/MIT.
+- **Auth:** sender's bearer token; recipient resolves messages addressed to their
+  `user_id` (already known from `auth_user_info`).
+
+This is intentionally *not* built here — it is documented so the stubbed sender
+can be pointed at it with one wiring change. The Rust op
+`lock::file_message_send` already encodes exactly this contract in its doc
+comment (it predates this spike) and is kept as the typed shape.
+
+---
+
+## 3. Reuse: the "who" is already known
+
+The hard half of "ask the holder" — *identifying* the holder — is already solved:
+
+- `lock.file_status(paths, branch)` → `[{ path, owner, locked_at }]`
+- `lock.file_query(branch, owner, path)` → held locks with `{ path, owner, branch, locked_at }`
+
+Both return the **owner** (holder) identity. The sender therefore always knows
+*who* to address; the only missing piece is the *channel to reach them*, which is
+section 1/2. The MVP exploits this: the Locks panel and the file view already
+show the holder, so "Request check-in from `<holder>`" needs no new lookup.
+
+---
+
+## MVP delivered on top of this verdict
+
+Because in-band lore delivery is blocked and the relay is premium/out-of-scope,
+the MVP delivers **locally** and stubs the network hop:
+
+- **Send** — `lock_request_checkin` Tauri command. It records the request in a
+  process-local **inbox** (`AppState.lock_inbox`) and immediately fires an OS
+  **tray notification** + emits a `lock/request` event to the frontend. On one
+  machine (the common dev/demo/single-host case, and the realistic path until the
+  relay lands) this is a *real, working* end-to-end loop: send → tray toast →
+  inbox → Release. The cross-*network* hop is the single clearly-marked TODO
+  (`// TODO(SBAI-4072 relay)`), where the same `LockRequest` would be POSTed to
+  the side-channel in section 2 instead of (or in addition to) the local inbox.
+- **Receive** — the holder's client shows a tray/OS notification ("X wants you to
+  check in `<file>`") and an **inbox** entry with **Release** (calls
+  `lock.file_release`) / **Dismiss**.
+- **Surfaces** — a "Request check-in…" action on any lock held by *someone else*
+  in the **Locks panel** and the **content/file view**, plus a palette entry, an
+  inbox drawer, and tray wiring. Themeable via `--surface-*`, accessible.
+
+What is **real** vs **stubbed**, precisely:
+
+| Piece | Status |
+|-------|--------|
+| Holder identity (`file_status`/`file_query`) | real |
+| Send request → local inbox + tray OS notification + `lock/request` event | real, in-process |
+| Inbox UI (list, Release, Dismiss) | real |
+| Release → `lock.file_release` | real (binds lore) |
+| **Cross-network delivery to another machine's client** | **stubbed** — one `TODO(SBAI-4072 relay)` seam; needs the section-2 side-channel or an upstream lore `publish`/`ExtensionEvent` change |
+
+The typed `lock::file_message_send` op in lore-vm is retained as the canonical
+shape of the relay payload; it stays `Err(... relay not implemented)` until the
+side-channel exists.

--- a/frontend/scripts/palette-parity-allowlist.json
+++ b/frontend/scripts/palette-parity-allowlist.json
@@ -22,7 +22,9 @@
     "host_server_clear_advertised_url",
     "read_text_file",
     "read_file_bytes",
-    "write_text_file"
+    "write_text_file",
+    "lock_inbox_list",
+    "lock_inbox_dismiss"
   ],
   "deferred": []
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import SettingsPanel from "./SettingsPanel";
 import StoragePanel from "./StoragePanel";
 import RepositoryPanel from "./RepositoryPanel";
 import LocksPanel from "./LocksPanel";
+import LockInbox from "./locks/LockInbox";
 import DependenciesPanel from "./DependenciesPanel";
 import HistoryPanel from "./HistoryPanel";
 import BranchesPanel from "./BranchesPanel";
@@ -37,6 +38,9 @@ import {
   revisionRevertLocalApi,
   revisionSyncApi,
   lockFileReleaseApi,
+  lockMessagingApi,
+  LOCK_REQUEST_EVENT,
+  type LockRequest,
   type Branch,
   type BranchInfoResult,
   type BranchMetadataEntry,
@@ -100,6 +104,8 @@ export default function App() {
   const [storageOpen, setStorageOpen] = useState(false);
   const [repoPanelOpen, setRepoPanelOpen] = useState(false);
   const [locksPanelOpen, setLocksPanelOpen] = useState(false);
+  const [lockInboxOpen, setLockInboxOpen] = useState(false);
+  const [pendingLockRequests, setPendingLockRequests] = useState(0);
   const [depsPanelOpen, setDepsPanelOpen] = useState(false);
   const [historyPanelOpen, setHistoryPanelOpen] = useState(false);
   const [branchesPanelOpen, setBranchesPanelOpen] = useState(false);
@@ -354,6 +360,35 @@ export default function App() {
     };
   }, [handleTrayAction]);
 
+  // Lock check-in requests (SBAI-4044): keep the inbox badge in sync and toast
+  // when a new request arrives. The Rust side fires the OS tray notification;
+  // this just updates in-app state. Seed the count on mount.
+  const refreshLockRequestCount = useCallback(async () => {
+    try {
+      const reqs = await lockMessagingApi.inboxList();
+      setPendingLockRequests(reqs.length);
+    } catch {
+      /* inbox unavailable — leave count as-is */
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshLockRequestCount();
+  }, [refreshLockRequestCount]);
+
+  useEffect(() => {
+    let unlisten: undefined | (() => void);
+    void (async () => {
+      unlisten = await listen<LockRequest>(LOCK_REQUEST_EVENT, ({ payload }) => {
+        void refreshLockRequestCount();
+        pushToast(`${payload.from} wants you to check in ${payload.path}.`);
+      });
+    })();
+    return () => {
+      if (unlisten) void unlisten();
+    };
+  }, [pushToast, refreshLockRequestCount]);
+
   const fetchBranchInfo = useCallback(
     async (name: string) => {
       if (branchInfoData?.name === name) {
@@ -568,6 +603,22 @@ export default function App() {
             title="File locks: query, status, acquire, release"
           >
             Locks
+          </button>
+          <button
+            onClick={() => setLockInboxOpen(true)}
+            title="Lock requests: teammates asking you to check in files"
+            aria-label={
+              pendingLockRequests > 0
+                ? `Lock requests (${pendingLockRequests} pending)`
+                : "Lock requests"
+            }
+          >
+            Requests
+            {pendingLockRequests > 0 && (
+              <span className="nav-badge" aria-hidden="true">
+                {pendingLockRequests}
+              </span>
+            )}
           </button>
           <button
             onClick={() => setStorageOpen(true)}
@@ -1236,6 +1287,15 @@ export default function App() {
         <LocksPanel onClose={() => setLocksPanelOpen(false)} />
       )}
 
+      {lockInboxOpen && (
+        <LockInbox
+          onClose={() => {
+            setLockInboxOpen(false);
+            void refreshLockRequestCount();
+          }}
+        />
+      )}
+
       {settingsOpen && <SettingsPanel onClose={() => setSettingsOpen(false)} />}
 
       {accountPanelOpen && (
@@ -1261,6 +1321,7 @@ export default function App() {
       {workspaceFile && (
         <ContentWorkspace
           path={workspaceFile.path}
+          branch={status?.branch ?? ""}
           changeKind={workspaceFile.kind}
           initialMode={workspaceFile.mode}
           sourceRevision={workspaceFile.sourceRevision}

--- a/frontend/src/LocksPanel.tsx
+++ b/frontend/src/LocksPanel.tsx
@@ -8,6 +8,7 @@ import {
   type LockEntry,
   type LockStatus,
 } from "./api";
+import LockRequestButton from "./locks/LockRequestButton";
 
 /**
  * Locks panel (sidebar/topbar nav, daily domain) — the rich home for the lock
@@ -305,6 +306,13 @@ export default function LocksPanel({ onClose }: { onClose: () => void }) {
                       >
                         Release…
                       </button>
+                      {/* Ask the holder to check in — renders only when the
+                          lock is held by someone else (SBAI-4044). */}
+                      <LockRequestButton
+                        path={lock.path}
+                        branch={lock.branch}
+                        compact
+                      />
                     </li>
                   ))}
                 </ul>
@@ -366,6 +374,11 @@ export default function LocksPanel({ onClose }: { onClose: () => void }) {
                         ● held by {lock.owner || "(unknown)"} ·{" "}
                         {fmtTime(lock.locked_at)}
                       </span>
+                      <LockRequestButton
+                        path={lock.path}
+                        branch={sBranch.trim()}
+                        compact
+                      />
                     </li>
                   ))}
                 </ul>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1449,6 +1449,60 @@ export const lockFileStatusApi = {
     invoke<FileStatusResult>("lock_file_status", { paths, branch }),
 };
 
+// --- lock messaging: request check-in from a holder (SBAI-4044) ---
+//
+// Transport note (see docs/lock-messaging-spike.md): lore's notification channel
+// can't carry arbitrary user→user messages in-band, so the core build delivers
+// requests **locally** (same process / single machine). Cross-network delivery
+// is the premium relay (SBAI-4072). The shape here is what the relay would carry.
+
+/** Tauri event emitted when a check-in request lands in this client's inbox. */
+export const LOCK_REQUEST_EVENT = "lock/request";
+
+/** An incoming "please check in <file>" request. */
+export interface LockRequest {
+  /** Stable id for inbox dedupe / dismissal. */
+  id: string;
+  /** File the lock applies to. */
+  path: string;
+  /** Branch the lock is on (empty = current). */
+  branch: string;
+  /** Display name of the requester (who is asking). */
+  from: string;
+  /** User id of the holder this request is addressed to. */
+  toUserId: string;
+  /** Display name of the holder. */
+  holder: string;
+  /** Optional free-text note from the requester. */
+  note: string;
+  /** Unix epoch millis when the request was created. */
+  createdAt: number;
+}
+
+export const lockMessagingApi = {
+  /** Ask the holder of a file's lock to check it in / release it. */
+  requestCheckin: (args: {
+    path: string;
+    branch: string;
+    from: string;
+    toUserId: string;
+    holder: string;
+    note?: string;
+  }) =>
+    invoke<LockRequest>("lock_request_checkin", {
+      path: args.path,
+      branch: args.branch,
+      from: args.from,
+      toUserId: args.toUserId,
+      holder: args.holder,
+      note: args.note ?? "",
+    }),
+  /** Read the incoming check-in request inbox. */
+  inboxList: () => invoke<LockRequest[]>("lock_inbox_list"),
+  /** Remove a request from the inbox (Dismiss, or after Release). */
+  inboxDismiss: (id: string) => invoke<boolean>("lock_inbox_dismiss", { id }),
+};
+
 // --- branch reset ---
 
 export interface BranchResetResult {

--- a/frontend/src/content/ContentWorkspace.tsx
+++ b/frontend/src/content/ContentWorkspace.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useEffect, useState } from "react";
 import PreviewView from "./PreviewView";
 import { kindOf } from "./kinds";
+import LockRequestButton from "../locks/LockRequestButton";
 import type { ChangeKind } from "../api";
 
 const DiffView = lazy(() => import("./DiffView"));
@@ -33,6 +34,7 @@ const TABS: { id: WorkspaceMode; label: string }[] = [
 
 export default function ContentWorkspace({
   path,
+  branch = "",
   changeKind = null,
   initialMode = "preview",
   sourceRevision = "",
@@ -42,6 +44,8 @@ export default function ContentWorkspace({
   onClose,
 }: {
   path: string;
+  /** Branch the file's lock is on; used by the "Request check-in" action. */
+  branch?: string;
   changeKind?: ChangeKind | null;
   initialMode?: WorkspaceMode;
   /** Diff source revision (empty = working tree). */
@@ -91,6 +95,9 @@ export default function ContentWorkspace({
               {path}
             </span>
           </div>
+          {/* If this file is locked by someone else, offer to ask them to
+              check it in (SBAI-4044). Renders nothing otherwise. */}
+          <LockRequestButton path={path} branch={branch} className="cw-lock-req" />
           <button className="cw-close" onClick={onClose} title="Close (Esc)">
             Close
           </button>

--- a/frontend/src/locks/LockInbox.tsx
+++ b/frontend/src/locks/LockInbox.tsx
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  api,
+  lockFileReleaseApi,
+  lockMessagingApi,
+  LOCK_REQUEST_EVENT,
+  type LockRequest,
+} from "../api";
+import { listen } from "@tauri-apps/api/event";
+
+/**
+ * Lock-request inbox drawer (SBAI-4044).
+ *
+ * The holder's surface for incoming "please check in <file>" requests. Each row
+ * shows who is asking and which file, with two actions:
+ *   - Release: calls `lock.file_release` for the file, then dismisses the row.
+ *   - Dismiss: drops the request without releasing.
+ *
+ * It listens live for the `lock/request` Tauri event (fired when a request lands
+ * locally) so the list updates without a reopen, and refetches on open. Themed
+ * via `--surface-*` (reuses the shared overlay-panel classes); Esc closes.
+ */
+
+function errMsg(e: unknown): string {
+  if (typeof e === "string") return e;
+  if (e && typeof e === "object") {
+    const o = e as { message?: unknown };
+    if (typeof o.message === "string") return o.message;
+  }
+  return JSON.stringify(e);
+}
+
+function fmtTime(ms: number): string {
+  if (!ms) return "";
+  try {
+    return new Date(ms).toLocaleString();
+  } catch {
+    return "";
+  }
+}
+
+export default function LockInbox({ onClose }: { onClose: () => void }) {
+  const [requests, setRequests] = useState<LockRequest[]>([]);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setRequests(await lockMessagingApi.inboxList());
+    } catch (e) {
+      setError(errMsg(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Live updates: a new request arriving locally fires `lock/request`.
+  useEffect(() => {
+    let unlisten: undefined | (() => void);
+    void (async () => {
+      unlisten = await listen<LockRequest>(LOCK_REQUEST_EVENT, () => {
+        void refresh();
+      });
+    })();
+    return () => {
+      if (unlisten) unlisten();
+    };
+  }, [refresh]);
+
+  // Esc closes (DESIGN-SYSTEM: overlays dismiss on Esc).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const dismiss = useCallback(
+    async (id: string) => {
+      setBusyId(id);
+      setError(null);
+      try {
+        await lockMessagingApi.inboxDismiss(id);
+        await refresh();
+      } catch (e) {
+        setError(errMsg(e));
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [refresh],
+  );
+
+  const release = useCallback(
+    async (req: LockRequest) => {
+      setBusyId(req.id);
+      setError(null);
+      try {
+        const user = await api.authUserInfo().catch(() => null);
+        // Release our own lock — owner is the signed-in user.
+        await lockFileReleaseApi.fileRelease(
+          [req.path],
+          req.branch,
+          user?.name || user?.id || req.holder,
+          user?.id || req.toUserId,
+        );
+        await lockMessagingApi.inboxDismiss(req.id);
+        await refresh();
+      } catch (e) {
+        setError(errMsg(e));
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [refresh],
+  );
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Lock requests"
+      className="storage-scrim"
+      onClick={onClose}
+    >
+      <div className="storage-panel" onClick={(e) => e.stopPropagation()}>
+        <header className="storage-panel-header">
+          <h2>Lock requests</h2>
+          <button onClick={onClose} title="Close (Esc)">
+            Close
+          </button>
+        </header>
+
+        <section className="storage-section">
+          <p className="storage-help">
+            Teammates asking you to check in (release) files you have locked.
+            Release frees the lock for them; Dismiss clears the request without
+            releasing.
+          </p>
+
+          {error && (
+            <div className="error storage-inline-error">{error}</div>
+          )}
+
+          {requests.length === 0 ? (
+            <p className="empty">No pending requests.</p>
+          ) : (
+            <ul className="storage-list">
+              {requests.map((req) => (
+                <li key={req.id}>
+                  <code>{req.path}</code>
+                  <span className="storage-status">
+                    {req.from} wants you to check this in
+                    {req.branch ? ` · ${req.branch}` : ""}
+                    {fmtTime(req.createdAt) ? ` · ${fmtTime(req.createdAt)}` : ""}
+                  </span>
+                  {req.note && <span className="lock-req-note">“{req.note}”</span>}
+                  <button
+                    className="storage-primary"
+                    disabled={busyId === req.id}
+                    onClick={() => void release(req)}
+                    title={`Release the lock on ${req.path}`}
+                  >
+                    {busyId === req.id ? "Releasing…" : "Release"}
+                  </button>
+                  <button
+                    disabled={busyId === req.id}
+                    onClick={() => void dismiss(req.id)}
+                    title="Clear this request without releasing"
+                  >
+                    Dismiss
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/locks/LockRequestButton.tsx
+++ b/frontend/src/locks/LockRequestButton.tsx
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useState } from "react";
+import { api, lockFileStatusApi, lockMessagingApi } from "../api";
+
+/**
+ * "Request check-in" action for a single file (SBAI-4044).
+ *
+ * Reusable across surfaces that show one file — the Locks panel row and the
+ * content/file workspace header. On mount it checks the file's lock status; it
+ * renders an action ONLY when the file is locked by **someone else** (you can't
+ * meaningfully ask yourself to release your own lock). Clicking sends a check-in
+ * request to the holder, who receives a tray notification + inbox entry.
+ *
+ * Transport: core build delivers locally (same machine); cross-network delivery
+ * is the premium relay (SBAI-4072). See docs/lock-messaging-spike.md.
+ *
+ * Themed via `--surface-*` (reuses shared button classes); no hardcoded colors.
+ */
+
+function errMsg(e: unknown): string {
+  if (typeof e === "string") return e;
+  if (e && typeof e === "object") {
+    const o = e as { message?: unknown };
+    if (typeof o.message === "string") return o.message;
+  }
+  return JSON.stringify(e);
+}
+
+type Holder = { owner: string } | null;
+
+export default function LockRequestButton({
+  path,
+  branch,
+  className = "",
+  compact = false,
+}: {
+  path: string;
+  /** Branch the lock is on; empty = current. */
+  branch?: string;
+  className?: string;
+  /** Render as a tight inline control (file row) vs a labelled button. */
+  compact?: boolean;
+}) {
+  const [holder, setHolder] = useState<Holder>(null);
+  const [me, setMe] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [res, user] = await Promise.all([
+          lockFileStatusApi.fileStatus([path], branch ?? ""),
+          api.authUserInfo().catch(() => null),
+        ]);
+        if (cancelled) return;
+        const lock = res.locks.find((l) => l.path === path) ?? null;
+        setHolder(lock ? { owner: lock.owner } : null);
+        setMe(user ? user.id || user.name : null);
+      } catch {
+        // Lock status unavailable (e.g. local-only repo) — render nothing.
+        if (!cancelled) setHolder(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [path, branch]);
+
+  const send = useCallback(async () => {
+    if (!holder) return;
+    setSending(true);
+    setError(null);
+    try {
+      const user = await api.authUserInfo().catch(() => null);
+      const from = user ? user.name || user.id : "A teammate";
+      await lockMessagingApi.requestCheckin({
+        path,
+        branch: branch ?? "",
+        from,
+        toUserId: holder.owner,
+        holder: holder.owner,
+      });
+      setSent(true);
+    } catch (e) {
+      setError(errMsg(e));
+    } finally {
+      setSending(false);
+    }
+  }, [holder, path, branch]);
+
+  // Nothing to do: file isn't locked, or it's locked by you.
+  if (!holder) return null;
+  const ownLock = me != null && holder.owner === me;
+  if (ownLock) return null;
+
+  if (sent) {
+    return (
+      <span className={`lock-req-sent ${className}`} role="status">
+        Requested check-in from {holder.owner}.
+      </span>
+    );
+  }
+
+  const label = compact ? "Request…" : "Request check-in";
+  return (
+    <span className={`lock-req ${className}`}>
+      <button
+        type="button"
+        className="lock-req-btn"
+        disabled={sending}
+        onClick={() => void send()}
+        title={`Ask ${holder.owner} to check in this file`}
+        aria-label={`Request check-in of ${path} from ${holder.owner}`}
+      >
+        {sending ? "Sending…" : label}
+      </button>
+      {error && (
+        <span className="lock-req-error error" role="alert">
+          {error}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/palette/manifest/lock/request_checkin.ts
+++ b/frontend/src/palette/manifest/lock/request_checkin.ts
@@ -1,0 +1,73 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Palette manifest for `lock.request_checkin` (SBAI-4044).
+ *
+ * Asks the current holder of a file's lock to check it in / release it. The
+ * holder receives a tray notification + an inbox entry on their client. See
+ * `docs/lock-messaging-spike.md` for the transport: the core build delivers
+ * locally; cross-network delivery is the premium relay (SBAI-4072).
+ */
+const manifest: OpManifest = {
+  id: "lock.request_checkin",
+  domain: "lock",
+  op: "request_checkin",
+  label: "Lock: Request Check-In",
+  description:
+    "Ask the holder of a locked file to check it in. They get a tray notification and an inbox entry with Release / Dismiss.",
+  command: "lock_request_checkin",
+  args: [
+    {
+      name: "path",
+      kind: "text",
+      label: "File path",
+      description: "The locked file you want released.",
+      required: true,
+      placeholder: "Content/Characters/hero.uasset",
+    },
+    {
+      name: "branch",
+      kind: "text",
+      label: "Branch",
+      description: "Branch the lock is on; leave empty for the current branch.",
+      required: false,
+      placeholder: "e.g. main",
+    },
+    {
+      name: "from",
+      kind: "text",
+      label: "Your name",
+      description: "Who the request is from (shown to the holder).",
+      required: true,
+      placeholder: "e.g. you@example.com",
+    },
+    {
+      name: "holder",
+      kind: "text",
+      label: "Holder",
+      description: "Display name of the current lock holder.",
+      required: true,
+      placeholder: "e.g. teammate@example.com",
+    },
+    {
+      name: "toUserId",
+      kind: "text",
+      label: "Holder user ID",
+      description: "User id of the holder (from the lock's owner field).",
+      required: true,
+      placeholder: "e.g. 12345",
+    },
+    {
+      name: "note",
+      kind: "text",
+      label: "Note",
+      description: "Optional message to the holder.",
+      required: false,
+      placeholder: "Need this for the merge — thanks!",
+    },
+  ],
+  resultKind: "json",
+  keywords: ["lock", "request", "check-in", "checkin", "nudge", "ask", "release"],
+};
+
+export default manifest;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1465,3 +1465,57 @@ h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; color: v
 .open-btn {
   font-size: 11px;
 }
+
+/* --- Lock-coordination messaging (SBAI-4044) --- */
+
+/* Pending-request count on the "Requests" nav button. */
+.nav-badge {
+  display: inline-block;
+  min-width: 16px;
+  margin-left: 6px;
+  padding: 0 5px;
+  border-radius: 9px;
+  font-size: 11px;
+  line-height: 16px;
+  text-align: center;
+  background: var(--surface-accent-bg, var(--accent));
+  color: var(--surface-primary-text, #ffffff);
+}
+
+/* "Request check-in" action shown on locks held by someone else. */
+.lock-req {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.lock-req-btn {
+  font-size: 11px;
+  background: var(--surface-secondary-bg, var(--panel2));
+  color: var(--surface-secondary-text, var(--text));
+  border: 1px solid var(--surface-secondary-border, var(--border));
+}
+
+.lock-req-btn:hover:not(:disabled) {
+  background: var(--surface-secondary-hover, var(--panel2));
+}
+
+.lock-req-sent {
+  font-size: 11px;
+  color: var(--surface-success-text, var(--green));
+}
+
+.lock-req-error {
+  font-size: 11px;
+  color: var(--surface-error-text, var(--red));
+}
+
+.lock-req-note {
+  font-style: italic;
+  color: var(--surface-overlay-text-secondary, var(--text-secondary));
+}
+
+/* Request action in the content-workspace header — push it left of Close. */
+.cw-lock-req {
+  margin-left: auto;
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-autostart = "2"
+tauri-plugin-notification = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 base64 = "0.22"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "dialog:default"
+    "dialog:default",
+    "notification:default"
   ]
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -46,6 +46,42 @@ pub struct AppState {
     /// is produced (no tunnel/bore logic lives here). `None` = no override, so
     /// the UI shows the real loopback URL. Cleared on stop.
     pub(crate) advertised_url: Mutex<Option<String>>,
+    /// Local lock-coordination inbox (SBAI-4044). Holds incoming check-in
+    /// requests addressed to *this* user. In the core/MIT build the sender and
+    /// receiver share one process (single machine), so a request is delivered by
+    /// pushing it here + firing a tray notification. Cross-*network* delivery
+    /// rides the premium relay (SBAI-4072) — see `docs/lock-messaging-spike.md`.
+    pub(crate) lock_inbox: Mutex<Vec<LockRequest>>,
+    /// Monotonic id source for lock requests.
+    pub(crate) lock_request_counter: AtomicU64,
+}
+
+/// A lock-coordination request: "please check in / release this file".
+///
+/// In the core build this is delivered to the local inbox. The same shape is
+/// what the premium relay (SBAI-4072) would carry across the network — see
+/// `lore_vm::ops::lock::file_message_send::FileMessageSendArgs` for the wire
+/// contract the relay would use.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LockRequest {
+    /// Stable id for inbox dedupe / dismissal.
+    pub id: String,
+    /// File the lock applies to.
+    pub path: String,
+    /// Branch the lock is on (empty = current).
+    pub branch: String,
+    /// Display name of the requester (who is asking).
+    pub from: String,
+    /// User id of the holder this request is addressed to.
+    pub to_user_id: String,
+    /// Display name of the holder (for the inbox row).
+    pub holder: String,
+    /// Optional free-text note from the requester.
+    #[serde(default)]
+    pub note: String,
+    /// Unix epoch millis when the request was created.
+    pub created_at: u64,
 }
 
 impl AppState {
@@ -655,6 +691,92 @@ pub async fn lock_file_release(
         },
     )
     .await
+}
+
+// --- lock messaging (SBAI-4044): request check-in from a lock holder ---
+//
+// Transport verdict (see `docs/lock-messaging-spike.md`): lore's high-level
+// `notification` crate carries only lock/branch lifecycle events — it has no
+// `publish` and drops `ExtensionEvent`, so it cannot relay an arbitrary
+// user→user message in-band. Cross-*network* delivery therefore needs the
+// premium relay (SBAI-4072). The core/MIT build delivers **locally**: the sender
+// and the holder share one process (single machine), so a request is delivered
+// by pushing it onto `AppState.lock_inbox`, firing an OS tray notification, and
+// emitting a `lock/request` event the UI listens for. This is a real, working
+// end-to-end loop on one host; the one network seam is marked `TODO(relay)`.
+
+use tauri::Emitter;
+
+/// Frontend event channel for a newly-arrived lock request.
+pub const LOCK_REQUEST_EVENT: &str = "lock/request";
+
+fn now_millis() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Ask the holder of a file's lock to check it in / release it.
+///
+/// `from` is the requester's display name, `holder`/`to_user_id` identify the
+/// current lock holder (already known to the caller from `lock_file_status` /
+/// `lock_file_query`). Returns the created [`LockRequest`] (with its assigned
+/// `id`) so the sender can show "request sent".
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+pub fn lock_request_checkin(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    path: String,
+    branch: String,
+    from: String,
+    to_user_id: String,
+    holder: String,
+    note: String,
+) -> Result<LockRequest, LoreError> {
+    let id = state.lock_request_counter.fetch_add(1, Ordering::SeqCst) + 1;
+    let request = LockRequest {
+        id: format!("lockreq-{id}"),
+        path,
+        branch,
+        from,
+        to_user_id,
+        holder,
+        note,
+        created_at: now_millis(),
+    };
+
+    // Local delivery: push onto the holder's inbox (same process in the core
+    // build). TODO(SBAI-4072 relay): when the sender and holder are on different
+    // machines, POST this same `LockRequest` to the relay side-channel instead
+    // of (or in addition to) the local inbox — see docs/lock-messaging-spike.md.
+    state.lock_inbox.lock().unwrap().push(request.clone());
+
+    // Fire the OS tray notification + nudge the window so the holder sees it.
+    crate::tray::notify_lock_request(&app, &request.from, &request.path);
+
+    // Tell the frontend so the inbox badge / drawer updates live.
+    let _ = app.emit(LOCK_REQUEST_EVENT, request.clone());
+
+    Ok(request)
+}
+
+/// Return the current lock-request inbox (incoming check-in requests).
+#[tauri::command]
+pub fn lock_inbox_list(state: State<'_, AppState>) -> Vec<LockRequest> {
+    state.lock_inbox.lock().unwrap().clone()
+}
+
+/// Remove a lock request from the inbox (Dismiss, or after Release). Returns
+/// `true` if it was present.
+#[tauri::command]
+pub fn lock_inbox_dismiss(state: State<'_, AppState>, id: String) -> bool {
+    let mut inbox = state.lock_inbox.lock().unwrap();
+    let before = inbox.len();
+    inbox.retain(|r| r.id != id);
+    inbox.len() != before
 }
 
 // --- auth local_user_info ---

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
             Some(vec!["--hidden"]),
@@ -63,6 +64,8 @@ pub fn run() {
             storage_session: Mutex::new(commands::StorageSession::default()),
             hosted_server: Mutex::new(None),
             advertised_url: Mutex::new(None),
+            lock_inbox: Mutex::new(Vec::new()),
+            lock_request_counter: AtomicU64::new(0),
         })
         .invoke_handler(tauri::generate_handler![
             commands::open_repository,
@@ -124,6 +127,9 @@ pub fn run() {
             commands::lock_file_query,
             commands::lock_file_acquire,
             commands::lock_file_status,
+            commands::lock_request_checkin,
+            commands::lock_inbox_list,
+            commands::lock_inbox_dismiss,
             commands::branch_reset,
             commands::branch_merge_start,
             commands::branch_merge_restart,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -169,6 +169,28 @@ fn emit_action<R: Runtime>(app: &AppHandle<R>, action: &str) -> tauri::Result<()
     )
 }
 
+/// Fire an OS notification for an incoming lock check-in request (SBAI-4044) and
+/// surface the window so the holder can act on it. Called from
+/// `commands::lock_request_checkin` when a request lands in the local inbox.
+///
+/// Notification failures are non-fatal (best-effort): if the notification
+/// permission is denied or the plugin is unavailable we still raise the window,
+/// and the in-app inbox drawer remains the reliable surface.
+pub fn notify_lock_request<R: Runtime>(app: &AppHandle<R>, from: &str, path: &str) {
+    use tauri_plugin_notification::NotificationExt;
+
+    let body = format!("{from} is asking you to check in {path}");
+    let _ = app
+        .notification()
+        .builder()
+        .title("Check-in requested")
+        .body(body)
+        .show();
+
+    // Bring the window forward so the inbox is visible without hunting for it.
+    let _ = show_main_window(app);
+}
+
 fn format_title(snapshot: &TraySnapshot) -> String {
     if snapshot.branch.trim().is_empty() {
         return "LoreGUI".to_string();


### PR DESCRIPTION
Request a check-in from a lock holder → OS tray notification + in-app Requests inbox (Release/Dismiss). Single-machine path works end-to-end; cross-machine delivery is a documented TODO(SBAI-4072 relay) seam with a typed lock.file_message_send op as the canonical payload. Transport spike (docs/lock-messaging-spike.md): lore's high-level notification crate can't carry user messages; needs the relay side-channel. Core/MIT. Themeable, a11y, design-review passed; guards green.