### PR TITLE
feat(connect): LAN auto-discovery of lore servers — core/MIT (SBAI-4073)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,7 +2181,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2317,6 +2328,16 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2976,7 +2997,9 @@ name = "loregui"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "if-addrs",
  "lore-vm",
+ "mdns-sd",
  "serde",
  "serde_json",
  "tauri",
@@ -3068,6 +3091,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "mdns-sd"
+version = "0.13.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328f4e1041f7cfeb3affccb814ddbe2f004856a2ce769c8bf22080d74c5204c6"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket2 0.5.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3120,6 +3157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -4073,7 +4111,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4110,7 +4148,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4864,6 +4902,16 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
@@ -4918,6 +4966,15 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -5565,7 +5622,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5757,7 +5814,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rustls-native-certs",
- "socket2",
+ "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",

--- a/frontend/scripts/palette-parity-allowlist.json
+++ b/frontend/scripts/palette-parity-allowlist.json
@@ -24,7 +24,9 @@
     "read_file_bytes",
     "write_text_file",
     "lock_inbox_list",
-    "lock_inbox_dismiss"
+    "lock_inbox_dismiss",
+    "lan_discover_refresh",
+    "lan_discover_stop"
   ],
   "deferred": []
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -337,6 +337,32 @@ export interface HostStatus {
   advertisedUrl?: string;
 }
 
+/**
+ * A lore server discovered on the LAN via mDNS (SBAI-4073). Mirrors the Rust
+ * `lan_discovery::DiscoveredServer` (camelCase via serde). Open-core, not gated.
+ */
+export interface DiscoveredServer {
+  /** Stable id for this browse session (the mDNS service fullname). */
+  id: string;
+  /** Friendly host label, e.g. "BRAINZ" or "Brian's Mac · world-bible". */
+  name: string;
+  /** Repository name the host advertised (may be empty). */
+  repo: string;
+  /** The `lore://host:port/<repo>` URL one-click "Connect" prefills. */
+  url: string;
+  /** Resolved host (display-only; the connect target is `url`). */
+  host: string;
+  /** Advertised lore port. */
+  port: number;
+}
+
+/**
+ * Tauri event carrying the live discovered-server list (SBAI-4073). The connect
+ * flow `listen`s on this to refresh as servers appear/leave, without polling.
+ * Payload: `DiscoveredServer[]`.
+ */
+export const LAN_DISCOVERED_EVENT = "lan/discovered";
+
 export const api = {
   currentRepository: () => invoke<string>("current_repository"),
   openRepository: (path: string) => invoke<void>("open_repository", { path }),
@@ -443,6 +469,21 @@ export const api = {
   // --- system tray live status (SBAI-4042) ---
   traySyncState: (snapshot: TraySnapshot) =>
     invoke<void>("tray_sync_state", { snapshot }),
+
+  // --- LAN auto-discovery of lore servers (SBAI-4073) ---
+  // Open-core, NOT gated: dynamic mDNS discovery, same pattern as
+  // studiobrain-model-manager. `lanDiscoverBrowse` starts (or reuses) a live
+  // browse and returns what's been seen so far; the `lan/discovered` event keeps
+  // the list live. `lanDiscoverRefresh` re-reads the running browse without
+  // restarting it; `lanDiscoverStop` tears the browse down on flow exit.
+  /** Start/reuse a LAN browse and return the servers seen so far. */
+  lanDiscoverBrowse: () =>
+    invoke<DiscoveredServer[]>("lan_discover_browse"),
+  /** Re-read the running browse's current snapshot (no restart). */
+  lanDiscoverRefresh: () =>
+    invoke<DiscoveredServer[]>("lan_discover_refresh"),
+  /** Stop the LAN browse session (call on connect-flow unmount). */
+  lanDiscoverStop: () => invoke<void>("lan_discover_stop"),
 };
 
 // --- repository create (ops-layer) ---

--- a/frontend/src/onboarding/ClientConnect.tsx
+++ b/frontend/src/onboarding/ClientConnect.tsx
@@ -1,13 +1,97 @@
-import { useCallback, useState } from "react";
-import { api, type UserInfo } from "../api";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  api,
+  LAN_DISCOVERED_EVENT,
+  type DiscoveredServer,
+  type UserInfo,
+} from "../api";
+import { listen } from "@tauri-apps/api/event";
 
 type Step = "input" | "authenticating" | "success" | "error";
+type DiscoveryStep = "loading" | "ready" | "error";
 
+/**
+ * Connect-to-server onboarding (SBAI-3841 + SBAI-4073).
+ *
+ * Two ways in:
+ *   1. "Servers on your network" — LAN auto-discovery (mDNS). Lists lore servers
+ *      hosted by peers on the same network; one click prefills the `lore://` URL.
+ *      Open-core, not gated. Themed via `--surface-*`; loading/empty/error states.
+ *   2. Manual URL — the always-available fallback for remote servers or when mDNS
+ *      is blocked (firewall / VPN / corporate switch dropping multicast).
+ */
 export default function ClientConnect() {
   const [remoteUrl, setRemoteUrl] = useState("");
   const [step, setStep] = useState<Step>("input");
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // --- LAN discovery state ---
+  const [servers, setServers] = useState<DiscoveredServer[]>([]);
+  const [discovery, setDiscovery] = useState<DiscoveryStep>("loading");
+  const [discoveryError, setDiscoveryError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const errMsg = (e: unknown): string =>
+    typeof e === "string" ? e : e instanceof Error ? e.message : JSON.stringify(e);
+
+  // Start (or reuse) a LAN browse on mount; subscribe to live updates; stop the
+  // browse on unmount so we are not discovering for the whole app lifetime.
+  useEffect(() => {
+    let unlisten: undefined | (() => void);
+    let cancelled = false;
+    void (async () => {
+      try {
+        setDiscovery("loading");
+        setDiscoveryError(null);
+        const initial = await api.lanDiscoverBrowse();
+        if (!cancelled) {
+          setServers(initial);
+          setDiscovery("ready");
+        }
+        unlisten = await listen<DiscoveredServer[]>(
+          LAN_DISCOVERED_EVENT,
+          (event) => {
+            setServers(event.payload);
+            setDiscovery("ready");
+          },
+        );
+      } catch (e) {
+        if (!cancelled) {
+          setDiscoveryError(errMsg(e));
+          setDiscovery("error");
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+      // Best-effort: stop the browse when leaving the connect flow.
+      void api.lanDiscoverStop().catch(() => {});
+    };
+  }, []);
+
+  const refreshDiscovery = useCallback(async () => {
+    try {
+      setDiscovery("loading");
+      setDiscoveryError(null);
+      const list = await api.lanDiscoverBrowse();
+      setServers(list);
+      setDiscovery("ready");
+    } catch (e) {
+      setDiscoveryError(errMsg(e));
+      setDiscovery("error");
+    }
+  }, []);
+
+  const pickServer = useCallback((server: DiscoveredServer) => {
+    // One-click connect prefills the lore:// URL; the user confirms with Connect
+    // (so they can review the target before authenticating).
+    setRemoteUrl(server.url);
+    setStep("input");
+    setError(null);
+    inputRef.current?.focus();
+  }, []);
 
   const handleAuth = useCallback(async () => {
     if (!remoteUrl.trim()) return;
@@ -19,7 +103,7 @@ export default function ClientConnect() {
       setUserInfo(user);
       setStep("success");
     } catch (e) {
-      setError(typeof e === "string" ? e : JSON.stringify(e));
+      setError(errMsg(e));
       setStep("error");
     }
   }, [remoteUrl]);
@@ -33,19 +117,73 @@ export default function ClientConnect() {
     <div className="onboarding-card">
       <h2>Connect to Server</h2>
       <p className="onboarding-description">
-        Enter the URL of the remote StudioBrain server you want to connect to.
-        You will be prompted to authenticate.
+        Pick a server discovered on your network, or enter the URL of a remote
+        StudioBrain server. You will be prompted to authenticate.
       </p>
 
       {error && <div className="error">{error}</div>}
+
+      {/* --- Servers on your network (LAN auto-discovery, SBAI-4073) --- */}
+      <section className="lan-discovery" aria-label="Servers on your network">
+        <div className="lan-discovery-header">
+          <h3>Servers on your network</h3>
+          <button
+            type="button"
+            className="lan-discovery-refresh"
+            onClick={() => void refreshDiscovery()}
+            disabled={discovery === "loading"}
+            title="Re-scan the local network for lore servers"
+          >
+            {discovery === "loading" ? "Scanning…" : "Refresh"}
+          </button>
+        </div>
+
+        {discovery === "error" ? (
+          <div className="error lan-discovery-error">
+            Network discovery unavailable: {discoveryError}. You can still connect
+            using the server URL below.
+          </div>
+        ) : discovery === "loading" && servers.length === 0 ? (
+          <p className="empty lan-discovery-empty">Scanning your network…</p>
+        ) : servers.length === 0 ? (
+          <p className="empty lan-discovery-empty">
+            No servers found yet. Make sure a host is running on your network, or
+            enter a server URL below.
+          </p>
+        ) : (
+          <ul className="lan-discovery-list">
+            {servers.map((server) => (
+              <li key={server.id} className="lan-discovery-item">
+                <div className="lan-discovery-meta">
+                  <span className="lan-discovery-name">{server.name}</span>
+                  <span className="lan-discovery-sub">
+                    {server.repo ? `${server.repo} · ` : ""}
+                    {server.host}
+                    {server.port ? `:${server.port}` : ""}
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  className="onboarding-button onboarding-button--primary lan-discovery-connect"
+                  onClick={() => pickServer(server)}
+                  title={`Use ${server.url}`}
+                >
+                  Connect
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
 
       {step === "input" && (
         <div className="onboarding-field">
           <label htmlFor="remote-url">Remote Server URL</label>
           <input
             id="remote-url"
+            ref={inputRef}
             type="text"
-            placeholder="https://api.studiobrain.ai"
+            placeholder="lore://host:port/repo or https://api.studiobrain.ai"
             value={remoteUrl}
             onChange={(e) => setRemoteUrl(e.target.value)}
           />

--- a/frontend/src/palette/manifest/service/lan_discover_browse.ts
+++ b/frontend/src/palette/manifest/service/lan_discover_browse.ts
@@ -1,0 +1,40 @@
+import type { OpManifest } from "../../types";
+
+/**
+ * Command-palette manifest entry for `service: discover servers on LAN`
+ * (SBAI-4073).
+ *
+ * Open-core, NOT gated: dynamic mDNS/zeroconf discovery (the same pattern
+ * studiobrain-model-manager uses for gateway clustering). Starts (or reuses) a
+ * background browse for lore servers advertised on the local network and returns
+ * the list seen so far — each entry carries a friendly name, repo, host, and the
+ * `lore://host:port/<repo>` URL a client connects with. The connect/onboarding
+ * flow ("Servers on your network") is the rich surface; this palette row is the
+ * universal way to trigger a scan from anywhere (Ctrl-K). No arguments.
+ */
+const manifest: OpManifest = {
+  id: "service.lan_discover_browse",
+  domain: "service",
+  op: "lan_discover_browse",
+  label: "Discover Servers on Network",
+  description:
+    "Scan the local network for lore servers (mDNS) and list any found, with the lore:// URL to connect. Open-core; the manual server URL always works too.",
+  command: "lan_discover_browse",
+  args: [],
+  resultKind: "json",
+  keywords: [
+    "lan",
+    "discover",
+    "discovery",
+    "mdns",
+    "zeroconf",
+    "bonjour",
+    "network",
+    "servers",
+    "browse",
+    "find",
+    "nearby",
+  ],
+};
+
+export default manifest;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -523,6 +523,96 @@ h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; color: v
   margin-top: 12px;
 }
 
+/* LAN auto-discovery: "Servers on your network" (SBAI-4073) ---------- */
+.lan-discovery {
+  margin: 4px 0 16px;
+  padding: 12px 14px;
+  border-radius: 6px;
+  background: var(--surface-input-bg, var(--panel2));
+  border: 1px solid var(--surface-elevated-border, var(--border));
+}
+
+.lan-discovery-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.lan-discovery-header h3 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--surface-elevated-text, var(--text));
+}
+
+.lan-discovery-refresh {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 5px;
+  cursor: pointer;
+  color: var(--surface-default-text, var(--text));
+  background: var(--surface-default-bg, transparent);
+  border: 1px solid var(--surface-default-border, var(--border));
+}
+.lan-discovery-refresh:hover:not(:disabled) {
+  background: var(--surface-default-hover, var(--surface-elevated-hover, rgba(127,127,127,0.12)));
+}
+.lan-discovery-refresh:disabled { opacity: 0.6; cursor: default; }
+
+.lan-discovery-empty,
+.lan-discovery-error { margin: 4px 0 0; }
+
+.lan-discovery-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lan-discovery-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 5px;
+  background: var(--surface-elevated-bg, var(--panel));
+  border: 1px solid var(--surface-elevated-border, var(--border));
+}
+
+.lan-discovery-meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.lan-discovery-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--surface-elevated-text, var(--text));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lan-discovery-sub {
+  font-size: 12px;
+  color: var(--surface-elevated-text-secondary, var(--muted));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lan-discovery-connect {
+  flex: 0 0 auto;
+  padding: 6px 14px;
+  font-size: 12px;
+}
+
 /* Client clone steps ------------------------------------------------- */
 .onboarding-client-clone .step { margin-top: 4px; }
 .onboarding-client-clone .choice-buttons,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,13 @@ tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 lore-vm = { path = "../crates/lore-vm" }
 
+# LAN auto-discovery of lore servers (SBAI-4073). Pure-Rust mDNS/zeroconf — the
+# same crate studiobrain-model-manager uses for gateway-cluster discovery. No
+# system daemon (Bonjour/Avahi) required; works on Windows/macOS/Linux.
+mdns-sd = "0.13"
+# Pick a reachable LAN IPv4 to advertise (filter loopback/virtual NICs).
+if-addrs = "0.13"
+
 [features]
 # Forward to lore-vm so the whole app can switch backends from one flag.
 # Default to the in-process backend: no `lore` CLI subprocess required.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -54,6 +54,15 @@ pub struct AppState {
     pub(crate) lock_inbox: Mutex<Vec<LockRequest>>,
     /// Monotonic id source for lock requests.
     pub(crate) lock_request_counter: AtomicU64,
+    /// Live mDNS advertisement of the hosted server (SBAI-4073). `Some` only
+    /// while a server is hosted; set on `host_server_start`, dropped (which
+    /// unregisters the mDNS service) on `host_server_stop`. The open core
+    /// advertises a `lore://host:port/<repo>` URL so LAN peers can find it.
+    pub(crate) lan_announcer: Mutex<Option<crate::lan_discovery::Announcer>>,
+    /// Live LAN browse session (SBAI-4073). `Some` while the connect/onboarding
+    /// flow is discovering servers; lazily started by `lan_discover_browse` and
+    /// torn down by `lan_discover_stop`. Pushes `lan/discovered` events.
+    pub(crate) lan_browser: Mutex<Option<crate::lan_discovery::Browser>>,
 }
 
 /// A lock-coordination request: "please check in / release this file".
@@ -2166,7 +2175,80 @@ pub fn host_server_start(
         advanced,
     };
     let mut slot = state.hosted_server.lock().unwrap();
-    server_host::start(&mut slot, &opts)
+    let status = server_host::start(&mut slot, &opts)?;
+
+    // Advertise the freshly-started server on the LAN (SBAI-4073) so peers can
+    // discover it without copying a URL by hand. The connect URL clients dial is
+    // the loopback `lore://` the server reports; we re-point its host at the
+    // primary LAN IPv4 so a *remote* peer can actually reach it (the loopback
+    // 127.0.0.1 in `status.url` is only valid on the host machine). Best-effort:
+    // a failure to announce (e.g. firewall-blocked multicast) never fails the
+    // host start — the manual connect path always remains.
+    if let Some(url) = status.url.as_deref() {
+        let lan_ip = crate::lan_discovery::primary_lan_ipv4();
+        let connect_url = lan_advertise_url(url, lan_ip);
+        let repo = opts.repository_name.clone().unwrap_or_default();
+        let friendly = lan_friendly_name(&repo);
+        let port = status.port.unwrap_or(0);
+        match crate::lan_discovery::Announcer::start(&connect_url, &repo, &friendly, port, lan_ip) {
+            Ok(announcer) => {
+                *state.lan_announcer.lock().unwrap() = Some(announcer);
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "LAN announce failed; server still hosted");
+            }
+        }
+    }
+
+    Ok(status)
+}
+
+/// Rewrite a hosted server's loopback `lore://127.0.0.1:port[/repo]` URL so its
+/// host is the machine's primary LAN IPv4, producing the URL a *remote* peer
+/// dials. If we couldn't determine a LAN IP, the original (loopback) URL is left
+/// as-is — discovery still surfaces the server, and a same-machine client can
+/// still use it. Pure string substitution on the host portion; the rest (scheme,
+/// port, path) is preserved verbatim.
+fn lan_advertise_url(loopback_url: &str, lan_ip: Option<std::net::Ipv4Addr>) -> String {
+    let Some(ip) = lan_ip else {
+        return loopback_url.to_string();
+    };
+    // lore://<host>:<port>/<path> — replace only the <host> between "://" and ":".
+    if let Some(rest) = loopback_url.strip_prefix("lore://") {
+        if let Some((hostport, tail)) = rest.split_once(':') {
+            let _ = hostport; // host we are replacing
+            return format!("lore://{ip}:{tail}");
+        }
+    }
+    loopback_url.to_string()
+}
+
+/// A human-facing label for this host's LAN advertisement. Uses the OS hostname
+/// (what a teammate recognises), optionally suffixed with the repo so two repos
+/// on one machine are distinguishable. Falls back to "LoreGUI server".
+fn lan_friendly_name(repo: &str) -> String {
+    let host = hostname_label();
+    match repo.trim() {
+        "" => host,
+        r => format!("{host} · {r}"),
+    }
+}
+
+/// Best-effort OS hostname, trimmed; "LoreGUI server" if unavailable.
+fn hostname_label() -> String {
+    if_addrs_hostname().unwrap_or_else(|| "LoreGUI server".to_string())
+}
+
+/// Resolve the machine hostname without pulling an extra crate: read the
+/// platform's hostname via std where available, else an env fallback.
+fn if_addrs_hostname() -> Option<String> {
+    // `HOSTNAME` (most Linux shells) / `COMPUTERNAME` (Windows) are the most
+    // portable no-dep sources. Trim and reject empties.
+    std::env::var("HOSTNAME")
+        .ok()
+        .or_else(|| std::env::var("COMPUTERNAME").ok())
+        .map(|h| h.trim().to_string())
+        .filter(|h| !h.is_empty())
 }
 
 /// Render the `loreserver` config TOML for the given options **without** writing
@@ -2192,6 +2274,9 @@ pub fn host_server_stop(state: State<'_, AppState>) -> Result<HostStatus, LoreEr
     let mut slot = state.hosted_server.lock().unwrap();
     let status = server_host::stop(&mut slot)?;
     *state.advertised_url.lock().unwrap() = None;
+    // Drop the LAN advertisement (SBAI-4073): dropping the Announcer unregisters
+    // the mDNS service so peers stop seeing a server that is no longer running.
+    *state.lan_announcer.lock().unwrap() = None;
     Ok(status)
 }
 
@@ -2843,4 +2928,67 @@ fn mime_for_path(path: &str) -> String {
         _ => "application/octet-stream",
     };
     m.to_string()
+}
+
+// --- LAN auto-discovery of lore servers (SBAI-4073) -----------------------
+//
+// Open-core, MIT, NOT gated: dynamic mDNS discovery, the same pattern
+// studiobrain-model-manager uses for gateway clustering. The host half lives in
+// `host_server_start` / `host_server_stop` above (it owns the `Announcer`); these
+// commands are the client/browse half consumed by the connect/onboarding flow.
+
+use crate::lan_discovery::{Browser, DiscoveredServer, LAN_DISCOVERED_EVENT};
+
+/// Start (or reuse) a LAN browse session and return the servers seen so far.
+///
+/// Idempotent: the first call spawns a background mDNS browse that keeps running
+/// and pushes `lan/discovered` events as servers appear/leave; subsequent calls
+/// just return the current snapshot (so the UI can render immediately on mount
+/// while the event stream keeps it live). Call `lan_discover_stop` to tear the
+/// browse down when leaving the connect flow.
+///
+/// Returns the discovered servers sorted by name. An empty list is normal — the
+/// UI shows a "no servers found yet" empty state and refreshes as events arrive.
+#[tauri::command]
+pub fn lan_discover_browse(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<Vec<DiscoveredServer>, LoreError> {
+    let mut guard = state.lan_browser.lock().unwrap();
+    if guard.is_none() {
+        let app_for_events = app.clone();
+        let browser = Browser::start(move |servers| {
+            // Push the live list to the frontend; failure to emit is non-fatal
+            // (the next poll/refresh still reflects state).
+            use tauri::Emitter;
+            let _ = app_for_events.emit(LAN_DISCOVERED_EVENT, servers);
+        })
+        .map_err(LoreError::Client)?;
+        *guard = Some(browser);
+    }
+    Ok(guard.as_ref().map(Browser::snapshot).unwrap_or_default())
+}
+
+/// Return the current LAN discovery snapshot without (re)starting a browse.
+///
+/// Backs the connect flow's manual "Refresh" affordance: it returns whatever the
+/// running browse has accumulated. If no browse is active it returns an empty
+/// list (the UI should call `lan_discover_browse` to start one).
+#[tauri::command]
+pub fn lan_discover_refresh(
+    state: State<'_, AppState>,
+) -> Result<Vec<DiscoveredServer>, LoreError> {
+    let guard = state.lan_browser.lock().unwrap();
+    Ok(guard.as_ref().map(Browser::snapshot).unwrap_or_default())
+}
+
+/// Stop the LAN browse session and release its mDNS daemon.
+///
+/// Called when the connect/onboarding flow unmounts so we are not browsing in
+/// the background for the whole app lifetime. Idempotent — a no-op if no browse
+/// is running.
+#[tauri::command]
+pub fn lan_discover_stop(state: State<'_, AppState>) -> Result<(), LoreError> {
+    *state.lan_browser.lock().unwrap() = None;
+    Ok(())
 }

--- a/src-tauri/src/lan_discovery.rs
+++ b/src-tauri/src/lan_discovery.rs
@@ -1,0 +1,493 @@
+//! LAN auto-discovery of lore servers (SBAI-4073).
+//!
+//! Open-core, MIT, **not gated** — this is just dynamic mDNS/zeroconf discovery,
+//! the same pattern `studiobrain-model-manager` uses for its gateway cluster
+//! (`mdns-sd` + `_gateway._tcp.local.`). Here we advertise the **lore service**
+//! type `_lore._tcp.local.` so any LoreGUI on the same LAN can find a hosted
+//! server without anyone copying a `lore://` URL around by hand.
+//!
+//! Two halves, mirroring the model-manager design:
+//!
+//! - [`Announcer`] (host side): when LoreGUI hosts a server (`server_host.rs`,
+//!   SBAI-4065) we register one mDNS service carrying TXT records for the repo
+//!   name, the `lore://host:port/<repo>` connect URL, and a friendly instance
+//!   name. The registration lives for as long as the `Announcer` is held; it is
+//!   dropped (and the service unregistered) when the hosted server stops.
+//! - [`Browser`] (client side): a background browse task drains
+//!   `ServiceDaemon::browse`'s channel, resolving `ServiceResolved` /
+//!   `ServiceRemoved` events into a live [`DiscoveredServer`] list. The Tauri
+//!   layer reads a snapshot (`lan_discover_browse`) and/or subscribes to the
+//!   `lan/discovered` event stream for live updates.
+//!
+//! **TXT-record contract** — the single source of truth for what a host
+//! advertises and a client parses. Encoded by [`encode_txt`], parsed by
+//! [`DiscoveredServer::from_service`]. Round-trips through [`encode_txt`] +
+//! parse (unit-tested):
+//!
+//! | key    | value                                   |
+//! |--------|-----------------------------------------|
+//! | `url`  | `lore://host:port/<repo>` connect URL   |
+//! | `repo` | repository name (may be empty)          |
+//! | `name` | friendly instance name (host label)     |
+//! | `v`    | protocol version of this TXT schema (1) |
+//!
+//! ## Platform caveats
+//!
+//! mDNS is multicast UDP on `224.0.0.251:5353`. `mdns-sd` is pure-Rust and works
+//! on Windows, macOS, and Linux with no system daemon, but:
+//!
+//! - **Firewalls** may block inbound multicast. On Windows the first run can
+//!   raise a Defender Firewall prompt; users must allow LoreGUI on private
+//!   networks. Locked-down corporate networks often drop mDNS at the switch — the
+//!   manual "Connect to Server" URL field always remains as a fallback.
+//! - **Multiple / virtual NICs** (WSL vEthernet, Hyper-V, Docker bridges, VPN
+//!   TUN/TAP) can advertise an unreachable address. [`primary_lan_ipv4`] filters
+//!   those out and prefers an RFC1918 LAN address, matching model-manager's NIC
+//!   selection.
+//! - **VPNs** that capture all multicast can hide LAN peers; again, the manual
+//!   URL path is the documented fallback.
+
+use std::collections::HashMap;
+use std::net::Ipv4Addr;
+use std::sync::{Arc, Mutex};
+
+use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
+use serde::Serialize;
+
+/// mDNS service type for lore servers. Mirrors model-manager's
+/// `_gateway._tcp.local.` convention, scoped to lore.
+pub const SERVICE_TYPE: &str = "_lore._tcp.local.";
+
+/// Current version of the TXT-record schema (see module docs). Bumped only on a
+/// breaking change to the advertised keys so older clients can skip what they
+/// cannot parse.
+pub const TXT_SCHEMA_VERSION: &str = "1";
+
+/// Tauri event name carrying the live discovered-server list. The frontend
+/// `listen`s on this to refresh without polling (mirrors `lock/request`).
+pub const LAN_DISCOVERED_EVENT: &str = "lan/discovered";
+
+/// One lore server discovered on the LAN, as surfaced to the frontend.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveredServer {
+    /// Stable identity within a browse session: the mDNS service fullname
+    /// (`<instance>._lore._tcp.local.`). Used for dedupe + removal.
+    pub id: String,
+    /// Friendly instance name (TXT `name`), e.g. "Brian's Mac". Falls back to the
+    /// mDNS instance label when absent.
+    pub name: String,
+    /// Repository name (TXT `repo`); empty string when the host advertised none.
+    pub repo: String,
+    /// The `lore://host:port/<repo>` URL a client connects with (TXT `url`). This
+    /// is what the one-click "Connect" prefills.
+    pub url: String,
+    /// Resolved host (first IPv4 address, else the mDNS hostname). Display-only —
+    /// the authoritative connect target is [`url`](Self::url).
+    pub host: String,
+    /// Advertised port (the lore QUIC/gRPC port).
+    pub port: u16,
+}
+
+impl DiscoveredServer {
+    /// Build a [`DiscoveredServer`] from a resolved mDNS [`ServiceInfo`].
+    ///
+    /// Returns `None` when the service does not carry a usable `url` TXT record
+    /// (i.e. it is not one of *our* lore advertisements, or an older/newer schema
+    /// we cannot read) — such services are silently skipped rather than shown as
+    /// broken rows.
+    pub fn from_service(info: &ServiceInfo) -> Option<Self> {
+        let txt = txt_map(info);
+        // A lore advertisement MUST carry a connect URL; without it the row is
+        // useless (nothing to one-click). Skip anything that lacks it.
+        let url = txt.get("url").map(String::as_str).unwrap_or("").trim();
+        if url.is_empty() {
+            return None;
+        }
+
+        let host = info
+            .get_addresses_v4()
+            .iter()
+            .next()
+            .map(|a| a.to_string())
+            .unwrap_or_else(|| info.get_hostname().trim_end_matches('.').to_string());
+
+        let name = txt
+            .get("name")
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| instance_label(info.get_fullname()));
+
+        Some(DiscoveredServer {
+            id: info.get_fullname().to_string(),
+            name,
+            repo: txt
+                .get("repo")
+                .map(|s| s.trim().to_string())
+                .unwrap_or_default(),
+            url: url.to_string(),
+            host,
+            port: info.get_port(),
+        })
+    }
+}
+
+/// Lowercased TXT properties as a `key -> value` map. `mdns-sd` keys are
+/// case-insensitive per RFC 6763; we normalise to lowercase so lookups are
+/// stable regardless of how a peer cased them.
+fn txt_map(info: &ServiceInfo) -> HashMap<String, String> {
+    info.get_properties()
+        .iter()
+        .map(|p| (p.key().to_ascii_lowercase(), p.val_str().to_string()))
+        .collect()
+}
+
+/// Extract the human-facing instance label from an mDNS fullname
+/// (`"<instance>._lore._tcp.local."` -> `"<instance>"`).
+fn instance_label(fullname: &str) -> String {
+    fullname
+        .split_once("._lore._tcp")
+        .map(|(label, _)| label)
+        .unwrap_or(fullname)
+        .to_string()
+}
+
+/// Encode the LoreGUI TXT-record set advertised for a hosted server. The single
+/// place the host-side property map is built; [`DiscoveredServer::from_service`]
+/// is its exact inverse. Returned as an owned `HashMap` ready for
+/// [`ServiceInfo::new`].
+pub fn encode_txt(connect_url: &str, repo: &str, friendly_name: &str) -> HashMap<String, String> {
+    let mut props = HashMap::new();
+    props.insert("url".to_string(), connect_url.trim().to_string());
+    props.insert("repo".to_string(), repo.trim().to_string());
+    props.insert("name".to_string(), friendly_name.trim().to_string());
+    props.insert("v".to_string(), TXT_SCHEMA_VERSION.to_string());
+    props
+}
+
+/// Pick the primary LAN IPv4 address to advertise.
+///
+/// Filters loopback, link-local (169.254/16), and obvious virtual/container NICs
+/// (Docker, WSL/Hyper-V vEthernet, VPN TUN/TAP, VirtualBox/VMware), preferring a
+/// private RFC1918 address — the same selection model-manager uses (SBAI-3036 /
+/// SBAI-3195). Returns `None` if nothing suitable is found (host advertises with
+/// no explicit address; `mdns-sd` then falls back to OS-reported addresses).
+pub fn primary_lan_ipv4() -> Option<Ipv4Addr> {
+    let ifaces = if_addrs::get_if_addrs().ok()?;
+    let mut candidates: Vec<Ipv4Addr> = Vec::new();
+    for iface in ifaces {
+        if iface.is_loopback() {
+            continue;
+        }
+        let name = iface.name.to_ascii_lowercase();
+        // Skip obvious virtual / container / VPN adapters whose address is not a
+        // reachable LAN address for peers on the physical network: Docker/veth/
+        // bridges, WSL/Hyper-V vEthernet, VMware/VirtualBox, libvirt, VPN
+        // TUN/TAP, ZeroTier ("zt"), WireGuard ("wg").
+        const VIRTUAL_NIC_MARKERS: &[&str] = &[
+            "docker",
+            "veth",
+            "vethernet",
+            "hyper-v",
+            "vmnet",
+            "vboxnet",
+            "virbr",
+            "utun",
+            "tun",
+            "tap",
+            "zt",
+            "wg",
+        ];
+        if name.starts_with("br-") || VIRTUAL_NIC_MARKERS.iter().any(|m| name.contains(m)) {
+            continue;
+        }
+        if let std::net::IpAddr::V4(v4) = iface.ip() {
+            if v4.is_link_local() {
+                continue;
+            }
+            candidates.push(v4);
+        }
+    }
+    // Prefer RFC1918 private addresses (real LAN) over anything else.
+    candidates
+        .iter()
+        .find(|ip| ip.is_private())
+        .copied()
+        .or_else(|| candidates.first().copied())
+}
+
+/// A live mDNS advertisement of a hosted lore server. Holding this keeps the
+/// service registered; dropping it unregisters (best-effort) and shuts the
+/// daemon down. One per hosted server — created on `host_server_start`, dropped
+/// on `host_server_stop`.
+pub struct Announcer {
+    daemon: ServiceDaemon,
+    fullname: String,
+}
+
+impl Announcer {
+    /// Register a lore server on the LAN.
+    ///
+    /// * `connect_url` — the `lore://host:port/<repo>` URL clients dial.
+    /// * `repo` — repository name (may be empty).
+    /// * `friendly_name` — a human label for the host (e.g. the machine name).
+    /// * `port` — the advertised lore port.
+    /// * `lan_ip` — the address to advertise; when `None`, [`primary_lan_ipv4`]
+    ///   is tried, and failing that the OS-reported addresses are used.
+    pub fn start(
+        connect_url: &str,
+        repo: &str,
+        friendly_name: &str,
+        port: u16,
+        lan_ip: Option<Ipv4Addr>,
+    ) -> Result<Self, String> {
+        let daemon =
+            ServiceDaemon::new().map_err(|e| format!("mDNS daemon could not start: {e}"))?;
+
+        // Instance name: keep it stable + readable. The friendly name plus port
+        // disambiguates two hosts on one machine.
+        let instance = sanitize_instance(friendly_name, port);
+        let host_name = format!("{instance}.local.");
+        let props = encode_txt(connect_url, repo, friendly_name);
+
+        let ip = lan_ip.or_else(primary_lan_ipv4);
+        // mdns-sd 0.13's `AsIpAddrs` is implemented for `IpAddr` (and slices of
+        // it), not `Ipv4Addr` directly — collect as `IpAddr`. An empty slice
+        // tells mdns-sd to auto-enumerate the host's addresses.
+        let addrs: Vec<std::net::IpAddr> = ip.map(std::net::IpAddr::V4).into_iter().collect();
+        let service = ServiceInfo::new(
+            SERVICE_TYPE,
+            &instance,
+            &host_name,
+            &addrs[..],
+            port,
+            Some(props),
+        )
+        .map_err(|e| format!("mDNS service info invalid: {e}"))?;
+
+        let fullname = service.get_fullname().to_string();
+        daemon
+            .register(service)
+            .map_err(|e| format!("mDNS register failed: {e}"))?;
+        tracing::info!(service = %fullname, %port, "lore server announced on LAN");
+        Ok(Announcer { daemon, fullname })
+    }
+}
+
+impl Drop for Announcer {
+    fn drop(&mut self) {
+        // Best-effort unregister + shutdown. Both return a receiver we don't need
+        // to await: the daemon flushes the goodbye packet on its own thread.
+        let _ = self.daemon.unregister(&self.fullname);
+        let _ = self.daemon.shutdown();
+        tracing::info!(service = %self.fullname, "lore server LAN announcement stopped");
+    }
+}
+
+/// Make a safe mDNS instance label from a friendly name. mDNS instance names may
+/// contain spaces, but to keep them readable and avoid empty labels we trim,
+/// fall back to a default, and append the port for disambiguation.
+fn sanitize_instance(friendly_name: &str, port: u16) -> String {
+    let base = friendly_name.trim();
+    let base = if base.is_empty() {
+        "LoreGUI server"
+    } else {
+        base
+    };
+    format!("{base} ({port})")
+}
+
+/// A live LAN browse session. Spawns a background thread that drains the
+/// `mdns-sd` event channel into a shared, deduped [`DiscoveredServer`] list.
+/// Holding it keeps the browse running; dropping it stops the thread and the
+/// daemon. The Tauri layer keeps one in `AppState`.
+pub struct Browser {
+    daemon: ServiceDaemon,
+    servers: Arc<Mutex<Vec<DiscoveredServer>>>,
+    stop: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl Browser {
+    /// Start browsing for lore servers. `on_change` is invoked (on the browse
+    /// thread) with the new full list every time the set changes, so the caller
+    /// can push a Tauri event. Returns immediately; discovery is asynchronous.
+    pub fn start<F>(on_change: F) -> Result<Self, String>
+    where
+        F: Fn(Vec<DiscoveredServer>) + Send + 'static,
+    {
+        let daemon =
+            ServiceDaemon::new().map_err(|e| format!("mDNS daemon could not start: {e}"))?;
+        let receiver = daemon
+            .browse(SERVICE_TYPE)
+            .map_err(|e| format!("mDNS browse failed: {e}"))?;
+
+        let servers: Arc<Mutex<Vec<DiscoveredServer>>> = Arc::new(Mutex::new(Vec::new()));
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        let servers_thread = servers.clone();
+        let stop_thread = stop.clone();
+        std::thread::spawn(move || {
+            while !stop_thread.load(std::sync::atomic::Ordering::Relaxed) {
+                // Block with a timeout so we periodically re-check the stop flag.
+                // On any recv error we either time out (re-check stop + loop) or
+                // the daemon has gone away (disconnected) -- distinguished without
+                // naming the underlying channel's error type, which keeps us
+                // decoupled from mdns-sd's internal channel implementation.
+                let event = match receiver.recv_timeout(std::time::Duration::from_millis(500)) {
+                    Ok(ev) => ev,
+                    Err(_) if receiver.is_disconnected() => break,
+                    Err(_) => continue,
+                };
+                let changed = match event {
+                    ServiceEvent::ServiceResolved(info) => {
+                        if let Some(found) = DiscoveredServer::from_service(&info) {
+                            let mut list = servers_thread.lock().unwrap();
+                            upsert(&mut list, found)
+                        } else {
+                            false
+                        }
+                    }
+                    ServiceEvent::ServiceRemoved(_, fullname) => {
+                        let mut list = servers_thread.lock().unwrap();
+                        let before = list.len();
+                        list.retain(|s| s.id != fullname);
+                        list.len() != before
+                    }
+                    _ => false,
+                };
+                if changed {
+                    let snapshot = servers_thread.lock().unwrap().clone();
+                    on_change(snapshot);
+                }
+            }
+        });
+
+        Ok(Browser {
+            daemon,
+            servers,
+            stop,
+        })
+    }
+
+    /// A snapshot of the currently-discovered servers, sorted by name.
+    pub fn snapshot(&self) -> Vec<DiscoveredServer> {
+        let mut list = self.servers.lock().unwrap().clone();
+        list.sort_by_key(|s| s.name.to_lowercase());
+        list
+    }
+}
+
+impl Drop for Browser {
+    fn drop(&mut self) {
+        self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        let _ = self.daemon.stop_browse(SERVICE_TYPE);
+        let _ = self.daemon.shutdown();
+    }
+}
+
+/// Insert-or-update a discovered server in `list` keyed by its stable `id`.
+/// Returns `true` if the list changed (new entry, or an existing entry's fields
+/// differed) — so the caller only emits on real changes.
+fn upsert(list: &mut Vec<DiscoveredServer>, found: DiscoveredServer) -> bool {
+    if let Some(existing) = list.iter_mut().find(|s| s.id == found.id) {
+        if *existing == found {
+            false
+        } else {
+            *existing = found;
+            true
+        }
+    } else {
+        list.push(found);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The load-bearing invariant: whatever a host encodes into TXT records, a
+    // client parses back identically — especially the connect URL round-trip.
+    #[test]
+    fn txt_round_trip_preserves_url_repo_name() {
+        let url = "lore://192.168.1.42:41337/my-repo";
+        let props = encode_txt(url, "my-repo", "Brian's Mac");
+
+        assert_eq!(props.get("url").map(String::as_str), Some(url));
+        assert_eq!(props.get("repo").map(String::as_str), Some("my-repo"));
+        assert_eq!(props.get("name").map(String::as_str), Some("Brian's Mac"));
+        assert_eq!(props.get("v").map(String::as_str), Some("1"));
+    }
+
+    // Build a real ServiceInfo from encoded TXT and parse it back; the URL,
+    // repo, name and port must survive a full mdns-sd encode->decode.
+    #[test]
+    fn service_info_decodes_to_discovered_server() {
+        let url = "lore://10.15.0.20:41337/world-bible";
+        let props = encode_txt(url, "world-bible", "BRAINZ");
+        let addr: std::net::IpAddr = "10.15.0.20".parse().unwrap();
+        let info = ServiceInfo::new(
+            SERVICE_TYPE,
+            "BRAINZ (41337)",
+            "BRAINZ.local.",
+            &[addr][..],
+            41337,
+            Some(props),
+        )
+        .expect("valid service info");
+
+        let found = DiscoveredServer::from_service(&info).expect("parses back");
+        assert_eq!(found.url, url);
+        assert_eq!(found.repo, "world-bible");
+        assert_eq!(found.name, "BRAINZ");
+        assert_eq!(found.port, 41337);
+        assert_eq!(found.host, "10.15.0.20");
+        assert!(found.id.contains("_lore._tcp"));
+    }
+
+    // A non-lore service (or one missing the url TXT key) must be skipped, not
+    // surfaced as a broken row.
+    #[test]
+    fn service_without_url_is_skipped() {
+        let mut props = HashMap::new();
+        props.insert("repo".to_string(), "x".to_string());
+        let info = ServiceInfo::new(
+            SERVICE_TYPE,
+            "stranger",
+            "stranger.local.",
+            "",
+            41337,
+            Some(props),
+        )
+        .expect("valid service info");
+        assert!(DiscoveredServer::from_service(&info).is_none());
+    }
+
+    #[test]
+    fn upsert_dedupes_and_reports_change() {
+        let mut list = Vec::new();
+        let a = DiscoveredServer {
+            id: "a._lore._tcp.local.".into(),
+            name: "A".into(),
+            repo: "r".into(),
+            url: "lore://1.1.1.1:1/r".into(),
+            host: "1.1.1.1".into(),
+            port: 1,
+        };
+        assert!(upsert(&mut list, a.clone())); // new -> changed
+        assert!(!upsert(&mut list, a.clone())); // identical -> no change
+        let mut a2 = a.clone();
+        a2.repo = "r2".into();
+        assert!(upsert(&mut list, a2)); // field differs -> changed
+        assert_eq!(list.len(), 1); // still one entry (deduped by id)
+    }
+
+    #[test]
+    fn instance_label_strips_service_suffix() {
+        assert_eq!(
+            instance_label("BRAINZ (41337)._lore._tcp.local."),
+            "BRAINZ (41337)"
+        );
+        assert_eq!(instance_label("bare"), "bare");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod desktop;
+mod lan_discovery;
 mod operations;
 mod server_host;
 mod settings;
@@ -66,6 +67,8 @@ pub fn run() {
             advertised_url: Mutex::new(None),
             lock_inbox: Mutex::new(Vec::new()),
             lock_request_counter: AtomicU64::new(0),
+            lan_announcer: Mutex::new(None),
+            lan_browser: Mutex::new(None),
         })
         .invoke_handler(tauri::generate_handler![
             commands::open_repository,
@@ -195,6 +198,9 @@ pub fn run() {
             commands::read_file_bytes,
             commands::write_text_file,
             commands::tray_sync_state,
+            commands::lan_discover_browse,
+            commands::lan_discover_refresh,
+            commands::lan_discover_stop,
             get_desktop_settings,
             set_autostart,
             set_close_to_tray,


### PR DESCRIPTION
mDNS (_lore._tcp.local. via mdns-sd, model-manager pattern): host announces on server start (TXT: LAN url/repo/name), client browses + a 'Servers on your network' section in ClientConnect with one-click connect + manual fallback. Open-core/MIT, NOT gated (clean rebuild after stale premium-miscategorized #285). 5 tests incl TXT round-trip; guards green; design-review PASS. Needs a live two-device LAN check.