### PR TITLE
ci: build mac + linux Tauri bundles on PRs (cross-platform PR gate)

### DIFF
--- a/.github/workflows/build-crossplatform.yml
+++ b/.github/workflows/build-crossplatform.yml
@@ -1,0 +1,94 @@
+name: build-crossplatform
+
+# PR gate for the NON-Windows installers. windows-build.yml proves the Windows
+# bundle still builds on every PR; the macOS + Linux installers were ONLY built
+# in release.yml (which runs on tag / push-to-main, never on PRs), so a PR could
+# silently break the mac/linux `tauri build` and nobody would notice until a
+# release. This workflow closes that gap: it build-only-bundles the Tauri app on
+# macOS (aarch64) and Linux (ubuntu-22.04) on every PR, mirroring
+# windows-build.yml's approach.
+#
+# Build-only, no signing, no publishing, no secrets beyond the default
+# GITHUB_TOKEN (used solely so tauri-action can resolve the release context; no
+# release is created on a PR). The real ~1 GB upstream `loreserver` sidecar is
+# NOT built here — `src-tauri/build.rs` auto-stages a tiny placeholder for the
+# current target triple so the bundler's externalBin existence check is
+# satisfied (same mechanism windows-build.yml relies on). release.yml stages the
+# genuine binary for actual releases.
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macos-latest is Apple Silicon (ARM64); build the aarch64 bundle to
+          # match release.yml's macOS target.
+          - platform: macos-latest
+            triple: aarch64-apple-darwin
+            args: --target aarch64-apple-darwin
+          - platform: ubuntu-22.04
+            triple: x86_64-unknown-linux-gnu
+            args: ""
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.triple }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      # Standard Tauri Linux build dependencies (webkit2gtk + gtk + appindicator
+      # + rsvg + patchelf). Same set release.yml installs for its Linux job.
+      - name: Linux build deps (webkit/gtk/appindicator)
+        if: ${{ matrix.platform == 'ubuntu-22.04' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev patchelf \
+            libayatana-appindicator3-dev
+
+      - name: Install frontend deps
+        run: npm --prefix frontend ci || npm --prefix frontend install
+
+      # `tauri.conf.json` declares `externalBin: ["binaries/loreserver"]`, so
+      # `tauri build` REQUIRES a sidecar named with this target's triple. The real
+      # loreserver is the ~1 GB upstream build that release.yml bundles — we do NOT
+      # build it on the PR gate. `src-tauri/build.rs` auto-stages a tiny
+      # placeholder for the current triple so the bundler is satisfied and the gate
+      # keeps proving the installer/config still builds per OS. The placeholder is
+      # never shipped.
+      - name: Build (Tauri → bundle)
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: .
+          args: ${{ matrix.args }}
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: loregui-${{ matrix.platform }}
+          path: |
+            target/release/bundle/**/*.dmg
+            target/release/bundle/**/*.app
+            target/release/bundle/**/*.deb
+            target/release/bundle/**/*.rpm
+            target/release/bundle/**/*.AppImage
+            target/${{ matrix.triple }}/release/bundle/**/*.dmg
+            target/${{ matrix.triple }}/release/bundle/**/*.app
+          if-no-files-found: warn


### PR DESCRIPTION
## Problem

`windows-build.yml` proves the **Windows** installer still builds on every PR, but the **macOS + Linux** installers only build in `release.yml`, which runs on tag / push-to-`main` — **never on PRs**. So a PR can silently break the mac/linux `tauri build` and it isn't caught until a release.

## Change

Adds a new workflow **`.github/workflows/build-crossplatform.yml`** — a build-only PR gate that bundles the Tauri app on:

- **macOS** `macos-latest` (Apple Silicon) → `aarch64-apple-darwin` (matches `release.yml`'s mac target)
- **Linux** `ubuntu-22.04`

mirroring `windows-build.yml`'s approach.

### Details
- **Trigger:** `pull_request: branches: [main]` + `workflow_dispatch` (same as `windows-build.yml`).
- **Build-only, no tests.** Just proves `tauri build` compiles + bundles per OS.
- **No signing, no publishing, no release created.** The only secret used is the default `GITHUB_TOKEN` (so `tauri-action` can resolve release context; no release is produced on a PR). No Apple certs, no notarization, no updater keys — those live only in `release.yml`.
- **Sidecar:** relies on `src-tauri/build.rs` auto-staging the tiny placeholder `loreserver` sidecar for the current target triple (the same mechanism `windows-build.yml` already depends on). The real ~1 GB upstream sidecar is **not** built here — `release.yml` bundles the genuine binary for actual releases.
- **Linux system deps:** installs the standard Tauri set — `libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev patchelf libayatana-appindicator3-dev` (same set `release.yml` installs).
- **Caching:** `Swatinem/rust-cache@v2` for cargo + `actions/setup-node@v4` for node, to keep it reasonably fast.
- Uploads the produced bundles (`.dmg`/`.app`/`.deb`/`.rpm`/`.AppImage`) as artifacts (`if-no-files-found: warn`).

### Not touched
`ci.yml` and `windows-build.yml` are unchanged.

## Verification
- `actionlint` passes clean on the new file **and** on the whole `.github/workflows/` dir.
- Job structure mirrors the working `windows-build.yml` (checkout → rust-toolchain → setup-node → rust-cache → frontend deps → `tauri-apps/tauri-action@v0`), plus the Linux dep install and the mac target flag taken from `release.yml`.

### Signing / secret assumptions
**None.** Build-only; the only secret referenced is `GITHUB_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)