### PR TITLE
fix(lorevm-ffi,lore-vm): serialise FFI dispatch+finalize, clear failed get buffer, correct put lifetime comment

### DIFF
--- a/crates/lore-vm/src/ops/storage/get.rs
+++ b/crates/lore-vm/src/ops/storage/get.rs
@@ -179,6 +179,13 @@ pub async fn storage_get(api: &LoreApi, args: StorageGetArgs) -> Result<StorageG
                 let accum = c.items.entry(ic.id).or_default();
                 accum.ok = ok;
                 accum.error = error;
+                // A failed item must not surface a partially-reassembled buffer:
+                // any GET_DATA fragments accumulated before the failure are
+                // incomplete/meaningless, so drop them. Callers see empty `data`
+                // alongside `ok == false`.
+                if !ok {
+                    accum.data.clear();
+                }
                 if !accum.seen_header {
                     accum.address = format!("{}", ic.address);
                 }

--- a/crates/lore-vm/src/ops/storage/put.rs
+++ b/crates/lore-vm/src/ops/storage/put.rs
@@ -119,13 +119,17 @@ fn build_lore_item(
 /// Calls upstream [`lore::storage::put::put`] in-process and collects the
 /// `StoragePutItemComplete` events to build a typed result.
 pub async fn put(api: &LoreApi, args: StoragePutArgs) -> Result<StoragePutResult> {
-    // Keep owned byte vectors alive for the duration of the call so the raw
-    // pointers inside `LoreBytes` remain valid until `Complete` fires.
-    let owned_bufs: Vec<&[u8]> = args.items.iter().map(|i| i.data.as_slice()).collect();
+    // The bytes the `LoreBytes` raw pointers refer to are owned by `args.items`
+    // (each `PutItem::data` is an owned `Vec<u8>`). These borrowed slices own
+    // nothing — they merely view into `args`, so `args` MUST stay alive and
+    // unmoved until the put completes (`Complete` fires). It does: `args` is a
+    // by-value parameter that lives for this whole function, past the `.await`s
+    // below, so the pointers remain valid for the duration of the call.
+    let item_slices: Vec<&[u8]> = args.items.iter().map(|i| i.data.as_slice()).collect();
 
     let mut lore_items: Vec<LoreStoragePutItem> = Vec::with_capacity(args.items.len());
 
-    for (item, buf) in args.items.iter().zip(owned_bufs.iter()) {
+    for (item, buf) in args.items.iter().zip(item_slices.iter()) {
         lore_items.push(build_lore_item(item, buf.as_ptr(), buf.len())?);
     }
 

--- a/crates/lorevm-ffi/src/lib.rs
+++ b/crates/lorevm-ffi/src/lib.rs
@@ -64,8 +64,27 @@
 //! - **Threading.** `lorevm_ffi_call` blocks the calling thread for the op's
 //!   duration (it `block_on`s the op on the handle's runtime). A UE host MUST call
 //!   it from a background thread, never the game thread. The handle is `Send` +
-//!   `Sync` and the warm `LoreApi` is cheap to clone, so concurrent calls on one
-//!   handle are sound (each enters the shared runtime).
+//!   `Sync`, so it is safe to *share* a handle pointer across threads and to make
+//!   concurrent calls on it.
+//!
+//!   However, each call is **not** a single atomic operation against the store: it
+//!   runs `lore_vm::dispatch(...).await` and then `lore_vm::finalize(...).await`,
+//!   and `finalize` is a *global, store-wide* flush (it drains every outstanding
+//!   guarded task for the repo, not just this op's). If two mutating calls on the
+//!   same handle (or on two handles rooted at the same working dir) ran
+//!   concurrently, their `dispatch`/`finalize` phases could interleave — one
+//!   call's flush could drain the other's half-written state, corrupting the
+//!   store. Concurrent *mutating* calls against one repo are therefore **NOT**
+//!   sound and MUST be serialised.
+//!
+//!   This crate enforces that internally: every `lorevm_ffi_call` takes a
+//!   per-handle async mutex around the whole `dispatch` + `finalize` critical
+//!   section, so calls on one handle are serialised end-to-end and the
+//!   non-atomic dispatch→finalize sequence can never interleave. (Two *separate*
+//!   handles on the *same* dir still share the on-disk store and are not mutually
+//!   serialised — drive one repo through one handle.) Read-only calls are
+//!   serialised too; that is a deliberate simplicity/safety trade since
+//!   `finalize` is store-wide and cannot cheaply be classified as a no-op here.
 
 use std::ffi::{c_char, CStr, CString};
 use std::panic::{catch_unwind, AssertUnwindSafe};
@@ -87,6 +106,12 @@ const ABI_VERSION: &str = "lorevm-ffi/1\0";
 pub struct LorevmHandle {
     runtime: Runtime,
     api: LoreApi,
+    /// Serialises the `dispatch` + `finalize` critical section across concurrent
+    /// `lorevm_ffi_call`s on this handle. `finalize` is a store-wide flush, so
+    /// two calls' phases must never interleave — see the module "Threading"
+    /// docs. An async mutex (not `std::sync::Mutex`) so the guard can be held
+    /// across the `.await`s.
+    call_lock: tokio::sync::Mutex<()>,
 }
 
 /// Deserialised `lorevm_ffi_open` request: how to build the warm [`LoreApi`].
@@ -173,7 +198,11 @@ fn build_handle(request_str: &str) -> Option<LorevmHandle> {
         global = global.identity(id.clone());
     }
     let api = LoreApi::from_global(global);
-    Some(LorevmHandle { runtime, api })
+    Some(LorevmHandle {
+        runtime,
+        api,
+        call_lock: tokio::sync::Mutex::new(()),
+    })
 }
 
 /// Invoke `<domain>.<op>` with JSON args on a warm `handle`; return a malloc'd
@@ -241,7 +270,15 @@ fn run_call(handle: &LorevmHandle, op_id: &str, args_str: &str) -> Value {
     // mutable-store write (e.g. the staged-revision anchor) is durable before we
     // return — the same durability contract the `lorevm` CLI enforces per
     // process. See `lore_vm::finalize`.
+    //
+    // `dispatch` then `finalize` is NOT atomic, and `finalize` is a store-wide
+    // flush, so two concurrent calls on this handle must not interleave their
+    // phases. Hold the per-handle async mutex across both awaits to serialise the
+    // whole critical section. Acquired *inside* `block_on` so the future enters
+    // the runtime context; the guard is an async mutex and so may be held across
+    // the `.await`s.
     let result = handle.runtime.block_on(async {
+        let _guard = handle.call_lock.lock().await;
         let r = lore_vm::dispatch(&handle.api, op_id, args).await;
         lore_vm::finalize(&handle.api).await;
         r


### PR DESCRIPTION
Confined to `crates/lorevm-ffi/src/lib.rs`, `crates/lore-vm/src/ops/storage/get.rs`, and `crates/lore-vm/src/ops/storage/put.rs`. No changes to `dispatch.rs`/`finalize` or `stage.rs`.

## 1. (MEDIUM) FFI: concurrent calls on one handle can corrupt the store

The `lorevm-ffi` module safety doc claimed concurrent calls on one handle are sound. They are not: each `lorevm_ffi_call` runs `lore_vm::dispatch(...).await` then `lore_vm::finalize(...).await` **non-atomically**, and `finalize` is a *global, store-wide* flush (`repository.flush`, draining every outstanding guarded task for the repo). Two concurrent mutating calls on one handle (or two handles rooted at the same dir) could interleave their dispatch/finalize phases — one call's flush draining the other's half-written state — and corrupt the store.

Fix:
- (a) Corrected the module "Threading" doc: concurrent *mutating* calls against one repo are **NOT** sound and must be serialised.
- (b) Added a per-handle `tokio::sync::Mutex` (`call_lock`) held across the whole `dispatch` + `finalize` critical section inside `block_on`, so calls on one handle are serialised end-to-end and the non-atomic sequence can never interleave. Read-only calls are serialised too (deliberate simplicity/safety trade — `finalize` is store-wide and can't cheaply be classed as a no-op here). `finalize` itself is untouched.

## 2. (LOW) storage/get: failed item carried partial data

A failed item (`ok == false`) still returned whatever partial `GET_DATA` fragments had been accumulated before the failure. Now `accum.data` is cleared when the item completes with `ok == false`, so callers see empty `data` alongside `ok == false`.

## 3. (LOW) storage/put: misattributed lifetime comment

`owned_bufs: Vec<&[u8]>` owns nothing — the "keep owned byte vectors alive" comment misattributed the lifetime. The bytes are owned by `args.items`. Renamed to `item_slices` and documented that `args` (the by-value parameter) is what must outlive `put().await` to keep the `LoreBytes` raw pointers valid.

## Deferred follow-up

FFI finalize is store-wide but does not target the specific storage *handle* opened by `storage open` — the finalize/flush path misses the open store handle's durability. Noted here as a deferred follow-up; not addressed in this PR.

## Verification

`cargo fmt --check`, `cargo check`, and `cargo clippy --all-targets` all clean on `-p lorevm-ffi -p lore-vm`. `cargo test` for both crates run as part of validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)