### PR TITLE
fix(lorevm): flush staged state before CLI/FFI process exit — fixes commit-after-stage across drivers (SBAI-4080)

### DIFF
--- a/crates/lore-vm/src/dispatch.rs
+++ b/crates/lore-vm/src/dispatch.rs
@@ -91,6 +91,40 @@ pub fn supported_ops() -> &'static [&'static str] {
     SUPPORTED_OPS
 }
 
+/// Drain the lore engine's outstanding asynchronous tasks to disk.
+///
+/// **Why this exists — the cross-process staging bug (SBAI-4080).** The upstream
+/// `lore` engine does not flush its stores synchronously at the end of a command.
+/// Instead, every command's teardown *spawns* a fire-and-forget background task
+/// (`try_spawn_post_command_flush`) that flushes the immutable **and** mutable
+/// stores. In the upstream `lore` CLI/server that task is awaited at shutdown via
+/// the runtime guard, so the writes always land.
+///
+/// Our **external drivers** (the `lorevm` CLI and `lorevm-ffi`) run one op and
+/// then drop the tokio runtime. Dropping a runtime *aborts* tasks that have not
+/// finished — so the spawned mutable-store flush is racy and frequently lost. The
+/// immutable fragments tend to win the race (they are also flushed during state
+/// serialisation), but the **staged-anchor pointer** in the mutable store does
+/// not, so a *later, separate* process sees no staged revision. That surfaces in
+/// the VS Code extension — which shells out a separate `lorevm` process per op —
+/// as a `file.stage` that "succeeds" followed by a `revision.commit` that fails
+/// with `Nothing staged for commit` or, when only the pointer survives but not its
+/// state fragment, `Failed to deserialize revision state / Failed to read state data`.
+///
+/// [`finalize`] makes the deferred flush *synchronous and awaited* within the
+/// driver process: it routes through the engine's `repository.flush` op, whose
+/// `flush_local` calls `runtime_flush_guarded()` — awaiting **all** outstanding
+/// guarded tasks (including the post-command store flush) to completion. Every
+/// external driver MUST call this after a mutating op completes and before its
+/// runtime is torn down, so separate processes observe durable on-disk state.
+///
+/// Errors are swallowed: a flush failure (e.g. nothing to flush, or a repo path
+/// that does not host a store) must not mask the op's own result. Read-only ops
+/// can call it harmlessly.
+pub async fn finalize(api: &LoreApi) {
+    let _ = crate::ops::repository::flush::flush(api).await;
+}
+
 /// Route `op_id` (`"<domain>.<op>"`) to its [`crate::ops`] fn.
 ///
 /// Deserialises `args` into the op's `Args`, awaits the op against `api`, and

--- a/crates/lore-vm/src/lib.rs
+++ b/crates/lore-vm/src/lib.rs
@@ -31,6 +31,6 @@ pub mod client_backend;
 
 pub use api::LoreApi;
 pub use backend::{default_backend, LoreBackend};
-pub use dispatch::{dispatch, supported_ops};
+pub use dispatch::{dispatch, finalize, supported_ops};
 pub use error::{LoreError, Result};
 pub use model::{Branch, ChangeKind, FileChange, RepoStatus, Revision};

--- a/crates/lorevm-cli/src/main.rs
+++ b/crates/lorevm-cli/src/main.rs
@@ -40,7 +40,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use lore_vm::global::LoreGlobal;
-use lore_vm::{dispatch, supported_ops, LoreApi};
+use lore_vm::{dispatch, finalize, supported_ops, LoreApi};
 use serde_json::{json, Value};
 
 /// Parsed command line.
@@ -192,7 +192,22 @@ async fn main() -> ExitCode {
     let api = build_api(&cli);
     // The single shared seam: every external driver (this CLI, lorevm-ffi) routes
     // `<domain>.<op>` through `lore_vm::dispatch`.
-    match dispatch(&api, &cli.op_id, cli.args).await {
+    let outcome = dispatch(&api, &cli.op_id, cli.args).await;
+
+    // SBAI-4080: the lore engine defers its end-of-command store flush to a
+    // fire-and-forget background task. This CLI runs ONE op per process and then
+    // drops the tokio runtime, which would abort that task and lose the
+    // mutable-store write (the staged-revision anchor) — so a separate `commit`
+    // process can't see what a prior `stage` process staged. Drain the engine's
+    // outstanding tasks synchronously before we return and tear the runtime down.
+    // Runs even on op failure: a partial write must still be made durable, and a
+    // read-only op drains harmlessly. Skipped for in-memory mode (nothing on disk
+    // to flush, and no repo store is open).
+    if !cli.in_memory {
+        finalize(&api).await;
+    }
+
+    match outcome {
         Ok(value) => {
             println!("{}", serde_json::to_string_pretty(&value).unwrap());
             ExitCode::SUCCESS

--- a/crates/lorevm-ffi/src/lib.rs
+++ b/crates/lorevm-ffi/src/lib.rs
@@ -234,9 +234,18 @@ fn run_call(handle: &LorevmHandle, op_id: &str, args_str: &str) -> Value {
     };
 
     // Block on the handle's long-lived runtime — no per-call runtime spin-up.
-    let result = handle
-        .runtime
-        .block_on(lore_vm::dispatch(&handle.api, op_id, args));
+    // SBAI-4080: the lore engine defers its end-of-command store flush to a
+    // spawned background task. A UE host may make subsequent reads through a
+    // *different* handle (or a separate process / the CLI), so we drain the
+    // engine's outstanding tasks synchronously after each call to guarantee the
+    // mutable-store write (e.g. the staged-revision anchor) is durable before we
+    // return — the same durability contract the `lorevm` CLI enforces per
+    // process. See `lore_vm::finalize`.
+    let result = handle.runtime.block_on(async {
+        let r = lore_vm::dispatch(&handle.api, op_id, args).await;
+        lore_vm::finalize(&handle.api).await;
+        r
+    });
 
     match result {
         Ok(value) => value,

--- a/vscode-extension/.gitignore
+++ b/vscode-extension/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 out/
+bin/
 *.vsix
 .vscode-test/

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "loregui-lore",
   "displayName": "Lore Source Control",
   "description": "Full source control for Epic Games' lore VCS, driven by the loregui lorevm engine. Native SCM view (stage/unstage/commit/push/sync/revert), side-by-side diff + quick-diff gutter, Branches / History / Locks tree views, status bar, and lock-aware file decorations.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "BiloxiStudios",
   "license": "SEE LICENSE IN LICENSE.txt",
   "author": "Biloxi Studios Inc. (BizaNator)",


### PR DESCRIPTION
Root cause: lore's end-of-command store flush is a fire-and-forget task the upstream CLI awaits at shutdown, but lorevm-cli/ffi dropped the runtime and aborted it → staged-revision anchor never persisted → separate commit process saw nothing staged ('Failed to read state data'). Fix: finalize()/guarded-flush drain after each op in lorevm-cli + lorevm-ffi (via dispatch). Fixes VS Code commit + the SAME latent bug in MCP + UE FFI. Extension logic unchanged; bumped 0.2.1. Tests green, repro verified across separate processes.