### PR TITLE
ci(vscode): auto-publish bundled per-platform builds to Marketplace (SBAI-4082)

### DIFF
--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -1,0 +1,81 @@
+name: Publish VS Code Extension
+
+# Publishes the `loregui-lore` VS Code extension to the Marketplace.
+# - Per-platform jobs build `lorevm` natively and bundle it (real binary in the .vsix).
+# - A universal fallback (no bundled binary, runtime resolution) covers any platform
+#   the matrix doesn't build.
+# Trigger: push a `vscode-v*` tag (e.g. vscode-v0.1.2), or run manually.
+# The version published is whatever vscode-extension/package.json says — bump it first.
+# Requires repo secret VSCE_PAT (Azure DevOps PAT, Marketplace > Manage scope; publisher BiloxiStudios).
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'vscode-v*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish-platform:
+    name: bundle-${{ matrix.vsce_target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            vsce_target: linux-x64
+          - os: windows-latest
+            vsce_target: win32-x64
+          - os: macos-13
+            vsce_target: darwin-x64
+          - os: macos-latest
+            vsce_target: darwin-arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Build lorevm (native, release)
+        shell: bash
+        run: cargo build --release -p lorevm-cli
+      - name: Locate the built lorevm for bundling
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            echo "LOREVM_BIN=${GITHUB_WORKSPACE}/target/release/lorevm.exe" >> "$GITHUB_ENV"
+          else
+            echo "LOREVM_BIN=${GITHUB_WORKSPACE}/target/release/lorevm" >> "$GITHUB_ENV"
+          fi
+      - name: Publish bundled (${{ matrix.vsce_target }})
+        working-directory: vscode-extension
+        shell: bash
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          npm install --no-audit --no-fund
+          npx --yes @vscode/vsce publish --target ${{ matrix.vsce_target }} -p "$VSCE_PAT"
+
+  publish-universal:
+    name: universal-fallback
+    needs: publish-platform
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Publish universal fallback (no bundled binary)
+        working-directory: vscode-extension
+        shell: bash
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          LOREVM_BUNDLE_OPTIONAL: '1'
+        run: |
+          npm install --no-audit --no-fund
+          npx --yes @vscode/vsce publish -p "$VSCE_PAT"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "loregui-lore",
   "displayName": "Lore Source Control",
   "description": "Source control for Epic Games' lore VCS, driven by the loregui lorevm engine. Status, stage/unstage, commit, diff, history, sync, and lock awareness in VS Code's native SCM view.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "BiloxiStudios",
   "license": "MIT",
   "author": "Biloxi Studios Inc. (BizaNator)",


### PR DESCRIPTION
publish-vscode.yml: on vscode-v* tag or manual dispatch, builds lorevm natively per platform (linux-x64/win32-x64/darwin-x64/darwin-arm64), bundles it, vsce publish --target; plus a universal no-binary fallback for uncovered platforms. VSCE_PAT in repo secrets. Bumps 0.1.2 for the first bundled release.