### PR TITLE
fix(website): point download CTAs at the real CI-published nightly assets

### DIFF
--- a/website/src/app/docs/install/page.mdx
+++ b/website/src/app/docs/install/page.mdx
@@ -17,7 +17,7 @@ Download the latest installer from [GitHub Releases](https://github.com/BiloxiSt
 - **Linux** — `.deb`, `.AppImage`, or `.rpm`
 - **macOS** — `.dmg` (when code-signing is enabled)
 
-The `nightly` release tracks the latest `main`. Windows installers are produced in CI on a `windows-latest` runner and published to Releases automatically.
+The rolling [`nightly`](https://github.com/BiloxiStudios/loregui/releases/tag/nightly) prerelease tracks the latest `main`: CI rebuilds Windows, Linux, and macOS (Apple Silicon) installers on every push and refreshes that release automatically. macOS builds are signed only when the Apple certificate is configured in CI; otherwise the `.dmg` is unsigned.
 
 ## Build from source
 

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -5,8 +5,10 @@ import { Badge } from "@/components/ui/Badge";
 import Image from "next/image";
 import { ArrowRightIcon, GithubIcon, WindowsIcon } from "@/components/icons";
 import { AppWindow } from "@/components/mockups/AppWindow";
+import { DOWNLOADS, RELEASES_PAGE } from "@/lib/downloads";
 
-const RELEASES_URL = "https://github.com/BiloxiStudios/loregui/releases/download/v0.1.0-alpha/LoreGUI_0.1.0_x64-setup.exe";
+// Windows installer from the CI-maintained rolling `nightly` release.
+const WINDOWS_DOWNLOAD_URL = DOWNLOADS.windowsExe;
 const GITHUB_URL = "https://github.com/BiloxiStudios/loregui";
 
 export function Hero() {
@@ -54,7 +56,7 @@ export function Hero() {
           </p>
 
           <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
-            <Button variant="primary" size="lg" href={RELEASES_URL}>
+            <Button variant="primary" size="lg" href={WINDOWS_DOWNLOAD_URL}>
               <WindowsIcon className="mr-2 h-5 w-5" />
               Download for Windows
             </Button>
@@ -77,9 +79,21 @@ export function Hero() {
               href="#install"
               className="ml-1 inline-flex items-center font-medium text-brand-accent transition-colors hover:text-brand-gold"
             >
-              winget &amp; scoop too
+              all platforms &amp; other installers
               <ArrowRightIcon className="ml-1 h-4 w-4" />
             </a>
+          </p>
+          <p className="mt-1 text-xs text-brand-muted">
+            On macOS or Linux?{" "}
+            <a
+              href={RELEASES_PAGE}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-brand-accent transition-colors hover:text-brand-gold"
+            >
+              Grab a build from GitHub Releases
+            </a>
+            .
           </p>
         </div>
 

--- a/website/src/components/Install.tsx
+++ b/website/src/components/Install.tsx
@@ -2,10 +2,7 @@ import { Container } from "@/components/ui/Container";
 import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
 import { WindowsIcon, AppleIcon, LinuxIcon } from "@/components/icons";
-
-// The releases page — the rolling `nightly` build (current main) sits at the top,
-// alongside any tagged stable releases. No stale version is pinned here.
-const RELEASES_LATEST = "https://github.com/BiloxiStudios/loregui/releases";
+import { DOWNLOADS, RELEASES_PAGE } from "@/lib/downloads";
 
 export function Install() {
   return (
@@ -24,38 +21,108 @@ export function Install() {
           </p>
         </div>
 
-        {/* Real, working download — signed installers on GitHub Releases. */}
+        {/* Real, working downloads — installers from the CI-maintained
+            `nightly` release. Each link is a direct asset URL. */}
         <div className="mx-auto mt-16 max-w-3xl">
           <Card highlight className="flex flex-col gap-6">
             <div className="text-center">
               <h3 className="font-heading text-lg font-semibold text-brand-text-bright">
-                Get the latest release
+                Get the latest build
               </h3>
               <p className="mt-1 text-sm text-brand-muted">
-                Signed installers built by CI live on GitHub Releases — Windows
-                <span className="text-brand-text-bright"> (.exe / .msi)</span> and
-                Linux
-                <span className="text-brand-text-bright"> (.deb / .AppImage)</span>
-                .
+                CI builds the current <code className="text-brand-text-bright">main</code> on
+                every push and publishes installers to GitHub Releases (the
+                rolling <span className="text-brand-text-bright">nightly</span> build).
               </p>
             </div>
-            <div className="flex flex-wrap items-center justify-center gap-3">
-              <Button variant="primary" size="md" href={RELEASES_LATEST}>
-                <WindowsIcon className="mr-2 h-5 w-5" />
-                Download for Windows
-              </Button>
-              <Button variant="secondary" size="md" href={RELEASES_LATEST}>
-                <LinuxIcon className="mr-2 h-5 w-5" />
-                Download for Linux
-              </Button>
-              <span className="inline-flex items-center gap-2 rounded-md border border-brand-muted/20 px-3 py-2 text-sm text-brand-muted">
-                <AppleIcon className="h-5 w-5" />
-                macOS — coming soon
-              </span>
+
+            <div className="grid gap-4 sm:grid-cols-3">
+              {/* Windows */}
+              <div className="flex flex-col items-center gap-2 rounded-lg border border-brand-muted/15 p-4 text-center">
+                <WindowsIcon className="h-6 w-6 text-brand-text-bright" />
+                <span className="text-sm font-semibold text-brand-text-bright">
+                  Windows
+                </span>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  href={DOWNLOADS.windowsExe}
+                  className="w-full"
+                >
+                  Installer (.exe)
+                </Button>
+                <a
+                  href={DOWNLOADS.windowsMsi}
+                  className="text-xs font-medium text-brand-accent transition-colors hover:text-brand-gold"
+                >
+                  or .msi
+                </a>
+              </div>
+
+              {/* Linux */}
+              <div className="flex flex-col items-center gap-2 rounded-lg border border-brand-muted/15 p-4 text-center">
+                <LinuxIcon className="h-6 w-6 text-brand-text-bright" />
+                <span className="text-sm font-semibold text-brand-text-bright">
+                  Linux
+                </span>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  href={DOWNLOADS.linuxAppImage}
+                  className="w-full"
+                >
+                  AppImage
+                </Button>
+                <span className="text-xs text-brand-muted">
+                  or{" "}
+                  <a
+                    href={DOWNLOADS.linuxDeb}
+                    className="font-medium text-brand-accent transition-colors hover:text-brand-gold"
+                  >
+                    .deb
+                  </a>{" "}
+                  /{" "}
+                  <a
+                    href={DOWNLOADS.linuxRpm}
+                    className="font-medium text-brand-accent transition-colors hover:text-brand-gold"
+                  >
+                    .rpm
+                  </a>
+                </span>
+              </div>
+
+              {/* macOS */}
+              <div className="flex flex-col items-center gap-2 rounded-lg border border-brand-muted/15 p-4 text-center">
+                <AppleIcon className="h-6 w-6 text-brand-text-bright" />
+                <span className="text-sm font-semibold text-brand-text-bright">
+                  macOS
+                </span>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  href={DOWNLOADS.macosDmg}
+                  className="w-full"
+                >
+                  Apple Silicon (.dmg)
+                </Button>
+                <span className="text-xs text-brand-muted">
+                  unsigned build — may need Gatekeeper override
+                </span>
+              </div>
             </div>
+
             <p className="text-center text-xs text-brand-muted">
-              Package managers (winget, Scoop, Homebrew) are on the roadmap.
-              In-app auto-update is coming so the client keeps itself current.
+              Need a different format or an older build?{" "}
+              <a
+                href={RELEASES_PAGE}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-brand-accent transition-colors hover:text-brand-gold"
+              >
+                Browse all GitHub Releases
+              </a>
+              . Package managers (winget, Scoop, Homebrew) and in-app
+              auto-update are on the roadmap.
             </p>
           </Card>
         </div>

--- a/website/src/lib/downloads.ts
+++ b/website/src/lib/downloads.ts
@@ -1,0 +1,31 @@
+// Canonical download URLs for LoreGUI installers.
+//
+// The release pipeline (.github/workflows/release.yml) publishes a rolling
+// `nightly` PRERELEASE on every push to `main`. That is the only deterministic,
+// non-draft release with assets for every platform — a pushed `v*` tag produces
+// a DRAFT release (no public assets), and GitHub's `releases/latest/download/`
+// shortcut deliberately SKIPS prereleases, so it would not resolve `nightly`.
+// We therefore pin the stable `nightly` tag explicitly.
+//
+// Asset names are produced by tauri-action from the bundle config:
+//   productName "LoreGUI", version 0.1.0 (src-tauri/tauri.conf.json).
+// Confirmed against the live `nightly` release assets. NOTE: the bundle version
+// is baked into each filename, so bump these when tauri.conf.json `version`
+// changes (or move to a redirect endpoint that resolves the current asset).
+const REPO = "https://github.com/BiloxiStudios/loregui";
+const NIGHTLY = `${REPO}/releases/download/nightly`;
+
+export const RELEASES_PAGE = `${REPO}/releases`;
+
+export const DOWNLOADS = {
+  // Windows
+  windowsExe: `${NIGHTLY}/LoreGUI_0.1.0_x64-setup.exe`,
+  windowsMsi: `${NIGHTLY}/LoreGUI_0.1.0_x64_en-US.msi`,
+  // Linux
+  linuxAppImage: `${NIGHTLY}/LoreGUI_0.1.0_amd64.AppImage`,
+  linuxDeb: `${NIGHTLY}/LoreGUI_0.1.0_amd64.deb`,
+  linuxRpm: `${NIGHTLY}/LoreGUI-0.1.0-1.x86_64.rpm`,
+  // macOS (Apple Silicon) — published, but only signed when the Apple cert
+  // secret is present in CI; otherwise the .dmg is unsigned.
+  macosDmg: `${NIGHTLY}/LoreGUI_0.1.0_aarch64.dmg`,
+} as const;


### PR DESCRIPTION
## Problem

The website's primary download CTA was broken. `website/src/components/Hero.tsx` hardcoded:

```
https://github.com/BiloxiStudios/loregui/releases/download/v0.1.0-alpha/LoreGUI_0.1.0_x64-setup.exe
```

`v0.1.0-alpha` is a stale, frozen tag that CI never refreshes. The release pipeline (`.github/workflows/release.yml`) only publishes:
- a rolling **`nightly` prerelease** on every push to `main` (all platforms, the real CI output), and
- a **draft `v*` release** for pushed tags (no public assets).

So the CTA pointed at a one-off snapshot, not the maintained build. `releases/latest/download/` is also unusable here because GitHub's "latest" deliberately **excludes prereleases**, so it would never resolve `nightly`.

## Fix

- **New `website/src/lib/downloads.ts`** — single source of truth for the canonical `nightly`-tag asset URLs, with a comment explaining why `nightly` (not `latest`/`v*`) is the right target and that the bundle version is baked into each filename.
- **Hero.tsx** — Windows button now points at the real `nightly` `.exe`; added a "On macOS or Linux? Grab a build from GitHub Releases" fallback line so the CTA works on every platform. (The "winget & scoop too" link, which pointed at an Install section that says those are only on the roadmap, was retargeted to "all platforms & other installers".)
- **Install.tsx** — replaced the two generic releases-page buttons with **real per-OS direct downloads**: Windows (`.exe` / `.msi`), Linux (`.AppImage` / `.deb` / `.rpm`), macOS (`.dmg`, labeled unsigned), plus a "Browse all GitHub Releases" fallback so there's always a working link.
- **docs/install/page.mdx** — corrected the note (CI builds Windows **and** Linux **and** macOS, not just Windows; macOS is signed only when the Apple cert is configured in CI).

`Header.tsx` and `Footer.tsx` already pointed at the releases page and were left as-is.

## Which release/tag the links target

All direct-download links now target the **`nightly`** prerelease tag. Verified asset names against the live release — every URL returns HTTP 206 anonymously:

| Platform | Asset |
|---|---|
| Windows | `LoreGUI_0.1.0_x64-setup.exe`, `LoreGUI_0.1.0_x64_en-US.msi` |
| Linux | `LoreGUI_0.1.0_amd64.AppImage`, `LoreGUI_0.1.0_amd64.deb`, `LoreGUI-0.1.0-1.x86_64.rpm` |
| macOS (Apple Silicon) | `LoreGUI_0.1.0_aarch64.dmg` |

## Assumptions to confirm

- **Version in filenames is baked in.** The `0.1.0` in every asset name comes from `src-tauri/tauri.conf.json` `version`. When that version bumps, the `nightly` asset names change and `downloads.ts` must be updated (noted in-file). A future improvement would be a small redirect endpoint that resolves the current asset.
- **macOS `.dmg` is Apple-Silicon-only and may be unsigned** (the CI matrix builds `aarch64-apple-darwin`; signing/notarization only run when the Apple cert secret is present). Labeled accordingly. No Intel/x86_64 macOS build is produced.

## Verification

- `npm run build` in `website/` passes: compile + typecheck + lint + 21 static pages generated.
- Built output's download URLs match `release.yml`'s asset names exactly (grep over `.next/server`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
