### PR TITLE
fix(vscode): harden diff baseline + binary/discard/branch UX

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loregui-lore",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loregui-lore",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/glob": "^8.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -151,7 +151,7 @@
       },
       {
         "command": "lore.discard",
-        "title": "Discard Changes",
+        "title": "Unstage (does not revert edits)",
         "category": "Lore",
         "icon": "$(discard)"
       },

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -538,9 +538,16 @@ class LoreRepository implements vscode.Disposable {
    * source_revision vs working and rely on the unified patch for rendering.
    */
   async baselineContent(rel: string, revision: string): Promise<string> {
+    // Binary files can't be rendered as a line diff — a utf8 read + reverse
+    // patch would yield mojibake. Short-circuit to a stable placeholder so the
+    // diff editor shows a graceful "binary file" notice on both sides instead.
+    const raw = this.readWorkingRaw(rel);
+    if (raw && isBinaryBuffer(raw)) {
+      return binaryPlaceholder(rel, raw.length);
+    }
     // Use file.diff with source = revision (or baseline) and target = working
     // to obtain the patch, then derive the "before" text from the working file.
-    const working = this.readWorking(rel);
+    const working = raw ? raw.toString('utf8') : '';
     const diff = await this.client
       .run<FileDiffEntry[]>('file.diff', {
         paths: [rel],
@@ -552,15 +559,42 @@ class LoreRepository implements vscode.Disposable {
       // No diff → baseline equals working.
       return working;
     }
-    return applyReversePatch(working, entry.patch);
+    try {
+      return applyReversePatch(working, entry.patch);
+    } catch (err) {
+      // LOUD failure: previously the patcher silently returned the working text,
+      // so a real change could render as "no change". Log it and fall back to the
+      // working text only as a last resort, but make the failure visible.
+      log(`applyReversePatch failed for ${rel} @ ${revision || 'baseline'}: ${describe(err)}`);
+      void vscode.window.showWarningMessage(
+        `Lore: could not reconstruct the baseline for ${path.basename(rel)}; ` +
+          'the diff may be incomplete (see the Lore output channel).',
+      );
+      return working;
+    }
+  }
+
+  /** Raw bytes of the working file, or undefined if it can't be read. */
+  readWorkingRaw(rel: string): Buffer | undefined {
+    try {
+      return fs.readFileSync(path.join(this.folder.uri.fsPath, rel));
+    } catch {
+      return undefined;
+    }
   }
 
   readWorking(rel: string): string {
-    try {
-      return fs.readFileSync(path.join(this.folder.uri.fsPath, rel), 'utf8');
-    } catch {
-      return '';
+    const raw = this.readWorkingRaw(rel);
+    return raw ? raw.toString('utf8') : '';
+  }
+
+  /** Whether the working file looks binary (NUL byte or a known binary ext). */
+  isBinaryWorking(rel: string): boolean {
+    if (hasBinaryExtension(rel)) {
+      return true;
     }
+    const raw = this.readWorkingRaw(rel);
+    return raw ? isBinaryBuffer(raw) : false;
   }
 
   dispose(): void {
@@ -645,23 +679,34 @@ function registerCommands(context: vscode.ExtensionContext): void {
     if (!repo || paths.length === 0) {
       return;
     }
+    // DISCARD SEMANTICS (documented choice):
+    // The dispatchable engine surface exposes NO per-file working-tree reset —
+    // `file.reset` and `revision.revert` are not in lorevm's dispatch table (see
+    // crates/lore-vm/src/dispatch.rs::supported_ops). The only reset primitive is
+    // `revision.sync { reset: true }`, which is TREE-WIDE (and its `root_files`
+    // arg pulls a dependency closure, so it can't safely scope to just the
+    // selected files). Rather than silently pretend to revert edits, we:
+    //   (a) UNSTAGE the selected files (the supported, file-scoped operation),
+    //   (b) make the confirmation say exactly that — it does NOT revert edits,
+    //   (c) point users at the real revert path ("Revert to Revision…").
+    // This keeps the label honest; a true scoped per-file revert is filed as a
+    // follow-up for when the engine routes `file.reset`.
     const confirm = await vscode.window.showWarningMessage(
-      `Discard staged changes to ${paths.length} file(s)?`,
+      `Unstage ${paths.length} file(s)? (Your edits are NOT reverted.)`,
       {
         modal: true,
         detail:
-          'This unstages the file(s) via the engine. To roll a file all the ' +
-          'way back to a committed revision, use "Compare with Revision…" or ' +
-          '"Sync (Pull)" with reset.',
+          'This removes the file(s) from the staged set; the working-tree edits ' +
+          'are left untouched. Lore has no per-file working-tree reset, so to ' +
+          'roll a file all the way back to a committed revision use ' +
+          '"Revert to Revision…" (resets the whole tree) or "Compare with ' +
+          'Revision…" to copy lines back manually.',
       },
-      'Discard',
+      'Unstage',
     );
-    if (confirm !== 'Discard') {
+    if (confirm !== 'Unstage') {
       return;
     }
-    // The dispatchable engine surface has no per-file working-tree reset
-    // (`file.reset`/`revision.revert` are not routed by lorevm). Unstaging is
-    // the supported discard primitive; tree-wide reset is Sync-with-reset.
     await guard(() => repo.client.run('file.unstage', { paths }));
     await repo.refresh();
   });
@@ -671,29 +716,10 @@ function registerCommands(context: vscode.ExtensionContext): void {
     if (!repo) {
       return;
     }
-    let message = repo.scm.inputBox.value.trim();
-    if (!message) {
-      message =
-        (await vscode.window.showInputBox({
-          prompt: 'Lore commit message',
-          placeHolder: 'Describe this revision',
-        })) ?? '';
-      message = message.trim();
-    }
-    if (!message) {
-      void vscode.window.showInformationMessage('Lore: commit aborted (empty message).');
-      return;
-    }
-    const result = await guard(() =>
-      repo.client.run<CommitResult>('revision.commit', { message }),
-    );
-    if (result) {
-      repo.scm.inputBox.value = '';
-      void vscode.window.showInformationMessage(
-        `Lore: checked in r${result.revision_number} on ${result.branch}.`,
-      );
-      await repo.refresh();
-    }
+    // If a message is passed directly (programmatic/tested path), use it;
+    // otherwise fall back to the SCM input box, then to an input-box prompt.
+    const direct = typeof arg === 'string' ? arg : undefined;
+    await commit(repo, direct);
   });
 
   reg('lore.openDiff', async (arg?: unknown) => {
@@ -836,11 +862,33 @@ function registerCommands(context: vscode.ExtensionContext): void {
     if (!name) {
       return;
     }
+    // lore stacks branches: branch.create AUTO-SWITCHES the working tree onto the
+    // new branch. Confirm so the user isn't silently moved off their current
+    // branch (this surprised people — surface it explicitly).
+    const current = repo.branchName;
+    const confirm = await vscode.window.showWarningMessage(
+      `Create branch "${name}" and switch to it now?`,
+      {
+        modal: true,
+        detail: current
+          ? `Lore stacks branches: creating "${name}" immediately switches your ` +
+            `working tree off "${current}" and onto the new branch.`
+          : 'Lore stacks branches: creating this branch immediately switches your ' +
+            'working tree onto it.',
+      },
+      'Create & Switch',
+    );
+    if (confirm !== 'Create & Switch') {
+      return;
+    }
     const res = await guard(() =>
       repo.client.run<BranchCreateResult>('branch.create', { branch: name }),
     );
     if (res) {
-      void vscode.window.showInformationMessage(`Lore: created branch ${res.name}.`);
+      void vscode.window.showInformationMessage(
+        `Lore: created branch ${res.name} and switched to it` +
+          (current ? ` (was on ${current}).` : '.'),
+      );
       await repo.refresh();
     }
   });
@@ -976,6 +1024,50 @@ function registerCommands(context: vscode.ExtensionContext): void {
   });
 }
 
+/**
+ * Check in the staged changes for `repo`.
+ *
+ * Message resolution (so the check-in path is testable without VS Code UI):
+ *   1. an explicit `message` argument, if provided and non-empty;
+ *   2. the SCM input box value;
+ *   3. an input-box prompt (interactive flow).
+ * An empty final message aborts. Returns the commit result (or undefined on
+ * abort/failure) so callers/tests can assert on it.
+ */
+export async function commit(
+  repo: LoreRepository,
+  message?: string,
+): Promise<CommitResult | undefined> {
+  let msg = (message ?? '').trim();
+  if (!msg) {
+    msg = repo.scm.inputBox.value.trim();
+  }
+  if (!msg) {
+    msg =
+      (
+        (await vscode.window.showInputBox({
+          prompt: 'Lore commit message',
+          placeHolder: 'Describe this revision',
+        })) ?? ''
+      ).trim();
+  }
+  if (!msg) {
+    void vscode.window.showInformationMessage('Lore: commit aborted (empty message).');
+    return undefined;
+  }
+  const result = await guard(() =>
+    repo.client.run<CommitResult>('revision.commit', { message: msg }),
+  );
+  if (result) {
+    repo.scm.inputBox.value = '';
+    void vscode.window.showInformationMessage(
+      `Lore: checked in r${result.revision_number} on ${result.branch}.`,
+    );
+    await repo.refresh();
+  }
+  return result;
+}
+
 // ---------------------------------------------------------------------------
 // Diff rendering (side-by-side + virtual baseline blob)
 // ---------------------------------------------------------------------------
@@ -992,6 +1084,25 @@ async function openDiff(
   revision: string,
 ): Promise<void> {
   const rel = path.relative(repo.folder.uri.fsPath, uri.fsPath);
+  // Binary files: never feed them to the line-diff machinery (it produces
+  // mojibake). Render a graceful "binary file — N bytes" notice on BOTH sides
+  // via the virtual doc provider so the editor shows the message, not garbage.
+  if (repo.isBinaryWorking(rel)) {
+    const bytes = repo.readWorkingRaw(rel)?.length ?? 0;
+    const notice = binaryPlaceholder(rel, bytes);
+    const left = buildBlobUri(repo.folder.uri.fsPath, rel, revision);
+    const right = buildBlobUri(repo.folder.uri.fsPath, rel, `${revision}~working`);
+    docProvider.set(left, notice);
+    docProvider.set(right, notice);
+    await vscode.commands.executeCommand(
+      'vscode.diff',
+      left,
+      right,
+      `${path.basename(rel)} (binary)`,
+      { preview: true },
+    );
+    return;
+  }
   const baseline = await guard(() => repo.baselineContent(rel, revision));
   if (baseline === undefined) {
     return;
@@ -1348,67 +1459,260 @@ function buildBlobUri(repoDir: string, rel: string, revision: string): vscode.Ur
 }
 
 // ---------------------------------------------------------------------------
+// Binary-file detection (so .uasset/image diffs don't render as mojibake)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extensions that are always treated as binary regardless of content sniffing.
+ * Covers Unreal asset/map containers and common image/media/archive formats —
+ * the files a lore game-dev repo most often holds that would diff as garbage.
+ */
+const BINARY_EXTENSIONS = new Set<string>([
+  // Unreal Engine
+  '.uasset', '.umap', '.ubulk', '.uexp', '.uptnl', '.upk', '.udk',
+  // Images
+  '.png', '.jpg', '.jpeg', '.gif', '.bmp', '.tga', '.tiff', '.tif',
+  '.psd', '.ico', '.webp', '.exr', '.hdr', '.dds',
+  // Audio / video
+  '.wav', '.mp3', '.ogg', '.flac', '.aiff', '.mp4', '.mov', '.avi', '.webm',
+  // 3D / fonts / archives / misc binaries
+  '.fbx', '.obj', '.blend', '.gltf', '.glb', '.ttf', '.otf', '.woff', '.woff2',
+  '.zip', '.gz', '.tar', '.7z', '.rar', '.pdf', '.bin', '.dll', '.so', '.dylib',
+  '.exe', '.wasm',
+]);
+
+/** True if `rel`'s extension is in the known-binary set. */
+export function hasBinaryExtension(rel: string): boolean {
+  return BINARY_EXTENSIONS.has(path.extname(rel).toLowerCase());
+}
+
+/**
+ * Heuristic binary sniff: a NUL byte in the first 8 KiB is the same signal git
+ * uses. Cheap, no full read interpretation, and robust for the asset/image
+ * files a lore repo holds. (UTF-16 text would trip this too — acceptable, since
+ * VS Code can't line-diff it usefully anyway.)
+ */
+export function isBinaryBuffer(buf: Buffer): boolean {
+  const n = Math.min(buf.length, 8192);
+  for (let i = 0; i < n; i++) {
+    if (buf[i] === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Human-readable placeholder shown on both sides of a binary diff. */
+export function binaryPlaceholder(rel: string, bytes: number): string {
+  return (
+    `Binary file — ${path.basename(rel)} (${bytes.toLocaleString()} bytes)\n` +
+    '\n' +
+    'Lore does not render a line-by-line diff for binary files.\n' +
+    'Open the file with its native tool to inspect changes.\n'
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Unified-patch reverse application (reconstruct the "before" text)
 // ---------------------------------------------------------------------------
 
 /**
+ * Thrown when a unified patch cannot be cleanly reverse-applied to the working
+ * text (line counts disagree, a context/added line doesn't match the working
+ * file, a hunk header is malformed, …). Callers MUST surface this rather than
+ * silently swallow it — a masked failure renders a real change as "no change".
+ */
+export class ReversePatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ReversePatchError';
+  }
+}
+
+/**
  * Reverse-apply a unified diff to working text to recover the baseline.
+ *
  * Given the working ("after") content and the patch that turns baseline into
  * working, produce the baseline ("before") content. This lets us render a real
  * left/right diff without a second engine round-trip for the blob.
  *
- * Tolerant: if hunks don't line up cleanly it falls back to returning the
- * working text (so the diff shows "no change" rather than corrupt content).
+ * Hardened (was: a tolerant best-effort that silently returned the working text
+ * on any mismatch — so a file with real changes could render as "no change"):
+ *
+ *  - Every context (` `) and added (`+`) hunk line is VALIDATED against the
+ *    working file at the expected position; a mismatch throws ReversePatchError
+ *    instead of producing corrupt or misleadingly-empty baseline text.
+ *  - Hunk `+`/`-`/context line counts are checked against the `@@` header.
+ *  - CRLF is preserved: line content (including any trailing `\r`) is compared
+ *    and reconstructed verbatim; only the `\n` record separator is split on.
+ *  - "\ No newline at end of file" markers are honoured so an added or removed
+ *    final newline round-trips exactly.
+ *  - add-only (baseline empty), delete-only (working empty) and multi-hunk
+ *    patches are all handled.
+ *
+ * On any inconsistency it THROWS; the caller (baselineContent) logs loudly and
+ * decides the fallback. It never silently masks a mismatch here.
  */
-function applyReversePatch(working: string, patch: string): string {
-  const lines = patch.split('\n');
-  const beforeAll = working.split('\n');
+export function applyReversePatch(working: string, patch: string): string {
+  // Model text as (lines[], finalNewline): "a\nb\n" -> (["a","b"], true);
+  // "a\nb" -> (["a","b"], false); "" -> ([], false). This lets us reconstruct
+  // a missing trailing newline exactly rather than guessing via join('\n').
+  const split = (s: string): { lines: string[]; finalNewline: boolean } => {
+    if (s === '') {
+      return { lines: [], finalNewline: false };
+    }
+    const finalNewline = s.endsWith('\n');
+    const body = finalNewline ? s.slice(0, -1) : s;
+    return { lines: body.split('\n'), finalNewline };
+  };
+
+  const work = split(working);
+  const patchLines = patch.split('\n');
+  // A patch string that ends with "\n" yields a trailing "" element — drop it;
+  // it is a record separator, not a hunk line.
+  if (patchLines.length > 0 && patchLines[patchLines.length - 1] === '') {
+    patchLines.pop();
+  }
+
   const result: string[] = [];
-  let cursor = 0; // index into beforeAll (the working/after lines)
+  // Final-newline tracking for the reconstructed BASELINE.
+  //   - baselineTailIsWorking: the baseline's last line was copied from the
+  //     working tail (no hunk touched EOF) → it inherits working's newline.
+  //   - lastBaselineNoNewline: the last baseline-side line a hunk emitted was
+  //     immediately followed by a "\ No newline at end of file" marker.
+  // A "\" marker applies to the line right before it; only a marker after a
+  // baseline-side ('-' or context) line tells us about the baseline's newline.
+  let baselineTailIsWorking = work.finalNewline;
+  let lastBaselineNoNewline = false;
+  let lastEmittedWasBaselineLine = false;
+  let cursor = 0; // 0-based index into work.lines (the "after" side)
   let i = 0;
 
   const hunkRe = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
 
-  while (i < lines.length) {
-    const m = hunkRe.exec(lines[i]);
+  while (i < patchLines.length) {
+    const header = patchLines[i];
+    // Skip file headers (---/+++/diff/index) and any preamble before a hunk.
+    const m = hunkRe.exec(header);
     if (!m) {
       i++;
       continue;
     }
-    const afterStart = parseInt(m[3], 10) - 1; // 0-based start in working
-    // Copy unchanged working lines up to this hunk.
-    while (cursor < afterStart && cursor < beforeAll.length) {
-      result.push(beforeAll[cursor++]);
+    const afterCount = m[4] === undefined ? 1 : parseInt(m[4], 10);
+    const beforeCount = m[2] === undefined ? 1 : parseInt(m[2], 10);
+    // Unified-diff uses a 1-based start; for an empty after side ("+N,0") the
+    // header line number is the line BEFORE the change, so clamp to 0-based.
+    const rawAfter = parseInt(m[3], 10);
+    const afterStart = afterCount === 0 ? rawAfter : rawAfter - 1;
+
+    if (afterStart < 0 || afterStart > work.lines.length) {
+      throw new ReversePatchError(
+        `hunk @@ +${afterStart + 1} starts past end of working text ` +
+          `(${work.lines.length} line(s))`,
+      );
+    }
+    // Emit unchanged working lines preceding this hunk into the baseline.
+    while (cursor < afterStart) {
+      if (cursor >= work.lines.length) {
+        throw new ReversePatchError(
+          `hunk @@ +${afterStart + 1} starts past working text while ` +
+            `copying leading context`,
+        );
+      }
+      result.push(work.lines[cursor++]);
     }
     i++;
-    // Process hunk body.
-    while (i < lines.length && !lines[i].startsWith('@@')) {
-      const ln = lines[i];
-      if (ln.startsWith('+')) {
-        // Added in working → drop from baseline; advance working cursor.
+
+    let seenAfter = 0; // working-side lines consumed by this hunk (+/context)
+    let seenBefore = 0; // baseline-side lines emitted by this hunk (-/context)
+    // Process the hunk body until the next header or EOF.
+    while (i < patchLines.length && !patchLines[i].startsWith('@@')) {
+      const ln = patchLines[i];
+      const kind = ln.length === 0 ? ' ' : ln[0];
+      const content = ln.length === 0 ? '' : ln.slice(1);
+      if (kind === '+') {
+        // Added in working → present on the after side, absent from baseline.
+        // Validate it matches the working file at the cursor, then skip it.
+        if (cursor >= work.lines.length || work.lines[cursor] !== content) {
+          throw new ReversePatchError(
+            `'+' line does not match working text at line ${cursor + 1}: ` +
+              `patch=${JSON.stringify(content)} ` +
+              `working=${JSON.stringify(work.lines[cursor])}`,
+          );
+        }
         cursor++;
-      } else if (ln.startsWith('-')) {
-        // Removed from working → present in baseline.
-        result.push(ln.slice(1));
-      } else if (ln.startsWith('\\')) {
-        // "No newline at end of file" marker — ignore.
+        seenAfter++;
+        lastEmittedWasBaselineLine = false; // '+' lines are working-only
+      } else if (kind === '-') {
+        // Removed from working → present in baseline only.
+        result.push(content);
+        seenBefore++;
+        baselineTailIsWorking = false;
+        lastEmittedWasBaselineLine = true;
+        lastBaselineNoNewline = false; // reset; a following "\" re-sets it
+      } else if (kind === '\\') {
+        // "\ No newline at end of file" — applies to the immediately preceding
+        // line. Only meaningful for the baseline if that line was baseline-side
+        // ('-' or context); a marker after a '+' line is about the working side.
+        if (lastEmittedWasBaselineLine) {
+          lastBaselineNoNewline = true;
+        }
+      } else if (kind === ' ') {
+        // Context line — present on both sides. Must match the working file.
+        if (cursor >= work.lines.length || work.lines[cursor] !== content) {
+          throw new ReversePatchError(
+            `context line does not match working text at line ${cursor + 1}: ` +
+              `patch=${JSON.stringify(content)} ` +
+              `working=${JSON.stringify(work.lines[cursor])}`,
+          );
+        }
+        result.push(content);
+        cursor++;
+        seenAfter++;
+        seenBefore++;
+        baselineTailIsWorking = false;
+        lastEmittedWasBaselineLine = true;
+        lastBaselineNoNewline = false;
       } else {
-        // Context line — present in both; emit and advance.
-        result.push(ln.startsWith(' ') ? ln.slice(1) : ln);
-        cursor++;
+        throw new ReversePatchError(
+          `unrecognised hunk line prefix ${JSON.stringify(kind)}: ${ln}`,
+        );
       }
       i++;
     }
+    // Validate the hunk consumed/produced the counts its header promised.
+    if (seenAfter !== afterCount) {
+      throw new ReversePatchError(
+        `hunk +count mismatch: header said ${afterCount}, saw ${seenAfter}`,
+      );
+    }
+    if (seenBefore !== beforeCount) {
+      throw new ReversePatchError(
+        `hunk -count mismatch: header said ${beforeCount}, saw ${seenBefore}`,
+      );
+    }
   }
-  // Trailing unchanged working lines.
-  while (cursor < beforeAll.length) {
-    result.push(beforeAll[cursor++]);
+  // Trailing unchanged working lines after the last hunk. These come from the
+  // working tail, so the baseline ends exactly as the working file does.
+  if (cursor < work.lines.length) {
+    while (cursor < work.lines.length) {
+      result.push(work.lines[cursor++]);
+    }
+    baselineTailIsWorking = true;
   }
-  // Sanity: if we produced nothing, fall back to working.
-  if (result.length === 0 && working.length > 0) {
-    return working;
+
+  if (result.length === 0) {
+    // A genuinely empty baseline (e.g. delete-only / a brand-new file's add)
+    // reverses to "". That is a valid result, NOT a failure to mask.
+    return '';
   }
-  return result.join('\n');
+  // Final newline: if the baseline's last line came from the working tail it
+  // ends like working; otherwise it ends with a newline unless the last
+  // baseline-side line carried a "\ No newline at end of file" marker.
+  const baselineFinalNewline = baselineTailIsWorking
+    ? work.finalNewline
+    : !lastBaselineNoNewline;
+  return result.join('\n') + (baselineFinalNewline ? '\n' : '');
 }
 
 // ---------------------------------------------------------------------------

--- a/vscode-extension/src/test/suite/applyReversePatch.test.ts
+++ b/vscode-extension/src/test/suite/applyReversePatch.test.ts
@@ -1,0 +1,225 @@
+// applyReversePatch.test.ts — table-driven unit tests for the hand-rolled
+// reverse-unified-diff used to reconstruct a file's baseline from its working
+// text + the engine's "baseline → working" patch.
+//
+// This codepath runs for EVERY diff a user opens and previously had ZERO tests.
+// It used to silently fall back to "show working text (no change)" on any
+// mismatch, so a file with real changes could render as "no changes". The
+// hardened version VALIDATES the patch against the working text and THROWS
+// (ReversePatchError) on inconsistency. These tests cover: multi-hunk, CRLF,
+// no-trailing-newline (both sides), add-only, delete-only, empty baseline, plus
+// the binary-detection helpers.
+
+import * as assert from 'assert';
+import {
+  applyReversePatch,
+  ReversePatchError,
+  hasBinaryExtension,
+  isBinaryBuffer,
+  binaryPlaceholder,
+} from '../../extension';
+
+// A unified-diff "patch" turns BASELINE into WORKING. Reverse-applying it to
+// WORKING must reproduce BASELINE. Each case below provides baseline + working
+// + the patch; the test reverse-applies and asserts it recovers baseline.
+interface Case {
+  name: string;
+  working: string;
+  patch: string;
+  expected: string; // the baseline we expect to reconstruct
+}
+
+const cases: Case[] = [
+  {
+    name: 'single hunk, one line changed',
+    working: 'alpha\nBETA\ngamma\n',
+    expected: 'alpha\nbeta\ngamma\n',
+    patch: ['@@ -1,3 +1,3 @@', ' alpha', '-beta', '+BETA', ' gamma', ''].join('\n'),
+  },
+  {
+    name: 'multi-hunk patch',
+    // baseline: l1..l8 ; working changes line2 and line7
+    working: ['one', 'TWO', 'three', 'four', 'five', 'six', 'SEVEN', 'eight', ''].join('\n'),
+    expected: ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', ''].join('\n'),
+    patch: [
+      '@@ -1,3 +1,3 @@',
+      ' one',
+      '-two',
+      '+TWO',
+      ' three',
+      '@@ -6,3 +6,3 @@',
+      ' six',
+      '-seven',
+      '+SEVEN',
+      ' eight',
+      '',
+    ].join('\n'),
+  },
+  {
+    name: 'CRLF line endings preserved',
+    working: 'a\r\nB\r\nc\r\n',
+    expected: 'a\r\nb\r\nc\r\n',
+    patch: ['@@ -1,3 +1,3 @@', ' a\r', '-b\r', '+B\r', ' c\r', ''].join('\n'),
+  },
+  {
+    name: 'no trailing newline on baseline (working added one)',
+    // baseline has no final newline; working added a newline + a line.
+    working: 'first\nsecond\n',
+    expected: 'first',
+    patch: [
+      '@@ -1 +1,2 @@',
+      '-first',
+      '\\ No newline at end of file',
+      '+first',
+      '+second',
+      '',
+    ].join('\n'),
+  },
+  {
+    name: 'no trailing newline on working (baseline had one)',
+    working: 'only',
+    expected: 'only\n',
+    patch: [
+      '@@ -1 +1 @@',
+      '-only',
+      '+only',
+      '\\ No newline at end of file',
+      '',
+    ].join('\n'),
+  },
+  {
+    name: 'add-only (baseline empty, working is a brand-new file)',
+    working: 'new line 1\nnew line 2\n',
+    expected: '',
+    patch: ['@@ -0,0 +1,2 @@', '+new line 1', '+new line 2', ''].join('\n'),
+  },
+  {
+    name: 'delete-only (working empty, baseline had content)',
+    working: '',
+    expected: 'gone 1\ngone 2\n',
+    patch: ['@@ -1,2 +0,0 @@', '-gone 1', '-gone 2', ''].join('\n'),
+  },
+  {
+    name: 'empty baseline AND empty working (no-op patch text)',
+    working: '',
+    expected: '',
+    patch: '',
+  },
+  {
+    name: 'patch with file headers before the hunk (--- / +++)',
+    working: 'x\nY\n',
+    expected: 'x\ny\n',
+    patch: [
+      'diff --git a/f b/f',
+      '--- a/f',
+      '+++ b/f',
+      '@@ -1,2 +1,2 @@',
+      ' x',
+      '-y',
+      '+Y',
+      '',
+    ].join('\n'),
+  },
+  {
+    name: 'pure addition into the middle of an existing file',
+    working: ['top', 'inserted', 'bottom', ''].join('\n'),
+    expected: ['top', 'bottom', ''].join('\n'),
+    patch: ['@@ -1,2 +1,3 @@', ' top', '+inserted', ' bottom', ''].join('\n'),
+  },
+  {
+    name: 'pure deletion from the middle of an existing file',
+    working: ['top', 'bottom', ''].join('\n'),
+    expected: ['top', 'removed', 'bottom', ''].join('\n'),
+    patch: ['@@ -1,3 +1,2 @@', ' top', '-removed', ' bottom', ''].join('\n'),
+  },
+];
+
+suite('applyReversePatch (baseline reconstruction)', () => {
+  for (const c of cases) {
+    test(c.name, () => {
+      const baseline = applyReversePatch(c.working, c.patch);
+      assert.strictEqual(
+        baseline,
+        c.expected,
+        `reverse-applying the patch to working text should reproduce baseline\n` +
+          `  working : ${JSON.stringify(c.working)}\n` +
+          `  patch   : ${JSON.stringify(c.patch)}\n` +
+          `  got     : ${JSON.stringify(baseline)}\n` +
+          `  expected: ${JSON.stringify(c.expected)}`,
+      );
+    });
+  }
+
+  // ---- Loud-failure cases: must THROW, not silently mask. ------------------
+
+  test('THROWS when a context line does not match the working text', () => {
+    // The context line " alpha" doesn't exist in the working text → the old
+    // code would have silently returned the working text (a masked failure).
+    const working = 'totally\ndifferent\n';
+    const patch = ['@@ -1,2 +1,2 @@', ' alpha', '-beta', '+BETA', ''].join('\n');
+    assert.throws(
+      () => applyReversePatch(working, patch),
+      ReversePatchError,
+      'a context-line mismatch must throw ReversePatchError, not be masked',
+    );
+  });
+
+  test('THROWS when a + line does not match the working text', () => {
+    const working = 'a\nNOTBETA\nc\n';
+    const patch = ['@@ -1,3 +1,3 @@', ' a', '-b', '+BETA', ' c', ''].join('\n');
+    assert.throws(() => applyReversePatch(working, patch), ReversePatchError);
+  });
+
+  test('THROWS on a hunk count mismatch (header lies about line counts)', () => {
+    // Header claims +1,3 but only two after-side lines follow.
+    const working = 'a\nc\n';
+    const patch = ['@@ -1,3 +1,3 @@', ' a', ' c', ''].join('\n');
+    assert.throws(() => applyReversePatch(working, patch), ReversePatchError);
+  });
+
+  test('round-trips a realistic multi-line edit deterministically', () => {
+    const baseline = 'function f() {\n  return 1;\n}\n';
+    const working = 'function f() {\n  return 2;\n}\n';
+    const patch = [
+      '@@ -1,3 +1,3 @@',
+      ' function f() {',
+      '-  return 1;',
+      '+  return 2;',
+      ' }',
+      '',
+    ].join('\n');
+    assert.strictEqual(applyReversePatch(working, patch), baseline);
+  });
+});
+
+suite('binary-file detection', () => {
+  test('hasBinaryExtension matches known binary extensions (case-insensitive)', () => {
+    assert.ok(hasBinaryExtension('Content/Hero.uasset'));
+    assert.ok(hasBinaryExtension('maps/Level.UMAP'));
+    assert.ok(hasBinaryExtension('art/icon.PNG'));
+    assert.ok(!hasBinaryExtension('docs/lore.md'));
+    assert.ok(!hasBinaryExtension('src/main.rs'));
+    assert.ok(!hasBinaryExtension('noextension'));
+  });
+
+  test('isBinaryBuffer detects a NUL byte in the sniff window', () => {
+    assert.ok(isBinaryBuffer(Buffer.from([0x41, 0x00, 0x42])), 'NUL byte → binary');
+    assert.ok(!isBinaryBuffer(Buffer.from('plain ascii text', 'utf8')));
+    assert.ok(!isBinaryBuffer(Buffer.from('', 'utf8')), 'empty buffer is not binary');
+  });
+
+  test('isBinaryBuffer only sniffs the first 8 KiB (NUL past the window is ignored)', () => {
+    const buf = Buffer.alloc(10000, 0x41); // 'A' * 10000
+    buf[9000] = 0x00; // NUL beyond the 8 KiB sniff window
+    assert.ok(!isBinaryBuffer(buf), 'NUL past 8 KiB is not sniffed');
+    buf[100] = 0x00; // NUL inside the window
+    assert.ok(isBinaryBuffer(buf), 'NUL inside 8 KiB is detected');
+  });
+
+  test('binaryPlaceholder reports the basename and byte count', () => {
+    const msg = binaryPlaceholder('Content/Sub/Hero.uasset', 12345);
+    assert.ok(msg.includes('Hero.uasset'), 'shows the file basename');
+    assert.ok(msg.includes('12,345 bytes'), 'shows a humanised byte count');
+    assert.ok(!msg.includes('Content/Sub/'), 'shows basename only, not full path');
+  });
+});


### PR DESCRIPTION
Fixes the highest-risk correctness/UX issues in the VS Code lore extension (`vscode-extension/src/extension.ts`). Diff is minimal and well-commented; new unit tests added.

## What changed

1. **`applyReversePatch` (the diff baseline reconstructor) — was silently masking real changes.** It runs for *every* diff a user opens and had zero tests. On any hunk mismatch it silently returned the working text, so a file with real changes could render as **"no changes."** Now:
   - every context (` `) and added (`+`) line is **validated** against the working text;
   - hunk `+`/`-`/context counts are checked against the `@@` header;
   - it **throws `ReversePatchError`** on inconsistency instead of masking it;
   - CRLF, no-trailing-newline (both sides), add-only, delete-only, empty-baseline, multi-hunk, and file-header preambles are all handled exactly.
   - `baselineContent()` catches the error, **logs it loudly + warns the user**, and only then falls back — the failure is no longer invisible.
   - **19 new table-driven unit tests** in `src/test/suite/applyReversePatch.test.ts`.

2. **Binary files.** `readWorking` forced utf8 + a line diff, so a `.uasset`/image diff rendered as mojibake. Added NUL-byte sniffing (first 8 KiB) + a known-binary-extension set (Unreal `.uasset/.umap/...`, images, audio/video, archives). `openDiff` and `baselineContent` now show a graceful **"Binary file — N bytes"** notice on both sides.

3. **Discard semantics (documented choice).** "Discard Changes" only **unstaged** — it never reverted edits, breaking trust. The engine dispatch table exposes **no per-file working-tree reset** (`file.reset`/`revision.revert` are not in `crates/lore-vm/src/dispatch.rs::supported_ops`; the only reset is tree-wide `revision.sync { reset: true }`). Rather than fake a revert, the command + confirmation are **relabeled to say exactly what they do** (unstage; edits untouched) and point users at the real **"Revert to Revision…"** path. Title in `package.json` updated to match. Choice documented inline.

4. **`branch.create` auto-switches** (lore stacks branches). Added an explicit **"Create & Switch"** confirmation modal + a post-create notification naming the branch the user was moved off.

5. **`commit()` refactor.** Extracted a testable `commit(repo, message?)` helper that takes an optional message arg while preserving the SCM input-box / prompt flow.

## Verification
- `npm run compile` + `npm run compile-tests` clean.
- Full VS Code test suite green: **41 passing** (existing SCM E2E + missing-binary + known-bug guards, plus the new `applyReversePatch` + binary-detection tests) under `xvfb-run npm test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)