### PR TITLE
feat(website): ecosystem section — VS Code extension (live) + Unreal plugin (coming soon)

### DIFF
--- a/frontend/src/commercial/entitlement.test.ts
+++ b/frontend/src/commercial/entitlement.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for the canonical entitlement model (SBAI-4089 / E0.7).
+ *
+ * Run with Node's built-in test runner (type-stripping handles the .ts import):
+ *   node --test --experimental-strip-types frontend/src/commercial/entitlement.test.ts
+ *
+ * Covers the canonical `tier` ordinal + `features[]` model (ADR-0001 §2.5):
+ *   - the LOCKED ordinal scheme,
+ *   - `tier >= MIN` monotonic gating via featuresForTier,
+ *   - legacy-string + numeric-string tier normalisation,
+ *   - bootstrapAccountsEntitlements union into the runtime injection slot,
+ *   - the gate (isEntitled) reading off the canonical resolution.
+ *
+ * These tests stub a minimal `window` so the injection-slot paths run under Node.
+ */
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  TIER,
+  TIER_ID,
+  FEATURE_MIN_TIER,
+  FEATURE_BYOK,
+  tierOrdinal,
+  featuresForTier,
+  bootstrapAccountsEntitlements,
+  isEntitled,
+  __resetLicensedFeaturesForTests,
+} from "./entitlement.ts";
+
+// Minimal window shim so the injection-slot code paths run under node:test.
+function resetWindow(): void {
+  (globalThis as unknown as { window?: unknown }).window = {
+    __LOREGUI_ENTITLEMENTS__: undefined,
+  };
+}
+
+beforeEach(() => {
+  resetWindow();
+  __resetLicensedFeaturesForTests();
+});
+
+// --- LOCKED ordinal scheme (cross-repo contract) -----------------------------
+
+test("tier ordinals match the LOCKED scheme", () => {
+  assert.equal(TIER.free, 0);
+  assert.equal(TIER.indie, 10);
+  assert.equal(TIER.team, 20);
+  assert.equal(TIER.enterprise, 30);
+  assert.equal(TIER.staff, 90);
+  assert.equal(TIER.superadmin, 99);
+});
+
+test("tier ids are the stable strings", () => {
+  assert.equal(TIER_ID[TIER.free], "free");
+  assert.equal(TIER_ID[TIER.indie], "indie");
+  assert.equal(TIER_ID[TIER.team], "team");
+  assert.equal(TIER_ID[TIER.enterprise], "enterprise");
+  assert.equal(TIER_ID[TIER.staff], "staff");
+  assert.equal(TIER_ID[TIER.superadmin], "superadmin");
+});
+
+// --- tierOrdinal normalisation ----------------------------------------------
+
+test("tierOrdinal accepts a canonical integer", () => {
+  assert.equal(tierOrdinal(30), 30);
+  assert.equal(tierOrdinal(0), 0);
+});
+
+test("tierOrdinal accepts a numeric string", () => {
+  assert.equal(tierOrdinal("20"), 20);
+});
+
+test("tierOrdinal maps legacy plan strings", () => {
+  assert.equal(tierOrdinal("enterprise"), TIER.enterprise);
+  assert.equal(tierOrdinal(" Team "), TIER.team);
+  assert.equal(tierOrdinal("INDIE"), TIER.indie);
+});
+
+test("tierOrdinal falls back to free for unknown/missing", () => {
+  assert.equal(tierOrdinal(null), TIER.free);
+  assert.equal(tierOrdinal(undefined), TIER.free);
+  assert.equal(tierOrdinal(""), TIER.free);
+  assert.equal(tierOrdinal("nonsense"), TIER.free);
+});
+
+// --- featuresForTier (tier >= MIN monotonic gating) --------------------------
+
+test("free unlocks no premium features", () => {
+  assert.deepEqual(featuresForTier(TIER.free), []);
+});
+
+test("team unlocks reporting only", () => {
+  assert.deepEqual(featuresForTier(TIER.team).sort(), ["reporting"]);
+});
+
+test("enterprise unlocks reporting, relay and dam", () => {
+  assert.deepEqual(featuresForTier(TIER.enterprise).sort(), ["dam", "relay", "reporting"]);
+});
+
+test("staff/superadmin are strict supersets of enterprise", () => {
+  for (const t of [TIER.staff, TIER.superadmin]) {
+    const f = featuresForTier(t).sort();
+    assert.deepEqual(f, ["dam", "relay", "reporting"]);
+  }
+});
+
+test("a reserved-band tier (40) gates exactly like its ordinal", () => {
+  // 40 >= team(20) but < enterprise(30)? No — 40 >= 30, so it unlocks all three.
+  assert.deepEqual(featuresForTier(40).sort(), ["dam", "relay", "reporting"]);
+  // 25 is between team and enterprise: reporting only.
+  assert.deepEqual(featuresForTier(25).sort(), ["reporting"]);
+});
+
+test("FEATURE_MIN_TIER thresholds are the documented ones", () => {
+  assert.equal(FEATURE_MIN_TIER.reporting, TIER.team);
+  assert.equal(FEATURE_MIN_TIER.relay, TIER.enterprise);
+  assert.equal(FEATURE_MIN_TIER.dam, TIER.enterprise);
+});
+
+// --- bootstrapAccountsEntitlements (canonical claim → injection slot) ---------
+
+test("bootstrap resolves monotonic features from the tier ordinal", () => {
+  const out = bootstrapAccountsEntitlements({ tier: TIER.team, tier_id: "team" });
+  assert.deepEqual(out.sort(), ["reporting"]);
+  assert.ok(isEntitled("reporting"));
+  assert.ok(!isEntitled("relay"));
+});
+
+test("bootstrap reads canonical integer tier directly (no plan translation)", () => {
+  bootstrapAccountsEntitlements({ tier: 30 });
+  assert.ok(isEntitled("reporting"));
+  assert.ok(isEntitled("relay"));
+  assert.ok(isEntitled("dam"));
+});
+
+test("bootstrap accepts a legacy string tier", () => {
+  bootstrapAccountsEntitlements({ tier: "enterprise" });
+  assert.ok(isEntitled("dam"));
+});
+
+test("non-monotonic add-ons from features[] pass through verbatim", () => {
+  const out = bootstrapAccountsEntitlements({ tier: TIER.team, features: [FEATURE_BYOK] });
+  assert.ok(out.includes(FEATURE_BYOK));
+  assert.ok(out.includes("reporting"));
+});
+
+test("bootstrap UNIONS with already-injected entitlements (only adds)", () => {
+  // Simulate an offline license already mirrored into the slot.
+  (globalThis as unknown as { window: { __LOREGUI_ENTITLEMENTS__?: string[] } }).window
+    .__LOREGUI_ENTITLEMENTS__ = ["reporting"];
+  const out = bootstrapAccountsEntitlements({ tier: TIER.enterprise });
+  // license-provided reporting is preserved, accounts adds relay+dam.
+  assert.ok(out.includes("reporting"));
+  assert.ok(out.includes("relay"));
+  assert.ok(out.includes("dam"));
+});
+
+test("a null/garbage claim contributes nothing", () => {
+  const out = bootstrapAccountsEntitlements(null);
+  assert.deepEqual(out, []);
+  assert.ok(!isEntitled("reporting"));
+});

--- a/frontend/src/commercial/entitlement.ts
+++ b/frontend/src/commercial/entitlement.ts
@@ -38,48 +38,122 @@
  * are public open core; only the private signing key (in Vaultwarden / Azure KV)
  * is secret. See `license.ts` and `docs/COMMERCIAL-ADDONS.md`.
  *
- * ## Future: StudioBrain accounts tiers (Free / Team / Enterprise)
+ * ## Canonical entitlement model (SBAI-4089 / E0.7, ADR-0001 §2.5)
  *
- * The offline signed license key is the FIRST real source (shipping now). The
- * StudioBrain accounts JWT (RS256, issued by accounts.studiobrain.ai) is the
- * planned SECOND source. Its `tier` claim maps to a feature set via
- * {@link TIER_FEATURES}. When the auth bridge lands, a bootstrap step will read
- * the JWT's `tier` claim and inject the resolved feature ids into
- * `window.__LOREGUI_ENTITLEMENTS__` (path 1 above) — so NO call site here
- * changes. `featuresForTier()` already encodes that mapping. This module never
- * parses or stores the JWT itself; that stays in the auth/accounts layer per the
+ * The StudioBrain accounts JWT (RS256, issued by accounts.studiobrain.ai) is the
+ * PRIMARY entitlement source. accounts now emits the *canonical* ecosystem-wide
+ * model verbatim — adopted identically here and in model-manager:
+ *
+ *   - `tier`: an **integer ordinal**, spaced for future insertion, paired with a
+ *     stable string id (`tier_id`). LOCKED scheme:
+ *       0 free · 10 indie · 20 team · 30 enterprise · 40–89 reserved ·
+ *       90 staff · 99 superadmin
+ *     A higher tier is a strict superset, so `tier >= MIN` gates the monotonic
+ *     features (see {@link TIER} / {@link FEATURE_MIN_TIER}).
+ *   - `features[]`: authoritative set for **non-monotonic add-ons** (e.g. BYOK is
+ *     Enterprise-only but isn't "more than Team" on every axis).
+ *   - `role` (owner/admin/member): a SEPARATE within-tenant axis — never folded
+ *     into `tier`. This module does not read `role`.
+ *
+ * These exact numbers are a cross-repo contract: they mirror accounts'
+ * `config/entitlement.py` and model-manager's per-request gating. Don't renumber
+ * without changing all three.
+ *
+ * {@link bootstrapAccountsEntitlements} reads the JWT's canonical claim directly
+ * (no `plan→tier` translation — convergence removed it) and injects the resolved
+ * feature ids into `window.__LOREGUI_ENTITLEMENTS__` (path 2 above) — so NO call
+ * site here changes. Resolution is a UNION across sources so "hooked into
+ * StudioBrain" only ever *adds* unlocks. This module never parses or stores the
+ * JWT itself; the host/auth layer extracts the claim and hands it in, per the
  * StudioBrain accounts security boundary.
  */
 
-import { resolveLicensedFeatures } from "./license";
+import { resolveLicensedFeatures } from "./license.ts";
 
-/** A gateable premium feature id. Keep in sync with TIER_FEATURES below. */
+/** A gateable premium feature id. Keep in sync with FEATURE_MIN_TIER below. */
 export type Feature = "reporting" | "relay" | "dam";
 
-/** Commercial tiers, as issued in the StudioBrain accounts JWT `tier` claim. */
-export type Tier = "free" | "team" | "enterprise";
-
 /**
- * The feature set unlocked by each tier. Reporting & Insights (SBAI-4061) is a
- * Team-and-up add-on; the cross-network Relay (SBAI-4072) — host a lore server
- * reachable across networks with no VPN, via the StudioBrain bore relay — is an
- * Enterprise add-on (it consumes shared relay infrastructure). The enhanced DAM
- * (SBAI-4077) — surface a lore repo's art/media in StudioBrain's entity-aware
- * Digital Asset Manager (semantic search, tagging, cross-refs) — is also an
- * Enterprise add-on (it consumes the shared StudioBrain content index). Adjust
- * here when packaging changes — call sites are unaffected.
+ * Canonical tier ordinals — the LOCKED scheme (ADR-0001 §2.5). Integer, spaced
+ * for future insertion, paired with a stable string id (see {@link TIER_ID}).
+ * Mirrors accounts' `config/entitlement.py`.
  */
-export const TIER_FEATURES: Record<Tier, readonly Feature[]> = {
-  free: [],
-  team: ["reporting"],
-  enterprise: ["reporting", "relay", "dam"],
+export const TIER = {
+  free: 0,
+  indie: 10,
+  team: 20,
+  enterprise: 30,
+  // 40–89 reserved for future paid tiers — leave the gaps.
+  staff: 90,
+  superadmin: 99,
+} as const;
+
+/** Stable string id for each canonical tier ordinal (logs / display). */
+export const TIER_ID: Readonly<Record<number, string>> = {
+  [TIER.free]: "free",
+  [TIER.indie]: "indie",
+  [TIER.team]: "team",
+  [TIER.enterprise]: "enterprise",
+  [TIER.staff]: "staff",
+  [TIER.superadmin]: "superadmin",
 };
 
-/** Resolve a tier name to its feature ids (unknown tier → no features). */
-export function featuresForTier(tier: string | null | undefined): Feature[] {
-  if (!tier) return [];
-  const key = tier.toLowerCase() as Tier;
-  return [...(TIER_FEATURES[key] ?? [])];
+/** Non-monotonic add-on feature ids carried in the canonical `features[]`. */
+export const FEATURE_BYOK = "byok";
+
+/**
+ * Minimum canonical tier ordinal that unlocks each **monotonic** premium
+ * feature. `tier >= MIN` is the gate. Reporting & Insights (SBAI-4061) is a
+ * Team-and-up add-on; the cross-network Relay (SBAI-4072) and the enhanced DAM
+ * (SBAI-4077) are Enterprise-and-up (they consume shared StudioBrain infra).
+ * Adjust here when packaging changes — call sites are unaffected.
+ *
+ * Non-monotonic add-ons (e.g. BYOK) do NOT belong here; they arrive via the
+ * JWT's `features[]` and are injected directly.
+ */
+export const FEATURE_MIN_TIER: Record<Feature, number> = {
+  reporting: TIER.team,
+  relay: TIER.enterprise,
+  dam: TIER.enterprise,
+};
+
+/** Legacy plan string → canonical tier ordinal (back-compat for old claims). */
+const PLAN_TO_TIER: Record<string, number> = {
+  free: TIER.free,
+  indie: TIER.indie,
+  team: TIER.team,
+  enterprise: TIER.enterprise,
+  staff: TIER.staff,
+  superadmin: TIER.superadmin,
+};
+
+/**
+ * Normalise a `tier` claim to a canonical integer ordinal. Accepts the canonical
+ * integer directly, a numeric string, or a legacy plan/tier string
+ * (`free`/`indie`/`team`/`enterprise`/…). Unknown/missing → `free` (0), i.e.
+ * least privilege.
+ */
+export function tierOrdinal(tier: number | string | null | undefined): number {
+  if (typeof tier === "number" && Number.isFinite(tier)) return tier;
+  if (typeof tier === "string") {
+    const trimmed = tier.trim();
+    if (/^-?\d+$/.test(trimmed)) return parseInt(trimmed, 10);
+    return PLAN_TO_TIER[trimmed.toLowerCase()] ?? TIER.free;
+  }
+  return TIER.free;
+}
+
+/**
+ * Resolve a canonical `tier` ordinal to the monotonic premium feature ids it
+ * unlocks (`tier >= MIN` per {@link FEATURE_MIN_TIER}). Non-monotonic add-ons
+ * from the JWT's `features[]` are NOT derived here — they are unioned in by
+ * {@link bootstrapAccountsEntitlements}. Accepts a legacy string tier too.
+ */
+export function featuresForTier(tier: number | string | null | undefined): Feature[] {
+  const ordinal = tierOrdinal(tier);
+  return (Object.keys(FEATURE_MIN_TIER) as Feature[]).filter(
+    (f) => ordinal >= FEATURE_MIN_TIER[f],
+  );
 }
 
 const LOCAL_STORAGE_KEY = "loregui.entitlements";
@@ -181,16 +255,76 @@ export function __resetLicensedFeaturesForTests(): void {
 }
 
 /**
+ * The canonical entitlement claim carried on the StudioBrain accounts user JWT
+ * (SBAI-4089). The host/auth layer extracts these claims from the verified JWT
+ * and hands them in — this module never parses or stores the token itself, per
+ * the accounts security boundary. `role` is intentionally absent: it is a
+ * separate within-tenant axis, not a subscription capability.
+ */
+export interface AccountsEntitlementClaim {
+  /** Canonical integer tier ordinal (or a legacy string tier). */
+  tier?: number | string | null;
+  /** Stable string id for the tier (informational; logs/display). */
+  tier_id?: string | null;
+  /** Non-monotonic add-on feature ids (e.g. `byok`). */
+  features?: readonly string[] | null;
+}
+
+/**
+ * Resolve the canonical accounts JWT entitlement claim (SBAI-4089 / E2.3) into
+ * concrete LoreGUI feature ids and UNION them into the runtime injection slot
+ * (`window.__LOREGUI_ENTITLEMENTS__`). Call this when the StudioBrain auth bridge
+ * provides a verified claim; it is additive, so "hooked into StudioBrain" only
+ * ever *adds* unlocks on top of any offline license already bootstrapped.
+ *
+ * Resolution keys off the canonical model directly — no `plan→tier` translation:
+ *   - monotonic features via `tier >= MIN` ({@link featuresForTier}), and
+ *   - non-monotonic add-ons passed through verbatim from the claim's `features[]`
+ *     (e.g. `byok`), so add-ons that don't fit the ordinal still flow through.
+ *
+ * Safe with a null/garbage claim: it simply contributes nothing.
+ */
+export function bootstrapAccountsEntitlements(
+  claim: AccountsEntitlementClaim | null | undefined,
+): string[] {
+  const resolved = new Set<string>();
+  if (claim) {
+    for (const f of featuresForTier(claim.tier)) resolved.add(f);
+    if (Array.isArray(claim.features)) {
+      for (const f of claim.features) if (typeof f === "string" && f) resolved.add(f);
+    }
+  }
+  if (typeof window !== "undefined") {
+    const existing = Array.isArray(window.__LOREGUI_ENTITLEMENTS__)
+      ? window.__LOREGUI_ENTITLEMENTS__
+      : [];
+    // Union with whatever is already injected (e.g. a verified offline license).
+    window.__LOREGUI_ENTITLEMENTS__ = [...new Set([...existing.map(String), ...resolved])];
+    return [...window.__LOREGUI_ENTITLEMENTS__];
+  }
+  return [...resolved];
+}
+
+/**
  * The resolved set of entitled feature ids for this session. Returns `["*"]`
  * when everything is unlocked (dev default). Order matters: see module docs.
  */
 function resolveEntitlements(): string[] {
-  // 1. verified signed license (authoritative production unlock)
-  if (licensedFeatures != null) return [...licensedFeatures];
+  const injected =
+    typeof window !== "undefined" && Array.isArray(window.__LOREGUI_ENTITLEMENTS__)
+      ? window.__LOREGUI_ENTITLEMENTS__.map(String)
+      : null;
 
-  // 2. runtime injection (host shell / future accounts bootstrap)
-  const injected = typeof window !== "undefined" ? window.__LOREGUI_ENTITLEMENTS__ : undefined;
-  if (Array.isArray(injected)) return injected.map(String);
+  // 1. verified signed license (authoritative production unlock) ∪ runtime
+  //    injection. Per ADR-0001 §2.5 the sources resolve as a UNION so that being
+  //    "hooked into StudioBrain" (accounts JWT → injection slot) only ever ADDS
+  //    unlocks on top of the offline license, never removes them.
+  if (licensedFeatures != null) {
+    return [...new Set([...licensedFeatures, ...(injected ?? [])])];
+  }
+
+  // 2. runtime injection (host shell / accounts JWT bootstrap)
+  if (injected != null) return injected;
 
   // 3. local override (dev / QA / in-app toggle)
   const override = typeof window !== "undefined" ? localOverride() : null;

--- a/website/src/app/docs/page.mdx
+++ b/website/src/app/docs/page.mdx
@@ -33,6 +33,15 @@ Lore is not git and it is not Perforce. If you are coming from either, read **[T
 
 LoreGUI is a toolkit, not just an app. The same in-process binding that powers the GUI also ships as an **[MCP server](/docs/mcp)** so AI agents drive Lore the way you drive the app. Every operation is catalogued in the **[operation reference](/docs/op-reference)**, which is generated automatically from the command-palette manifests — so the docs track the real API.
 
+## Ecosystem
+
+LoreGUI is a toolkit, not just one app. The same `lorevm` engine runs across four surfaces:
+
+- **[VS Code extension](/docs/vscode)** — Lore source control in VS Code's native SCM panel. Published as `BiloxiStudios.loregui-lore`.
+- **[Unreal Engine plugin](/docs/unreal)** — Content-browser lock overlays and commit/sync from inside Unreal. Coming soon.
+- **[MCP & agent skills](/docs/mcp)** — Drive Lore from Claude Code and other AI agents.
+- **Desktop app** — The full cross-platform GUI documented in this knowledge base.
+
 ## How LoreGUI is built
 
 | Path | What |

--- a/website/src/app/docs/unreal/page.mdx
+++ b/website/src/app/docs/unreal/page.mdx
@@ -1,0 +1,40 @@
+export const metadata = {
+  title: "Unreal Engine plugin — LoreGUI docs",
+  description:
+    "StudioBrain for Unreal: Lore source control inside Unreal Engine's content browser — lock/status overlays, checkout = lock, check-in = commit, sync. Coming soon.",
+  alternates: { canonical: "/docs/unreal" },
+};
+
+# Unreal Engine plugin — StudioBrain for Unreal
+
+> **Coming soon.** The Unreal Engine plugin is in development. This page describes the planned design. No download is available yet — follow the [GitHub repo](https://github.com/BiloxiStudios/loregui) for updates.
+
+The **StudioBrain for Unreal** plugin integrates Lore source control directly into Unreal Engine's content browser and source-control toolbar. It drives `lorevm-ffi` — the same in-process lore engine that powers LoreGUI Desktop and the VS Code extension — giving Unreal teams native Lore workflows without leaving the editor.
+
+## Planned feature set
+
+| Feature | Description |
+| --- | --- |
+| **Content-browser overlays** | Lock and status icons on every asset in the content browser |
+| **Checkout = lock** | Checking out an asset acquires an exclusive Lore lock |
+| **Check-in = commit** | Checking in creates a Lore revision with an audit trail |
+| **Sync** | Pull the latest revisions from the remote server via the toolbar |
+| **Drives lorevm-ffi** | The plugin links `lorevm-ffi`'s C ABI — no CLI shelling, no subprocess |
+
+## Engine bridge: lorevm-ffi
+
+Unreal plugins run in a managed C++ environment where spawning subprocesses for every SCM call is expensive. The plugin therefore links `lorevm-ffi` — a thin C-ABI shared library that wraps the same `lore-vm` Rust crate used everywhere else in the LoreGUI ecosystem. The bridge is documented in `docs/ue-lorevm-bridge-spike.md` in the LoreGUI repo.
+
+## Roadmap
+
+Beyond the core lock/status/commit/sync MVP:
+
+- **Entity-aware versioning** — Lore metadata fields mapped to Unreal asset properties so version notes appear in the asset editor.
+- **Merge / conflict resolution** — Guided merge flow for binary assets using Lore's three-way diff surface.
+- **Offline grace** — Work offline; sync when reconnected, same as the desktop client.
+
+## Status
+
+The plugin builds against the `unreal-plugin/` tree in the LoreGUI repository (`feat/ue-plugin-mvp` branch). UE build pipeline integration and Marketplace submission are pending. The `lorevm-ffi` C ABI it depends on is stable on the `feat/lore-vm-dispatch` branch.
+
+For the Lore model the plugin operates on, see **[The Lore mental model](/docs/lore-model)**.

--- a/website/src/app/docs/vscode/page.mdx
+++ b/website/src/app/docs/vscode/page.mdx
@@ -1,0 +1,64 @@
+export const metadata = {
+  title: "VS Code extension — LoreGUI docs",
+  description:
+    "Lore Source Control: drive Lore VCS from inside VS Code's native SCM panel. Stage, commit, diff, history, file locks — published as BiloxiStudios.loregui-lore.",
+  alternates: { canonical: "/docs/vscode" },
+};
+
+# VS Code extension — Lore Source Control
+
+The **Lore Source Control** extension brings Lore version control into VS Code's native Source Control panel. It is powered by the same `lorevm` engine as the desktop app — so every op you can do in LoreGUI Desktop you can also reach from the editor.
+
+Published as **`BiloxiStudios.loregui-lore`** on the VS Code Marketplace.
+
+## Install
+
+One-liner:
+
+```bash
+code --install-extension BiloxiStudios.loregui-lore
+```
+
+Or open the Extensions panel (`Ctrl+Shift+X` / `⌘+Shift+X`), search **Lore Source Control**, and click **Install**.
+
+[Open in Marketplace →](https://marketplace.visualstudio.com/items?itemName=BiloxiStudios.loregui-lore)
+
+## What it does
+
+The extension registers a **Source Control Provider** in VS Code. Once a Lore repository is detected in the workspace it surfaces:
+
+| Panel / view | What you get |
+| --- | --- |
+| **Source Control** | Staged and unstaged changes, commit message box, commit button |
+| **Changes tree** | Files grouped by staged / unstaged; click to open the built-in diff editor |
+| **History** | Inline revision log for the current branch |
+| **File locks** | Lock status overlays on files held by you or a teammate |
+
+## Requirements
+
+- `lorevm` binary on your `PATH` (or configured via `loregui.lorevm.path`). Build it from the LoreGUI checkout:
+
+```bash
+cargo build -p lorevm-cli
+# binary lands at: target/debug/lorevm
+```
+
+- A Lore repository reachable from your VS Code workspace folder.
+
+## Configuration
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `loregui.lorevm.path` | `lorevm` | Path to the `lorevm` binary. |
+| `loregui.offline` | `false` | Run in offline mode (no remote sync). |
+| `loregui.autoStage` | `false` | Automatically stage saves before commit. |
+
+## Engine: lorevm
+
+Like all LoreGUI surfaces, the extension never shells out to the legacy `lore` CLI. It calls the `lorevm` binary (or links `lorevm-ffi` on platforms that support it), which binds the Lore engine in-process. The VS Code host communicates with `lorevm` over JSON stdio — each op maps to the same dispatch table used by the desktop app and the MCP server.
+
+## Built for Verse / UEFN and asset-heavy teams
+
+File locking is a first-class citizen. When a teammate holds a lock on a binary asset (texture, mesh, audio), VS Code shows a lock icon in the file tree and prevents accidental edits. Releasing a lock is a single click from the SCM panel.
+
+For full Lore concepts — revisions, staging, fragments, locks — see **[The Lore mental model](/docs/lore-model)**.

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -3,6 +3,7 @@ import { Hero } from "@/components/Hero";
 import { Features } from "@/components/Features";
 import { BuiltOnApi } from "@/components/BuiltOnApi";
 import { ForAgents } from "@/components/ForAgents";
+import { Ecosystem } from "@/components/Ecosystem";
 import { Screenshots } from "@/components/Screenshots";
 import { Install } from "@/components/Install";
 import { Footer } from "@/components/Footer";
@@ -16,6 +17,7 @@ export default function Home() {
         <Features />
         <BuiltOnApi />
         <ForAgents />
+        <Ecosystem />
         <Screenshots />
         <Install />
       </main>

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -25,6 +25,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.8,
     },
+    {
+      url: `${SITE_URL}/docs/vscode`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
+      url: `${SITE_URL}/docs/unreal`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
     ...docs,
   ];
 }

--- a/website/src/components/Ecosystem.tsx
+++ b/website/src/components/Ecosystem.tsx
@@ -1,0 +1,292 @@
+import { Container } from "@/components/ui/Container";
+import { Card } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { CodeBlock } from "@/components/CodeBlock";
+import {
+  LoreIcon,
+  VSCodeIcon,
+  UnrealIcon,
+  TerminalIcon,
+  ArrowRightIcon,
+  CheckIcon,
+} from "@/components/icons";
+
+const VSCODE_MARKETPLACE_URL =
+  "https://marketplace.visualstudio.com/items?itemName=BiloxiStudios.loregui-lore";
+const VSCODE_INSTALL_CMD = [
+  "code --install-extension BiloxiStudios.loregui-lore",
+];
+
+type SurfaceStatus = "live" | "coming";
+
+interface SurfaceCta {
+  label: string;
+  href: string;
+  external?: boolean;
+}
+
+interface Surface {
+  id: string;
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  status: SurfaceStatus;
+  headline: string;
+  description: string;
+  cta: SurfaceCta | null;
+  detail: string[] | null;
+  features: string[];
+}
+
+const surfaces: Surface[] = [
+  {
+    id: "desktop",
+    icon: LoreIcon,
+    label: "Desktop app",
+    status: "live",
+    headline: "LoreGUI Desktop",
+    description:
+      "The full GUI: branches, commits, merge, diff, file locking, theming — everything in one cross-platform window. Binds the lore engine in-process; no daemon, no CLI shelling.",
+    cta: { label: "Download", href: "/#install" },
+    detail: null,
+    features: [
+      "Visual branch, merge & diff",
+      "File locking for binaries",
+      "Command palette (⌘K)",
+      "Fully themeable",
+      "Windows, macOS & Linux",
+    ],
+  },
+  {
+    id: "vscode",
+    icon: VSCodeIcon,
+    label: "VS Code extension",
+    status: "live",
+    headline: "Lore Source Control",
+    description:
+      "Lore source control inside VS Code's native SCM panel. Stage, commit, view history, compare diffs, and manage file locks without leaving your editor. Built for Verse/UEFN teams and asset-heavy projects — powered by the same lorevm engine as the desktop app.",
+    cta: {
+      label: "Install from Marketplace",
+      href: VSCODE_MARKETPLACE_URL,
+      external: true,
+    },
+    detail: VSCODE_INSTALL_CMD,
+    features: [
+      "Native SCM panel integration",
+      "Stage, commit & diff inline",
+      "Revision history in-editor",
+      "File-lock awareness & status",
+      "One-line install",
+    ],
+  },
+  {
+    id: "unreal",
+    icon: UnrealIcon,
+    label: "Unreal Engine plugin",
+    status: "coming",
+    headline: "StudioBrain for Unreal",
+    description:
+      "Lore source control inside Unreal Engine's content browser. Lock/status overlays on assets, checkout = lock, check-in = commit, sync — all driving lorevm-ffi for the hot path. Entity-aware versioning is on the roadmap.",
+    cta: null,
+    detail: null,
+    features: [
+      "Content-browser lock overlays",
+      "Checkout = lock, check-in = commit",
+      "Sync from Unreal toolbar",
+      "Drives lorevm-ffi (C ABI)",
+      "Entity-aware versioning (roadmap)",
+    ],
+  },
+  {
+    id: "mcp",
+    icon: TerminalIcon,
+    label: "MCP / agents",
+    status: "live",
+    headline: "lore-mcp",
+    description:
+      "Drive Lore from AI agents (Claude Code and others) via the MCP server included in the repo. One tool per Lore operation, schemas generated from the same palette manifests as the desktop app — so the agent and the app stay in lock-step.",
+    cta: { label: "Read the docs", href: "/docs/mcp" },
+    detail: null,
+    features: [
+      "One MCP tool per Lore op",
+      "Schemas from palette manifests",
+      "Status, history, diff, locks",
+      "Commit, branch, stage, lock",
+      "Agent self-onboarding skills",
+    ],
+  },
+];
+
+export function Ecosystem() {
+  return (
+    <section
+      id="ecosystem"
+      className="relative overflow-hidden border-t border-brand-muted/10 py-20 sm:py-32"
+    >
+      <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+        <div className="absolute left-1/3 top-0 h-[400px] w-[600px] -translate-x-1/2 rounded-full bg-vapor-purple/[0.08] blur-3xl" />
+        <div className="absolute right-0 top-1/2 h-[300px] w-[400px] -translate-y-1/2 rounded-full bg-vapor-blue/[0.08] blur-3xl" />
+      </div>
+
+      <Container className="relative">
+        <div className="mx-auto max-w-2xl text-center">
+          <Badge variant="accent" className="mb-6">
+            One toolkit, four surfaces
+          </Badge>
+          <h2 className="font-heading text-3xl font-bold tracking-tight text-brand-text-bright sm:text-4xl">
+            Lore anywhere you work
+          </h2>
+          <p className="mt-4 text-lg text-brand-muted">
+            Whether you&rsquo;re in a desktop GUI, a code editor, Unreal
+            Engine, or an AI agent &mdash; the same{" "}
+            <span className="font-semibold text-brand-text">lorevm</span> engine
+            drives every surface, and every op is consistent across all of them.
+          </p>
+        </div>
+
+        {/* Surface pill strip */}
+        <div className="mx-auto mt-10 flex max-w-2xl flex-wrap items-center justify-center gap-3">
+          {surfaces.map((s) => (
+            <span
+              key={s.id}
+              className="inline-flex items-center gap-1.5 rounded-full border border-brand-muted/20 bg-brand-surface/60 px-4 py-1.5 text-sm font-medium text-brand-muted"
+            >
+              <s.icon className="h-4 w-4 shrink-0" />
+              {s.label}
+              {s.status === "coming" && (
+                <span className="ml-1 rounded-full bg-brand-gold/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-brand-gold">
+                  soon
+                </span>
+              )}
+            </span>
+          ))}
+        </div>
+
+        {/* Surface cards */}
+        <div className="mt-16 grid gap-6 sm:grid-cols-2">
+          {surfaces.map((surface) => (
+            <Card
+              key={surface.id}
+              hover={surface.status !== "coming"}
+              highlight={surface.id === "desktop"}
+              className="flex flex-col gap-5"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex items-center gap-3">
+                  <div className="inline-flex rounded-lg bg-brand-accent/10 p-3">
+                    <surface.icon className="h-6 w-6 text-brand-accent" />
+                  </div>
+                  <div>
+                    <h3 className="font-heading text-lg font-semibold text-brand-text-bright">
+                      {surface.headline}
+                    </h3>
+                    <p className="text-xs text-brand-muted">{surface.label}</p>
+                  </div>
+                </div>
+                {surface.status === "coming" ? (
+                  <span className="shrink-0 rounded-full border border-brand-gold/30 bg-brand-gold/10 px-2.5 py-1 text-xs font-semibold text-brand-gold">
+                    Coming soon
+                  </span>
+                ) : (
+                  <span className="shrink-0 rounded-full border border-vapor-green/30 bg-vapor-green/10 px-2.5 py-1 text-xs font-semibold text-vapor-green">
+                    Live
+                  </span>
+                )}
+              </div>
+
+              <p className="text-sm leading-relaxed text-brand-muted">
+                {surface.description}
+              </p>
+
+              <ul className="grid grid-cols-1 gap-y-2" role="list">
+                {surface.features.map((f) => (
+                  <li key={f} className="flex items-start gap-2">
+                    <CheckIcon className="mt-0.5 h-4 w-4 shrink-0 text-vapor-green" />
+                    <span className="text-sm text-brand-text">{f}</span>
+                  </li>
+                ))}
+              </ul>
+
+              {surface.detail && (
+                <div className="mt-1">
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-brand-muted">
+                    One-liner install
+                  </p>
+                  <CodeBlock lines={surface.detail} />
+                </div>
+              )}
+
+              {surface.cta && (
+                <div className="mt-auto pt-2">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    href={surface.cta.href}
+                    {...(surface.cta.external
+                      ? { target: "_blank", rel: "noopener noreferrer" }
+                      : {})}
+                  >
+                    {surface.cta.label}
+                    <ArrowRightIcon className="ml-2 h-4 w-4" />
+                  </Button>
+                </div>
+              )}
+
+              {surface.status === "coming" && (
+                <p className="mt-auto pt-2 text-xs text-brand-muted">
+                  No download yet &mdash; follow the{" "}
+                  <a
+                    href="https://github.com/BiloxiStudios/loregui"
+                    className="text-brand-accent hover:text-brand-accent-hover"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    GitHub repo
+                  </a>{" "}
+                  for updates.
+                </p>
+              )}
+            </Card>
+          ))}
+        </div>
+
+        {/* VS Code install highlight */}
+        <div className="mx-auto mt-12 max-w-2xl rounded-2xl border border-brand-accent/20 bg-brand-surface/60 p-6">
+          <div className="flex items-center gap-3">
+            <VSCodeIcon className="h-6 w-6 text-brand-accent" />
+            <h3 className="font-heading text-base font-semibold text-brand-text-bright">
+              Install the VS Code extension now
+            </h3>
+          </div>
+          <p className="mt-3 text-sm leading-relaxed text-brand-muted">
+            Published as{" "}
+            <code className="rounded bg-brand-deep/70 px-1.5 py-0.5 font-mono text-xs text-brand-text">
+              BiloxiStudios.loregui-lore
+            </code>{" "}
+            on the VS Code Marketplace. Run the one-liner or search &ldquo;Lore
+            Source Control&rdquo; in the Extensions panel.
+          </p>
+          <div className="mt-4">
+            <CodeBlock lines={VSCODE_INSTALL_CMD} />
+          </div>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <Button
+              variant="primary"
+              size="sm"
+              href={VSCODE_MARKETPLACE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <VSCodeIcon className="mr-2 h-4 w-4" />
+              Open in Marketplace
+            </Button>
+            <Button variant="secondary" size="sm" href="/docs/vscode">
+              Read the docs
+              <ArrowRightIcon className="ml-2 h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -13,6 +13,12 @@ const footerLinks: Record<string, { label: string; href: string; external?: bool
     { label: "Documentation", href: "/docs" },
     { label: "Install", href: "/#install" },
   ],
+  Ecosystem: [
+    { label: "Desktop app", href: "/#install" },
+    { label: "VS Code extension", href: "https://marketplace.visualstudio.com/items?itemName=BiloxiStudios.loregui-lore", external: true },
+    { label: "Unreal plugin (soon)", href: "/#ecosystem" },
+    { label: "MCP & agents", href: "/docs/mcp" },
+  ],
   Project: [
     { label: "Lore on GitHub", href: GITHUB_URL, external: true },
     { label: "Releases", href: "https://github.com/BiloxiStudios/loregui/releases", external: true },

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -12,6 +12,7 @@ const navLinks = [
   { label: "Features", href: "/#features" },
   { label: "API", href: "/#api" },
   { label: "For agents", href: "/#agents" },
+  { label: "Ecosystem", href: "/#ecosystem" },
   { label: "Screens", href: "/#screens" },
   { label: "Guide", href: "/guide" },
   { label: "Docs", href: "/docs" },

--- a/website/src/components/icons/index.tsx
+++ b/website/src/components/icons/index.tsx
@@ -234,3 +234,27 @@ export function CopyIcon({ className = "h-4 w-4" }: IconProps) {
     </svg>
   );
 }
+
+export function VSCodeIcon({ className = "h-6 w-6" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M23.15 2.587 18.21.21a1.494 1.494 0 0 0-1.705.29l-9.46 8.63-4.12-3.128a.999.999 0 0 0-1.276.057L.327 7.261A1 1 0 0 0 .326 8.74L3.899 12 .326 15.26a1 1 0 0 0 .001 1.479L1.65 17.94a.999.999 0 0 0 1.276.057l4.12-3.128 9.46 8.63a1.492 1.492 0 0 0 1.704.29l4.942-2.377A1.5 1.5 0 0 0 24 19.983V4.017a1.5 1.5 0 0 0-.85-1.43zm-5.146 14.861L10.826 12l7.178-5.448v10.896z" />
+    </svg>
+  );
+}
+
+export function UnrealIcon({ className = "h-6 w-6" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm0 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2zm0 2.18c-4.31 0-7.82 3.51-7.82 7.82s3.51 7.82 7.82 7.82 7.82-3.51 7.82-7.82-3.51-7.82-7.82-7.82zm-.55 2.56h1.1l2.75 5.12-1.1 2.02-1.65-3.08-1.65 3.08-1.1-2.02 2.75-5.12z" />
+    </svg>
+  );
+}
+
+export function PuzzleIcon({ className = "h-6 w-6" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" {...stroke}>
+      <path d="M19.5 12a2.5 2.5 0 0 0-2.5 2.5V14H14v-3h.5a2.5 2.5 0 0 0 0-5H14V3H5v9h-.5a2.5 2.5 0 0 0 0 5H5v4h9v-.5a2.5 2.5 0 0 1 5 0v.5h2v-9h-.5z" />
+    </svg>
+  );
+}

--- a/website/src/lib/docs-nav.ts
+++ b/website/src/lib/docs-nav.ts
@@ -106,6 +106,23 @@ export const DOCS_NAV: DocsSection[] = [
       },
     ],
   },
+  {
+    title: "Ecosystem",
+    pages: [
+      {
+        title: "VS Code extension",
+        href: "/docs/vscode",
+        description:
+          "Lore Source Control in VS Code's native SCM panel — stage, commit, diff, history, and file locks from the editor.",
+      },
+      {
+        title: "Unreal Engine plugin",
+        href: "/docs/unreal",
+        description:
+          "Content-browser lock overlays, checkout = lock, check-in = commit — Lore inside Unreal. Coming soon.",
+      },
+    ],
+  },
 ];
 
 /** Flat, ordered list of every docs page — used for prev/next and search. */


### PR DESCRIPTION
Ecosystem section (Desktop · VS Code · Unreal soon · MCP) on the homepage + nav/footer; /docs/vscode (live, marketplace link) + /docs/unreal (coming soon, MVP-scoped). Builds 21 pages clean.