### PR TITLE
Harden vscode-extension lorevmClient (envelope parse, timeout, no input mutation)

### DIFF
--- a/vscode-extension/src/lorevmClient.ts
+++ b/vscode-extension/src/lorevmClient.ts
@@ -53,11 +53,96 @@ export interface LorevmClientOptions {
   loreguiDirs?: string[];
   /** Absolute path to the extension's installation root (context.extensionPath). */
   extensionPath?: string;
-  /** Per-invocation timeout in ms (default 120s, matching lore-mcp). */
+  /**
+   * Per-invocation timeout in ms. When unset, defaults to 120s for local ops
+   * and 600s for network ops (revision.sync / branch.push). An explicit value
+   * overrides both.
+   */
   timeoutMs?: number;
 }
 
 const BIN_NAME = process.platform === 'win32' ? 'lorevm.exe' : 'lorevm';
+
+/** Default per-invocation timeout for local ops (ms). Matches lore-mcp. */
+const DEFAULT_TIMEOUT_MS = 120_000;
+/**
+ * Larger default for network ops (sync / push). These contact a remote lore
+ * server and can legitimately run well past the 120s local default; killing
+ * them mid-transfer is worse than waiting.
+ */
+const NETWORK_TIMEOUT_MS = 600_000;
+/** Grace period between SIGTERM and the hard SIGKILL on timeout (ms). */
+const KILL_GRACE_MS = 2_000;
+
+/** True for op ids that perform network I/O and warrant a larger timeout. */
+function isNetworkOp(opId: string): boolean {
+  return opId === 'revision.sync' || opId === 'branch.push';
+}
+
+/** Strip a leading UTF-8 BOM (U+FEFF) if present. */
+function stripBom(s: string): string {
+  return s.charCodeAt(0) === 0xfeff ? s.slice(1) : s;
+}
+
+/**
+ * Recover the structured lorevm JSON envelope from possibly-noisy stdout.
+ *
+ * lorevm is supposed to print exactly one JSON object on stdout, but stray
+ * lines (progress text, a leftover BOM, or multiple JSON objects) make a naive
+ * `JSON.parse(stdout)` throw — masking the real engine error as a generic
+ * `kind:'parse'`. Instead we scan candidate lines from LAST to FIRST and return
+ * the first that parses to an object, preferring one that carries an `error`
+ * key (the structured failure shape). Whole-string parse is tried first so a
+ * normal single-object result is unaffected.
+ *
+ * Returns the parsed object, or `undefined` if nothing parses to an object.
+ */
+export function recoverEnvelope(stdout: string): Record<string, unknown> | undefined {
+  const cleaned = stripBom(stdout);
+
+  const tryParse = (candidate: string): Record<string, unknown> | undefined => {
+    const t = stripBom(candidate).trim();
+    if (!t) {
+      return undefined;
+    }
+    try {
+      const v = JSON.parse(t);
+      // lorevm's contract is always a JSON object envelope — reject arrays and
+      // scalars so a stray `[...]` / number line isn't mistaken for a result.
+      if (v && typeof v === 'object' && !Array.isArray(v)) {
+        return v as Record<string, unknown>;
+      }
+    } catch {
+      // not JSON; caller keeps scanning
+    }
+    return undefined;
+  };
+
+  // Fast path: the whole (trimmed) output is a single JSON object.
+  const whole = tryParse(cleaned);
+  if (whole) {
+    return whole;
+  }
+
+  // Scan lines from last to first, collecting every object that parses. Prefer
+  // one that contains an `error` key so a structured engine error wins over a
+  // stray progress object.
+  let firstObject: Record<string, unknown> | undefined;
+  const lines = cleaned.split(/\r?\n/);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const obj = tryParse(lines[i]);
+    if (!obj) {
+      continue;
+    }
+    if ('error' in obj) {
+      return obj;
+    }
+    if (!firstObject) {
+      firstObject = obj;
+    }
+  }
+  return firstObject;
+}
 
 /**
  * Resolve the `lorevm` binary the same way lore-mcp does:
@@ -89,7 +174,9 @@ export function resolveLorevmBin(opts: {
     return onPath;
   }
 
-  const dirs = opts.loreguiDirs ?? [];
+  // Defensive copy: never mutate the caller-provided array, or repeated calls
+  // would accumulate duplicate LOREGUI_DIR entries.
+  const dirs = opts.loreguiDirs ? [...opts.loreguiDirs] : [];
   if (process.env.LOREGUI_DIR) {
     dirs.push(process.env.LOREGUI_DIR);
   }
@@ -193,38 +280,53 @@ export class LorevmClient {
 
     const { stdout, stderr, code } = await this.spawn(bin, argv);
 
-    const out = stdout.trim();
+    const out = stripBom(stdout).trim();
     if (out) {
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(out);
-      } catch {
+      // Tolerant recovery: scan stdout (last→first, BOM-stripped) for the JSON
+      // envelope rather than parsing the whole buffer, so stray progress lines
+      // or a leading BOM don't mask a real structured engine error.
+      const parsed = recoverEnvelope(stdout);
+      if (parsed) {
+        if ('error' in parsed) {
+          const body = (parsed as { error: LorevmErrorBody }).error;
+          throw new LorevmError(
+            body && typeof body === 'object'
+              ? body
+              : { kind: 'unknown', message: String(body) },
+          );
+        }
+        return parsed as TResult;
+      }
+
+      // Nothing in stdout parsed to an object. If the process also failed,
+      // surface stderr as an exec error (more useful than a generic parse
+      // error); otherwise report the unparseable output, with raw streams
+      // attached for diagnostics.
+      const trimmedErr = stderr.trim();
+      if (code !== 0 && code !== null) {
         throw new LorevmError({
-          kind: 'parse',
-          message: 'lorevm produced non-JSON output',
+          kind: 'exec',
+          message: trimmedErr || `lorevm exited ${code} with non-JSON output`,
           stdout: out,
-          stderr: stderr.trim(),
+          stderr: trimmedErr,
+          code,
         });
       }
-      if (
-        parsed &&
-        typeof parsed === 'object' &&
-        'error' in (parsed as Record<string, unknown>)
-      ) {
-        const body = (parsed as { error: LorevmErrorBody }).error;
-        throw new LorevmError(
-          body && typeof body === 'object'
-            ? body
-            : { kind: 'unknown', message: String(body) },
-        );
-      }
-      return parsed as TResult;
+      throw new LorevmError({
+        kind: 'parse',
+        message: 'lorevm produced non-JSON output',
+        stdout: out,
+        stderr: trimmedErr,
+        code,
+      });
     }
 
     // No stdout — surface stderr / exit code.
     throw new LorevmError({
       kind: 'exec',
       message: stderr.trim() || `lorevm exited ${code}`,
+      stderr: stderr.trim(),
+      code,
     });
   }
 
@@ -233,7 +335,11 @@ export class LorevmClient {
     bin: string,
     argv: string[],
   ): Promise<{ stdout: string; stderr: string; code: number | null }> {
-    const timeoutMs = this.opts.timeoutMs ?? 120_000;
+    // Explicit override wins; otherwise pick a default by op kind. argv[0] is
+    // the op id (e.g. "revision.sync").
+    const timeoutMs =
+      this.opts.timeoutMs ??
+      (isNetworkOp(argv[0]) ? NETWORK_TIMEOUT_MS : DEFAULT_TIMEOUT_MS);
     return new Promise((resolve, reject) => {
       const child = spawn(bin, argv, {
         cwd: this.opts.repoDir,
@@ -243,17 +349,30 @@ export class LorevmClient {
       let stdout = '';
       let stderr = '';
       let settled = false;
+      let killTimer: NodeJS.Timeout | undefined;
 
       const timer = setTimeout(() => {
         if (settled) {
           return;
         }
         settled = true;
-        child.kill('SIGKILL');
+        // Graceful shutdown: SIGTERM first so the engine can finish/rollback an
+        // in-flight write, then a hard SIGKILL after a short grace if it hangs.
+        child.kill('SIGTERM');
+        killTimer = setTimeout(() => {
+          if (!child.killed) {
+            child.kill('SIGKILL');
+          }
+        }, KILL_GRACE_MS);
+        // Unref so the grace timer never keeps the host process alive.
+        killTimer.unref?.();
         reject(
           new LorevmError({
             kind: 'timeout',
             message: `${argv[0]} timed out after ${timeoutMs}ms`,
+            stdout: stripBom(stdout).trim(),
+            stderr: stderr.trim(),
+            timeoutMs,
           }),
         );
       }, timeoutMs);
@@ -267,6 +386,9 @@ export class LorevmClient {
         }
         settled = true;
         clearTimeout(timer);
+        if (killTimer) {
+          clearTimeout(killTimer);
+        }
         reject(
           new LorevmError({
             kind: 'exec',

--- a/vscode-extension/src/test/suite/lorevmClient.test.ts
+++ b/vscode-extension/src/test/suite/lorevmClient.test.ts
@@ -1,0 +1,116 @@
+// lorevmClient.test.ts — pure unit tests for the lorevmClient hardening
+// (fix/vscode-lorevmclient-hardening). These exercise the engine-agnostic
+// primitives directly (no VS Code APIs, no real lorevm spawn):
+//
+//   1. recoverEnvelope() — tolerant JSON-envelope recovery from noisy stdout
+//      (stray progress lines, leading BOM, multiple JSON objects), preferring a
+//      structured `error` envelope so a real engine error is never masked.
+//   2. resolveLorevmBin() — must NOT mutate the caller-provided loreguiDirs
+//      array (no accumulating duplicate LOREGUI_DIR entries across calls).
+//
+// We import from the compiled JS, the same way missingBinary.test.ts does.
+
+import * as assert from 'assert';
+import * as path from 'path';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const lorevmClient = require(path.resolve(__dirname, '../../lorevmClient.js')) as {
+  recoverEnvelope: (stdout: string) => Record<string, unknown> | undefined;
+  resolveLorevmBin: (opts: {
+    binPath?: string;
+    loreguiDirs?: string[];
+    extensionPath?: string;
+  }) => string | null;
+};
+
+suite('lorevmClient — envelope-parse recovery', function () {
+  const { recoverEnvelope } = lorevmClient;
+
+  test('parses a clean single-object result', () => {
+    const env = recoverEnvelope('{"ok": true, "value": 42}');
+    assert.deepStrictEqual(env, { ok: true, value: 42 });
+  });
+
+  test('recovers the JSON object when stray progress text precedes it', () => {
+    const stdout = 'syncing...\nfetching index\n{"files_updated": 3}';
+    const env = recoverEnvelope(stdout);
+    assert.deepStrictEqual(env, { files_updated: 3 });
+  });
+
+  test('strips a leading BOM before parsing', () => {
+    const env = recoverEnvelope('﻿{"ok": true}');
+    assert.deepStrictEqual(env, { ok: true });
+  });
+
+  test('strips a BOM that appears on the JSON line amid noise', () => {
+    const env = recoverEnvelope('progress\n﻿{"ok": true}');
+    assert.deepStrictEqual(env, { ok: true });
+  });
+
+  test('prefers an envelope containing an `error` key over a stray object', () => {
+    // A stray progress object appears AFTER the structured error. last→first
+    // scanning would hit the stray object first; the `error` preference must
+    // still win so the real engine error is surfaced.
+    const stdout =
+      '{"error": {"kind": "lock", "message": "file is locked"}}\n' +
+      '{"progress": "done"}';
+    const env = recoverEnvelope(stdout);
+    assert.ok(env && 'error' in env, 'must recover the error envelope');
+    assert.deepStrictEqual(env.error, { kind: 'lock', message: 'file is locked' });
+  });
+
+  test('returns the last object when multiple non-error objects are present', () => {
+    const stdout = '{"step": 1}\n{"step": 2}\n{"final": true}';
+    const env = recoverEnvelope(stdout);
+    assert.deepStrictEqual(env, { final: true });
+  });
+
+  test('returns undefined when nothing parses to an object', () => {
+    assert.strictEqual(recoverEnvelope('not json at all'), undefined);
+    assert.strictEqual(recoverEnvelope(''), undefined);
+    // A bare JSON array/number/string is not an object envelope.
+    assert.strictEqual(recoverEnvelope('[1,2,3]'), undefined);
+    assert.strictEqual(recoverEnvelope('42'), undefined);
+  });
+
+  test('tolerates CRLF line endings', () => {
+    const env = recoverEnvelope('progress\r\n{"ok": true}\r\n');
+    assert.deepStrictEqual(env, { ok: true });
+  });
+});
+
+suite('lorevmClient — resolveLorevmBin does not mutate input', function () {
+  const { resolveLorevmBin } = lorevmClient;
+
+  test('does not push LOREGUI_DIR onto the caller-provided loreguiDirs array', () => {
+    const savedEnv = process.env.LOREVM_BIN;
+    const savedPath = process.env.PATH;
+    const savedLoregui = process.env.LOREGUI_DIR;
+    try {
+      // Force every other resolution source to miss so the LOREGUI_DIR branch
+      // (the one that used to mutate `dirs`) is exercised.
+      delete process.env.LOREVM_BIN;
+      process.env.PATH = '';
+      process.env.LOREGUI_DIR = '/nonexistent/loregui-env';
+
+      const dirs = ['/nonexistent/a', '/nonexistent/b'];
+      const before = [...dirs];
+
+      // Call twice: a mutating impl would grow the array on each call.
+      resolveLorevmBin({ loreguiDirs: dirs });
+      resolveLorevmBin({ loreguiDirs: dirs });
+
+      assert.deepStrictEqual(
+        dirs,
+        before,
+        'resolveLorevmBin must not mutate the caller-provided loreguiDirs array',
+      );
+    } finally {
+      if (savedEnv !== undefined) process.env.LOREVM_BIN = savedEnv;
+      else delete process.env.LOREVM_BIN;
+      process.env.PATH = savedPath;
+      if (savedLoregui !== undefined) process.env.LOREGUI_DIR = savedLoregui;
+      else delete process.env.LOREGUI_DIR;
+    }
+  });
+});


### PR DESCRIPTION
Fixes three confirmed bugs in `vscode-extension/src/lorevmClient.ts` (this file only — `extension.ts` deliberately untouched, it's owned by open PRs #334/#335).

## 1. MEDIUM — brittle error-envelope parse
`run()` did `JSON.parse(stdout.trim())` over the **entire** stdout, so any stray stdout line / BOM / progress text / multiple JSON objects threw and the real structured engine error was masked as a generic `kind:'parse'` "non-JSON output".

- New exported `recoverEnvelope(stdout)`: strips a leading BOM, then scans stdout lines **last → first**, `JSON.parse`-ing each trimmed candidate and accepting the first that parses to an object — **preferring one that contains an `error` key** so a structured engine error always wins over a stray progress object. Arrays/scalars are rejected (the lorevm contract is always a JSON object).
- If nothing parses **and** the process exited non-zero, surface stderr as `kind:'exec'` instead of the generic parse error.
- Raw `stdout`/`stderr`/`code` are attached to thrown errors for diagnostics.

## 2. LOW — hard 120s SIGKILL on timeout
The per-invocation timeout force-killed all ops (incl. network sync/push) with `SIGKILL` and a generic error.

- Now **SIGTERM-then-SIGKILL** with a short grace (`KILL_GRACE_MS = 2s`) so the engine can finish / roll back an in-flight write before the hard kill.
- The timeout error now includes the accumulated `stdout`/`stderr` (and `timeoutMs`).
- Network ops (`revision.sync` / `branch.push`) get a larger default timeout (600s vs 120s local). An explicit `timeoutMs` still overrides both.
- `makeClient`/config wiring lives in `extension.ts` and is left as a **noted follow-up** — not touched here.

## 3. LOW — resolveLorevmBin mutated caller input
`resolveLorevmBin` pushed `process.env.LOREGUI_DIR` onto the caller-provided `loreguiDirs` array, accumulating duplicate entries across repeated calls. Now takes a defensive copy (`const dirs = opts.loreguiDirs ? [...opts.loreguiDirs] : []`).

## Tests
New `src/test/suite/lorevmClient.test.ts` — pure unit tests (no VS Code host, import compiled JS like `missingBinary.test.ts`):
- envelope-parse recovery: clean object, stray-progress prefix, leading BOM, BOM amid noise, `error`-key preference, last-object selection, undefined for non-JSON / array / scalar, CRLF tolerance
- `resolveLorevmBin` non-mutation across two calls

## Verification
- `npm run compile`, `npm run compile-tests`, `npm run lint` (tsc) all pass clean.
- New unit tests: **9 passing** via mocha (`out-test/test/suite/lorevmClient.test.js`).
- The full E2E suite (`npm test`) requires a built Rust `lorevm` binary + a downloaded VS Code Electron + xvfb display, none available in this sandbox; it is unaffected by these logic-only changes and the whole suite compiles.

Diff is confined to `lorevmClient.ts` + the new test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)