### PR TITLE
test(lore-vm): behavioral integration tests for the storage layer

### DIFF
--- a/crates/lore-vm/tests/storage_disk_roundtrip.rs
+++ b/crates/lore-vm/tests/storage_disk_roundtrip.rs
@@ -1,0 +1,377 @@
+//! Behavioral integration tests for the `storage` op layer against a REAL,
+//! disk-backed content-addressed store (SBAI storage-coverage work).
+//!
+//! The existing per-op unit tests only prove arg/result *serialisation*, and
+//! `integration_roundtrip::storage_roundtrip_against_real_lore` exercises a
+//! single in-memory `put → get → obliterate` happy path. This suite goes
+//! further: it drives the **file-oriented** storage ops (`put_file`,
+//! `get_file`, `get_metadata`, `flush`, `close`) against an **on-disk** store
+//! and asserts on real behaviour — byte-for-byte content integrity, the
+//! `(partition, context)` hex addressing contract, fragment metadata, and the
+//! large-file chunked-fragment path.
+//!
+//! Disk-backed (not in-memory) is the point: it is the closest stand-in for a
+//! self-hosted user's `.urc` store and a stronger guard against on-disk
+//! persistence/addressing regressions. The store is opened against a REAL repo
+//! created with `repository::create` + a shared store living OUTSIDE the
+//! working tree (mirroring `e2e_lifecycle`).
+//!
+//! Gated behind the `integration-tests` cargo feature exactly like
+//! `e2e_lifecycle.rs` and `integration_roundtrip.rs`:
+//!
+//! ```sh
+//! cargo test -p lore-vm --features integration-tests --test storage_disk_roundtrip
+//! ```
+#![cfg(feature = "integration-tests")]
+
+mod storage_support;
+
+use storage_support::{create_disk_repo, on_disk_api, DiskRepo, PARTITION, PARTITION_TWO};
+
+use lore_vm::ops;
+
+/// Open a disk-backed store handle against `repo`'s working tree. `in_memory`
+/// is false so the immutable/mutable stores live on disk under the repo.
+async fn open_disk_store(repo: &DiskRepo) -> u64 {
+    let opened = ops::storage::open::open(
+        &repo.api,
+        ops::storage::open::StorageOpenArgs {
+            repository_path: repo.repo_path.to_string_lossy().into_owned(),
+            in_memory: false,
+            remote_url: String::new(),
+            cache_target_bytes: 0,
+            cache_target_fragments: 0,
+        },
+    )
+    .await
+    .expect("storage::open should succeed against an on-disk repo");
+    assert!(
+        opened.handle != 0,
+        "open returned a zero handle: {opened:?}"
+    );
+    opened.handle
+}
+
+/// put_file → get_file → flush → get_metadata round trip on a disk store:
+/// asserts content integrity (bytes written out match bytes read back) and
+/// that the fragment metadata reports the right content size.
+#[tokio::test]
+async fn put_file_get_file_flush_metadata_roundtrip_on_disk() {
+    let repo = create_disk_repo("storage-disk", "alice").await;
+    let handle = open_disk_store(&repo).await;
+
+    // Source file on disk that we store into the content-addressed store.
+    const CONTENT: &[u8] = b"disk-backed storage round trip: the quick brown fox\n";
+    let src = repo.work.path().join("payload.bin");
+    storage_support::write_file(&src, CONTENT);
+
+    // ---- put_file ----------------------------------------------------------
+    let put = ops::storage::put_file::put_file(
+        &repo.api,
+        ops::storage::put_file::StoragePutFileArgs {
+            handle,
+            items: vec![ops::storage::put_file::PutFileItem {
+                id: 7,
+                partition: PARTITION.to_string(),
+                context: String::new(),
+                path: src.to_string_lossy().into_owned(),
+                remote_write: false,
+                local_cache: false,
+                fixed_size_chunk: 0,
+            }],
+        },
+    )
+    .await
+    .expect("storage::put_file should succeed on disk");
+    let put_item = put.items.first().expect("put_file returned no items");
+    assert!(put_item.ok, "put_file item reported error: {put_item:?}");
+    assert_eq!(put_item.id, 7, "put_file echoed the wrong id: {put_item:?}");
+    let address = put_item.address.clone();
+    assert!(
+        !address.is_empty(),
+        "put_file returned an empty address: {put_item:?}"
+    );
+
+    // ---- flush (fsync to disk) ---------------------------------------------
+    ops::storage::flush::flush(
+        &repo.api,
+        ops::storage::flush::StorageFlushArgs { handle },
+    )
+    .await
+    .expect("storage::flush should succeed on disk");
+
+    // ---- get_metadata ------------------------------------------------------
+    // Metadata is fetched without transferring payload bytes; assert the
+    // content size matches what we stored.
+    let meta = ops::storage::get_metadata::storage_get_metadata(
+        &repo.api,
+        ops::storage::get_metadata::StorageGetMetadataArgs {
+            handle,
+            items: vec![ops::storage::get_metadata::GetMetadataItem {
+                id: 7,
+                partition: PARTITION.to_string(),
+                address: address.clone(),
+            }],
+        },
+    )
+    .await
+    .expect("storage::get_metadata should succeed");
+    let meta_item = meta.items.first().expect("get_metadata returned no items");
+    assert!(meta_item.ok, "get_metadata reported error: {meta_item:?}");
+    let frag = meta_item
+        .fragment
+        .as_ref()
+        .expect("get_metadata should carry a fragment on success");
+    assert_eq!(
+        frag.size_content as usize,
+        CONTENT.len(),
+        "fragment content size must equal the stored byte count: {meta_item:?}"
+    );
+
+    // ---- get_file (write content back to a fresh path) ---------------------
+    let out = repo.work.path().join("restored.bin");
+    let got = ops::storage::get_file::storage_get_file(
+        &repo.api,
+        ops::storage::get_file::StorageGetFileArgs {
+            handle,
+            items: vec![ops::storage::get_file::GetFileItem {
+                id: 7,
+                partition: PARTITION.to_string(),
+                address: address.clone(),
+                path: out.to_string_lossy().into_owned(),
+                local_cache: false,
+            }],
+        },
+    )
+    .await
+    .expect("storage::get_file should succeed on disk");
+    let got_item = got.items.first().expect("get_file returned no items");
+    assert!(got_item.ok, "get_file item reported error: {got_item:?}");
+
+    // Content integrity: the file get_file wrote must be byte-identical.
+    let restored = std::fs::read(&out).expect("read restored file");
+    assert_eq!(
+        restored, CONTENT,
+        "get_file content mismatch: wrote {CONTENT:?}, read {restored:?}"
+    );
+
+    // Cleanup the handle.
+    ops::storage::close::close(
+        &repo.api,
+        ops::storage::close::StorageCloseArgs { handle },
+    )
+    .await
+    .expect("storage::close should succeed");
+}
+
+/// Hex `(partition, context)` addressing contract: storing the SAME bytes under
+/// a non-zero dedup context yields a *different* address than the zero-context
+/// store, and each address is independently retrievable from its own partition.
+#[tokio::test]
+async fn partition_and_context_hex_addressing() {
+    let repo = create_disk_repo("storage-ctx", "alice").await;
+    let handle = open_disk_store(&repo).await;
+
+    const CONTENT: &[u8] = b"same bytes, different context\n";
+    let src = repo.work.path().join("ctx.bin");
+    storage_support::write_file(&src, CONTENT);
+
+    let non_zero_ctx = "ffffffffffffffffffffffffffffffff";
+
+    // Store the same source file twice: once with zero context (default), once
+    // with an explicit non-zero context. Different partitions, distinct ids.
+    let put = ops::storage::put_file::put_file(
+        &repo.api,
+        ops::storage::put_file::StoragePutFileArgs {
+            handle,
+            items: vec![
+                ops::storage::put_file::PutFileItem {
+                    id: 1,
+                    partition: PARTITION.to_string(),
+                    context: String::new(),
+                    path: src.to_string_lossy().into_owned(),
+                    remote_write: false,
+                    local_cache: false,
+                    fixed_size_chunk: 0,
+                },
+                ops::storage::put_file::PutFileItem {
+                    id: 2,
+                    partition: PARTITION_TWO.to_string(),
+                    context: non_zero_ctx.to_string(),
+                    path: src.to_string_lossy().into_owned(),
+                    remote_write: false,
+                    local_cache: false,
+                    fixed_size_chunk: 0,
+                },
+            ],
+        },
+    )
+    .await
+    .expect("storage::put_file (two contexts) should succeed");
+    assert_eq!(put.items.len(), 2, "expected two put results: {put:?}");
+
+    let zero_ctx_item = put.items.iter().find(|i| i.id == 1).expect("id=1 result");
+    let ctx_item = put.items.iter().find(|i| i.id == 2).expect("id=2 result");
+    assert!(zero_ctx_item.ok && ctx_item.ok, "both puts must succeed: {put:?}");
+
+    // The content hash is the same payload but the full address embeds the
+    // context, so the two addresses must differ.
+    assert_ne!(
+        zero_ctx_item.address, ctx_item.address,
+        "non-zero context must produce a distinct address from zero context: {put:?}"
+    );
+
+    // Each address resolves under its own partition, returning the same bytes.
+    for (id, partition, address) in [
+        (1u64, PARTITION, &zero_ctx_item.address),
+        (2u64, PARTITION_TWO, &ctx_item.address),
+    ] {
+        let out = repo.work.path().join(format!("ctx-out-{id}.bin"));
+        let got = ops::storage::get_file::storage_get_file(
+            &repo.api,
+            ops::storage::get_file::StorageGetFileArgs {
+                handle,
+                items: vec![ops::storage::get_file::GetFileItem {
+                    id,
+                    partition: partition.to_string(),
+                    address: address.clone(),
+                    path: out.to_string_lossy().into_owned(),
+                    local_cache: false,
+                }],
+            },
+        )
+        .await
+        .expect("storage::get_file should resolve a context-addressed item");
+        assert!(
+            got.items.first().map(|i| i.ok).unwrap_or(false),
+            "get_file for id={id} should succeed: {got:?}"
+        );
+        let restored = std::fs::read(&out).expect("read ctx-addressed output");
+        assert_eq!(
+            restored, CONTENT,
+            "context-addressed content must round-trip for id={id}"
+        );
+    }
+
+    ops::storage::close::close(
+        &repo.api,
+        ops::storage::close::StorageCloseArgs { handle },
+    )
+    .await
+    .expect("storage::close should succeed");
+}
+
+/// Large-file fragment path: store a payload that exceeds a small
+/// `fixed_size_chunk` so the engine splits it into multiple leaf fragments,
+/// then prove the chunked content reassembles byte-for-byte via get_file and
+/// that the metadata content size matches the original.
+#[tokio::test]
+async fn large_file_chunked_fragments_roundtrip() {
+    let repo = create_disk_repo("storage-large", "alice").await;
+    let handle = open_disk_store(&repo).await;
+
+    // ~256 KiB of non-repeating-ish bytes so the chunker has real work.
+    let mut content = Vec::with_capacity(256 * 1024);
+    for i in 0..(256 * 1024u32) {
+        content.push((i.wrapping_mul(2654435761) >> 13) as u8);
+    }
+    let src = repo.work.path().join("large.bin");
+    storage_support::write_file(&src, &content);
+
+    // Force a small leaf fragment size so the file is chunked into many leaves.
+    let put = ops::storage::put_file::put_file(
+        &repo.api,
+        ops::storage::put_file::StoragePutFileArgs {
+            handle,
+            items: vec![ops::storage::put_file::PutFileItem {
+                id: 99,
+                partition: PARTITION.to_string(),
+                context: String::new(),
+                path: src.to_string_lossy().into_owned(),
+                remote_write: false,
+                local_cache: false,
+                fixed_size_chunk: 4096,
+            }],
+        },
+    )
+    .await
+    .expect("storage::put_file (large) should succeed");
+    let put_item = put.items.first().expect("put_file returned no items");
+    assert!(put_item.ok, "large put_file reported error: {put_item:?}");
+    let address = put_item.address.clone();
+
+    ops::storage::flush::flush(
+        &repo.api,
+        ops::storage::flush::StorageFlushArgs { handle },
+    )
+    .await
+    .expect("flush after large put should succeed");
+
+    // Metadata content size equals the full (reassembled) byte count even though
+    // it is split across many leaf fragments on disk.
+    let meta = ops::storage::get_metadata::storage_get_metadata(
+        &repo.api,
+        ops::storage::get_metadata::StorageGetMetadataArgs {
+            handle,
+            items: vec![ops::storage::get_metadata::GetMetadataItem {
+                id: 99,
+                partition: PARTITION.to_string(),
+                address: address.clone(),
+            }],
+        },
+    )
+    .await
+    .expect("get_metadata for large file should succeed");
+    let frag = meta
+        .items
+        .first()
+        .and_then(|i| i.fragment.as_ref())
+        .expect("large file should report fragment metadata");
+    assert_eq!(
+        frag.size_content as usize,
+        content.len(),
+        "large-file content size must equal original length: {meta:?}"
+    );
+
+    // Reassemble via get_file and assert byte-for-byte equality.
+    let out = repo.work.path().join("large-out.bin");
+    let got = ops::storage::get_file::storage_get_file(
+        &repo.api,
+        ops::storage::get_file::StorageGetFileArgs {
+            handle,
+            items: vec![ops::storage::get_file::GetFileItem {
+                id: 99,
+                partition: PARTITION.to_string(),
+                address,
+                path: out.to_string_lossy().into_owned(),
+                local_cache: false,
+            }],
+        },
+    )
+    .await
+    .expect("get_file for large file should succeed");
+    assert!(
+        got.items.first().map(|i| i.ok).unwrap_or(false),
+        "large get_file should succeed: {got:?}"
+    );
+    let restored = std::fs::read(&out).expect("read reassembled large file");
+    assert_eq!(
+        restored.len(),
+        content.len(),
+        "reassembled large file length mismatch"
+    );
+    assert!(
+        restored == content,
+        "chunked large file must reassemble byte-for-byte"
+    );
+
+    ops::storage::close::close(
+        &repo.api,
+        ops::storage::close::StorageCloseArgs { handle },
+    )
+    .await
+    .expect("storage::close should succeed");
+
+    // Silence the unused-import warning when only this test compiles.
+    let _ = on_disk_api;
+}

--- a/crates/lore-vm/tests/storage_obliterate_copy_errors.rs
+++ b/crates/lore-vm/tests/storage_obliterate_copy_errors.rs
@@ -1,0 +1,374 @@
+//! Behavioral integration tests for the `storage` mutation + error-path ops:
+//! `copy`, `obliterate`, and the failure modes of `get_file` / `get_metadata`.
+//!
+//! The per-op unit tests only cover serialisation; this suite drives the REAL
+//! disk-backed engine and asserts on behaviour:
+//!
+//!   1. copy — duplicate content into a second partition and prove the copy is
+//!      independently retrievable with identical bytes.
+//!   2. obliterate — delete a stored fragment and prove a subsequent get_file /
+//!      get_metadata for it now misses; obliterate is idempotent (a second call
+//!      on the already-gone address still reports success).
+//!   3. error paths — get_file / get_metadata for a never-stored (missing)
+//!      address report a per-item failure (not a hard call error); a malformed
+//!      address surfaces as an op-level error.
+//!
+//! Gated behind the `integration-tests` feature like `e2e_lifecycle.rs`:
+//!
+//! ```sh
+//! cargo test -p lore-vm --features integration-tests --test storage_obliterate_copy_errors
+//! ```
+#![cfg(feature = "integration-tests")]
+
+mod storage_support;
+
+use storage_support::{create_disk_repo, write_file, DiskRepo, PARTITION, PARTITION_TWO};
+
+use lore_vm::ops;
+
+/// Open a disk-backed store handle against `repo`'s working tree.
+async fn open_disk_store(repo: &DiskRepo) -> u64 {
+    ops::storage::open::open(
+        &repo.api,
+        ops::storage::open::StorageOpenArgs {
+            repository_path: repo.repo_path.to_string_lossy().into_owned(),
+            in_memory: false,
+            remote_url: String::new(),
+            cache_target_bytes: 0,
+            cache_target_fragments: 0,
+        },
+    )
+    .await
+    .expect("storage::open should succeed")
+    .handle
+}
+
+/// Store `content` from a temp file under `PARTITION` and return its address.
+async fn put_payload(repo: &DiskRepo, handle: u64, name: &str, content: &[u8]) -> String {
+    let src = repo.work.path().join(name);
+    write_file(&src, content);
+    let put = ops::storage::put_file::put_file(
+        &repo.api,
+        ops::storage::put_file::StoragePutFileArgs {
+            handle,
+            items: vec![ops::storage::put_file::PutFileItem {
+                id: 1,
+                partition: PARTITION.to_string(),
+                context: String::new(),
+                path: src.to_string_lossy().into_owned(),
+                remote_write: false,
+                local_cache: false,
+                fixed_size_chunk: 0,
+            }],
+        },
+    )
+    .await
+    .expect("storage::put_file should succeed");
+    let item = put.items.first().expect("put returned no items");
+    assert!(item.ok, "put reported error: {item:?}");
+    item.address.clone()
+}
+
+/// `copy` duplicates content into a second partition; the copy is retrievable
+/// and byte-identical to the source.
+#[tokio::test]
+async fn copy_duplicates_content_into_second_partition() {
+    let repo = create_disk_repo("storage-copy", "alice").await;
+    let handle = open_disk_store(&repo).await;
+
+    const CONTENT: &[u8] = b"content to be copied across partitions\n";
+    let src_addr = put_payload(&repo, handle, "copysrc.bin", CONTENT).await;
+
+    let copied = ops::storage::copy::copy(
+        &repo.api,
+        ops::storage::copy::StorageCopyArgs {
+            handle,
+            items: vec![ops::storage::copy::CopyItem {
+                id: 5,
+                source_partition: PARTITION.to_string(),
+                target_partition: PARTITION_TWO.to_string(),
+                source_address: src_addr.clone(),
+                target_context: String::new(),
+            }],
+        },
+    )
+    .await
+    .expect("storage::copy should succeed");
+    let copy_item = copied.items.first().expect("copy returned no items");
+    assert!(copy_item.ok, "copy reported error: {copy_item:?}");
+    assert_eq!(copy_item.id, 5, "copy echoed wrong id: {copy_item:?}");
+
+    // The copy is retrievable from the TARGET partition with the same content.
+    // Content hash is preserved by copy, so the source address resolves there.
+    let out = repo.work.path().join("copy-out.bin");
+    let got = ops::storage::get_file::storage_get_file(
+        &repo.api,
+        ops::storage::get_file::StorageGetFileArgs {
+            handle,
+            items: vec![ops::storage::get_file::GetFileItem {
+                id: 5,
+                partition: PARTITION_TWO.to_string(),
+                address: src_addr.clone(),
+                path: out.to_string_lossy().into_owned(),
+                local_cache: false,
+            }],
+        },
+    )
+    .await
+    .expect("storage::get_file from the copy target should succeed");
+    assert!(
+        got.items.first().map(|i| i.ok).unwrap_or(false),
+        "get_file from the copied partition should succeed: {got:?}"
+    );
+    assert_eq!(
+        std::fs::read(&out).expect("read copied content"),
+        CONTENT,
+        "copied content must be byte-identical to the source"
+    );
+
+    ops::storage::close::close(
+        &repo.api,
+        ops::storage::close::StorageCloseArgs { handle },
+    )
+    .await
+    .expect("close should succeed");
+}
+
+/// `obliterate` removes a stored fragment so a subsequent get misses; a second
+/// obliterate of the now-gone address is idempotent (still reports success).
+#[tokio::test]
+async fn obliterate_removes_then_is_idempotent() {
+    let repo = create_disk_repo("storage-obl", "alice").await;
+    let handle = open_disk_store(&repo).await;
+
+    const CONTENT: &[u8] = b"transient fragment to obliterate\n";
+    let addr = put_payload(&repo, handle, "obl.bin", CONTENT).await;
+
+    // Sanity: it is retrievable before obliteration.
+    let pre = ops::storage::get_metadata::storage_get_metadata(
+        &repo.api,
+        ops::storage::get_metadata::StorageGetMetadataArgs {
+            handle,
+            items: vec![ops::storage::get_metadata::GetMetadataItem {
+                id: 1,
+                partition: PARTITION.to_string(),
+                address: addr.clone(),
+            }],
+        },
+    )
+    .await
+    .expect("pre-obliterate metadata should succeed");
+    let pre_item = pre.items.first().expect("pre metadata returned no items");
+    assert!(
+        pre_item.ok,
+        "fragment should resolve before obliteration: {pre_item:?}"
+    );
+    let pre_size = pre_item
+        .fragment
+        .as_ref()
+        .map(|f| f.size_content)
+        .expect("pre-obliterate fragment should carry a content size");
+    assert_eq!(
+        pre_size as usize,
+        CONTENT.len(),
+        "pre-obliterate content size should match the stored bytes: {pre_item:?}"
+    );
+
+    // Obliterate it.
+    let obl = ops::storage::obliterate::obliterate(
+        &repo.api,
+        ops::storage::obliterate::StorageObliterateArgs {
+            handle,
+            items: vec![ops::storage::obliterate::ObliterateItem {
+                id: 1,
+                partition: PARTITION.to_string(),
+                address: addr.clone(),
+            }],
+        },
+    )
+    .await
+    .expect("storage::obliterate should succeed");
+    let obl_item = obl.items.first().expect("obliterate returned no items");
+    assert!(obl_item.ok, "obliterate reported error: {obl_item:?}");
+    assert!(
+        obl_item.local_success,
+        "local obliteration should report success: {obl_item:?}"
+    );
+
+    // Behavioral finding: after obliteration the payload is gone, but the
+    // metadata lookup still RESOLVES — it returns a tombstoned/zeroed fragment
+    // (a non-zero flag bit set, size_content == 0) rather than a hard miss. So
+    // we assert the fragment is now empty (content size dropped from the stored
+    // length to 0), which is how an obliterated entry distinguishes itself from
+    // a live one.
+    let post = ops::storage::get_metadata::storage_get_metadata(
+        &repo.api,
+        ops::storage::get_metadata::StorageGetMetadataArgs {
+            handle,
+            items: vec![ops::storage::get_metadata::GetMetadataItem {
+                id: 1,
+                partition: PARTITION.to_string(),
+                address: addr.clone(),
+            }],
+        },
+    )
+    .await
+    .expect("post-obliterate metadata call should still succeed (tombstone)");
+    let post_item = post.items.first().expect("post metadata returned no items");
+    let post_size = post_item
+        .fragment
+        .as_ref()
+        .map(|f| f.size_content)
+        .unwrap_or(0);
+    assert_eq!(
+        post_size, 0,
+        "obliterated fragment must report zero content size (tombstone): {post_item:?}"
+    );
+
+    // And actually fetching the payload bytes must now fail at the op level —
+    // there is no data left to reassemble.
+    let out = repo.work.path().join("obl-after.bin");
+    let got_after = ops::storage::get_file::storage_get_file(
+        &repo.api,
+        ops::storage::get_file::StorageGetFileArgs {
+            handle,
+            items: vec![ops::storage::get_file::GetFileItem {
+                id: 1,
+                partition: PARTITION.to_string(),
+                address: addr.clone(),
+                path: out.to_string_lossy().into_owned(),
+                local_cache: false,
+            }],
+        },
+    )
+    .await;
+    assert!(
+        got_after.is_err() || !out.exists(),
+        "fetching an obliterated payload must not produce its original bytes: {got_after:?}"
+    );
+
+    // Idempotency: obliterating the already-gone address still reports success.
+    let obl2 = ops::storage::obliterate::obliterate(
+        &repo.api,
+        ops::storage::obliterate::StorageObliterateArgs {
+            handle,
+            items: vec![ops::storage::obliterate::ObliterateItem {
+                id: 2,
+                partition: PARTITION.to_string(),
+                address: addr.clone(),
+            }],
+        },
+    )
+    .await
+    .expect("second obliterate should succeed");
+    assert!(
+        obl2.items.first().map(|i| i.ok).unwrap_or(false),
+        "obliterate must be idempotent on an already-gone address: {obl2:?}"
+    );
+
+    ops::storage::close::close(
+        &repo.api,
+        ops::storage::close::StorageCloseArgs { handle },
+    )
+    .await
+    .expect("close should succeed");
+}
+
+/// A get for a never-stored (missing) address surfaces as an OP-LEVEL error.
+///
+/// Behavioral finding: the storage bindings classify a not-found item via the
+/// upstream `Complete` status. When an item misses, that status is non-zero, so
+/// `get_metadata` / `get_file` return `Err(CommandFailed(...))` rather than an
+/// `Ok` carrying a per-item `ok:false`. This test pins that contract so a future
+/// change (e.g. downgrading misses to per-item failures) is a conscious one.
+#[tokio::test]
+async fn missing_address_surfaces_op_level_error() {
+    let repo = create_disk_repo("storage-miss", "alice").await;
+    let handle = open_disk_store(&repo).await;
+
+    // A syntactically valid but never-stored address: 64-hex hash + 32-hex ctx.
+    let missing = format!("{}-{}", "ab".repeat(32), "00".repeat(16));
+
+    // get_metadata for a missing address surfaces as an op-level Err.
+    let meta = ops::storage::get_metadata::storage_get_metadata(
+        &repo.api,
+        ops::storage::get_metadata::StorageGetMetadataArgs {
+            handle,
+            items: vec![ops::storage::get_metadata::GetMetadataItem {
+                id: 1,
+                partition: PARTITION.to_string(),
+                address: missing.clone(),
+            }],
+        },
+    )
+    .await;
+    assert!(
+        meta.is_err(),
+        "get_metadata for a missing address must surface an op-level Err: {meta:?}"
+    );
+
+    // get_file for a missing address: same op-level Err, and no file produced.
+    let out = repo.work.path().join("missing-out.bin");
+    let got = ops::storage::get_file::storage_get_file(
+        &repo.api,
+        ops::storage::get_file::StorageGetFileArgs {
+            handle,
+            items: vec![ops::storage::get_file::GetFileItem {
+                id: 1,
+                partition: PARTITION.to_string(),
+                address: missing,
+                path: out.to_string_lossy().into_owned(),
+                local_cache: false,
+            }],
+        },
+    )
+    .await;
+    assert!(
+        got.is_err(),
+        "get_file for a missing address must surface an op-level Err: {got:?}"
+    );
+    assert!(
+        !out.exists(),
+        "no output file should be produced for a missing address"
+    );
+
+    ops::storage::close::close(
+        &repo.api,
+        ops::storage::close::StorageCloseArgs { handle },
+    )
+    .await
+    .expect("close should succeed");
+}
+
+/// A malformed (non-hex / wrong-length) address surfaces as an op-level error
+/// from the binding's arg conversion, not a panic.
+#[tokio::test]
+async fn malformed_address_surfaces_an_error() {
+    let repo = create_disk_repo("storage-bad", "alice").await;
+    let handle = open_disk_store(&repo).await;
+
+    let result = ops::storage::get_metadata::storage_get_metadata(
+        &repo.api,
+        ops::storage::get_metadata::StorageGetMetadataArgs {
+            handle,
+            items: vec![ops::storage::get_metadata::GetMetadataItem {
+                id: 1,
+                partition: PARTITION.to_string(),
+                // Not valid hex, and the wrong shape for an address.
+                address: "not-a-valid-address".to_string(),
+            }],
+        },
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "a malformed address must surface as an Err, got: {result:?}"
+    );
+
+    ops::storage::close::close(
+        &repo.api,
+        ops::storage::close::StorageCloseArgs { handle },
+    )
+    .await
+    .expect("close should succeed");
+}

--- a/crates/lore-vm/tests/storage_remote_backend.rs
+++ b/crates/lore-vm/tests/storage_remote_backend.rs
@@ -1,0 +1,305 @@
+//! Behavioral integration coverage for the storage layer's MULTI-BACKEND
+//! (local + remote) surface, to the extent CI can drive it headlessly.
+//!
+//! A genuine second backend (a remote content store) requires a live QUIC
+//! `lore` server with TLS material — the same deferred gap `e2e_lifecycle.rs`
+//! documents for `branch::push` (`NoRemote` offline). There is no in-process
+//! mock remote exposed by the upstream crate, so a true two-backend transfer is
+//! NOT runnable in CI here. Rather than skip the surface entirely, this suite:
+//!
+//!   1. Exercises the remote-config WIRING on `storage::open`: opening with a
+//!      `remote_url` is accepted and yields a usable handle whose local side
+//!      still round-trips (the remote is configured but unreachable offline).
+//!   2. Exercises the `upload` op (the local→remote push trait method) against
+//!      a store with NO remote configured, asserting it surfaces a typed
+//!      outcome rather than panicking — covering the trait + the offline/no-
+//!      remote branch.
+//!   3. Asserts the `obliterate` result's remote-side reporting fields behave
+//!      correctly when no remote is configured (remote skipped, local success).
+//!
+//! The genuine networked path (open with a reachable remote → put local →
+//! upload → obliterate-remote) is documented here as a deferred gap; closing it
+//! needs the same TLS+server harness as the networked server↔client flow.
+//!
+//! Gated behind the `integration-tests` feature like `e2e_lifecycle.rs`:
+//!
+//! ```sh
+//! cargo test -p lore-vm --features integration-tests --test storage_remote_backend
+//! ```
+#![cfg(feature = "integration-tests")]
+
+mod storage_support;
+
+use storage_support::{create_disk_repo, write_file, DiskRepo, PARTITION};
+
+use lore_vm::ops;
+
+/// Open a disk-backed handle, optionally with a remote URL configured.
+async fn open_with_remote(repo: &DiskRepo, remote_url: &str) -> u64 {
+    ops::storage::open::open(
+        &repo.api,
+        ops::storage::open::StorageOpenArgs {
+            repository_path: repo.repo_path.to_string_lossy().into_owned(),
+            in_memory: false,
+            remote_url: remote_url.to_string(),
+            cache_target_bytes: 0,
+            cache_target_fragments: 0,
+        },
+    )
+    .await
+    .expect("storage::open should succeed")
+    .handle
+}
+
+/// Opening a store WITH a remote configured is accepted and the local side
+/// still round-trips offline — the remote is wired but never contacted.
+#[tokio::test]
+async fn open_with_remote_config_local_side_still_roundtrips() {
+    let repo = create_disk_repo("storage-remote-open", "alice").await;
+
+    // A plausible-looking but unreachable remote endpoint. Offline, the engine
+    // must not block on it for purely-local ops.
+    let handle = open_with_remote(&repo, "lore://localhost:7777/remote-store").await;
+    assert!(handle != 0, "open with remote should yield a non-zero handle");
+
+    const CONTENT: &[u8] = b"local op against a remote-configured store\n";
+    let src = repo.work.path().join("remote-cfg.bin");
+    write_file(&src, CONTENT);
+
+    // remote_write stays false: this is a purely local put/get, which must
+    // succeed even though a remote is configured but unreachable.
+    let put = ops::storage::put_file::put_file(
+        &repo.api,
+        ops::storage::put_file::StoragePutFileArgs {
+            handle,
+            items: vec![ops::storage::put_file::PutFileItem {
+                id: 1,
+                partition: PARTITION.to_string(),
+                context: String::new(),
+                path: src.to_string_lossy().into_owned(),
+                remote_write: false,
+                local_cache: true,
+                fixed_size_chunk: 0,
+            }],
+        },
+    )
+    .await
+    .expect("local put against a remote-configured store should succeed");
+    let addr = put
+        .items
+        .first()
+        .filter(|i| i.ok)
+        .map(|i| i.address.clone())
+        .expect("local put should produce an address");
+
+    let out = repo.work.path().join("remote-cfg-out.bin");
+    let got = ops::storage::get_file::storage_get_file(
+        &repo.api,
+        ops::storage::get_file::StorageGetFileArgs {
+            handle,
+            items: vec![ops::storage::get_file::GetFileItem {
+                id: 1,
+                partition: PARTITION.to_string(),
+                address: addr,
+                path: out.to_string_lossy().into_owned(),
+                local_cache: false,
+            }],
+        },
+    )
+    .await
+    .expect("local get against a remote-configured store should succeed");
+    assert!(
+        got.items.first().map(|i| i.ok).unwrap_or(false),
+        "local get should round-trip offline: {got:?}"
+    );
+    assert_eq!(
+        std::fs::read(&out).expect("read local round-tripped content"),
+        CONTENT,
+        "local content must round-trip even with a remote configured"
+    );
+
+    ops::storage::close::close(
+        &repo.api,
+        ops::storage::close::StorageCloseArgs { handle },
+    )
+    .await
+    .expect("close should succeed");
+}
+
+/// `upload` (the local→remote push trait method) against a store with NO remote
+/// configured must surface a typed outcome rather than panic. We don't assert a
+/// specific success/failure code — only that the binding returns cleanly and,
+/// if it returns Ok, the per-item result is well-formed. This covers the trait
+/// surface and the no-remote branch without a live server.
+#[tokio::test]
+async fn upload_without_remote_surfaces_typed_outcome() {
+    let repo = create_disk_repo("storage-upload", "alice").await;
+
+    // Open WITHOUT a remote.
+    let handle = ops::storage::open::open(
+        &repo.api,
+        ops::storage::open::StorageOpenArgs {
+            repository_path: repo.repo_path.to_string_lossy().into_owned(),
+            in_memory: false,
+            remote_url: String::new(),
+            cache_target_bytes: 0,
+            cache_target_fragments: 0,
+        },
+    )
+    .await
+    .expect("open should succeed")
+    .handle;
+
+    // Store something locally to have a real address to attempt uploading.
+    let src = repo.work.path().join("to-upload.bin");
+    write_file(&src, b"bytes that have no remote to go to\n");
+    let put = ops::storage::put_file::put_file(
+        &repo.api,
+        ops::storage::put_file::StoragePutFileArgs {
+            handle,
+            items: vec![ops::storage::put_file::PutFileItem {
+                id: 1,
+                partition: PARTITION.to_string(),
+                context: String::new(),
+                path: src.to_string_lossy().into_owned(),
+                remote_write: false,
+                local_cache: false,
+                fixed_size_chunk: 0,
+            }],
+        },
+    )
+    .await
+    .expect("put should succeed");
+    let addr = put
+        .items
+        .first()
+        .filter(|i| i.ok)
+        .map(|i| i.address.clone())
+        .expect("put should produce an address");
+
+    // Attempt upload. With no remote, this either errors at the op level or
+    // returns a per-item failure — both are acceptable; a panic / hang is not.
+    let result = ops::storage::upload::upload(
+        &repo.api,
+        ops::storage::upload::StorageUploadArgs {
+            handle,
+            items: vec![ops::storage::upload::UploadItem {
+                id: 1,
+                partition: PARTITION.to_string(),
+                address: addr,
+            }],
+        },
+    )
+    .await;
+
+    match result {
+        Ok(res) => {
+            // If the op returns Ok, the per-item result must be well-formed:
+            // either it reports not-ok (no remote) or already_durable. We don't
+            // require a specific code, just internal consistency.
+            if let Some(item) = res.items.first() {
+                if item.ok {
+                    // A spurious "ok" with no remote would still be well-formed
+                    // (already_durable path); just assert no error text leaked.
+                    assert!(
+                        item.error.is_empty(),
+                        "ok upload item must not carry an error string: {item:?}"
+                    );
+                } else {
+                    assert!(
+                        !item.error.is_empty(),
+                        "a failed upload item should carry an error code: {item:?}"
+                    );
+                }
+            }
+        }
+        Err(_) => {
+            // Acceptable: no remote configured surfaces as an op-level error.
+        }
+    }
+
+    ops::storage::close::close(
+        &repo.api,
+        ops::storage::close::StorageCloseArgs { handle },
+    )
+    .await
+    .expect("close should succeed");
+}
+
+/// `obliterate` with no remote configured reports the remote side as skipped
+/// while the local side succeeds — covering the multi-side result reporting
+/// fields that only matter once a remote is in play.
+#[tokio::test]
+async fn obliterate_reports_remote_skipped_without_remote() {
+    let repo = create_disk_repo("storage-obl-remote", "alice").await;
+    let handle = ops::storage::open::open(
+        &repo.api,
+        ops::storage::open::StorageOpenArgs {
+            repository_path: repo.repo_path.to_string_lossy().into_owned(),
+            in_memory: false,
+            remote_url: String::new(),
+            cache_target_bytes: 0,
+            cache_target_fragments: 0,
+        },
+    )
+    .await
+    .expect("open should succeed")
+    .handle;
+
+    let src = repo.work.path().join("obl-remote.bin");
+    write_file(&src, b"local-only fragment\n");
+    let put = ops::storage::put_file::put_file(
+        &repo.api,
+        ops::storage::put_file::StoragePutFileArgs {
+            handle,
+            items: vec![ops::storage::put_file::PutFileItem {
+                id: 1,
+                partition: PARTITION.to_string(),
+                context: String::new(),
+                path: src.to_string_lossy().into_owned(),
+                remote_write: false,
+                local_cache: false,
+                fixed_size_chunk: 0,
+            }],
+        },
+    )
+    .await
+    .expect("put should succeed");
+    let addr = put
+        .items
+        .first()
+        .filter(|i| i.ok)
+        .map(|i| i.address.clone())
+        .expect("put should produce an address");
+
+    let obl = ops::storage::obliterate::obliterate(
+        &repo.api,
+        ops::storage::obliterate::StorageObliterateArgs {
+            handle,
+            items: vec![ops::storage::obliterate::ObliterateItem {
+                id: 1,
+                partition: PARTITION.to_string(),
+                address: addr,
+            }],
+        },
+    )
+    .await
+    .expect("obliterate should succeed");
+    let item = obl.items.first().expect("obliterate returned no items");
+    assert!(item.ok, "obliterate should succeed: {item:?}");
+    assert!(
+        item.local_success,
+        "local side should report success: {item:?}"
+    );
+    assert!(
+        item.remote_skipped,
+        "with no remote configured, the remote side must be skipped: {item:?}"
+    );
+
+    ops::storage::close::close(
+        &repo.api,
+        ops::storage::close::StorageCloseArgs { handle },
+    )
+    .await
+    .expect("close should succeed");
+}

--- a/crates/lore-vm/tests/storage_shared_store_sync.rs
+++ b/crates/lore-vm/tests/storage_shared_store_sync.rs
@@ -1,0 +1,240 @@
+//! Behavioral integration tests for cross-repo sync through a SHARED STORE,
+//! going beyond `e2e_lifecycle::multi_repo_shared_store_sync_observes_remote_commit`
+//! (which only proves a single ADD propagates host → client).
+//!
+//! Here we drive the harder, mutation-heavy cases through two repos that share
+//! one on-disk store, fully OFFLINE (the CI-headless server↔client stand-in):
+//!
+//!   1. UPDATE propagation — host modifies a file's content; client sees the
+//!      new bytes after sync.
+//!   2. DELETE propagation — host removes a tracked file; client's working tree
+//!      drops it after sync.
+//!   3. CONCURRENT divergent commits — both repos commit different files from a
+//!      common base; after each syncs, both observe BOTH revisions through the
+//!      shared store (no data lost), exercising the merge path.
+//!
+//! Gated behind the `integration-tests` feature like `e2e_lifecycle.rs`:
+//!
+//! ```sh
+//! cargo test -p lore-vm --features integration-tests --test storage_shared_store_sync
+//! ```
+#![cfg(feature = "integration-tests")]
+
+mod storage_support;
+
+use lore_vm::ops;
+use storage_support::{
+    commit, create_disk_repo, history, join_disk_repo, stage_path, sync, write_file,
+};
+
+/// Build the same `lore://localhost/<name>` URL `create_disk_repo` used, so a
+/// joiner can target the SAME repository. `create_disk_repo` embeds the pid and
+/// a per-process unique suffix; we re-derive it from the DiskRepo's id only if
+/// needed — but here we capture the url at creation by re-creating with a known
+/// scheme. To keep it simple and robust, the host creates the repo and we join
+/// by id against the same shared store with a fresh url that lore reconciles by
+/// id (matching how `e2e_lifecycle` joins).
+const JOIN_URL: &str = "lore://localhost/shared-join";
+
+/// Host UPDATEs a file; client observes the updated bytes after sync.
+#[tokio::test]
+async fn update_propagates_through_shared_store() {
+    let host = create_disk_repo("share-update", "host").await;
+
+    // Host adds, then a client joins the same repo+store BEFORE the update so we
+    // sync the update across (not the initial add).
+    let file = host.repo_path.join("doc.txt");
+    write_file(&file, b"v1\n");
+    stage_path(&host.api, &file).await;
+    let _rev_v1 = commit(&host.api, "add doc v1").await;
+
+    let (client_api, _client_work, client_path) =
+        join_disk_repo(JOIN_URL, &host.repo_id, &host.store_path, "client").await;
+
+    // Client syncs the initial state.
+    sync(&client_api).await;
+    let client_file = client_path.join("doc.txt");
+    assert_eq!(
+        std::fs::read(&client_file).expect("client should have doc.txt after first sync"),
+        b"v1\n",
+        "client should observe v1 after first sync"
+    );
+
+    // Host updates the file and commits.
+    write_file(&file, b"v2 updated\n");
+    stage_path(&host.api, &file).await;
+    let rev_v2 = commit(&host.api, "update doc to v2").await;
+
+    // Client syncs again and must observe the new content + the new revision.
+    let synced = sync(&client_api).await;
+    assert!(
+        synced.revisions.iter().any(|r| r.revision == rev_v2)
+            || history(&client_api).await.entries.iter().any(|e| e.revision == rev_v2),
+        "client should observe the host's update revision {rev_v2}: {synced:?}"
+    );
+    assert_eq!(
+        std::fs::read(&client_file).expect("read client doc.txt after update sync"),
+        b"v2 updated\n",
+        "client working tree must reflect the host's update after sync"
+    );
+}
+
+/// Host DELETEs a tracked file; client's working tree drops it after sync.
+#[tokio::test]
+async fn delete_propagates_through_shared_store() {
+    let host = create_disk_repo("share-delete", "host").await;
+
+    // Host adds two files; client joins and syncs so both exist on the client.
+    let keep = host.repo_path.join("keep.txt");
+    let gone = host.repo_path.join("gone.txt");
+    write_file(&keep, b"keep me\n");
+    write_file(&gone, b"delete me\n");
+    stage_path(&host.api, &keep).await;
+    stage_path(&host.api, &gone).await;
+    let _rev_add = commit(&host.api, "add keep + gone").await;
+
+    let (client_api, _client_work, client_path) =
+        join_disk_repo(JOIN_URL, &host.repo_id, &host.store_path, "client").await;
+    sync(&client_api).await;
+    assert!(
+        client_path.join("gone.txt").exists(),
+        "client should have gone.txt after first sync"
+    );
+
+    // Host deletes gone.txt (remove from disk, stage the removal, commit).
+    std::fs::remove_file(&gone).expect("remove gone.txt on host");
+    let staged = stage_path(&host.api, &gone).await;
+    assert!(
+        staged.files.iter().any(|f| f.path.ends_with("gone.txt")),
+        "host stage should report the deletion: {staged:?}"
+    );
+    let rev_del = commit(&host.api, "delete gone").await;
+
+    // Client syncs: gone.txt should be removed from the client tree, keep stays.
+    let synced = sync(&client_api).await;
+    assert!(
+        synced.revisions.iter().any(|r| r.revision == rev_del)
+            || history(&client_api).await.entries.iter().any(|e| e.revision == rev_del),
+        "client should observe the delete revision {rev_del}: {synced:?}"
+    );
+    assert!(
+        !client_path.join("gone.txt").exists(),
+        "client working tree should drop gone.txt after the delete syncs"
+    );
+    assert!(
+        client_path.join("keep.txt").exists(),
+        "keep.txt must survive a delete of an unrelated file on the client"
+    );
+}
+
+/// CONFLICT detection through the shared store: with two repos on a common base
+/// sharing one mutable store, the store enforces a compare-and-swap on the
+/// branch tip. If the host advances the shared branch, a client still sitting on
+/// the old base CANNOT commit on top of it — the commit is rejected with
+/// "Branch has been advanced by another instance, sync and re-stage". After the
+/// client syncs to absorb the host's revision, its commit then succeeds, and
+/// both the host's and the client's revisions are visible — nothing is lost.
+#[tokio::test]
+async fn concurrent_branch_advance_is_rejected_until_sync() {
+    let host = create_disk_repo("share-diverge", "host").await;
+
+    // Common base commit, then client joins and syncs to the same base.
+    let base = host.repo_path.join("base.txt");
+    write_file(&base, b"base\n");
+    stage_path(&host.api, &base).await;
+    let rev_base = commit(&host.api, "base commit").await;
+
+    let (client_api, _client_work, client_path) =
+        join_disk_repo(JOIN_URL, &host.repo_id, &host.store_path, "client").await;
+    sync(&client_api).await;
+    assert!(
+        history(&client_api)
+            .await
+            .entries
+            .iter()
+            .any(|e| e.revision == rev_base),
+        "client should share the base revision before diverging"
+    );
+
+    // Host advances the SHARED branch tip past the client's base.
+    let host_only = host.repo_path.join("host-only.txt");
+    write_file(&host_only, b"authored on host\n");
+    stage_path(&host.api, &host_only).await;
+    let rev_host = commit(&host.api, "host divergent commit").await;
+    assert_ne!(rev_host, rev_base, "host commit must be a new revision");
+
+    // Client (still at base) stages a divergent file and tries to commit WITHOUT
+    // syncing. The shared store's branch-tip CAS must reject it.
+    let client_only = client_path.join("client-only.txt");
+    write_file(&client_only, b"authored on client\n");
+    stage_path(&client_api, &client_only).await;
+    let stale_commit = ops::revision::commit::commit(
+        &client_api,
+        ops::revision::commit::CommitArgs {
+            message: "client divergent commit (stale)".into(),
+        },
+    )
+    .await;
+    assert!(
+        stale_commit.is_err(),
+        "committing on a stale branch tip must be rejected by the shared store: {stale_commit:?}"
+    );
+    let err = format!("{}", stale_commit.unwrap_err());
+    assert!(
+        err.contains("advanced") || err.contains("sync"),
+        "rejection should explain the branch was advanced / needs sync, got: {err}"
+    );
+
+    // The shared store refuses to sync while a staged state lingers, so the
+    // client must first unstage the rejected change, sync to absorb the host's
+    // revision, then re-stage and commit — the documented recovery sequence.
+    ops::file::unstage::unstage(
+        &client_api,
+        ops::file::unstage::FileUnstageArgs {
+            paths: vec![client_only.to_string_lossy().into_owned()],
+        },
+    )
+    .await
+    .expect("client should be able to unstage the rejected change before syncing");
+
+    sync(&client_api).await;
+    assert!(
+        history(&client_api)
+            .await
+            .entries
+            .iter()
+            .any(|e| e.revision == rev_host),
+        "after sync the client must see the host's revision {rev_host}"
+    );
+    stage_path(&client_api, &client_only).await;
+    let rev_client = commit(&client_api, "client divergent commit (after sync)").await;
+    assert_ne!(
+        rev_client, rev_host,
+        "client's post-sync commit must be a distinct revision"
+    );
+
+    // Final state: the client's history contains the base, the host's commit,
+    // and its own — proving the host's work was preserved across the conflict.
+    let client_hist = history(&client_api).await;
+    for (rname, rev) in [
+        ("base", &rev_base),
+        ("host", &rev_host),
+        ("client", &rev_client),
+    ] {
+        assert!(
+            client_hist.entries.iter().any(|e| &e.revision == rev),
+            "client history must contain the {rname} revision {rev}: {client_hist:?}"
+        );
+    }
+
+    // The host can sync to pick up the client's follow-on commit too.
+    sync(&host.api).await;
+    assert!(
+        history(&host.api)
+            .await
+            .entries
+            .iter()
+            .any(|e| e.revision == rev_client),
+        "host should observe the client's post-sync commit {rev_client} after syncing"
+    );
+}

--- a/crates/lore-vm/tests/storage_support/mod.rs
+++ b/crates/lore-vm/tests/storage_support/mod.rs
@@ -1,0 +1,202 @@
+//! Shared helpers for the `storage`/`shared_store` behavioral integration
+//! suites. Placed under `tests/storage_support/` (a subdirectory module, not a
+//! top-level `tests/*.rs`) so cargo does NOT treat it as its own test binary —
+//! it is `mod storage_support;`-included by each suite that needs it.
+//!
+//! Only compiled when the `integration-tests` feature is on; each including
+//! suite is itself `#![cfg(feature = "integration-tests")]`, and these helpers
+//! are gated too so a normal `cargo test -p lore-vm` never builds them.
+#![cfg(feature = "integration-tests")]
+#![allow(dead_code)]
+
+use std::path::Path;
+
+use lore_vm::api::LoreApi;
+use lore_vm::global::LoreGlobal;
+use lore_vm::ops;
+
+/// A canonical onboarding-style partition (mirrors the GUI connectivity check).
+pub const PARTITION: &str = "00000000000000000000000000000001";
+/// A second distinct partition for multi-partition addressing assertions.
+pub const PARTITION_TWO: &str = "00000000000000000000000000000002";
+
+/// Build a `LoreApi` for headless **on-disk** operation as `identity`:
+/// a real `.urc` store on disk, no server (`offline = 1`), no in-memory store.
+pub fn on_disk_api(dir: &Path, identity: &str) -> LoreApi {
+    let global = LoreGlobal::new(dir.to_path_buf())
+        .in_memory(false)
+        .offline(true)
+        .identity(identity);
+    LoreApi::from_global(global)
+}
+
+/// Write `contents` to `path`, creating parent directories as needed.
+pub fn write_file(path: &Path, contents: &[u8]) {
+    use std::io::Write;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dirs");
+    }
+    let mut f = std::fs::File::options()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(path)
+        .expect("create file");
+    f.write_all(contents).expect("write file");
+}
+
+/// A fully created, on-disk lore repository backed by a shared store that lives
+/// OUTSIDE the working tree — the closest stand-in for a self-hosted layout.
+/// Holds the tempdirs so they outlive the test body.
+pub struct DiskRepo {
+    pub api: LoreApi,
+    /// The repository working tree.
+    pub work: tempfile::TempDir,
+    /// The directory containing the shared store (kept disjoint from `work`).
+    pub store: tempfile::TempDir,
+    /// Absolute path to the repo working tree (== `work.path()`).
+    pub repo_path: std::path::PathBuf,
+    /// Absolute path to the shared store.
+    pub store_path: std::path::PathBuf,
+    /// The created repository id.
+    pub repo_id: String,
+}
+
+/// Create a fresh on-disk repo named `<name_prefix>-<pid>-<unique>` backed by a
+/// shared store outside the working tree, authored by `identity`.
+pub async fn create_disk_repo(name_prefix: &str, identity: &str) -> DiskRepo {
+    let work = tempfile::tempdir().expect("create work tempdir");
+    let store = tempfile::tempdir().expect("create store tempdir");
+    let repo_path = work.path().to_path_buf();
+    let store_path = store.path().join("shared-store");
+
+    let api = on_disk_api(&repo_path, identity);
+
+    ops::shared_store::create::create(
+        &api,
+        ops::shared_store::create::SharedStoreCreateArgs {
+            remote_url: String::new(),
+            path: Some(store_path.to_string_lossy().into_owned()),
+            make_default: false,
+        },
+    )
+    .await
+    .expect("shared_store::create should succeed");
+
+    let unique = next_unique();
+    let repo_url = format!(
+        "lore://localhost/{name_prefix}-{}-{unique}",
+        std::process::id()
+    );
+    let created = ops::repository::create::create(
+        &api,
+        ops::repository::create::CreateArgs {
+            repository_url: repo_url,
+            description: format!("lore-vm storage-coverage repo ({name_prefix})"),
+            id: String::new(),
+            use_shared_store: true,
+            shared_store_path: store_path.to_string_lossy().into_owned(),
+        },
+    )
+    .await
+    .expect("repository::create should succeed");
+    assert!(
+        !created.id.is_empty(),
+        "repository::create returned an empty id: {created:?}"
+    );
+
+    DiskRepo {
+        api,
+        work,
+        store,
+        repo_path,
+        store_path,
+        repo_id: created.id,
+    }
+}
+
+/// Join an existing repo (same shared store + same id) on a fresh working tree
+/// authored by `identity`. Used to exercise cross-repo shared-store sync.
+pub async fn join_disk_repo(
+    repo_url: &str,
+    repo_id: &str,
+    store_path: &Path,
+    identity: &str,
+) -> (LoreApi, tempfile::TempDir, std::path::PathBuf) {
+    let work = tempfile::tempdir().expect("create joiner work tempdir");
+    let repo_path = work.path().to_path_buf();
+    let api = on_disk_api(&repo_path, identity);
+
+    let created = ops::repository::create::create(
+        &api,
+        ops::repository::create::CreateArgs {
+            repository_url: repo_url.to_string(),
+            description: "lore-vm storage-coverage joiner".into(),
+            id: repo_id.to_string(),
+            use_shared_store: true,
+            shared_store_path: store_path.to_string_lossy().into_owned(),
+        },
+    )
+    .await
+    .expect("repository::create (joiner, same id) should succeed");
+    assert_eq!(
+        created.id, repo_id,
+        "joiner must join the same repository id"
+    );
+
+    (api, work, repo_path)
+}
+
+/// Stage a single absolute path and assert the op succeeded.
+pub async fn stage_path(api: &LoreApi, path: &Path) -> ops::file::stage::FileStageResult {
+    ops::file::stage::stage(
+        api,
+        ops::file::stage::FileStageArgs {
+            paths: vec![path.to_string_lossy().into_owned()],
+            case_change: ops::file::stage::CaseChange::Error,
+            scan: true,
+        },
+    )
+    .await
+    .unwrap_or_else(|e| panic!("file::stage should succeed for {}: {e}", path.display()))
+}
+
+/// Commit the staged state, asserting a non-empty revision hash, and return it.
+pub async fn commit(api: &LoreApi, message: &str) -> String {
+    let res = ops::revision::commit::commit(
+        api,
+        ops::revision::commit::CommitArgs {
+            message: message.into(),
+        },
+    )
+    .await
+    .unwrap_or_else(|e| panic!("revision::commit({message:?}) should succeed: {e}"));
+    assert!(
+        !res.revision.is_empty(),
+        "commit({message:?}) returned an empty revision hash: {res:?}"
+    );
+    res.revision
+}
+
+/// Full revision history for the current branch, newest-first.
+pub async fn history(api: &LoreApi) -> ops::revision::history::RevisionHistoryResult {
+    ops::revision::history::history(api, ops::revision::history::RevisionHistoryArgs::default())
+        .await
+        .expect("revision::history should succeed")
+}
+
+/// Sync the current repo against its shared store (offline) and return the tip
+/// revisions observed.
+pub async fn sync(api: &LoreApi) -> ops::revision::sync::RevisionSyncResult {
+    ops::revision::sync::sync(api, ops::revision::sync::RevisionSyncArgs::default())
+        .await
+        .expect("revision::sync should succeed against the shared store")
+}
+
+/// Process-local monotonic counter so repos created within one test binary get
+/// distinct urls/ids even at the same pid.
+fn next_unique() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
+}


### PR DESCRIPTION
## What

Adds real **behavioral** integration tests for the `lore-vm` storage layer (`crates/lore-vm/src/ops/storage/*` + `ops/shared_store/*`), which previously had only serde-round-trip unit tests plus one in-memory `put/get/obliterate` happy path. New test files only — **no `src/` changes**. All gated behind the `integration-tests` cargo feature, exactly like `e2e_lifecycle.rs`, and wired the same way (compile to zero tests without the feature).

## New test files (`crates/lore-vm/tests/`)

1. **`storage_disk_roundtrip.rs`** — `put_file → get_file → flush → get_metadata` round trips against a REAL **on-disk** store (not in-memory): byte-for-byte content integrity, the `(partition, context)` hex addressing contract (same bytes under a non-zero context yield a distinct address), and the large-file chunked-fragment path (4 KiB `fixed_size_chunk` over a 256 KiB payload reassembles byte-for-byte; metadata reports the full content size).
2. **`storage_shared_store_sync.rs`** — cross-repo sync through a shared store, beyond the e2e single-add case: **update** propagation, **delete** propagation, and **conflict** detection — the shared mutable store's branch-tip compare-and-swap rejects a stale commit (`"Branch has been advanced by another instance"`), and the documented recovery (unstage → sync → re-stage → commit) succeeds with no commit lost.
3. **`storage_obliterate_copy_errors.rs`** — `copy` into a second partition (independently retrievable, byte-identical); `obliterate` tombstone behavior (payload gone, metadata resolves with `size_content == 0`) + idempotency; missing-address and malformed-address error paths.
4. **`storage_remote_backend.rs`** — the multi-backend surface to the extent CI can drive headlessly: remote-config wiring on `open` (local side still round-trips offline), the `upload` trait method with no remote configured, and `obliterate`'s `remote_skipped` reporting. The genuine networked second backend (live QUIC server + TLS) is documented inline as a **deferred gap** (same constraint as the networked server↔client path).

`storage_support/` is a shared helper module placed in a subdirectory so cargo does not treat it as its own test binary.

## Behavioral findings surfaced (pinned by the tests)

- A missing-address `get_metadata`/`get_file` surfaces as an **op-level `Err`** (the binding does not downgrade a not-found to a per-item `ok:false`).
- `obliterate` leaves a **tombstoned/zeroed fragment** (metadata still resolves, `size_content == 0`) rather than a hard not-found.
- The shared store enforces a **branch-tip CAS**; a stale commit is rejected, and `sync` refuses to run while a staged state lingers.

## Verification

`cargo test -p lore-vm --features integration-tests` passes (all suites green, no warnings). `cargo test -p lore-vm` (no feature) also passes — the new suites compile to zero tests, as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)