### PR TITLE
docs: OSS community & governance files for public launch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug report
+description: Report a problem with LoreGUI
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report!
+
+        - **Security issue?** Do **not** file it here — follow [`SECURITY.md`](https://github.com/BiloxiStudios/loregui/blob/main/SECURITY.md).
+        - **Upstream `lore` engine bug?** If it reproduces against Epic's `lore` directly, please report it to [EpicGames/lore](https://github.com/EpicGames/lore) instead.
+        - Please search existing issues first to avoid duplicates.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected to happen.
+      placeholder: When I ... LoreGUI did ... but I expected ...
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce it?
+      placeholder: |
+        1. Open LoreGUI and connect to ...
+        2. Run the ... op from the palette
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: LoreGUI version
+      description: Release version, or the commit SHA if you built from source.
+      placeholder: "v0.1.0 / nightly / <git sha>"
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      multiple: false
+      options:
+        - Windows
+        - Linux
+        - macOS
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which surface?
+      description: Where did the bug occur?
+      options:
+        - Desktop GUI
+        - Command palette
+        - Host a server (loreserver config)
+        - MCP server
+        - VS Code extension
+        - Build from source
+        - Other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: install-method
+    attributes:
+      label: Install method
+      description: Signed installer from Releases, or built from source? If from source, note your Rust and Node versions.
+      placeholder: "Installer (Releases) — or — built from source with Rust 1.xx / Node 20.x"
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / output
+      description: Relevant logs or error output. **Redact any credentials, tokens, or private repo paths.**
+      render: shell
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: This is not a security vulnerability (those go through SECURITY.md).
+          required: true
+        - label: I have redacted any credentials, tokens, or private paths from the report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/BiloxiStudios/loregui/security/advisories/new
+    about: Please report security issues privately — do not open a public issue. See SECURITY.md.
+  - name: Community & questions
+    url: https://braindeadguild.com/discord
+    about: Ask questions and chat with the BrainDeadGuild community on Discord.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: Feature request
+description: Suggest an idea or improvement for LoreGUI
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! A few notes before you start:
+
+        - LoreGUI aims for **full parity** with the upstream `lore` op surface — if you're requesting an op that exists in `lore` but isn't exposed yet, say so; that's a parity gap, not a new feature.
+        - Please search existing issues and the [`docs/IMPLEMENTATION-PLAN.md`](https://github.com/BiloxiStudios/loregui/blob/main/docs/IMPLEMENTATION-PLAN.md) roadmap first.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or the pain point. What are you trying to do?
+      placeholder: When working with ... I can't ... which makes ... hard.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like LoreGUI to do? How might it look or behave?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Command palette / op coverage
+        - A domain panel (branches, history, locks, storage, …)
+        - Theming / UI
+        - Host a server flow
+        - MCP server / agent tools
+        - VS Code extension
+        - Unreal Engine plugin
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds you're using today, or other approaches you weighed.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and the roadmap, and this is not already tracked.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+<!--
+Thanks for contributing to LoreGUI! Please fill out the sections below.
+Keep PRs focused — one op = one file per layer; don't touch files outside the
+scope of your change (PRs that reformat unrelated files are bounced).
+-->
+
+## Summary
+
+<!-- What does this PR do and why? Lead with the Jira key if there is one,
+     e.g. "SBAI-XXXX: branch merge_resolve_theirs". -->
+
+## Related issue / ticket
+
+<!-- Closes #123  /  SBAI-XXXX -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New lore op / feature
+- [ ] UI / UX
+- [ ] Docs only
+- [ ] Build / CI / tooling
+- [ ] Upstream `lore` pin bump (manager-owned — see CONTRIBUTING.md)
+
+## Checklist
+
+- [ ] `cargo fmt --all --check` passes
+- [ ] `cargo clippy -p lore-vm -- -D warnings` passes
+- [ ] `cargo test -p lore-vm` passes (and integration tests if `crates/lore-vm/**` changed)
+- [ ] `cargo check -p loregui` passes
+- [ ] `npm --prefix frontend run build` passes
+- [ ] `node frontend/scripts/palette-parity.mjs` passes (if an op was added/exposed)
+- [ ] New/changed ops land in the app coherently (surface decided, semantic
+      theme tokens used, help/description added) — see the coherence mandate in
+      `CLAUDE.md`
+- [ ] No files outside the scope of this change were touched/reformatted
+- [ ] Docs updated if behavior or workflow changed
+
+## Notes for reviewers
+
+<!-- Screenshots for UI changes, design-review notes, anything reviewers should
+     know. Redact any credentials or repo paths. -->

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,43 @@
+# CODEOWNERS for LoreGUI
+#
+# These owners are requested for review automatically when a PR touches matching
+# paths. Order matters: the LAST matching pattern wins. See
+# https://docs.github.com/articles/about-code-owners
+#
+# NOTE: `main` is not branch-protected; CODEOWNERS here drives review routing,
+# not a hard merge block.
+
+# Default — anything not matched below
+*                           @BiloxiStudios/loregui-maintainers
+
+# Core engine (GUI-agnostic lore bindings) + the external-driver seam
+/crates/                    @BiloxiStudios/loregui-engine
+/crates/lore-vm/            @BiloxiStudios/loregui-engine
+/crates/lorevm-cli/         @BiloxiStudios/loregui-engine
+/crates/lorevm-ffi/         @BiloxiStudios/loregui-engine
+
+# Tauri desktop shell
+/src-tauri/                 @BiloxiStudios/loregui-desktop
+
+# Frontend GUI (Vite + React + TypeScript)
+/frontend/                  @BiloxiStudios/loregui-frontend
+
+# VS Code extension
+/vscode-extension/          @BiloxiStudios/loregui-frontend
+
+# MCP server (agent tool surface)
+/lore-mcp/                  @BiloxiStudios/loregui-engine
+
+# Unreal Engine plugin (links lorevm-ffi)
+/unreal-plugin/             @BiloxiStudios/loregui-engine
+
+# Marketing website
+/website/                   @BiloxiStudios/loregui-frontend
+
+# Docs
+/docs/                      @BiloxiStudios/loregui-maintainers
+
+# Build, CI, and the upstream `lore` pin — manager-owned, change deliberately
+/.github/                   @BiloxiStudios/loregui-maintainers
+/Cargo.toml                 @BiloxiStudios/loregui-maintainers
+/Cargo.lock                 @BiloxiStudios/loregui-maintainers

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**conduct@braindeadguild.com**.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,161 @@
+# Contributing to LoreGUI
+
+Thanks for your interest in LoreGUI — a fast, themeable, cross-platform desktop
+GUI for [Lore](https://github.com/EpicGames/lore), Epic Games' next-generation
+version control. This guide covers how to build, test, and land changes.
+
+> **Community project.** Not affiliated with or endorsed by Epic Games. "Lore"
+> is a trademark of Epic Games, Inc. Licensed under MIT.
+
+> **Agents:** read [`.claude/skills/loregui/SKILL.md`](.claude/skills/loregui/SKILL.md) —
+> it's the single entry point to install, set up the MCP, configure, and drive
+> LoreGUI.
+
+## Repository layout
+
+| Path | What |
+|---|---|
+| `crates/lore-vm/` | Reusable, GUI-agnostic core. Binds the upstream `lore` crate in-process; one file per operation. |
+| `crates/lorevm-cli/` | `lorevm` CLI — the external-driver seam (used by `lore-mcp` and the VS Code extension). |
+| `crates/lorevm-ffi/` | C-ABI bridge (`lorevm-ffi`) for native consumers such as the Unreal Engine plugin. |
+| `src-tauri/` | Tauri v2 desktop shell. One `#[tauri::command]` per operation. |
+| `frontend/` | The GUI (Vite + React 19 + TypeScript). Per-domain panels + the universal command palette. |
+| `lore-mcp/` | MCP server exposing lore ops as agent tools (one tool per op). |
+| `vscode-extension/` | The `loregui-lore` VS Code extension (shells out to `lorevm`). |
+| `website/` | Marketing landing site (Next.js) for [loregui.com](https://loregui.com). |
+| `docs/` | The full-parity build plan, per-domain design notes, and ADRs. |
+
+`lore-vm` is intentionally decoupled from the GUI so it can be embedded in larger
+tooling. See [`docs/IMPLEMENTATION-PLAN.md`](docs/IMPLEMENTATION-PLAN.md) for the
+full architecture and parity roadmap.
+
+## Prerequisites
+
+- **Rust** — stable toolchain, edition-2024-capable, with `clippy` and `rustfmt`.
+- **Node.js 20+** (for `frontend/` and `vscode-extension/`).
+- **Tauri v2 system dependencies** for your platform — see the
+  [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/).
+- On Debian/Ubuntu, the core build also needs `build-essential` and `pkg-config`.
+
+## The upstream `lore` pin (read this first)
+
+LoreGUI binds the upstream `lore` Rust crate **directly, in-process** — it never
+shells out to the CLI and never runs a background daemon. The crate is pinned to
+an **exact git revision** in the root [`Cargo.toml`](Cargo.toml):
+
+```toml
+lore = { git = "https://github.com/EpicGames/lore.git", rev = "<sha>" }
+```
+
+A couple of consequences you need to know:
+
+- **`quinn-proto` patch is mandatory.** Upstream `lore` patches `quinn-proto` to a
+  vendored fork (it adds `TransportErrorCode::is_crypto()`). A Cargo `[patch]`
+  does **not** propagate through a git dependency, so the root `Cargo.toml`
+  re-declares the same `[patch.crates-io]` at the same rev. Without it,
+  `lore-transport` fails to compile (`no method named is_crypto`). Every consumer
+  of the `lore` crate needs this patch.
+- **The pin is manager-owned.** Lore is pre-1.0; its op surface and signatures
+  can change between revisions. Bumping the pin is a **deliberate, standalone PR**
+  — it is not something to fold into a feature change. The scheduled
+  `upstream-parity` workflow watches for drift and proposes bumps. If you hit a
+  signature mismatch against the pinned rev, that's an upstream-coupling issue,
+  not a bug in your op — flag it rather than working around it.
+
+## Building
+
+```bash
+# Frontend deps (first time / after package.json changes)
+npm --prefix frontend install
+
+# Hot-reload desktop development (from the repo root)
+cargo tauri dev
+
+# Full platform installer
+cargo tauri build
+```
+
+The first build compiles the upstream `lore` crate (and the vendored
+`quinn-proto`), so expect it to be slow the first time. `Swatinem/rust-cache`
+keeps CI fast; locally, the `target/` cache does the same.
+
+## Running tests
+
+| Surface | Command |
+|---|---|
+| Core engine (fast unit tests) | `cargo test -p lore-vm` |
+| Format check | `cargo fmt --all --check` |
+| Lints | `cargo clippy -p lore-vm -- -D warnings` |
+| Tauri shell compiles | `cargo check -p loregui` |
+| Frontend type-check + build | `npm --prefix frontend run build` |
+| Frontend unit tests | `npm --prefix frontend test` |
+| Command-palette parity | `node frontend/scripts/palette-parity.mjs` |
+| VS Code extension E2E | `npm --prefix vscode-extension test` |
+
+Heavier suites, gated behind the `integration-tests` feature, drive the **real**
+in-process `lore` engine against temp repos:
+
+```bash
+# Happy-path roundtrip (create → stage → commit → status → branch → history)
+cargo test -p lore-vm --features integration-tests --test integration_roundtrip
+
+# Full revision lifecycle + two-repo shared-store sync (non-skippable in CI)
+cargo test -p lore-vm --features integration-tests --test e2e_lifecycle
+```
+
+The VS Code extension E2E (`@vscode/test-electron` + mocha) builds the real
+`lorevm` engine, seeds a `.lore` repo, launches a headless VS Code, and drives
+the extension's SCM provider / commands / tree views. Its `pretest` step compiles
+and seeds a workspace automatically.
+
+## CI gates
+
+Pull requests must pass these checks before merge (see
+[`.github/workflows/`](.github/workflows/)):
+
+| Workflow | What it proves |
+|---|---|
+| `ci.yml` → `core-check` | `cargo fmt --all --check`, `cargo check -p lore-vm`, `cargo clippy -p lore-vm -D warnings`, `cargo test -p lore-vm`. |
+| `ci.yml` → `palette-parity` | Every registered Tauri command is exposed in the command palette (a manifest entry) or explicitly allowlisted — the GUI stays in lock-step with the API surface. |
+| `integration.yml` | The `integration_roundtrip` and non-skippable `e2e_lifecycle` suites against a real on-disk `lore` instance (runs when `crates/lore-vm/**` changes). |
+| `vscode-test.yml` | Headless VS Code E2E for the extension (runs when the extension or the engine it shells out to changes). |
+| `windows-build.yml` | Proves the Windows installer (Tauri → NSIS + MSI) still builds. |
+
+`release.yml` (multi-platform installers) and `publish-vscode.yml` / `upstream-parity.yml`
+run on pushes/tags/schedules, not as PR gates.
+
+> Note: `main` is **not** branch-protected, so green CI is on you — please don't
+> merge red.
+
+## Branch & PR conventions
+
+- **Branch names** describe the change; ticketed work uses the Jira key, e.g.
+  `SBAI-XXXX-<domain>-<op>` or `docs/<slug>`.
+- **PR titles** lead with the ticket where there is one: `SBAI-XXXX: <summary>`.
+- **One op = one file per layer.** Palette manifest entries auto-discover via
+  `import.meta.glob` — there are no index files to edit. Do **not** reformat or
+  touch files outside the scope of your change; PRs that do are bounced.
+- **Adding or exposing a lore op is more than a palette row.** Every operation
+  must land in the full app coherently — decide its surface (panel, nav/menu,
+  and/or palette entry), use the theme's semantic surface tokens (never hardcode
+  colors), and add help/description text. See the coherence mandate in
+  [`CLAUDE.md`](CLAUDE.md) and the design docs under `docs/`.
+- Run the full verify set locally before opening a PR:
+  `cargo check -p loregui`, `cargo fmt --all --check`,
+  `npm --prefix frontend run build`, `node frontend/scripts/palette-parity.mjs`.
+
+## Reporting bugs & requesting features
+
+Use the issue templates under
+[`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/). For security issues, do
+**not** open a public issue — follow [`SECURITY.md`](SECURITY.md).
+
+## Code of Conduct
+
+By participating, you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+[MIT License](LICENSE).

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,58 @@
+# Privacy
+
+**Short version: LoreGUI has no telemetry, no analytics, and no phone-home.** It
+is a local-first desktop application. Your repository data stays wherever your
+storage backend puts it. We don't collect it, and we never see it.
+
+## What LoreGUI does and does not do
+
+- **No analytics or usage telemetry.** LoreGUI does not embed an analytics SDK,
+  does not send usage events, crash pings, or "anonymous statistics" anywhere,
+  and has no account or sign-in. There is nothing to opt out of.
+- **No background phone-home.** The app does not call back to BiloxiStudios,
+  BrainDeadGuild, or any first-party service on launch or in the background.
+- **Local-first by design.** LoreGUI binds the `lore` engine in-process. The
+  network traffic it makes is the traffic *you* direct: talking to the lore
+  server you connect to or host, and to the storage backend you configure.
+- **Your data stays where your storage backend is.** Repository contents,
+  revisions, and assets live in the lore server / storage you point LoreGUI at.
+  LoreGUI is a client and (optionally) a local host for that — it is not an
+  intermediary that copies your data elsewhere.
+
+## A note on "telemetry" in the server config
+
+When you use the **Host a server** flow, LoreGUI generates a `loreserver` TOML
+that includes a `[telemetry]` section. That is **`loreserver`'s own logging and
+metrics configuration** (log format, log output/file, and optional metrics
+endpoints you control) — it is *your server's* operational logging, written to
+where *you* choose. It is **not** LoreGUI analytics and it does not report
+anything to us. You own that server and its logs.
+
+## Network connections LoreGUI makes
+
+All network activity is initiated by your actions, not by background collection:
+
+- **The lore server you connect to or host** — for version-control operations
+  (status, commit, branch, sync, locks, …).
+- **The storage backend you configure** — content-addressed object storage for
+  assets and revisions.
+- **GitHub Releases** — only when you choose to check for or download an update.
+
+## Third-party services
+
+LoreGUI does not integrate any third-party analytics, advertising, or tracking
+services. The optional MCP server runs locally and is driven by an AI agent that
+**you** configure; any data that agent sends to its own model provider is
+governed by that agent's and that provider's policies, not LoreGUI's.
+
+## Changes to this policy
+
+LoreGUI is open source under the MIT license. If the privacy posture ever
+changes, it will be a visible, reviewable change to this file in the public
+repository.
+
+## Questions
+
+Open a [discussion or issue](https://github.com/BiloxiStudios/loregui/issues), or
+reach the community via [BrainDeadGuild](https://braindeadguild.com/discord). For
+security concerns specifically, see [`SECURITY.md`](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,78 @@
+# Security Policy
+
+We take the security of LoreGUI seriously. LoreGUI is a desktop application that
+**bundles a `loreserver` sidecar** and **handles credentials for your lore
+repositories and storage backends**, so we treat vulnerability reports with
+priority.
+
+## Supported versions
+
+LoreGUI is pre-1.0 and under active development. Security fixes land on `main`
+and ship in the next signed release. Please test against the
+[latest release](https://github.com/BiloxiStudios/loregui/releases/latest) or a
+recent `main` build before reporting.
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Report privately using either of:
+
+1. **GitHub Private Vulnerability Reporting** — preferred. Go to the
+   [Security tab](https://github.com/BiloxiStudios/loregui/security/advisories/new)
+   and open a draft advisory. This keeps the report private until a fix is ready.
+2. **Email** — `security@braindeadguild.com` with a clear subject line. If you
+   want to encrypt, ask for a key in your first (non-sensitive) message.
+
+Please include, where possible:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce (a proof of concept helps a lot).
+- Affected version / commit, platform, and configuration.
+- Any relevant logs — but **redact credentials, tokens, and repo paths**.
+
+## What to expect
+
+- **Acknowledgement** within 5 business days.
+- An initial assessment and severity triage shortly after.
+- Coordinated disclosure: we'll agree on a timeline with you and credit you in
+  the advisory and release notes (unless you'd prefer to remain anonymous).
+
+We ask that you give us a reasonable window to ship a fix before any public
+disclosure.
+
+## Scope & sensitive surfaces
+
+LoreGUI's threat surface is mostly local, but a few areas warrant extra care:
+
+- **Bundled `loreserver` sidecar.** Releases bundle a real `loreserver` binary
+  that LoreGUI can launch when you host a server. Reports about how the sidecar
+  is launched, configured, or exposed on the network are in scope. (LoreGUI
+  *generates* the `loreserver` TOML — including network/QUIC/gRPC/HTTP and mTLS
+  replication settings — so misconfiguration paths that could expose a server
+  insecurely are relevant.)
+- **Repository & storage credentials.** LoreGUI connects to lore servers and
+  storage backends and may handle access tokens, keys, and mTLS material.
+  Issues around how this data is stored, logged, or transmitted are high
+  priority.
+- **MCP server.** The built-in MCP server exposes lore operations as tools to AI
+  agents. Reports about command/argument injection, path traversal, or
+  unintended capability exposure through the MCP surface are in scope.
+- **Tauri IPC / command surface.** The desktop shell exposes lore ops as Tauri
+  commands; issues that let untrusted content invoke privileged commands are in
+  scope.
+
+### Out of scope
+
+- The upstream `lore` engine itself — please report those to
+  [EpicGames/lore](https://github.com/EpicGames/lore). If a LoreGUI default or
+  the generated `loreserver` config makes an upstream issue materially worse,
+  that part is in scope here.
+- Vulnerabilities requiring a fully compromised local machine or physical access.
+- Findings from automated scanners without a demonstrated, realistic impact.
+
+## Privacy note
+
+LoreGUI is local-first and ships **no telemetry or analytics** — see
+[`PRIVACY.md`](PRIVACY.md). If you believe you've found code that exfiltrates
+data, that is squarely a security issue and we want to hear about it.


### PR DESCRIPTION
## Summary

Adds the standard open-source community & governance files ahead of LoreGUI's public launch. **No application code is touched** — docs and `.github/` only.

## What's included

- **CONTRIBUTING.md** — repo layout, prerequisites, how to build (`cargo tauri dev` / `build`, frontend install), the full test matrix (`cargo test -p lore-vm`, frontend + VS Code E2E, palette-parity, the `integration-tests`-gated `integration_roundtrip` / `e2e_lifecycle`), the CI gates (`ci.yml`, `integration.yml`, `vscode-test.yml`, `windows-build.yml`), branch/PR conventions, and the **upstream `lore` pin caveat** (exact-rev pin, mandatory `quinn-proto` `[patch]`, manager-owned bumps).
- **SECURITY.md** — private vulnerability disclosure (GitHub advisories + email), with explicit scope notes that the app **bundles the `loreserver` sidecar** and **handles repo/storage credentials**.
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1.
- **PRIVACY.md** — states the privacy posture plainly: **no telemetry, no analytics, no phone-home; local-first**, repo data stays where the user's storage backend is. Clarifies that the `loreserver` `[telemetry]` config is the user's own server logging, not app analytics (verified: the only `telemetry` references in the codebase are loreserver TOML config, not app analytics).
- **CODEOWNERS** — review routing for `crates/*` (engine), `src-tauri/*`, `frontend/*`, `vscode-extension/*`, `lore-mcp/*`, `website/*`, `docs/`, and the lore pin.
- **.github/ISSUE_TEMPLATE/** — `bug_report.yml` + `feature_request.yml` + `config.yml` (routes security reports to the private advisory flow).
- **.github/PULL_REQUEST_TEMPLATE.md** — mirrors the CONTRIBUTING checklist (fmt/clippy/test/build/palette-parity + coherence mandate).

All content matches the README's voice/tone and the real workflow described in `README.md`, `CLAUDE.md`, and `docs/IMPLEMENTATION-PLAN.md`. Issue-template YAML validated; markdown is well-formed.

Please review and merge at your discretion — opened, not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
