### PR TITLE
SBAI-4170: [LoreGUI] Gate on features[] only — drop local tier map; relay->lore_relay

### DIFF
--- a/frontend/src/commercial/entitlement.test.ts
+++ b/frontend/src/commercial/entitlement.test.ts
@@ -4,12 +4,14 @@
  * Run with Node's built-in test runner (type-stripping handles the .ts import):
  *   node --test --experimental-strip-types frontend/src/commercial/entitlement.test.ts
  *
- * Covers the canonical `tier` ordinal + minted `features[]` model (ADR-0001
- * §2.5; SBAI-4170 / SBAI-4167 convergence):
+ * Covers the canonical `tier` ordinal + `features[]` HYBRID model (ADR-0001
+ * §2.5; SBAI-4170 correction):
  *   - the LOCKED ordinal scheme,
- *   - gating PURELY off the minted `features[]` claim (no local feature→tier),
+ *   - MONOTONIC features (reporting/relay/dam) gated by `tier >= MIN` from the
+ *     local MONOTONIC_FEATURE_MIN_TIER map (mirrors accounts config/entitlement.py),
+ *   - NON-MONOTONIC add-ons (byok) gated PURELY off the minted `features[]` claim,
  *   - legacy-string + numeric-string tier normalisation (PLAN_TO_TIER back-compat),
- *   - bootstrapAccountsEntitlements union into the runtime injection slot,
+ *   - bootstrapAccountsEntitlements union (both axes) into the runtime slot,
  *   - the gate (isEntitled) reading off the canonical resolution.
  *
  * These tests stub a minimal `window` so the injection-slot paths run under Node.
@@ -21,6 +23,7 @@ import {
   TIER,
   TIER_ID,
   FEATURE_BYOK,
+  MONOTONIC_FEATURE_MIN_TIER,
   tierOrdinal,
   bootstrapAccountsEntitlements,
   isEntitled,
@@ -59,6 +62,14 @@ test("tier ids are the stable strings", () => {
   assert.equal(TIER_ID[TIER.superadmin], "superadmin");
 });
 
+// --- monotonic feature min-tiers (mirror accounts config/entitlement.py) ------
+
+test("monotonic feature min-tiers match the canonical thresholds", () => {
+  assert.equal(MONOTONIC_FEATURE_MIN_TIER.reporting, TIER.team);
+  assert.equal(MONOTONIC_FEATURE_MIN_TIER.relay, TIER.enterprise);
+  assert.equal(MONOTONIC_FEATURE_MIN_TIER.dam, TIER.enterprise);
+});
+
 // --- tierOrdinal normalisation ----------------------------------------------
 
 test("tierOrdinal accepts a canonical integer", () => {
@@ -87,66 +98,108 @@ test("tierOrdinal falls back to free for unknown/missing", () => {
   assert.equal(tierOrdinal("nonsense"), TIER.free);
 });
 
-// --- gating off the minted features[] claim (SBAI-4170 / SBAI-4167) ----------
-// LoreGUI no longer owns a feature→tier table; accounts mints the resolved
-// feature ids onto features[]. These tests assert we gate purely off that array.
+// --- HYBRID gating: monotonic = tier-gated, non-monotonic = features[] --------
+// accounts tier-gates reporting/relay/dam (never mints them into features[]) and
+// mints only the non-monotonic add-ons (byok) onto features[]. LoreGUI mirrors.
 
-test("a JWT with features:['relay'] grants relay", () => {
-  const out = bootstrapAccountsEntitlements({ tier: TIER.enterprise, features: ["relay"] });
-  assert.ok(out.includes("relay"));
-  assert.ok(isEntitled("relay"));
-});
-
-test("without relay in features[], relay is denied even at enterprise tier", () => {
-  // The tier ordinal is NOT consulted for unlocks — only the minted array is.
-  bootstrapAccountsEntitlements({ tier: TIER.enterprise, features: [] });
+test("team tier unlocks reporting but NOT relay/dam", () => {
+  bootstrapAccountsEntitlements({ tier: TIER.team, features: [] });
+  assert.ok(isEntitled("reporting"));
   assert.ok(!isEntitled("relay"));
   assert.ok(!isEntitled("dam"));
-  assert.ok(!isEntitled("reporting"));
 });
 
-test("minted features[] are gated verbatim (reporting/relay/dam)", () => {
-  const out = bootstrapAccountsEntitlements({
-    tier_id: "enterprise",
-    features: ["reporting", "relay", "dam"],
-  });
-  assert.deepEqual(out.sort(), ["dam", "relay", "reporting"]);
+test("enterprise tier unlocks reporting + relay + dam (monotonic superset)", () => {
+  const out = bootstrapAccountsEntitlements({ tier: TIER.enterprise, features: [] });
+  assert.deepEqual([...out].sort(), ["dam", "relay", "reporting"]);
   assert.ok(isEntitled("reporting"));
   assert.ok(isEntitled("relay"));
   assert.ok(isEntitled("dam"));
 });
 
-test("dam is granted when minted, regardless of tier value", () => {
-  bootstrapAccountsEntitlements({ tier: TIER.team, features: ["dam"] });
-  assert.ok(isEntitled("dam"));
-});
-
-test("non-monotonic add-ons (byok) pass through verbatim", () => {
-  const out = bootstrapAccountsEntitlements({ tier: TIER.team, features: [FEATURE_BYOK, "reporting"] });
-  assert.ok(out.includes(FEATURE_BYOK));
-  assert.ok(out.includes("reporting"));
-});
-
-test("bootstrap ignores the tier ordinal for unlocks (no local feature→tier)", () => {
-  // A high tier with NO minted features unlocks nothing.
-  const out = bootstrapAccountsEntitlements({ tier: TIER.superadmin });
-  assert.deepEqual(out, []);
+test("indie tier unlocks none of the monotonic features", () => {
+  bootstrapAccountsEntitlements({ tier: TIER.indie, features: [] });
+  assert.ok(!isEntitled("reporting"));
   assert.ok(!isEntitled("relay"));
+  assert.ok(!isEntitled("dam"));
 });
+
+test("free tier unlocks nothing", () => {
+  const out = bootstrapAccountsEntitlements({ tier: TIER.free, features: [] });
+  assert.deepEqual(out, []);
+  assert.ok(!isEntitled("reporting"));
+});
+
+test("monotonic gating accepts a legacy/numeric-string tier", () => {
+  bootstrapAccountsEntitlements({ tier: "enterprise", features: [] });
+  assert.ok(isEntitled("relay"));
+  bootstrapAccountsEntitlements({ tier: "20", features: [] });
+  assert.ok(isEntitled("reporting"));
+});
+
+// --- non-monotonic add-on byok: from features[] ONLY, never tier-gated --------
+
+test("byok requires features:['byok'] — granted when minted", () => {
+  const out = bootstrapAccountsEntitlements({ tier: TIER.enterprise, features: [FEATURE_BYOK] });
+  assert.ok(out.includes(FEATURE_BYOK));
+  assert.ok(isEntitled("byok"));
+});
+
+test("byok is DENIED even at enterprise tier if not minted into features[]", () => {
+  // byok is non-monotonic: it never comes from the tier ordinal, only the array.
+  bootstrapAccountsEntitlements({ tier: TIER.enterprise, features: [] });
+  assert.ok(!isEntitled("byok"));
+});
+
+test("byok is denied even at superadmin tier when not minted", () => {
+  bootstrapAccountsEntitlements({ tier: TIER.superadmin, features: [] });
+  assert.ok(!isEntitled("byok"));
+});
+
+// --- both axes resolve together ----------------------------------------------
+
+test("enterprise + byok minted unlocks all monotonic features AND byok", () => {
+  const out = bootstrapAccountsEntitlements({
+    tier: TIER.enterprise,
+    features: [FEATURE_BYOK],
+  });
+  assert.deepEqual([...out].sort(), ["byok", "dam", "relay", "reporting"]);
+  assert.ok(isEntitled("reporting"));
+  assert.ok(isEntitled("relay"));
+  assert.ok(isEntitled("dam"));
+  assert.ok(isEntitled("byok"));
+});
+
+test("team tier + byok minted unlocks reporting + byok, but NOT relay/dam", () => {
+  bootstrapAccountsEntitlements({ tier: TIER.team, features: [FEATURE_BYOK] });
+  assert.ok(isEntitled("reporting"));
+  assert.ok(isEntitled("byok"));
+  assert.ok(!isEntitled("relay"));
+  assert.ok(!isEntitled("dam"));
+});
+
+// --- bootstrap edge cases ----------------------------------------------------
 
 test("bootstrap UNIONS with already-injected entitlements (only adds)", () => {
   // Simulate an offline license already mirrored into the slot.
   (globalThis as unknown as { window: { __LOREGUI_ENTITLEMENTS__?: string[] } }).window
-    .__LOREGUI_ENTITLEMENTS__ = ["reporting"];
-  const out = bootstrapAccountsEntitlements({ tier: TIER.enterprise, features: ["relay", "dam"] });
-  // license-provided reporting is preserved, accounts adds the minted relay+dam.
-  assert.ok(out.includes("reporting"));
-  assert.ok(out.includes("relay"));
-  assert.ok(out.includes("dam"));
+    .__LOREGUI_ENTITLEMENTS__ = ["dam"];
+  const out = bootstrapAccountsEntitlements({ tier: TIER.team, features: [FEATURE_BYOK] });
+  // license-provided dam is preserved; accounts adds tier-gated reporting + minted byok.
+  assert.ok(out.includes("dam")); // from the pre-injected license
+  assert.ok(out.includes("reporting")); // team tier
+  assert.ok(out.includes("byok")); // minted add-on
 });
 
 test("a null/garbage claim contributes nothing", () => {
   const out = bootstrapAccountsEntitlements(null);
   assert.deepEqual(out, []);
   assert.ok(!isEntitled("reporting"));
+});
+
+test("a claim with no tier and no features contributes nothing", () => {
+  const out = bootstrapAccountsEntitlements({});
+  assert.deepEqual(out, []);
+  assert.ok(!isEntitled("reporting"));
+  assert.ok(!isEntitled("byok"));
 });

--- a/frontend/src/commercial/entitlement.test.ts
+++ b/frontend/src/commercial/entitlement.test.ts
@@ -4,14 +4,19 @@
  * Run with Node's built-in test runner (type-stripping handles the .ts import):
  *   node --test --experimental-strip-types frontend/src/commercial/entitlement.test.ts
  *
- * Covers the canonical `tier` ordinal + `features[]` HYBRID model (ADR-0001
- * §2.5; SBAI-4170 correction):
- *   - the LOCKED ordinal scheme,
- *   - MONOTONIC features (reporting/relay/dam) gated by `tier >= MIN` from the
- *     local MONOTONIC_FEATURE_MIN_TIER map (mirrors accounts config/entitlement.py),
- *   - NON-MONOTONIC add-ons (byok) gated PURELY off the minted `features[]` claim,
- *   - legacy-string + numeric-string tier normalisation (PLAN_TO_TIER back-compat),
- *   - bootstrapAccountsEntitlements union (both axes) into the runtime slot,
+ * Covers the canonical `tier` + `features[]` model (ADR-0001 §2.5; SBAI-4170
+ * re-correction). The ONE gating rule (CLAUDE.md "Entitlement vs Plan",
+ * SBAI-4165): gate on `features[]` ONLY — never re-derive a feature→tier map.
+ * accounts' `config/entitlement.py` (SBAI-4167) mints the FULL resolved
+ * `features[]` via `features_for_tier()`, so LoreGUI gates off that list verbatim:
+ *   - the LOCKED ordinal scheme (for the `tier_id` DISPLAY label),
+ *   - EVERY gateable feature (reporting/lore_relay/dam/byok) gated PURELY off the
+ *     minted `features[]` claim — NO local min-tier map of any kind,
+ *   - a high `tier` with empty `features[]` unlocks NOTHING (gating is
+ *     features[]-only; tier is display-only),
+ *   - legacy-string + numeric-string tier normalisation (PLAN_TO_TIER back-compat,
+ *     for the display label only; SBAI-4168 DROPPED, plan retained as billing SKU),
+ *   - bootstrapAccountsEntitlements unions features[] verbatim into the slot,
  *   - the gate (isEntitled) reading off the canonical resolution.
  *
  * These tests stub a minimal `window` so the injection-slot paths run under Node.
@@ -23,7 +28,6 @@ import {
   TIER,
   TIER_ID,
   FEATURE_BYOK,
-  MONOTONIC_FEATURE_MIN_TIER,
   tierOrdinal,
   bootstrapAccountsEntitlements,
   isEntitled,
@@ -42,7 +46,7 @@ beforeEach(() => {
   __resetLicensedFeaturesForTests();
 });
 
-// --- LOCKED ordinal scheme (cross-repo contract) -----------------------------
+// --- LOCKED ordinal scheme (cross-repo contract; display label only) ---------
 
 test("tier ordinals match the LOCKED scheme", () => {
   assert.equal(TIER.free, 0);
@@ -53,7 +57,7 @@ test("tier ordinals match the LOCKED scheme", () => {
   assert.equal(TIER.superadmin, 99);
 });
 
-test("tier ids are the stable strings", () => {
+test("tier ids are the stable strings (used for display, not gating)", () => {
   assert.equal(TIER_ID[TIER.free], "free");
   assert.equal(TIER_ID[TIER.indie], "indie");
   assert.equal(TIER_ID[TIER.team], "team");
@@ -62,15 +66,7 @@ test("tier ids are the stable strings", () => {
   assert.equal(TIER_ID[TIER.superadmin], "superadmin");
 });
 
-// --- monotonic feature min-tiers (mirror accounts config/entitlement.py) ------
-
-test("monotonic feature min-tiers match the canonical thresholds", () => {
-  assert.equal(MONOTONIC_FEATURE_MIN_TIER.reporting, TIER.team);
-  assert.equal(MONOTONIC_FEATURE_MIN_TIER.relay, TIER.enterprise);
-  assert.equal(MONOTONIC_FEATURE_MIN_TIER.dam, TIER.enterprise);
-});
-
-// --- tierOrdinal normalisation ----------------------------------------------
+// --- tierOrdinal normalisation (for the tier_id DISPLAY label only) ----------
 
 test("tierOrdinal accepts a canonical integer", () => {
   assert.equal(tierOrdinal(30), 30);
@@ -81,9 +77,10 @@ test("tierOrdinal accepts a numeric string", () => {
   assert.equal(tierOrdinal("20"), 20);
 });
 
-test("tierOrdinal maps legacy plan strings (PLAN_TO_TIER back-compat — removed under SBAI-4168)", () => {
-  // PLAN_TO_TIER is intentionally still present until SBAI-4168 deprecates the
-  // legacy `plan` string ecosystem-wide. These assert it still resolves.
+test("tierOrdinal maps legacy plan strings (PLAN_TO_TIER back-compat — SBAI-4168 DROPPED)", () => {
+  // PLAN_TO_TIER is intentionally still present: `plan` is retained as the
+  // billing SKU (SBAI-4168 was dropped). It normalises a legacy string tier for
+  // the DISPLAY label only — it is NEVER gated on.
   assert.equal(tierOrdinal("enterprise"), TIER.enterprise);
   assert.equal(tierOrdinal(" Team "), TIER.team);
   assert.equal(tierOrdinal("INDIE"), TIER.indie);
@@ -98,84 +95,70 @@ test("tierOrdinal falls back to free for unknown/missing", () => {
   assert.equal(tierOrdinal("nonsense"), TIER.free);
 });
 
-// --- HYBRID gating: monotonic = tier-gated, non-monotonic = features[] --------
-// accounts tier-gates reporting/relay/dam (never mints them into features[]) and
-// mints only the non-monotonic add-ons (byok) onto features[]. LoreGUI mirrors.
+// --- features[]-ONLY gating (CLAUDE.md SBAI-4165) ----------------------------
+// accounts (config/entitlement.py, SBAI-4167) mints the FULL resolved features[]
+// via features_for_tier(); LoreGUI gates off that list verbatim and never
+// re-derives feature→tier. There is NO local min-tier map.
 
-test("team tier unlocks reporting but NOT relay/dam", () => {
-  bootstrapAccountsEntitlements({ tier: TIER.team, features: [] });
+test("features:['reporting'] entitles reporting, NOT lore_relay/dam", () => {
+  bootstrapAccountsEntitlements({ tier: TIER.team, tier_id: "team", features: ["reporting"] });
   assert.ok(isEntitled("reporting"));
-  assert.ok(!isEntitled("relay"));
+  assert.ok(!isEntitled("lore_relay"));
   assert.ok(!isEntitled("dam"));
 });
 
-test("enterprise tier unlocks reporting + relay + dam (monotonic superset)", () => {
-  const out = bootstrapAccountsEntitlements({ tier: TIER.enterprise, features: [] });
-  assert.deepEqual([...out].sort(), ["dam", "relay", "reporting"]);
+test("the full minted superset entitles reporting + lore_relay + dam + byok", () => {
+  const out = bootstrapAccountsEntitlements({
+    tier: TIER.enterprise,
+    tier_id: "enterprise",
+    features: ["reporting", "lore_relay", "dam", FEATURE_BYOK],
+  });
+  assert.deepEqual([...out].sort(), ["byok", "dam", "lore_relay", "reporting"]);
   assert.ok(isEntitled("reporting"));
-  assert.ok(isEntitled("relay"));
+  assert.ok(isEntitled("lore_relay"));
   assert.ok(isEntitled("dam"));
-});
-
-test("indie tier unlocks none of the monotonic features", () => {
-  bootstrapAccountsEntitlements({ tier: TIER.indie, features: [] });
-  assert.ok(!isEntitled("reporting"));
-  assert.ok(!isEntitled("relay"));
-  assert.ok(!isEntitled("dam"));
-});
-
-test("free tier unlocks nothing", () => {
-  const out = bootstrapAccountsEntitlements({ tier: TIER.free, features: [] });
-  assert.deepEqual(out, []);
-  assert.ok(!isEntitled("reporting"));
-});
-
-test("monotonic gating accepts a legacy/numeric-string tier", () => {
-  bootstrapAccountsEntitlements({ tier: "enterprise", features: [] });
-  assert.ok(isEntitled("relay"));
-  bootstrapAccountsEntitlements({ tier: "20", features: [] });
-  assert.ok(isEntitled("reporting"));
-});
-
-// --- non-monotonic add-on byok: from features[] ONLY, never tier-gated --------
-
-test("byok requires features:['byok'] — granted when minted", () => {
-  const out = bootstrapAccountsEntitlements({ tier: TIER.enterprise, features: [FEATURE_BYOK] });
-  assert.ok(out.includes(FEATURE_BYOK));
   assert.ok(isEntitled("byok"));
 });
 
-test("byok is DENIED even at enterprise tier if not minted into features[]", () => {
-  // byok is non-monotonic: it never comes from the tier ordinal, only the array.
+test("empty features[] entitles NOTHING — even with a high tier claim (gating is features[]-only)", () => {
+  // tier is DISPLAY-only; a superadmin tier with no minted features unlocks none.
+  const out = bootstrapAccountsEntitlements({
+    tier: TIER.superadmin,
+    tier_id: "superadmin",
+    features: [],
+  });
+  assert.deepEqual(out, []);
+  assert.ok(!isEntitled("reporting"));
+  assert.ok(!isEntitled("lore_relay"));
+  assert.ok(!isEntitled("dam"));
+  assert.ok(!isEntitled("byok"));
+});
+
+test("byok is entitled only when minted into features[], denied otherwise", () => {
+  bootstrapAccountsEntitlements({ tier: TIER.enterprise, features: [FEATURE_BYOK] });
+  assert.ok(isEntitled("byok"));
+  // re-resolve with no minted features at the same tier -> denied.
+  resetWindow();
   bootstrapAccountsEntitlements({ tier: TIER.enterprise, features: [] });
   assert.ok(!isEntitled("byok"));
 });
 
-test("byok is denied even at superadmin tier when not minted", () => {
-  bootstrapAccountsEntitlements({ tier: TIER.superadmin, features: [] });
-  assert.ok(!isEntitled("byok"));
+test("lore_relay requires the minted id, not a tier threshold", () => {
+  // a high tier with no lore_relay minted does NOT unlock it.
+  bootstrapAccountsEntitlements({ tier: TIER.enterprise, features: ["reporting"] });
+  assert.ok(!isEntitled("lore_relay"));
+  // minting the id unlocks it.
+  resetWindow();
+  bootstrapAccountsEntitlements({ tier: TIER.free, features: ["lore_relay"] });
+  assert.ok(isEntitled("lore_relay"));
 });
 
-// --- both axes resolve together ----------------------------------------------
+// --- tier_id passes through for DISPLAY --------------------------------------
 
-test("enterprise + byok minted unlocks all monotonic features AND byok", () => {
-  const out = bootstrapAccountsEntitlements({
-    tier: TIER.enterprise,
-    features: [FEATURE_BYOK],
-  });
-  assert.deepEqual([...out].sort(), ["byok", "dam", "relay", "reporting"]);
-  assert.ok(isEntitled("reporting"));
-  assert.ok(isEntitled("relay"));
-  assert.ok(isEntitled("dam"));
-  assert.ok(isEntitled("byok"));
-});
-
-test("team tier + byok minted unlocks reporting + byok, but NOT relay/dam", () => {
-  bootstrapAccountsEntitlements({ tier: TIER.team, features: [FEATURE_BYOK] });
-  assert.ok(isEntitled("reporting"));
-  assert.ok(isEntitled("byok"));
-  assert.ok(!isEntitled("relay"));
-  assert.ok(!isEntitled("dam"));
+test("tier_id is available for the display label (not used for gating)", () => {
+  const claim = { tier: TIER.enterprise, tier_id: "enterprise", features: [] as string[] };
+  assert.equal(claim.tier_id, "enterprise");
+  assert.equal(TIER_ID[tierOrdinal(claim.tier)], "enterprise");
 });
 
 // --- bootstrap edge cases ----------------------------------------------------
@@ -184,11 +167,13 @@ test("bootstrap UNIONS with already-injected entitlements (only adds)", () => {
   // Simulate an offline license already mirrored into the slot.
   (globalThis as unknown as { window: { __LOREGUI_ENTITLEMENTS__?: string[] } }).window
     .__LOREGUI_ENTITLEMENTS__ = ["dam"];
-  const out = bootstrapAccountsEntitlements({ tier: TIER.team, features: [FEATURE_BYOK] });
-  // license-provided dam is preserved; accounts adds tier-gated reporting + minted byok.
+  const out = bootstrapAccountsEntitlements({
+    tier: TIER.team,
+    features: ["reporting", FEATURE_BYOK],
+  });
   assert.ok(out.includes("dam")); // from the pre-injected license
-  assert.ok(out.includes("reporting")); // team tier
-  assert.ok(out.includes("byok")); // minted add-on
+  assert.ok(out.includes("reporting")); // minted
+  assert.ok(out.includes("byok")); // minted
 });
 
 test("a null/garbage claim contributes nothing", () => {
@@ -197,8 +182,8 @@ test("a null/garbage claim contributes nothing", () => {
   assert.ok(!isEntitled("reporting"));
 });
 
-test("a claim with no tier and no features contributes nothing", () => {
-  const out = bootstrapAccountsEntitlements({});
+test("a claim with no features contributes nothing (tier alone unlocks nothing)", () => {
+  const out = bootstrapAccountsEntitlements({ tier: TIER.enterprise });
   assert.deepEqual(out, []);
   assert.ok(!isEntitled("reporting"));
   assert.ok(!isEntitled("byok"));

--- a/frontend/src/commercial/entitlement.test.ts
+++ b/frontend/src/commercial/entitlement.test.ts
@@ -4,10 +4,11 @@
  * Run with Node's built-in test runner (type-stripping handles the .ts import):
  *   node --test --experimental-strip-types frontend/src/commercial/entitlement.test.ts
  *
- * Covers the canonical `tier` ordinal + `features[]` model (ADR-0001 §2.5):
+ * Covers the canonical `tier` ordinal + minted `features[]` model (ADR-0001
+ * §2.5; SBAI-4170 / SBAI-4167 convergence):
  *   - the LOCKED ordinal scheme,
- *   - `tier >= MIN` monotonic gating via featuresForTier,
- *   - legacy-string + numeric-string tier normalisation,
+ *   - gating PURELY off the minted `features[]` claim (no local feature→tier),
+ *   - legacy-string + numeric-string tier normalisation (PLAN_TO_TIER back-compat),
  *   - bootstrapAccountsEntitlements union into the runtime injection slot,
  *   - the gate (isEntitled) reading off the canonical resolution.
  *
@@ -19,10 +20,8 @@ import assert from "node:assert/strict";
 import {
   TIER,
   TIER_ID,
-  FEATURE_MIN_TIER,
   FEATURE_BYOK,
   tierOrdinal,
-  featuresForTier,
   bootstrapAccountsEntitlements,
   isEntitled,
   __resetLicensedFeaturesForTests,
@@ -71,10 +70,14 @@ test("tierOrdinal accepts a numeric string", () => {
   assert.equal(tierOrdinal("20"), 20);
 });
 
-test("tierOrdinal maps legacy plan strings", () => {
+test("tierOrdinal maps legacy plan strings (PLAN_TO_TIER back-compat — removed under SBAI-4168)", () => {
+  // PLAN_TO_TIER is intentionally still present until SBAI-4168 deprecates the
+  // legacy `plan` string ecosystem-wide. These assert it still resolves.
   assert.equal(tierOrdinal("enterprise"), TIER.enterprise);
   assert.equal(tierOrdinal(" Team "), TIER.team);
   assert.equal(tierOrdinal("INDIE"), TIER.indie);
+  assert.equal(tierOrdinal("free"), TIER.free);
+  assert.equal(tierOrdinal("STAFF"), TIER.staff);
 });
 
 test("tierOrdinal falls back to free for unknown/missing", () => {
@@ -84,73 +87,59 @@ test("tierOrdinal falls back to free for unknown/missing", () => {
   assert.equal(tierOrdinal("nonsense"), TIER.free);
 });
 
-// --- featuresForTier (tier >= MIN monotonic gating) --------------------------
+// --- gating off the minted features[] claim (SBAI-4170 / SBAI-4167) ----------
+// LoreGUI no longer owns a feature→tier table; accounts mints the resolved
+// feature ids onto features[]. These tests assert we gate purely off that array.
 
-test("free unlocks no premium features", () => {
-  assert.deepEqual(featuresForTier(TIER.free), []);
+test("a JWT with features:['relay'] grants relay", () => {
+  const out = bootstrapAccountsEntitlements({ tier: TIER.enterprise, features: ["relay"] });
+  assert.ok(out.includes("relay"));
+  assert.ok(isEntitled("relay"));
 });
 
-test("team unlocks reporting only", () => {
-  assert.deepEqual(featuresForTier(TIER.team).sort(), ["reporting"]);
-});
-
-test("enterprise unlocks reporting, relay and dam", () => {
-  assert.deepEqual(featuresForTier(TIER.enterprise).sort(), ["dam", "relay", "reporting"]);
-});
-
-test("staff/superadmin are strict supersets of enterprise", () => {
-  for (const t of [TIER.staff, TIER.superadmin]) {
-    const f = featuresForTier(t).sort();
-    assert.deepEqual(f, ["dam", "relay", "reporting"]);
-  }
-});
-
-test("a reserved-band tier (40) gates exactly like its ordinal", () => {
-  // 40 >= team(20) but < enterprise(30)? No — 40 >= 30, so it unlocks all three.
-  assert.deepEqual(featuresForTier(40).sort(), ["dam", "relay", "reporting"]);
-  // 25 is between team and enterprise: reporting only.
-  assert.deepEqual(featuresForTier(25).sort(), ["reporting"]);
-});
-
-test("FEATURE_MIN_TIER thresholds are the documented ones", () => {
-  assert.equal(FEATURE_MIN_TIER.reporting, TIER.team);
-  assert.equal(FEATURE_MIN_TIER.relay, TIER.enterprise);
-  assert.equal(FEATURE_MIN_TIER.dam, TIER.enterprise);
-});
-
-// --- bootstrapAccountsEntitlements (canonical claim → injection slot) ---------
-
-test("bootstrap resolves monotonic features from the tier ordinal", () => {
-  const out = bootstrapAccountsEntitlements({ tier: TIER.team, tier_id: "team" });
-  assert.deepEqual(out.sort(), ["reporting"]);
-  assert.ok(isEntitled("reporting"));
+test("without relay in features[], relay is denied even at enterprise tier", () => {
+  // The tier ordinal is NOT consulted for unlocks — only the minted array is.
+  bootstrapAccountsEntitlements({ tier: TIER.enterprise, features: [] });
   assert.ok(!isEntitled("relay"));
+  assert.ok(!isEntitled("dam"));
+  assert.ok(!isEntitled("reporting"));
 });
 
-test("bootstrap reads canonical integer tier directly (no plan translation)", () => {
-  bootstrapAccountsEntitlements({ tier: 30 });
+test("minted features[] are gated verbatim (reporting/relay/dam)", () => {
+  const out = bootstrapAccountsEntitlements({
+    tier_id: "enterprise",
+    features: ["reporting", "relay", "dam"],
+  });
+  assert.deepEqual(out.sort(), ["dam", "relay", "reporting"]);
   assert.ok(isEntitled("reporting"));
   assert.ok(isEntitled("relay"));
   assert.ok(isEntitled("dam"));
 });
 
-test("bootstrap accepts a legacy string tier", () => {
-  bootstrapAccountsEntitlements({ tier: "enterprise" });
+test("dam is granted when minted, regardless of tier value", () => {
+  bootstrapAccountsEntitlements({ tier: TIER.team, features: ["dam"] });
   assert.ok(isEntitled("dam"));
 });
 
-test("non-monotonic add-ons from features[] pass through verbatim", () => {
-  const out = bootstrapAccountsEntitlements({ tier: TIER.team, features: [FEATURE_BYOK] });
+test("non-monotonic add-ons (byok) pass through verbatim", () => {
+  const out = bootstrapAccountsEntitlements({ tier: TIER.team, features: [FEATURE_BYOK, "reporting"] });
   assert.ok(out.includes(FEATURE_BYOK));
   assert.ok(out.includes("reporting"));
+});
+
+test("bootstrap ignores the tier ordinal for unlocks (no local feature→tier)", () => {
+  // A high tier with NO minted features unlocks nothing.
+  const out = bootstrapAccountsEntitlements({ tier: TIER.superadmin });
+  assert.deepEqual(out, []);
+  assert.ok(!isEntitled("relay"));
 });
 
 test("bootstrap UNIONS with already-injected entitlements (only adds)", () => {
   // Simulate an offline license already mirrored into the slot.
   (globalThis as unknown as { window: { __LOREGUI_ENTITLEMENTS__?: string[] } }).window
     .__LOREGUI_ENTITLEMENTS__ = ["reporting"];
-  const out = bootstrapAccountsEntitlements({ tier: TIER.enterprise });
-  // license-provided reporting is preserved, accounts adds relay+dam.
+  const out = bootstrapAccountsEntitlements({ tier: TIER.enterprise, features: ["relay", "dam"] });
+  // license-provided reporting is preserved, accounts adds the minted relay+dam.
   assert.ok(out.includes("reporting"));
   assert.ok(out.includes("relay"));
   assert.ok(out.includes("dam"));

--- a/frontend/src/commercial/entitlement.ts
+++ b/frontend/src/commercial/entitlement.ts
@@ -43,68 +43,72 @@
  * The StudioBrain accounts JWT (RS256, issued by accounts.studiobrain.ai) is the
  * PRIMARY entitlement source. accounts emits the *canonical* ecosystem-wide model
  * verbatim as TOP-LEVEL claims (`tier`, `tier_id`, `features`) — adopted
- * identically here and in model-manager. There are TWO axes, and they are gated
- * DIFFERENTLY (the hybrid contract — see {@link MONOTONIC_FEATURE_MIN_TIER}):
+ * identically here and in model-manager. There are two axes:
  *
  *   - `tier`: an **integer ordinal**, spaced for future insertion, paired with a
  *     stable string id (`tier_id`). LOCKED scheme:
  *       0 free · 10 indie · 20 team · 30 enterprise · 40–89 reserved ·
  *       90 staff · 99 superadmin
- *     A higher tier is a strict superset. **Monotonic** features (the ones a
- *     higher tier strictly includes — `reporting`/`relay`/`dam`) are gated by
- *     `tierOrdinal(tier) >= MIN`. accounts deliberately does NOT mint monotonic
- *     features into `features[]`; it tier-gates them. accounts also does not
- *     centralize their min-tiers, so LoreGUI owns that map locally (kept in sync
- *     with accounts' `config/entitlement.py`).
- *   - `features[]`: the minted set of **non-monotonic add-on** feature ids for
- *     this session (today: just `byok`, gated at tier>=enterprise). These are
- *     unlocks that do NOT follow the tier ladder, so accounts cannot express them
- *     as a simple `tier >= MIN` and instead mints the resolved id onto the array.
- *     LoreGUI gates these PURELY off `features.includes(...)`. accounts'
- *     `features_for_tier()` returns ONLY these add-ons (e.g. `["byok"]` at
- *     tier>=enterprise) — it never returns `reporting`/`relay`/`dam`.
+ *     The tier is read for DISPLAY only (the `tier_id` label) — **never for
+ *     gating**. LoreGUI does NOT re-derive a feature→tier mapping. See the gating
+ *     rule below.
+ *   - `features[]`: the FULL, fully-resolved set of capability feature ids for
+ *     this session. As of SBAI-4167, accounts' `config/entitlement.py` is the
+ *     single canonical feature→tier registry (`FEATURE_MIN_TIER`, 35 entries) and
+ *     `features_for_tier(tier)` returns EVERY feature whose `min_tier <= tier` —
+ *     so the resolved superset (e.g. `reporting`, `lore_relay`, `dam`, `byok` at
+ *     enterprise) is minted onto `features[]` directly. LoreGUI gates EVERY
+ *     gateable feature PURELY off `features.includes("<id>")`.
  *   - `role` (owner/admin/member): a SEPARATE within-tenant axis — never folded
  *     into `tier`. This module does not read `role`.
  *
- * The tier ordinals are a cross-repo contract: they mirror accounts'
- * `config/entitlement.py` and model-manager's per-request gating. Don't renumber
- * without changing all three.
+ * ## The ONE gating rule (CLAUDE.md "Entitlement vs Plan", SBAI-4165)
  *
- * ## Hybrid gating (SBAI-4170 — correcting the over-broad SBAI-4170 first pass)
+ * **Gate on `features[]` ONLY. Never re-derive the feature→tier mapping in any
+ * service or frontend.** Read the minted `features[]` from the JWT. The canonical
+ * registry is accounts' `config/entitlement.py` (SBAI-4167), which already
+ * resolves tier → the full feature set. There is intentionally NO local min-tier
+ * map of any kind in this module.
  *
- * An earlier pass DELETED the local feature→tier map and tried to gate
- * `reporting`/`relay`/`dam` off `features.includes(...)`. That was WRONG: accounts
- * never mints those into `features[]` (its `features_for_tier()` returns only the
- * non-monotonic add-ons, e.g. `["byok"]`), so they became un-unlockable. The
- * correct, canonical model is HYBRID and is restored here:
+ * A note on history: an interim pass added a local `MONOTONIC_FEATURE_MIN_TIER`
+ * hybrid (gate `reporting`/`relay`/`dam` off a local tier map, only `byok` off
+ * `features[]`). That was based on a STALE accounts checkout in which
+ * `features_for_tier()` returned only the enterprise add-ons. The LIVE accounts
+ * (post-SBAI-4167) mints the FULL resolved feature set into `features[]`, so the
+ * hybrid is wrong and has been removed: gate `features[]`-only.
  *
- *   - reporting → `tierOrdinal(tier) >= TIER.team`        (monotonic, tier-gated)
- *   - relay     → `tierOrdinal(tier) >= TIER.enterprise`  (monotonic, tier-gated)
- *   - dam       → `tierOrdinal(tier) >= TIER.enterprise`  (monotonic, tier-gated)
- *   - byok      → `features.includes("byok")`             (non-monotonic, from features[])
+ * `plan` (the legacy billing SKU string) is retained as `tier`-normalisation
+ * back-compat (see {@link PLAN_TO_TIER}) but is NEVER gated on. SBAI-4168 (which
+ * would have removed the legacy `plan` string) was DROPPED — plan stays as the
+ * billing SKU; entitlement gating uses `features[]` exclusively.
  *
- * {@link bootstrapAccountsEntitlements} reads BOTH top-level claims (`tier` AND
- * `features`) and unions both axes into `window.__LOREGUI_ENTITLEMENTS__` (path 2
- * above) — so NO call site here changes. Resolution is a UNION across sources so
- * "hooked into StudioBrain" only ever *adds* unlocks. This module never parses or
- * stores the JWT itself; the host/auth layer extracts the claim and hands it in,
- * per the StudioBrain accounts security boundary.
+ * {@link bootstrapAccountsEntitlements} unions `claim.features[]` VERBATIM into
+ * `window.__LOREGUI_ENTITLEMENTS__` (path 2 above) — so NO call site here changes.
+ * Resolution is a UNION across sources so "hooked into StudioBrain" only ever
+ * *adds* unlocks. This module never parses or stores the JWT itself; the
+ * host/auth layer extracts the claim and hands it in, per the StudioBrain
+ * accounts security boundary.
  */
 
 import { resolveLicensedFeatures } from "./license.ts";
 
 /**
- * A gateable premium feature id. Two kinds, gated differently (the hybrid
- * contract): **monotonic** features (`reporting`/`relay`/`dam`) are tier-gated via
- * {@link MONOTONIC_FEATURE_MIN_TIER}; the **non-monotonic** add-on `byok` is gated
- * off the minted `features[]` claim. See the module docs.
+ * A gateable premium feature id. Each value is a canonical feature id minted by
+ * accounts into the JWT's `features[]` claim (`config/entitlement.py`,
+ * SBAI-4167) and gated here PURELY off `features.includes(id)`. The id
+ * `lore_relay` is deliberately distinct from accounts' free-tier
+ * `fileserver_relay` to avoid a namespace collision (a user-facing "Relay" LABEL
+ * is fine; the entitlement id must be `lore_relay` to match the minted claim).
  */
-export type Feature = "reporting" | "relay" | "dam" | "byok";
+export type Feature = "reporting" | "lore_relay" | "dam" | "byok";
 
 /**
  * Canonical tier ordinals — the LOCKED scheme (ADR-0001 §2.5). Integer, spaced
  * for future insertion, paired with a stable string id (see {@link TIER_ID}).
  * Mirrors accounts' `config/entitlement.py`.
+ *
+ * Used for the `tier_id` DISPLAY label only. **Never used for feature gating** —
+ * gating is `features[]`-only (CLAUDE.md SBAI-4165).
  */
 export const TIER = {
   free: 0,
@@ -127,48 +131,20 @@ export const TIER_ID: Readonly<Record<number, string>> = {
 };
 
 /**
- * Minimum canonical tier ordinal that unlocks each **monotonic** feature.
- *
- * These min-tiers live HERE (not in accounts' minted `features[]`) because the
- * canonical accounts model intentionally tier-gates monotonic features rather
- * than minting them into `features[]`: accounts' `features_for_tier()` returns
- * ONLY the non-monotonic add-ons (today `["byok"]` at tier>=enterprise) and never
- * `reporting`/`relay`/`dam`. accounts does not centralize the monotonic
- * min-tiers, so each product owns the map. Keep it in sync with accounts'
- * `config/entitlement.py` — these mirror its monotonic thresholds.
- */
-export const MONOTONIC_FEATURE_MIN_TIER: Readonly<Record<string, number>> = {
-  reporting: TIER.team,
-  relay: TIER.enterprise,
-  dam: TIER.enterprise,
-};
-
-/**
- * The id of the non-monotonic add-on `byok` (bring-your-own-key). Non-monotonic
- * features do NOT follow the tier ladder, so accounts mints the resolved id onto
- * the JWT's `features[]` (at tier>=enterprise today) and LoreGUI gates off
- * `features.includes(FEATURE_BYOK)` — never off a tier threshold.
+ * The id of the bring-your-own-key add-on. Like every gateable feature it is
+ * gated off `features.includes(FEATURE_BYOK)` — accounts mints it into
+ * `features[]` (at tier>=enterprise today) via `features_for_tier()`.
  */
 export const FEATURE_BYOK = "byok";
 
 /**
- * The set of NON-MONOTONIC add-on feature ids — gated off the minted `features[]`
- * claim, not off the tier ordinal. Today this is just `byok`. accounts'
- * `features_for_tier()` is the authority for what lands in `features[]`.
- *
- * Resolution doesn't need to consult this set (the resolved entitlement set
- * already encodes both axes — see {@link bootstrapAccountsEntitlements}), but it
- * documents the contract and is the canonical list of ids gated off `features[]`.
- */
-export const NON_MONOTONIC_FEATURES: ReadonlySet<string> = new Set<string>([FEATURE_BYOK]);
-
-/**
  * Legacy plan string → canonical tier ordinal (back-compat for old claims).
  *
- * TODO(SBAI-4168): REMOVE once the legacy `plan` string is deprecated
- * ecosystem-wide. Phase 1 migrates all readers to `tier`/`tier_id`/`features[]`
- * while accounts still emits `plan`; Phase 2 stops emitting `plan`. Until that
- * lands, `tierOrdinal` still accepts a legacy string tier via this map.
+ * `plan` is the billing SKU; it is RETAINED for `tier` normalisation only and is
+ * NEVER gated on (gating is `features[]`-only — CLAUDE.md SBAI-4165).
+ * SBAI-4168, which would have removed the legacy `plan` string ecosystem-wide,
+ * was DROPPED — so `tierOrdinal` still accepts a legacy string tier via this map
+ * to render the `tier_id` display label.
  */
 const PLAN_TO_TIER: Record<string, number> = {
   free: TIER.free,
@@ -185,9 +161,9 @@ const PLAN_TO_TIER: Record<string, number> = {
  * (`free`/`indie`/`team`/`enterprise`/…). Unknown/missing → `free` (0), i.e.
  * least privilege.
  *
- * Used for monotonic feature gating (`tier >= MIN`, see
- * {@link MONOTONIC_FEATURE_MIN_TIER}) and to normalise a legacy string tier. It
- * is NOT used to derive non-monotonic unlocks (those come minted in `features[]`).
+ * Used ONLY to derive the `tier_id` DISPLAY label and to normalise a legacy
+ * string tier. It is NOT used for any feature gating — gating reads the minted
+ * `features[]` claim exclusively (CLAUDE.md SBAI-4165).
  */
 export function tierOrdinal(tier: number | string | null | undefined): number {
   if (typeof tier === "number" && Number.isFinite(tier)) return tier;
@@ -306,17 +282,18 @@ export function __resetLicensedFeaturesForTests(): void {
  */
 export interface AccountsEntitlementClaim {
   /**
-   * Canonical integer tier ordinal (or a legacy string tier). Gates the
-   * **monotonic** features (`reporting`/`relay`/`dam`) via
-   * {@link MONOTONIC_FEATURE_MIN_TIER}.
+   * Canonical integer tier ordinal (or a legacy string tier). Read for DISPLAY
+   * only (the `tier_id` label) — NEVER for gating. Gating reads `features[]`.
    */
   tier?: number | string | null;
   /** Stable string id for the tier (informational; logs/display). */
   tier_id?: string | null;
   /**
-   * The minted set of **non-monotonic** add-on feature ids (today: `byok`).
-   * accounts' `features_for_tier()` (`config/entitlement.py`, SBAI-4089) returns
-   * ONLY these add-ons — never `reporting`/`relay`/`dam`, which are tier-gated.
+   * The FULL, fully-resolved set of canonical feature ids for this session.
+   * accounts' `features_for_tier()` (`config/entitlement.py`, SBAI-4167) returns
+   * EVERY feature whose `min_tier <= tier` (e.g. `reporting`, `lore_relay`,
+   * `dam`, `byok` at enterprise). LoreGUI gates off this list VERBATIM and never
+   * re-derives capability from `tier`.
    */
   features?: readonly string[] | null;
 }
@@ -328,12 +305,10 @@ export interface AccountsEntitlementClaim {
  * provides a verified claim; it is additive, so "hooked into StudioBrain" only
  * ever *adds* unlocks on top of any offline license already bootstrapped.
  *
- * Resolution is HYBRID across BOTH top-level claims (SBAI-4170 correction):
- *   - For each **monotonic** feature in {@link MONOTONIC_FEATURE_MIN_TIER}, unlock
- *     it iff `tierOrdinal(claim.tier) >= its min`. accounts tier-gates these and
- *     does NOT mint them into `features[]`.
- *   - PLUS every id in `claim.features` (the **non-monotonic** add-ons, e.g.
- *     `byok`), gated verbatim off the minted array.
+ * Gating is `features[]`-ONLY (CLAUDE.md SBAI-4165): accounts already resolved
+ * tier → the full feature set (`features_for_tier`, SBAI-4167), so this unions
+ * `claim.features` VERBATIM. `claim.tier`/`tier_id` are read for DISPLAY only,
+ * never to derive a feature. There is NO local feature→tier map.
  *
  * Safe with a null/garbage claim: it simply contributes nothing.
  */
@@ -341,17 +316,10 @@ export function bootstrapAccountsEntitlements(
   claim: AccountsEntitlementClaim | null | undefined,
 ): string[] {
   const resolved = new Set<string>();
-  if (claim) {
-    // Axis 1 — monotonic features tier-gated locally (accounts does not mint
-    // these into features[]; their min-tiers mirror config/entitlement.py).
-    const ordinal = tierOrdinal(claim.tier);
-    for (const [feature, min] of Object.entries(MONOTONIC_FEATURE_MIN_TIER)) {
-      if (ordinal >= min) resolved.add(feature);
-    }
-    // Axis 2 — non-monotonic add-ons minted onto features[] (e.g. byok).
-    if (Array.isArray(claim.features)) {
-      for (const f of claim.features) if (typeof f === "string" && f) resolved.add(f);
-    }
+  if (claim && Array.isArray(claim.features)) {
+    // Union the minted features[] VERBATIM — accounts already resolved tier →
+    // the full feature set (features_for_tier, SBAI-4167). NO local min-tier map.
+    for (const f of claim.features) if (typeof f === "string" && f) resolved.add(f);
   }
   if (typeof window !== "undefined") {
     const existing = Array.isArray(window.__LOREGUI_ENTITLEMENTS__)
@@ -400,11 +368,9 @@ function resolveEntitlements(): string[] {
 /**
  * Is the given premium feature unlocked for this session?
  *
- * The resolved entitlement set already encodes the hybrid contract: a monotonic
- * feature lands in the set only when `tierOrdinal(tier) >= its min` (resolved in
- * {@link bootstrapAccountsEntitlements}); a non-monotonic add-on (`byok`) lands in
- * the set only when minted into `features[]`. So membership-in-set is the right
- * check for BOTH kinds.
+ * Gating is `features[]`-only (CLAUDE.md SBAI-4165): the resolved entitlement set
+ * is the minted `features[]` (unioned with any offline license), so
+ * membership-in-set is the right check. No tier threshold is consulted.
  *
  * The open core never calls this for its own surfaces — only premium add-ons do.
  * A locked feature must render an upsell affordance, never a broken control.

--- a/frontend/src/commercial/entitlement.ts
+++ b/frontend/src/commercial/entitlement.ts
@@ -48,20 +48,34 @@
  *     stable string id (`tier_id`). LOCKED scheme:
  *       0 free · 10 indie · 20 team · 30 enterprise · 40–89 reserved ·
  *       90 staff · 99 superadmin
- *     A higher tier is a strict superset, so `tier >= MIN` gates the monotonic
- *     features (see {@link TIER} / {@link FEATURE_MIN_TIER}).
- *   - `features[]`: authoritative set for **non-monotonic add-ons** (e.g. BYOK is
- *     Enterprise-only but isn't "more than Team" on every axis).
+ *     A higher tier is a strict superset. This module keeps the ordinal only for
+ *     genuinely monotonic checks (none today); it no longer derives feature
+ *     unlocks from it (see {@link TIER}).
+ *   - `features[]`: the **authoritative, minted set of unlocked feature ids** for
+ *     this session. accounts resolves EVERY feature→min-tier mapping centrally in
+ *     its `config/entitlement.py` (the single registry, SBAI-4167) and mints the
+ *     fully-resolved feature ids onto the JWT — including the monotonic add-ons
+ *     `reporting`/`relay`/`dam` and non-monotonic ones like `byok`. LoreGUI gates
+ *     PURELY off this array and NEVER decides feature thresholds locally.
  *   - `role` (owner/admin/member): a SEPARATE within-tenant axis — never folded
  *     into `tier`. This module does not read `role`.
  *
- * These exact numbers are a cross-repo contract: they mirror accounts'
+ * The tier ordinals are a cross-repo contract: they mirror accounts'
  * `config/entitlement.py` and model-manager's per-request gating. Don't renumber
  * without changing all three.
  *
+ * ## No local feature→tier table (SBAI-4170 / SBAI-4167 convergence)
+ *
+ * This module previously owned a local `FEATURE_MIN_TIER` map
+ * (`{ reporting: team, relay: enterprise, dam: enterprise }`) and derived unlocks
+ * from `tier >= MIN`. That table is DELETED. Per the convergence (epic SBAI-4165,
+ * registry SBAI-4167) no product may re-implement feature→tier gating — accounts
+ * owns the single registry and mints the resolved `features[]`. LoreGUI now reads
+ * `features.includes("relay")` / `"dam"` / `"reporting"` from the minted claim.
+ *
  * {@link bootstrapAccountsEntitlements} reads the JWT's canonical claim directly
- * (no `plan→tier` translation — convergence removed it) and injects the resolved
- * feature ids into `window.__LOREGUI_ENTITLEMENTS__` (path 2 above) — so NO call
+ * (no `plan→tier` translation — convergence removed it) and unions the minted
+ * `features[]` into `window.__LOREGUI_ENTITLEMENTS__` (path 2 above) — so NO call
  * site here changes. Resolution is a UNION across sources so "hooked into
  * StudioBrain" only ever *adds* unlocks. This module never parses or stores the
  * JWT itself; the host/auth layer extracts the claim and hands it in, per the
@@ -70,7 +84,11 @@
 
 import { resolveLicensedFeatures } from "./license.ts";
 
-/** A gateable premium feature id. Keep in sync with FEATURE_MIN_TIER below. */
+/**
+ * A gateable premium feature id. These ids are minted onto the JWT's `features[]`
+ * by accounts (the single registry, SBAI-4167) — LoreGUI gates off the claim and
+ * never decides their min-tiers locally.
+ */
 export type Feature = "reporting" | "relay" | "dam";
 
 /**
@@ -98,26 +116,31 @@ export const TIER_ID: Readonly<Record<number, string>> = {
   [TIER.superadmin]: "superadmin",
 };
 
-/** Non-monotonic add-on feature ids carried in the canonical `features[]`. */
+/**
+ * A feature id carried in the canonical, minted `features[]`. accounts resolves
+ * the full feature→min-tier registry centrally (SBAI-4167) and mints every
+ * unlocked id — `reporting`, `relay`, `dam`, `byok`, … — so LoreGUI gates off the
+ * array verbatim. This constant exists only as a readable reference to the id.
+ */
 export const FEATURE_BYOK = "byok";
 
-/**
- * Minimum canonical tier ordinal that unlocks each **monotonic** premium
- * feature. `tier >= MIN` is the gate. Reporting & Insights (SBAI-4061) is a
- * Team-and-up add-on; the cross-network Relay (SBAI-4072) and the enhanced DAM
- * (SBAI-4077) are Enterprise-and-up (they consume shared StudioBrain infra).
- * Adjust here when packaging changes — call sites are unaffected.
- *
- * Non-monotonic add-ons (e.g. BYOK) do NOT belong here; they arrive via the
- * JWT's `features[]` and are injected directly.
- */
-export const FEATURE_MIN_TIER: Record<Feature, number> = {
-  reporting: TIER.team,
-  relay: TIER.enterprise,
-  dam: TIER.enterprise,
-};
+// NOTE (SBAI-4170 / SBAI-4167): the former local `FEATURE_MIN_TIER` map
+// (`{ reporting: team, relay: enterprise, dam: enterprise }`) and the
+// `featuresForTier(tier)` derivation it powered are DELETED. accounts'
+// `config/entitlement.py` is the single registry of every feature→min-tier and
+// mints the resolved ids onto the JWT's `features[]`. LoreGUI consumes that
+// array (see {@link bootstrapAccountsEntitlements}) and never recomputes
+// thresholds locally. The canonical tier ordinal is kept ONLY for genuinely
+// monotonic checks (none today).
 
-/** Legacy plan string → canonical tier ordinal (back-compat for old claims). */
+/**
+ * Legacy plan string → canonical tier ordinal (back-compat for old claims).
+ *
+ * TODO(SBAI-4168): REMOVE once the legacy `plan` string is deprecated
+ * ecosystem-wide. Phase 1 migrates all readers to `tier`/`tier_id`/`features[]`
+ * while accounts still emits `plan`; Phase 2 stops emitting `plan`. Until that
+ * lands, `tierOrdinal` still accepts a legacy string tier via this map.
+ */
 const PLAN_TO_TIER: Record<string, number> = {
   free: TIER.free,
   indie: TIER.indie,
@@ -132,6 +155,9 @@ const PLAN_TO_TIER: Record<string, number> = {
  * integer directly, a numeric string, or a legacy plan/tier string
  * (`free`/`indie`/`team`/`enterprise`/…). Unknown/missing → `free` (0), i.e.
  * least privilege.
+ *
+ * Kept for genuinely monotonic checks and to normalise a legacy string tier; it
+ * is NOT used to derive feature unlocks (those come minted in `features[]`).
  */
 export function tierOrdinal(tier: number | string | null | undefined): number {
   if (typeof tier === "number" && Number.isFinite(tier)) return tier;
@@ -141,19 +167,6 @@ export function tierOrdinal(tier: number | string | null | undefined): number {
     return PLAN_TO_TIER[trimmed.toLowerCase()] ?? TIER.free;
   }
   return TIER.free;
-}
-
-/**
- * Resolve a canonical `tier` ordinal to the monotonic premium feature ids it
- * unlocks (`tier >= MIN` per {@link FEATURE_MIN_TIER}). Non-monotonic add-ons
- * from the JWT's `features[]` are NOT derived here — they are unioned in by
- * {@link bootstrapAccountsEntitlements}. Accepts a legacy string tier too.
- */
-export function featuresForTier(tier: number | string | null | undefined): Feature[] {
-  const ordinal = tierOrdinal(tier);
-  return (Object.keys(FEATURE_MIN_TIER) as Feature[]).filter(
-    (f) => ordinal >= FEATURE_MIN_TIER[f],
-  );
 }
 
 const LOCAL_STORAGE_KEY = "loregui.entitlements";
@@ -262,11 +275,18 @@ export function __resetLicensedFeaturesForTests(): void {
  * separate within-tenant axis, not a subscription capability.
  */
 export interface AccountsEntitlementClaim {
-  /** Canonical integer tier ordinal (or a legacy string tier). */
+  /**
+   * Canonical integer tier ordinal (or a legacy string tier). Informational here
+   * — NOT used to derive feature unlocks (those are minted in `features[]`).
+   */
   tier?: number | string | null;
   /** Stable string id for the tier (informational; logs/display). */
   tier_id?: string | null;
-  /** Non-monotonic add-on feature ids (e.g. `byok`). */
+  /**
+   * The authoritative, minted set of unlocked feature ids (e.g. `reporting`,
+   * `relay`, `dam`, `byok`). accounts' `config/entitlement.py` (SBAI-4167)
+   * resolves every feature→min-tier centrally and mints the result here.
+   */
   features?: readonly string[] | null;
 }
 
@@ -277,10 +297,11 @@ export interface AccountsEntitlementClaim {
  * provides a verified claim; it is additive, so "hooked into StudioBrain" only
  * ever *adds* unlocks on top of any offline license already bootstrapped.
  *
- * Resolution keys off the canonical model directly — no `plan→tier` translation:
- *   - monotonic features via `tier >= MIN` ({@link featuresForTier}), and
- *   - non-monotonic add-ons passed through verbatim from the claim's `features[]`
- *     (e.g. `byok`), so add-ons that don't fit the ordinal still flow through.
+ * Resolution reads the minted `features[]` claim VERBATIM (SBAI-4170 / SBAI-4167)
+ * — no local feature→tier computation. accounts is the single registry: it has
+ * already resolved every feature→min-tier (`reporting`/`relay`/`dam`/`byok`/…)
+ * and minted the unlocked ids onto `features[]`. This module never re-derives
+ * thresholds from `tier`.
  *
  * Safe with a null/garbage claim: it simply contributes nothing.
  */
@@ -288,11 +309,8 @@ export function bootstrapAccountsEntitlements(
   claim: AccountsEntitlementClaim | null | undefined,
 ): string[] {
   const resolved = new Set<string>();
-  if (claim) {
-    for (const f of featuresForTier(claim.tier)) resolved.add(f);
-    if (Array.isArray(claim.features)) {
-      for (const f of claim.features) if (typeof f === "string" && f) resolved.add(f);
-    }
+  if (claim && Array.isArray(claim.features)) {
+    for (const f of claim.features) if (typeof f === "string" && f) resolved.add(f);
   }
   if (typeof window !== "undefined") {
     const existing = Array.isArray(window.__LOREGUI_ENTITLEMENTS__)

--- a/frontend/src/commercial/entitlement.ts
+++ b/frontend/src/commercial/entitlement.ts
@@ -41,22 +41,28 @@
  * ## Canonical entitlement model (SBAI-4089 / E0.7, ADR-0001 §2.5)
  *
  * The StudioBrain accounts JWT (RS256, issued by accounts.studiobrain.ai) is the
- * PRIMARY entitlement source. accounts now emits the *canonical* ecosystem-wide
- * model verbatim — adopted identically here and in model-manager:
+ * PRIMARY entitlement source. accounts emits the *canonical* ecosystem-wide model
+ * verbatim as TOP-LEVEL claims (`tier`, `tier_id`, `features`) — adopted
+ * identically here and in model-manager. There are TWO axes, and they are gated
+ * DIFFERENTLY (the hybrid contract — see {@link MONOTONIC_FEATURE_MIN_TIER}):
  *
  *   - `tier`: an **integer ordinal**, spaced for future insertion, paired with a
  *     stable string id (`tier_id`). LOCKED scheme:
  *       0 free · 10 indie · 20 team · 30 enterprise · 40–89 reserved ·
  *       90 staff · 99 superadmin
- *     A higher tier is a strict superset. This module keeps the ordinal only for
- *     genuinely monotonic checks (none today); it no longer derives feature
- *     unlocks from it (see {@link TIER}).
- *   - `features[]`: the **authoritative, minted set of unlocked feature ids** for
- *     this session. accounts resolves EVERY feature→min-tier mapping centrally in
- *     its `config/entitlement.py` (the single registry, SBAI-4167) and mints the
- *     fully-resolved feature ids onto the JWT — including the monotonic add-ons
- *     `reporting`/`relay`/`dam` and non-monotonic ones like `byok`. LoreGUI gates
- *     PURELY off this array and NEVER decides feature thresholds locally.
+ *     A higher tier is a strict superset. **Monotonic** features (the ones a
+ *     higher tier strictly includes — `reporting`/`relay`/`dam`) are gated by
+ *     `tierOrdinal(tier) >= MIN`. accounts deliberately does NOT mint monotonic
+ *     features into `features[]`; it tier-gates them. accounts also does not
+ *     centralize their min-tiers, so LoreGUI owns that map locally (kept in sync
+ *     with accounts' `config/entitlement.py`).
+ *   - `features[]`: the minted set of **non-monotonic add-on** feature ids for
+ *     this session (today: just `byok`, gated at tier>=enterprise). These are
+ *     unlocks that do NOT follow the tier ladder, so accounts cannot express them
+ *     as a simple `tier >= MIN` and instead mints the resolved id onto the array.
+ *     LoreGUI gates these PURELY off `features.includes(...)`. accounts'
+ *     `features_for_tier()` returns ONLY these add-ons (e.g. `["byok"]` at
+ *     tier>=enterprise) — it never returns `reporting`/`relay`/`dam`.
  *   - `role` (owner/admin/member): a SEPARATE within-tenant axis — never folded
  *     into `tier`. This module does not read `role`.
  *
@@ -64,32 +70,36 @@
  * `config/entitlement.py` and model-manager's per-request gating. Don't renumber
  * without changing all three.
  *
- * ## No local feature→tier table (SBAI-4170 / SBAI-4167 convergence)
+ * ## Hybrid gating (SBAI-4170 — correcting the over-broad SBAI-4170 first pass)
  *
- * This module previously owned a local `FEATURE_MIN_TIER` map
- * (`{ reporting: team, relay: enterprise, dam: enterprise }`) and derived unlocks
- * from `tier >= MIN`. That table is DELETED. Per the convergence (epic SBAI-4165,
- * registry SBAI-4167) no product may re-implement feature→tier gating — accounts
- * owns the single registry and mints the resolved `features[]`. LoreGUI now reads
- * `features.includes("relay")` / `"dam"` / `"reporting"` from the minted claim.
+ * An earlier pass DELETED the local feature→tier map and tried to gate
+ * `reporting`/`relay`/`dam` off `features.includes(...)`. That was WRONG: accounts
+ * never mints those into `features[]` (its `features_for_tier()` returns only the
+ * non-monotonic add-ons, e.g. `["byok"]`), so they became un-unlockable. The
+ * correct, canonical model is HYBRID and is restored here:
  *
- * {@link bootstrapAccountsEntitlements} reads the JWT's canonical claim directly
- * (no `plan→tier` translation — convergence removed it) and unions the minted
- * `features[]` into `window.__LOREGUI_ENTITLEMENTS__` (path 2 above) — so NO call
- * site here changes. Resolution is a UNION across sources so "hooked into
- * StudioBrain" only ever *adds* unlocks. This module never parses or stores the
- * JWT itself; the host/auth layer extracts the claim and hands it in, per the
- * StudioBrain accounts security boundary.
+ *   - reporting → `tierOrdinal(tier) >= TIER.team`        (monotonic, tier-gated)
+ *   - relay     → `tierOrdinal(tier) >= TIER.enterprise`  (monotonic, tier-gated)
+ *   - dam       → `tierOrdinal(tier) >= TIER.enterprise`  (monotonic, tier-gated)
+ *   - byok      → `features.includes("byok")`             (non-monotonic, from features[])
+ *
+ * {@link bootstrapAccountsEntitlements} reads BOTH top-level claims (`tier` AND
+ * `features`) and unions both axes into `window.__LOREGUI_ENTITLEMENTS__` (path 2
+ * above) — so NO call site here changes. Resolution is a UNION across sources so
+ * "hooked into StudioBrain" only ever *adds* unlocks. This module never parses or
+ * stores the JWT itself; the host/auth layer extracts the claim and hands it in,
+ * per the StudioBrain accounts security boundary.
  */
 
 import { resolveLicensedFeatures } from "./license.ts";
 
 /**
- * A gateable premium feature id. These ids are minted onto the JWT's `features[]`
- * by accounts (the single registry, SBAI-4167) — LoreGUI gates off the claim and
- * never decides their min-tiers locally.
+ * A gateable premium feature id. Two kinds, gated differently (the hybrid
+ * contract): **monotonic** features (`reporting`/`relay`/`dam`) are tier-gated via
+ * {@link MONOTONIC_FEATURE_MIN_TIER}; the **non-monotonic** add-on `byok` is gated
+ * off the minted `features[]` claim. See the module docs.
  */
-export type Feature = "reporting" | "relay" | "dam";
+export type Feature = "reporting" | "relay" | "dam" | "byok";
 
 /**
  * Canonical tier ordinals — the LOCKED scheme (ADR-0001 §2.5). Integer, spaced
@@ -117,21 +127,40 @@ export const TIER_ID: Readonly<Record<number, string>> = {
 };
 
 /**
- * A feature id carried in the canonical, minted `features[]`. accounts resolves
- * the full feature→min-tier registry centrally (SBAI-4167) and mints every
- * unlocked id — `reporting`, `relay`, `dam`, `byok`, … — so LoreGUI gates off the
- * array verbatim. This constant exists only as a readable reference to the id.
+ * Minimum canonical tier ordinal that unlocks each **monotonic** feature.
+ *
+ * These min-tiers live HERE (not in accounts' minted `features[]`) because the
+ * canonical accounts model intentionally tier-gates monotonic features rather
+ * than minting them into `features[]`: accounts' `features_for_tier()` returns
+ * ONLY the non-monotonic add-ons (today `["byok"]` at tier>=enterprise) and never
+ * `reporting`/`relay`/`dam`. accounts does not centralize the monotonic
+ * min-tiers, so each product owns the map. Keep it in sync with accounts'
+ * `config/entitlement.py` — these mirror its monotonic thresholds.
+ */
+export const MONOTONIC_FEATURE_MIN_TIER: Readonly<Record<string, number>> = {
+  reporting: TIER.team,
+  relay: TIER.enterprise,
+  dam: TIER.enterprise,
+};
+
+/**
+ * The id of the non-monotonic add-on `byok` (bring-your-own-key). Non-monotonic
+ * features do NOT follow the tier ladder, so accounts mints the resolved id onto
+ * the JWT's `features[]` (at tier>=enterprise today) and LoreGUI gates off
+ * `features.includes(FEATURE_BYOK)` — never off a tier threshold.
  */
 export const FEATURE_BYOK = "byok";
 
-// NOTE (SBAI-4170 / SBAI-4167): the former local `FEATURE_MIN_TIER` map
-// (`{ reporting: team, relay: enterprise, dam: enterprise }`) and the
-// `featuresForTier(tier)` derivation it powered are DELETED. accounts'
-// `config/entitlement.py` is the single registry of every feature→min-tier and
-// mints the resolved ids onto the JWT's `features[]`. LoreGUI consumes that
-// array (see {@link bootstrapAccountsEntitlements}) and never recomputes
-// thresholds locally. The canonical tier ordinal is kept ONLY for genuinely
-// monotonic checks (none today).
+/**
+ * The set of NON-MONOTONIC add-on feature ids — gated off the minted `features[]`
+ * claim, not off the tier ordinal. Today this is just `byok`. accounts'
+ * `features_for_tier()` is the authority for what lands in `features[]`.
+ *
+ * Resolution doesn't need to consult this set (the resolved entitlement set
+ * already encodes both axes — see {@link bootstrapAccountsEntitlements}), but it
+ * documents the contract and is the canonical list of ids gated off `features[]`.
+ */
+export const NON_MONOTONIC_FEATURES: ReadonlySet<string> = new Set<string>([FEATURE_BYOK]);
 
 /**
  * Legacy plan string → canonical tier ordinal (back-compat for old claims).
@@ -156,8 +185,9 @@ const PLAN_TO_TIER: Record<string, number> = {
  * (`free`/`indie`/`team`/`enterprise`/…). Unknown/missing → `free` (0), i.e.
  * least privilege.
  *
- * Kept for genuinely monotonic checks and to normalise a legacy string tier; it
- * is NOT used to derive feature unlocks (those come minted in `features[]`).
+ * Used for monotonic feature gating (`tier >= MIN`, see
+ * {@link MONOTONIC_FEATURE_MIN_TIER}) and to normalise a legacy string tier. It
+ * is NOT used to derive non-monotonic unlocks (those come minted in `features[]`).
  */
 export function tierOrdinal(tier: number | string | null | undefined): number {
   if (typeof tier === "number" && Number.isFinite(tier)) return tier;
@@ -269,23 +299,24 @@ export function __resetLicensedFeaturesForTests(): void {
 
 /**
  * The canonical entitlement claim carried on the StudioBrain accounts user JWT
- * (SBAI-4089). The host/auth layer extracts these claims from the verified JWT
- * and hands them in — this module never parses or stores the token itself, per
- * the accounts security boundary. `role` is intentionally absent: it is a
- * separate within-tenant axis, not a subscription capability.
+ * (SBAI-4089), as TOP-LEVEL claims. The host/auth layer extracts these from the
+ * verified JWT and hands them in — this module never parses or stores the token
+ * itself, per the accounts security boundary. `role` is intentionally absent: it
+ * is a separate within-tenant axis, not a subscription capability.
  */
 export interface AccountsEntitlementClaim {
   /**
-   * Canonical integer tier ordinal (or a legacy string tier). Informational here
-   * — NOT used to derive feature unlocks (those are minted in `features[]`).
+   * Canonical integer tier ordinal (or a legacy string tier). Gates the
+   * **monotonic** features (`reporting`/`relay`/`dam`) via
+   * {@link MONOTONIC_FEATURE_MIN_TIER}.
    */
   tier?: number | string | null;
   /** Stable string id for the tier (informational; logs/display). */
   tier_id?: string | null;
   /**
-   * The authoritative, minted set of unlocked feature ids (e.g. `reporting`,
-   * `relay`, `dam`, `byok`). accounts' `config/entitlement.py` (SBAI-4167)
-   * resolves every feature→min-tier centrally and mints the result here.
+   * The minted set of **non-monotonic** add-on feature ids (today: `byok`).
+   * accounts' `features_for_tier()` (`config/entitlement.py`, SBAI-4089) returns
+   * ONLY these add-ons — never `reporting`/`relay`/`dam`, which are tier-gated.
    */
   features?: readonly string[] | null;
 }
@@ -297,11 +328,12 @@ export interface AccountsEntitlementClaim {
  * provides a verified claim; it is additive, so "hooked into StudioBrain" only
  * ever *adds* unlocks on top of any offline license already bootstrapped.
  *
- * Resolution reads the minted `features[]` claim VERBATIM (SBAI-4170 / SBAI-4167)
- * — no local feature→tier computation. accounts is the single registry: it has
- * already resolved every feature→min-tier (`reporting`/`relay`/`dam`/`byok`/…)
- * and minted the unlocked ids onto `features[]`. This module never re-derives
- * thresholds from `tier`.
+ * Resolution is HYBRID across BOTH top-level claims (SBAI-4170 correction):
+ *   - For each **monotonic** feature in {@link MONOTONIC_FEATURE_MIN_TIER}, unlock
+ *     it iff `tierOrdinal(claim.tier) >= its min`. accounts tier-gates these and
+ *     does NOT mint them into `features[]`.
+ *   - PLUS every id in `claim.features` (the **non-monotonic** add-ons, e.g.
+ *     `byok`), gated verbatim off the minted array.
  *
  * Safe with a null/garbage claim: it simply contributes nothing.
  */
@@ -309,8 +341,17 @@ export function bootstrapAccountsEntitlements(
   claim: AccountsEntitlementClaim | null | undefined,
 ): string[] {
   const resolved = new Set<string>();
-  if (claim && Array.isArray(claim.features)) {
-    for (const f of claim.features) if (typeof f === "string" && f) resolved.add(f);
+  if (claim) {
+    // Axis 1 — monotonic features tier-gated locally (accounts does not mint
+    // these into features[]; their min-tiers mirror config/entitlement.py).
+    const ordinal = tierOrdinal(claim.tier);
+    for (const [feature, min] of Object.entries(MONOTONIC_FEATURE_MIN_TIER)) {
+      if (ordinal >= min) resolved.add(feature);
+    }
+    // Axis 2 — non-monotonic add-ons minted onto features[] (e.g. byok).
+    if (Array.isArray(claim.features)) {
+      for (const f of claim.features) if (typeof f === "string" && f) resolved.add(f);
+    }
   }
   if (typeof window !== "undefined") {
     const existing = Array.isArray(window.__LOREGUI_ENTITLEMENTS__)
@@ -358,6 +399,12 @@ function resolveEntitlements(): string[] {
 
 /**
  * Is the given premium feature unlocked for this session?
+ *
+ * The resolved entitlement set already encodes the hybrid contract: a monotonic
+ * feature lands in the set only when `tierOrdinal(tier) >= its min` (resolved in
+ * {@link bootstrapAccountsEntitlements}); a non-monotonic add-on (`byok`) lands in
+ * the set only when minted into `features[]`. So membership-in-set is the right
+ * check for BOTH kinds.
  *
  * The open core never calls this for its own surfaces — only premium add-ons do.
  * A locked feature must render an upsell affordance, never a broken control.

--- a/frontend/src/commercial/relay-registry.ts
+++ b/frontend/src/commercial/relay-registry.ts
@@ -25,8 +25,10 @@ import type { HostStatus } from "../api";
  * `null` and `ServiceSetup` renders zero relay UI. A commercial build's overlay
  * entry imports the relay module, which calls {@link registerRelayControl} at
  * import time. The control is still gated: `ServiceSetup` only mounts it when
- * `isEntitled(control.feature)` (`"relay"`) is true, otherwise it shows a locked
- * upsell affordance.
+ * `isEntitled(control.feature)` (`"lore_relay"`) is true, otherwise it shows a
+ * locked upsell affordance. (The user-facing LABEL is "Relay"; the entitlement
+ * id is `lore_relay` to match accounts' minted `features[]` claim — see
+ * `entitlement.ts`.)
  *
  * Dependency-light (just React's `ComponentType` + the `Feature` id + the
  * `HostStatus` shape) so the overlay can register synchronously at module load.
@@ -50,9 +52,9 @@ export interface RelayControlProps {
 
 /** A relay control contributed by a commercial overlay. */
 export interface RelayControl {
-  /** Stable id, e.g. "relay". */
+  /** Stable control id (NOT the entitlement id), e.g. "relay-toggle". */
   id: string;
-  /** The entitlement feature this control is gated behind (e.g. "relay"). */
+  /** The entitlement feature this control is gated behind (`"lore_relay"`). */
   feature: Feature;
   /** Short label for the locked-upsell affordance, e.g. "Cross-network relay". */
   label: string;

--- a/frontend/src/onboarding/server/ServiceSetup.tsx
+++ b/frontend/src/onboarding/server/ServiceSetup.tsx
@@ -46,7 +46,7 @@ export default function ServiceSetup({
   // Cross-network relay control (SBAI-4072). The open core registers nothing, so
   // `relayControl` is null and no relay UI renders. A commercial build's overlay
   // registers a control here; it is only mounted when the studio is entitled to
-  // the "relay" feature (otherwise a locked upsell shows).
+  // the "lore_relay" feature (otherwise a locked upsell shows).
   const relayControl = useMemo(() => getRelayControl(), []);
   const relayEntitled = relayControl ? isEntitled(relayControl.feature) : false;
 


### PR DESCRIPTION
## Summary

Part of epic **SBAI-4165** (entitlement convergence), LoreGUI handoff **SBAI-4170**, depends on the canonical registry **SBAI-4167**.

**The ONE rule (CLAUDE.md "Entitlement vs Plan", SBAI-4165): gate on `features[]` ONLY; never re-derive the feature->tier mapping in any frontend.** accounts' `config/entitlement.py` is the single registry and mints the **fully-resolved** `features[]` array onto the JWT; products consume it verbatim.

## Re-correction note (this push)

An **interim pass** on this branch added a local `MONOTONIC_FEATURE_MIN_TIER` *hybrid* (gate `reporting`/`relay`/`dam` off a local tier map, only `byok` off `features[]`). That was based on a **STALE accounts checkout** in which `features_for_tier()` returned only the enterprise add-ons. The **LIVE accounts** (origin/main, post-**SBAI-4167**, commit `09dbd54`) has a 35-entry `FEATURE_MIN_TIER` registry and `features_for_tier(tier)` returns **EVERY** feature whose `min_tier <= tier` -- so the full resolved superset (e.g. `reporting`, `lore_relay`, `dam`, `byok` at enterprise) is minted into `features[]`. The hybrid is therefore wrong; this push removes it and gates `features[]`-only, per SBAI-4165.

## What changed

`frontend/src/commercial/entitlement.ts`:
- **DELETED** `MONOTONIC_FEATURE_MIN_TIER` and `NON_MONOTONIC_FEATURES`. **No local min-tier map of any kind.**
- `bootstrapAccountsEntitlements()` unions `claim.features[]` **VERBATIM** into the runtime slot. `tier`/`tier_id` are read for **DISPLAY only** (the tier_id label), never for gating.
- `isEntitled()` is membership-in-`features[]` for **every** gateable feature.
- **Renamed the entitlement id `relay` -> `lore_relay`** (the `Feature` union + all call-site/docstring usages) to match accounts' minted claim id. accounts: *"lore_relay (LoreGUI's relay feature) is deliberately distinct"* from the free-tier `fileserver_relay`. The user-facing **LABEL "Relay" is unchanged**; only the entitlement id moved.
- **KEPT** `TIER`/`TIER_ID`/`tierOrdinal`/`PLAN_TO_TIER` for the display label. **SBAI-4168 was DROPPED** -- `plan` is retained as the billing SKU (never gated on).
- Module docs rewritten to state the `features[]`-only contract and reference CLAUDE.md SBAI-4165 + accounts `config/entitlement.py` (SBAI-4167).

## relay -> lore_relay rename scope

`Feature` union (`entitlement.ts`); docstrings + the `feature: Feature` field doc in `relay-registry.ts`; the entitled-feature comment in `onboarding/server/ServiceSetup.tsx`. The `RelayControl.feature` / `PremiumPanel.feature` fields are typed `Feature`, so the cloud overlay must now register `lore_relay`; `tsc` enforces this. Grep confirms **zero** `isEntitled("relay")` and zero `"relay"` entitlement-id literals remain (only `lore_relay`).

## Gating (final)

| feature | gate |
|---|---|
| `reporting` | `features.includes("reporting")` |
| `lore_relay` | `features.includes("lore_relay")` |
| `dam` | `features.includes("dam")` |
| `byok` | `features.includes("byok")` |

A high `tier` with empty `features[]` unlocks **nothing**. LoreGUI surfaces only these four ids (verified against the `Feature` union + premium-registry/relay-registry); `spatial_3d`/`cluster`/`cloud_sync` exist in accounts' registry but have no LoreGUI UI, so are not gated here.

## Tests

`frontend/src/commercial/entitlement.test.ts` rewritten for the `features[]`-only contract: `features:["reporting"]` => reporting only (not lore_relay/dam); full minted superset => all four entitled; **empty `features[]` => none even at superadmin tier**; byok/lore_relay require the minted id (no tier threshold); `tier_id` passes through for display; `PLAN_TO_TIER` present; **no local min-tier map referenced.** 15/15 pass.

## Verification

- `node --test --experimental-strip-types "frontend/src/**/*.test.ts"` -> 25/25 pass (entitlement 15 + license 10)
- `npm --prefix frontend run build` (`tsc && vite build`) -> green (the `relay`->`lore_relay` type rename compiles cleanly across all consumers)
- grep: zero remaining feature->tier map; zero `"relay"` entitlement ids (only `lore_relay`)

Matches accounts origin/main `config/entitlement.py` (SBAI-4167) + CLAUDE.md SBAI-4165.

## Do NOT merge

Keep OPEN -- review-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
