### PR TITLE
fix(vscode+lore-vm): real-flow SCM — refresh on editor save + self-heal dangling staged anchor (vscode 0.2.3, SBAI-4080)

### DIFF
--- a/crates/lore-vm/src/ops/file/stage.rs
+++ b/crates/lore-vm/src/ops/file/stage.rs
@@ -134,7 +134,43 @@ pub struct FileStageResult {
 ///
 /// Calls the upstream `lore::file::stage` in-process and collects
 /// `FileStageFile` / `FileStageRevision` events into a typed result.
+///
+/// **Self-heals a dangling staged anchor (SBAI-4080, the "real-flow" stage bug).**
+/// Every stage first deserialises the *pre-existing* staged state (upstream
+/// `State::deserialize_current_and_staged`). If a *prior* process wrote the
+/// staged-anchor pointer into the mutable store but its state fragment never
+/// became durable in the immutable store — the classic "anchor present, fragment
+/// missing" corruption that surfaces in real repos as
+/// `Failed to deserialize staged state: Failed to read state data` (or
+/// `Failed to deserialize revision state` / `Not found`) — then **every**
+/// subsequent `file.stage` is permanently stuck: the engine can't read the state
+/// it's supposed to extend.
+///
+/// The only thing that clears a dangling anchor is dropping it before any
+/// deserialize touches it (`repository.status` with `reset = true`, which calls
+/// `delete_staged_anchor` up front). So when a stage fails with the
+/// dangling-anchor signature we drop the bad anchor and retry **once**. The retry
+/// runs against a clean staged state and re-stages the file the user actually
+/// edited — turning a permanently broken repo into a transparent recovery. A
+/// retry is only attempted for that specific signature so genuine stage errors
+/// (bad path, conflict, …) still surface immediately.
 pub async fn stage(api: &LoreApi, args: FileStageArgs) -> Result<FileStageResult> {
+    match stage_once(api, args.clone()).await {
+        Ok(result) => Ok(result),
+        Err(err) if is_dangling_staged_state(&err) => {
+            // Drop the unreadable staged anchor, then re-attempt the stage once
+            // against a clean staged state. If the reset itself fails, surface
+            // the ORIGINAL stage error (more actionable than the reset error).
+            reset_staged_anchor(api).await.map_err(|_| err)?;
+            stage_once(api, args).await
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// One raw attempt at the upstream stage — no recovery. Factored out so [`stage`]
+/// can retry it after healing a dangling staged anchor.
+async fn stage_once(api: &LoreApi, args: FileStageArgs) -> Result<FileStageResult> {
     let (callback, rx) = collect_events();
 
     let globals = api.globals();
@@ -171,6 +207,46 @@ pub async fn stage(api: &LoreApi, args: FileStageArgs) -> Result<FileStageResult
     }
 
     Ok(FileStageResult { files, revision })
+}
+
+/// True when `err` is the "dangling staged anchor" failure: the mutable store
+/// points at a staged revision whose immutable state fragment is missing or
+/// unreadable. Upstream surfaces this as one of a small family of messages
+/// depending on which tier failed the read; match them all so a real-repo user
+/// who hit the cross-process flush race auto-recovers on their next stage.
+/// Test-only re-export of [`is_dangling_staged_state`] so the integration
+/// harness can assert the classifier directly.
+#[doc(hidden)]
+pub fn is_dangling_staged_state_for_test(err: &LoreError) -> bool {
+    is_dangling_staged_state(err)
+}
+
+fn is_dangling_staged_state(err: &LoreError) -> bool {
+    let msg = err.to_string();
+    msg.contains("deserialize staged state")
+        || msg.contains("deserialize revision state")
+        || msg.contains("Failed to read state data")
+        // The local-only store classifies the missing fragment as a bare
+        // "Not found"; only treat that as dangling-anchor when it came from a
+        // stage/state read (the only LoreError carrying it here).
+        || msg.contains("Not found")
+}
+
+/// Drop a dangling staged anchor by routing through `repository.status` with
+/// `reset = true` — the one upstream path that deletes the staged-anchor pointer
+/// *before* any deserialize touches it (`delete_staged_anchor`). Used only as a
+/// recovery step inside [`stage`].
+async fn reset_staged_anchor(api: &LoreApi) -> Result<()> {
+    use crate::ops::repository::status::{status, RepositoryStatusArgs};
+    status(
+        api,
+        RepositoryStatusArgs {
+            reset: true,
+            ..Default::default()
+        },
+    )
+    .await
+    .map(|_| ())
 }
 
 #[cfg(test)]

--- a/crates/lore-vm/tests/stage_real_flow.rs
+++ b/crates/lore-vm/tests/stage_real_flow.rs
@@ -1,0 +1,394 @@
+//! Real-flow staging regression harness for `lore-vm` (SBAI-4080 — 0.2.3).
+//!
+//! The 0.2.1 cross-process flush fix and the 0.2.2 relative-path fix were both
+//! validated against a CLEAN, CLI-created scratch repo. That missed the way a
+//! REAL VS Code-extension user drives the engine: they EDIT a tracked file in
+//! the editor (not via the CLI) and then stage it, with one `lorevm` process per
+//! op. Two real-flow gaps fell through:
+//!
+//!   1. **`repository.status` only reports editor-edited working-tree changes
+//!      when `scan = true`.** Without `scan` the engine reports nothing the user
+//!      hasn't already staged, so a freshly edited tracked file + a new untracked
+//!      file are invisible — the SCM "Changes" group looks empty. (The extension
+//!      now always polls `status { scan: true }`; this asserts the engine
+//!      contract that backs it.)
+//!
+//!   2. **A dangling staged anchor permanently breaks staging.** If a prior
+//!      process wrote the staged-anchor pointer (mutable store) but its state
+//!      fragment never became durable (immutable store) — the cross-process
+//!      flush race — every later `file.stage` hits
+//!      `Failed to deserialize staged state: Failed to read state data` (or the
+//!      local-store `Not found`) because stage first deserialises the existing
+//!      staged state. `file::stage` now self-heals: it drops the bad anchor and
+//!      retries once, recovering a repo that was otherwise stuck forever.
+//!
+//! Runs against a REAL on-disk repo (`in_memory = 0`, `offline = 1`) backed by a
+//! shared store OUTSIDE the working tree, so we can manipulate the on-disk
+//! immutable store to reproduce the dangling-anchor corruption deterministically.
+//!
+//! ```sh
+//! cargo test -p lore-vm --features integration-tests --test stage_real_flow
+//! ```
+#![cfg(feature = "integration-tests")]
+
+use std::io::Write;
+use std::path::Path;
+
+use lore_vm::api::LoreApi;
+use lore_vm::global::LoreGlobal;
+use lore_vm::ops;
+
+/// On-disk headless api as a given identity, mirroring `e2e_lifecycle.rs`.
+fn on_disk_api(dir: &Path, identity: &str) -> LoreApi {
+    let global = LoreGlobal::new(dir.to_path_buf())
+        .in_memory(false)
+        .offline(true)
+        .identity(identity);
+    LoreApi::from_global(global)
+}
+
+fn write_file(path: &Path, contents: &[u8]) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dirs");
+    }
+    let mut f = std::fs::File::options()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(path)
+        .expect("create file");
+    f.write_all(contents).expect("write file");
+}
+
+/// Stage repo-RELATIVE paths exactly as the VS Code extension does
+/// (`path.relative(repoRoot, uri)` + `scan: true`).
+async fn stage_rel(
+    api: &LoreApi,
+    paths: &[&str],
+) -> lore_vm::error::Result<ops::file::stage::FileStageResult> {
+    ops::file::stage::stage(
+        api,
+        ops::file::stage::FileStageArgs {
+            paths: paths.iter().map(|p| p.to_string()).collect(),
+            case_change: ops::file::stage::CaseChange::Error,
+            scan: true,
+        },
+    )
+    .await
+}
+
+async fn status(
+    api: &LoreApi,
+    args: ops::repository::status::RepositoryStatusArgs,
+) -> ops::repository::status::RepositoryStatusResult {
+    ops::repository::status::status(api, args)
+        .await
+        .expect("repository::status should succeed")
+}
+
+/// Build a real on-disk repo with a shared store outside the tree and one
+/// committed baseline file (`tracked.txt`). Returns the api.
+async fn setup_repo(repo_path: &Path, store_path: &Path, identity: &str) -> LoreApi {
+    let api = on_disk_api(repo_path, identity);
+
+    let name = format!("real-flow-{}", std::process::id());
+    ops::repository::create::create(
+        &api,
+        ops::repository::create::CreateArgs {
+            repository_url: format!("lore://localhost/{name}"),
+            description: "stage real-flow harness".into(),
+            id: String::new(),
+            use_shared_store: true,
+            shared_store_path: store_path.to_string_lossy().into_owned(),
+        },
+    )
+    .await
+    .expect("repository::create should succeed");
+
+    write_file(&repo_path.join("tracked.txt"), b"baseline v1\n");
+    stage_rel(&api, &["tracked.txt"])
+        .await
+        .expect("baseline stage should succeed");
+    ops::revision::commit::commit(
+        &api,
+        ops::revision::commit::CommitArgs {
+            message: "baseline".into(),
+        },
+    )
+    .await
+    .expect("baseline commit should succeed");
+
+    api
+}
+
+/// BUG #1 (real flow): an editor edit to a tracked file + a new untracked file
+/// must BOTH show up as working-tree changes — but ONLY when status scans the
+/// filesystem. This is the engine contract behind the SCM "Changes" group.
+#[tokio::test]
+async fn status_scan_lists_editor_edited_and_untracked_files() {
+    let work = tempfile::tempdir().expect("work tempdir");
+    let store = tempfile::tempdir().expect("store tempdir");
+    let repo = work.path();
+    let store_path = store.path().join("shared-store");
+
+    let api = setup_repo(repo, &store_path, "alice").await;
+
+    // Simulate the editor: modify the tracked file ON DISK (not via the CLI) and
+    // drop a brand-new untracked file next to it.
+    write_file(
+        &repo.join("tracked.txt"),
+        b"baseline v1\nEDITED IN EDITOR\n",
+    );
+    write_file(&repo.join("untracked.txt"), b"brand new\n");
+
+    // Without scan the working-tree edits are invisible — this is exactly why a
+    // naive poll left the SCM view empty.
+    let bare = status(
+        &api,
+        ops::repository::status::RepositoryStatusArgs::default(),
+    )
+    .await;
+    assert!(
+        !bare.files.iter().any(|f| f.path.ends_with("tracked.txt")),
+        "precondition: a non-scanning status must NOT surface the editor edit \
+         (that's the bug the extension works around with scan:true): {bare:?}"
+    );
+
+    // With scan (what the extension now always sends) BOTH changes appear.
+    let scanned = status(
+        &api,
+        ops::repository::status::RepositoryStatusArgs {
+            scan: true,
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(
+        scanned
+            .files
+            .iter()
+            .any(|f| f.path.ends_with("tracked.txt") && f.dirty),
+        "scanning status must report the editor-edited tracked file: {scanned:?}"
+    );
+    assert!(
+        scanned
+            .files
+            .iter()
+            .any(|f| f.path.ends_with("untracked.txt") && f.dirty),
+        "scanning status must report the new untracked file: {scanned:?}"
+    );
+}
+
+/// BUG #2 (real flow): the full editor edit → stage → commit cycle, across the
+/// SAME api but exercising each op independently, must persist the edit.
+#[tokio::test]
+async fn editor_edit_stage_commit_persists() {
+    let work = tempfile::tempdir().expect("work tempdir");
+    let store = tempfile::tempdir().expect("store tempdir");
+    let repo = work.path();
+    let store_path = store.path().join("shared-store");
+
+    let api = setup_repo(repo, &store_path, "alice").await;
+
+    write_file(&repo.join("tracked.txt"), b"baseline v1\nEDITED\n");
+    let staged = stage_rel(&api, &["tracked.txt"])
+        .await
+        .expect("stage of editor-edited file should succeed");
+    assert!(
+        staged.files.iter().any(|f| f.path.ends_with("tracked.txt")),
+        "stage should report the edited file: {staged:?}"
+    );
+
+    let committed = ops::revision::commit::commit(
+        &api,
+        ops::revision::commit::CommitArgs {
+            message: "edit tracked".into(),
+        },
+    )
+    .await
+    .expect("commit should succeed");
+    assert!(
+        !committed.revision.is_empty(),
+        "commit must return a revision: {committed:?}"
+    );
+
+    // The edit is durable: HEAD's delta touches the file and the tree is clean.
+    let info = ops::revision::info::info(
+        &api,
+        ops::revision::info::RevisionInfoArgs {
+            revision: committed.revision.clone(),
+            delta: true,
+            metadata: false,
+        },
+    )
+    .await
+    .expect("revision::info should succeed");
+    assert!(
+        info.deltas.iter().any(|d| d.path.ends_with("tracked.txt")),
+        "committed revision must include the edit in its delta: {info:?}"
+    );
+
+    let after = status(
+        &api,
+        ops::repository::status::RepositoryStatusArgs {
+            scan: true,
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(
+        !after.files.iter().any(|f| f.path.ends_with("tracked.txt")),
+        "after committing the edit, tracked.txt should be clean: {after:?}"
+    );
+}
+
+/// Direct unit coverage for the dangling-anchor error classifier that gates the
+/// self-heal retry. The full cross-process recovery is proven in
+/// `dangling_anchor_self_heals_across_processes` below (the in-process api keeps
+/// the immutable fragment cached, so on-disk corruption is invisible to it —
+/// only a *fresh* process actually fails the read).
+#[test]
+fn dangling_anchor_signatures_are_recognized() {
+    use lore_vm::error::LoreError;
+    use lore_vm::ops::file::stage::is_dangling_staged_state_for_test as is_dangling;
+
+    for msg in [
+        "Failed to deserialize staged state: Failed to read state data",
+        "Failed to deserialize revision state: Failed to read state data",
+        "Failed to read state data",
+        "Not found",
+    ] {
+        assert!(
+            is_dangling(&LoreError::CommandFailed(msg.into())),
+            "{msg:?} should be classified as a dangling staged anchor"
+        );
+    }
+
+    // A genuine, unrelated stage failure must NOT trigger the self-heal retry.
+    assert!(
+        !is_dangling(&LoreError::CommandFailed(
+            "path 'nope.txt' does not exist".into()
+        )),
+        "unrelated stage errors must surface, not loop through the heal retry"
+    );
+}
+
+/// BUG #2 (self-heal, REAL cross-process flow): a dangling staged anchor —
+/// staged-anchor pointer present in the mutable store, its state fragment GONE
+/// from the immutable store — must NOT permanently brick staging. This drives the
+/// built `lorevm` CLI with ONE process per op (exactly how the VS Code extension
+/// shells out) so each op opens a fresh store with no warm in-process cache —
+/// the only way the missing fragment actually fails a read. Before the fix the
+/// stuck repo's every `file.stage` errored "Not found" / "Failed to read state
+/// data" forever; after it, the next stage drops the bad anchor, retries, and the
+/// repo commits cleanly.
+#[test]
+fn dangling_anchor_self_heals_across_processes() {
+    let lorevm = match locate_lorevm() {
+        Some(p) => p,
+        None => {
+            eprintln!("skipping cross-process self-heal test: lorevm binary not built");
+            return;
+        }
+    };
+    let work = tempfile::tempdir().expect("work tempdir");
+    let repo = work.path();
+
+    let run = |op: &str, args: &str| -> serde_json::Value {
+        let out = std::process::Command::new(&lorevm)
+            .args([op, "--dir"])
+            .arg(repo)
+            .args(["--offline", "--args", args])
+            .output()
+            .expect("spawn lorevm");
+        serde_json::from_slice(&out.stdout)
+            .unwrap_or_else(|_| panic!("lorevm {op} produced non-JSON: {:?}", out.stdout))
+    };
+
+    run(
+        "repository.create",
+        r#"{"repository_url":"lore://localhost/heal"}"#,
+    );
+    write_file(&repo.join("a.txt"), b"content one\n");
+    run("file.stage", r#"{"paths":["a.txt"],"scan":true}"#);
+
+    // Find the staged revision, then delete its on-disk immutable fragment bucket
+    // to leave the mutable anchor dangling.
+    let status = run("repository.status", "{}");
+    let staged_rev = status["revision"]["revision_staged"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        staged_rev.len() >= 2,
+        "expected a staged revision after stage: {status}"
+    );
+    let bucket = &staged_rev[..2];
+    let frag_dir = repo
+        .join(".lore")
+        .join("immutable")
+        .join("index")
+        .join(bucket)
+        .join("pack");
+    if let Ok(rd) = std::fs::read_dir(&frag_dir) {
+        for entry in rd.flatten() {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+
+    // A fresh process now fails to read the dangling staged state.
+    let broken = run("repository.status", "{}");
+    assert!(
+        broken.get("error").is_some(),
+        "precondition: a fresh process must fail to read the dangling staged \
+         state before the self-heal can be proven: {broken}"
+    );
+
+    // The next stage must self-heal: drop the bad anchor, retry, succeed.
+    let healed = run("file.stage", r#"{"paths":["a.txt"],"scan":true}"#);
+    assert!(
+        healed.get("error").is_none(),
+        "stage must self-heal the dangling anchor, got: {healed}"
+    );
+    assert!(
+        healed["files"]
+            .as_array()
+            .is_some_and(|f| f.iter().any(|e| e["path"] == "a.txt")),
+        "after self-heal, stage should report a.txt: {healed}"
+    );
+
+    // The recovered repo commits cleanly in yet another fresh process.
+    let committed = run("revision.commit", r#"{"message":"recovered"}"#);
+    assert!(
+        committed.get("error").is_none()
+            && committed["revision"]
+                .as_str()
+                .is_some_and(|s| !s.is_empty()),
+        "commit after self-heal should succeed: {committed}"
+    );
+}
+
+/// Locate the built `lorevm` CLI (release preferred, then debug) for the
+/// cross-process self-heal test. Returns `None` when it hasn't been built, so the
+/// test self-skips rather than failing on a clean checkout.
+fn locate_lorevm() -> Option<std::path::PathBuf> {
+    if let Ok(p) = std::env::var("LOREVM_BIN") {
+        let p = std::path::PathBuf::from(p);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    // CARGO_MANIFEST_DIR = crates/lore-vm; the workspace target/ is two up.
+    let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let target = manifest
+        .ancestors()
+        .nth(2)
+        .map(|root| root.join("target"))?;
+    for profile in ["release", "debug"] {
+        let cand = target.join(profile).join("lorevm");
+        if cand.exists() {
+            return Some(cand);
+        }
+    }
+    None
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "loregui-lore",
   "displayName": "Lore Source Control",
   "description": "Full source control for Epic Games' lore VCS, driven by the loregui lorevm engine. Native SCM view (stage/unstage/commit/push/sync/revert), side-by-side diff + quick-diff gutter, Branches / History / Locks tree views, status bar, and lock-aware file decorations.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "BiloxiStudios",
   "license": "SEE LICENSE IN LICENSE.txt",
   "author": "Biloxi Studios Inc. (BizaNator)",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -321,12 +321,21 @@ class LoreRepository implements vscode.Disposable {
     if (!autoRefresh) {
       return;
     }
+    // Belongs to this repo's working tree (and not the .lore metadata dir, whose
+    // churn would cause refresh storms).
+    const ownsPath = (fsPath: string): boolean => {
+      const rel = path.relative(this.folder.uri.fsPath, fsPath);
+      if (rel.startsWith('..') || path.isAbsolute(rel)) {
+        return false; // outside this workspace folder
+      }
+      return !fsPath.includes(`${path.sep}.lore${path.sep}`);
+    };
+
     const watcher = vscode.workspace.createFileSystemWatcher(
       new vscode.RelativePattern(this.folder, '**/*'),
     );
     const onChange = (uri: vscode.Uri) => {
-      // Ignore churn inside the .lore metadata dir to avoid refresh storms.
-      if (uri.fsPath.includes(`${path.sep}.lore${path.sep}`)) {
+      if (!ownsPath(uri.fsPath)) {
         return;
       }
       this.scheduleRefresh();
@@ -335,6 +344,41 @@ class LoreRepository implements vscode.Disposable {
     watcher.onDidChange(onChange);
     watcher.onDidDelete(onChange);
     this.disposables.push(watcher);
+
+    // CRITICAL (SBAI-4080 — the "real flow" SCM-empty bug): the OS-level
+    // FileSystemWatcher does NOT reliably fire when the file is saved from the VS
+    // Code editor. With safe-save (atomic write-to-temp-then-rename, the default
+    // on many setups), network/virtual filesystems, or simply event coalescing,
+    // an in-editor save can produce no onDidChange — so a user who EDITS a tracked
+    // file and saves it sees the SCM "Changes" group stay empty. Refreshing on the
+    // editor's own save/create/delete document events closes that gap: these fire
+    // for the exact buffers the user touched, independent of the fs watcher.
+    this.disposables.push(
+      vscode.workspace.onDidSaveTextDocument((doc) => {
+        if (ownsPath(doc.uri.fsPath)) {
+          this.scheduleRefresh();
+        }
+      }),
+      vscode.workspace.onDidCreateFiles((e) => {
+        if (e.files.some((u) => ownsPath(u.fsPath))) {
+          this.scheduleRefresh();
+        }
+      }),
+      vscode.workspace.onDidDeleteFiles((e) => {
+        if (e.files.some((u) => ownsPath(u.fsPath))) {
+          this.scheduleRefresh();
+        }
+      }),
+      vscode.workspace.onDidRenameFiles((e) => {
+        if (
+          e.files.some(
+            (f) => ownsPath(f.oldUri.fsPath) || ownsPath(f.newUri.fsPath),
+          )
+        ) {
+          this.scheduleRefresh();
+        }
+      }),
+    );
   }
 
   /** Debounced refresh so a burst of file events triggers one status call. */

--- a/vscode-extension/src/test/BUGS.md
+++ b/vscode-extension/src/test/BUGS.md
@@ -95,6 +95,80 @@ second modify→stage→commit cycle also persists.
 
 ---
 
+## BUG #5 — SCM view empty after an EDITOR edit (real-flow SCM bug)  (P0) — FIXED (SBAI-4080, vscode 0.2.3)
+
+**FIXED in the extension.** The 0.2.1 flush + 0.2.2 relative-path fixes were
+validated against a CLEAN CLI-created scratch repo and missed how a real user
+drives the extension: they **edit a tracked file in the VS Code editor and save**,
+not via the CLI.
+
+Two engine facts make the difference:
+- `repository.status` only reports editor-edited working-tree changes (modified
+  tracked + untracked) when **`scan = true`**. The extension already polls
+  `status { scan: true }`, so the engine side was fine — the gap was entirely in
+  WHEN the extension refreshed.
+- The SCM groups are only rebuilt on `refresh()`, and `refresh()` was driven
+  **only** by an OS `FileSystemWatcher`. That watcher does NOT reliably fire for
+  in-editor saves (safe-save = atomic write-to-temp + rename, network/virtual
+  filesystems, event coalescing), so after editing+saving a tracked file the SCM
+  "Changes" group stayed empty until something else triggered a refresh.
+
+**Fix (`extension.ts` `setupWatcher`):** also refresh on the editor's own
+document events — `onDidSaveTextDocument`, `onDidCreateFiles`, `onDidDeleteFiles`,
+`onDidRenameFiles` (scoped to this repo's working tree, ignoring `.lore/`). These
+fire for the exact buffers the user touched, independent of the fs watcher.
+
+Guards: `scm.test.ts` → "editing a tracked file in the editor + saving surfaces
+it as a working-tree change" (drives open → edit → save → assert the engine
+status the SCM groups are built from lists it). Engine contract guarded by
+`crates/lore-vm/tests/stage_real_flow.rs` →
+`status_scan_lists_editor_edited_and_untracked_files`.
+
+---
+
+## BUG #6 — `file.stage` permanently broken by a dangling staged anchor  (P0) — FIXED (SBAI-4080, vscode 0.2.3)
+
+**FIXED in the engine (`crates/lore-vm/src/ops/file/stage.rs`).** The user's
+report — staging a file fails with `Lore: CommandFailed: Failed to deserialize
+staged state: Failed to read state data` — is a **persistent** corruption, not a
+one-shot flush race.
+
+Root cause: every `file.stage` first deserialises the *pre-existing* staged state
+(upstream `State::deserialize_current_and_staged`). The cross-process flush is
+ordered fragment-then-anchor but the upstream post-command flush swallows errors
+and still writes the mutable **anchor** even if the immutable **state fragment**
+flush failed (upstream `lore-revision/src/repository.rs:637-642`,
+`let _ = immutable.flush(); let _ = mutable.flush();`). That leaves an anchor in
+the mutable store pointing at a staged revision whose state fragment is missing
+from the immutable store. From then on **every** stage (and `status`, branch
+switch, sync) fails to read it — the SCM "stage" button is dead forever. The
+literal `Failed to read state data` surfaces when the durable/remote read errors
+with a non-not-found class; a local-only store surfaces the same dangling anchor
+as a bare `Not found`.
+
+The only thing that clears a dangling anchor is dropping it before any
+deserialize touches it: `repository.status` with `reset = true` calls
+`delete_staged_anchor` up front. So `file::stage` now **self-heals**: a stage that
+fails with the dangling-anchor signature drops the bad anchor and retries once
+against a clean staged state, re-staging the file the user edited. A repo that was
+permanently stuck recovers transparently on the user's next stage. The retry is
+gated to that specific signature, so genuine stage errors (bad path, conflict)
+still surface immediately.
+
+Guards: `knownBugs.test.ts` → "BUG#5: file.stage self-heals a dangling staged
+anchor (real cross-process flow)" (separate `lorevm` processes, deletes the
+on-disk fragment to reproduce the corruption, asserts recovery + commit). Engine
+unit + cross-process coverage in `crates/lore-vm/tests/stage_real_flow.rs`
+(`dangling_anchor_signatures_are_recognized`,
+`dangling_anchor_self_heals_across_processes`).
+
+> **Upstream follow-up (not fixed here):** the swallowed-error, anchor-after-
+> failed-fragment ordering lives in the vendored `lore` engine and should be
+> reported upstream (flush immutable; only persist the anchor if the fragment
+> flush succeeded). Our self-heal recovers any repo that already hit it.
+
+---
+
 ## BUG #4 — Locks view / lock decorations dead on local (offline) repos  (P2) — FIXED (SBAI-4080)
 
 **FIXED.** When `lock.file_query` fails with "No remote configured", the

--- a/vscode-extension/src/test/suite/knownBugs.test.ts
+++ b/vscode-extension/src/test/suite/knownBugs.test.ts
@@ -129,4 +129,77 @@ suite('Lore — known-bug regression guards (expected RED until fixed)', functio
       `expected 2 revisions after two commits; got ${hist.entries.length}`,
     );
   });
+
+  // ---------------------------------------------------------------------
+  // BUG #5 (P0, the REAL-flow staging bug — SBAI-4080 0.2.3): a dangling
+  // staged anchor must NOT permanently brick staging.
+  //
+  // The 0.2.1/0.2.2 fixes were validated against a CLEAN scratch repo and
+  // missed this. In a real repo, the cross-process flush race can leave the
+  // staged-anchor POINTER in the mutable store while its state FRAGMENT never
+  // became durable in the immutable store. Every subsequent `file.stage` then
+  // fails with `Failed to deserialize staged state: Failed to read state data`
+  // (or, on a local-only store, `Not found`) because stage first deserialises
+  // the existing staged state — so the user's SCM "stage" button is dead forever.
+  //
+  // The engine fix self-heals: a stage that hits the dangling-anchor signature
+  // drops the bad anchor (status reset) and retries once. We reproduce the
+  // corruption deterministically with SEPARATE processes (one per op, exactly as
+  // the extension shells out) — a fresh process has no warm in-memory cache, so
+  // the missing fragment actually fails the read — then assert the next stage
+  // recovers and a commit persists.
+  // ---------------------------------------------------------------------
+  test('BUG#5: file.stage self-heals a dangling staged anchor (real cross-process flow)', () => {
+    const repo = freshRepo();
+    fs.writeFileSync(path.join(repo, 'a.txt'), 'content one\n');
+    op(repo, 'file.stage', { paths: ['a.txt'], scan: true });
+
+    // The staged anchor points at this revision; its state fragment lives in the
+    // immutable bucket named by the first two hex chars.
+    const st = op(repo, 'repository.status', {}) as {
+      revision?: { revision_staged?: string };
+    };
+    const stagedRev = st.revision?.revision_staged ?? '';
+    assert.ok(
+      stagedRev.length >= 2,
+      `expected a staged revision after stage; got ${JSON.stringify(st)}`,
+    );
+
+    // Delete the on-disk fragment to leave the anchor dangling.
+    const bucket = stagedRev.slice(0, 2);
+    const fragDir = path.join(repo, '.lore', 'immutable', 'index', bucket, 'pack');
+    if (fs.existsSync(fragDir)) {
+      for (const f of fs.readdirSync(fragDir)) {
+        fs.rmSync(path.join(fragDir, f), { force: true });
+      }
+    }
+
+    // Precondition: a FRESH process now fails to read the dangling staged state.
+    const broken = op(repo, 'repository.status', {}) as Record<string, unknown>;
+    assert.ok(
+      'error' in broken,
+      `precondition: a fresh process must fail on the dangling staged state ` +
+        `before the self-heal can be proven; got ${JSON.stringify(broken)}`,
+    );
+
+    // The next stage must self-heal instead of erroring.
+    const healed = op(repo, 'file.stage', { paths: ['a.txt'], scan: true }) as {
+      files?: { path: string }[];
+      error?: unknown;
+    };
+    assert.ok(
+      !healed.error && healed.files && healed.files.length > 0,
+      `file.stage must self-heal the dangling anchor and re-stage the file; ` +
+        `got ${JSON.stringify(healed)}`,
+    );
+
+    // And the recovered repo commits cleanly.
+    const commit = op(repo, 'revision.commit', { message: 'recovered' }) as
+      | { revision_number: number }
+      | { error: unknown };
+    assert.ok(
+      'revision_number' in commit,
+      `commit after self-heal must persist; got ${JSON.stringify(commit)}`,
+    );
+  });
 });

--- a/vscode-extension/src/test/suite/scm.test.ts
+++ b/vscode-extension/src/test/suite/scm.test.ts
@@ -99,6 +99,43 @@ suite('Lore SCM E2E', function () {
     );
   });
 
+  test('editing a tracked file in the editor + saving surfaces it as a working-tree change (real-flow SCM bug, SBAI-4080)', async () => {
+    // THE REAL bug: a user edits a tracked file in the VS Code editor and saves;
+    // the SCM "Changes" group must show it. The OS FileSystemWatcher can miss the
+    // in-editor save (safe-save temp+rename, coalescing, virtual FS), so the
+    // extension now ALSO refreshes on onDidSaveTextDocument. This drives that exact
+    // path: open → edit via the editor API → save → wait for the debounced refresh
+    // → assert the engine status the SCM groups are built from lists the edit.
+    const trackedPath = path.join(workspaceRoot(), 'tracked.txt');
+    const uri = vscode.Uri.file(trackedPath);
+
+    const doc = await vscode.workspace.openTextDocument(uri);
+    const editor = await vscode.window.showTextDocument(doc);
+    const marker = `// edited-in-editor ${Date.now()}\n`;
+    await editor.edit((b) => b.insert(new vscode.Position(0, 0), marker));
+    assert.ok(doc.isDirty, 'document should be dirty after an editor edit');
+
+    // Saving fires onDidSaveTextDocument — the event the extension now listens to.
+    const saved = await doc.save();
+    assert.ok(saved, 'document saved');
+
+    // Wait out the 400ms debounce + lorevm shell-out, then confirm the engine
+    // (the SCM groups' data source) reports the edited tracked file as dirty.
+    const seen = await waitFor(() => {
+      const s = status();
+      return s.files.some((f) => f.path.endsWith('tracked.txt') && f.dirty);
+    }, 12_000);
+    assert.ok(
+      seen,
+      'after editing+saving tracked.txt in the editor, repository.status (scan) ' +
+        'must report it as a working-tree change — this is what populates the ' +
+        'SCM Changes group.',
+    );
+
+    // The extension's own refresh path must also run clean against this state.
+    await vscode.commands.executeCommand('lore.refresh');
+  });
+
   test('stage → commit via extension commands persists a new revision (flush guard)', async () => {
     const before = (
       runOp('revision.history', { length: 50 }) as {


### PR DESCRIPTION
Removes local `FEATURE_MIN_TIER` gating table from LoreGUI and switches to consuming features exclusively from the JWT claim `features[]`.

## Changes
- Removed `FEATURE_MIN_TIER` from `entitlement.ts`.
- Deprecated `featuresForTier` (now returns an empty array).
- Updated unit tests to expect features to be provided via the claim rather than being derived locally.