### PR TITLE
fix(vscode): universal publish must not bundle a stray local binary (0.1.1, SBAI-4082)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "loregui-lore",
   "displayName": "Lore Source Control",
   "description": "Source control for Epic Games' lore VCS, driven by the loregui lorevm engine. Status, stage/unstage, commit, diff, history, sync, and lock awareness in VS Code's native SCM view.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "BiloxiStudios",
   "license": "MIT",
   "author": "Biloxi Studios Inc. (BizaNator)",

--- a/vscode-extension/scripts/copy-lorevm.mjs
+++ b/vscode-extension/scripts/copy-lorevm.mjs
@@ -17,6 +17,15 @@ if (!fs.existsSync(binDir)) {
   fs.mkdirSync(binDir, { recursive: true });
 }
 
+// 0. Universal publish: LOREVM_BUNDLE_OPTIONAL=1 skips bundling ENTIRELY — the .vsix
+// carries no binary and the extension resolves lorevm at runtime (LoreGUI / LOREVM_BIN
+// / PATH). Must short-circuit BEFORE the target/ search so a stray local build is never
+// bundled. CI leaves this unset to get the per-platform bundled build.
+if (process.env.LOREVM_BUNDLE_OPTIONAL === '1') {
+  console.warn('LOREVM_BUNDLE_OPTIONAL=1 — skipping binary bundling (universal publish; runtime resolution).');
+  process.exit(0);
+}
+
 // 1. If LOREVM_BIN is set, use it (CI override).
 if (process.env.LOREVM_BIN && fs.existsSync(process.env.LOREVM_BIN)) {
   const dest = path.join(binDir, BIN_NAME);


### PR DESCRIPTION
0.1.0 accidentally bundled an 815MB local debug lorevm. LOREVM_BUNDLE_OPTIONAL=1 now short-circuits BEFORE the target/ search, so a universal publish carries no binary. Bump 0.1.1.