### PR TITLE
fix(onboarding): treat no-repo first-run as onboarding, not a crash (#331, SBAI-4205)

### DIFF
--- a/frontend/src/App.spec.tsx
+++ b/frontend/src/App.spec.tsx
@@ -1,0 +1,121 @@
+/**
+ * First-run / no-repo robustness tests for the app shell (loregui #331).
+ *
+ * Regression target: on a fresh Windows install the working dir is the app-data
+ * folder, which is NOT a lore repo, so `status` rejects with
+ * `{ kind: "CommandFailed", message: "...Repository not found..." }`. Before the
+ * fix this uncaught error crash-closed the React tree to a blank window. These
+ * tests pin the new behavior:
+ *   1. fresh install (no `loregui.onboarded`)        -> onboarding renders, no crash
+ *   2. previously onboarded but no repo open          -> usable shell + "Set Up
+ *                                                        Repository", no crash
+ *   3. an UNEXPECTED throw on the shell path          -> ErrorBoundary recovery,
+ *                                                        not a blank close
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+// App subscribes to tray/lock events on mount; give listen() a no-op unlisten.
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: () => Promise.resolve(() => {}),
+}));
+
+import App from "./App";
+import ErrorBoundary from "./ErrorBoundary";
+
+// lore's "no repository here" signal, exactly as it reaches the frontend: a
+// serialized LoreError::CommandFailed carrying "Repository not found".
+const NOT_A_REPO = {
+  kind: "CommandFailed",
+  message:
+    "`lore status` exited 1: [Error] Repository not found: C:/Users/MyUser/AppData/Local/LoreGUI",
+};
+
+/** Route invoke() by command name; `status` rejects as a non-repo by default. */
+function routeInvoke(overrides: Record<string, unknown> = {}) {
+  invokeMock.mockImplementation((cmd: string) => {
+    if (cmd in overrides) {
+      const v = overrides[cmd] as { __reject?: unknown };
+      return v && typeof v === "object" && "__reject" in v
+        ? Promise.reject(v.__reject)
+        : Promise.resolve(v);
+    }
+    switch (cmd) {
+      case "current_repository":
+        return Promise.resolve("C:/Users/MyUser/AppData/Local/LoreGUI");
+      case "status":
+        return Promise.reject(NOT_A_REPO);
+      case "branches":
+        return Promise.resolve([]);
+      case "log":
+        return Promise.resolve([]);
+      case "tray_sync_state":
+        return Promise.resolve();
+      case "lock_messaging_inbox_list":
+        return Promise.resolve([]);
+      default:
+        return Promise.resolve(null);
+    }
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  invokeMock.mockReset();
+});
+
+describe("App first-run / no-repo handling (#331)", () => {
+  it("renders onboarding (not a crash) on a fresh install where status is not-a-repo", async () => {
+    routeInvoke();
+    render(<App />);
+
+    // The onboarding mode-select must appear — the app stayed alive.
+    expect(
+      await screen.findByText(/Choose Your Setup Mode/i),
+    ).toBeInTheDocument();
+
+    // The raw CommandFailed JSON must NOT leak into the UI.
+    expect(screen.queryByText(/CommandFailed/)).toBeNull();
+    expect(screen.queryByText(/Repository not found/)).toBeNull();
+  });
+
+  it("keeps a usable shell with a re-entry path when onboarded but no repo is open", async () => {
+    localStorage.setItem("loregui.onboarded", "true");
+    routeInvoke();
+    render(<App />);
+
+    // Shell renders; the topbar shows no-repo state and an explicit way back to
+    // setup — the user is never locked out.
+    expect(await screen.findByText("no repository open")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Set Up Repository/i }),
+    ).toBeInTheDocument();
+    // Settings is always reachable even with no repo.
+    expect(screen.getByRole("button", { name: /^Settings$/ })).toBeInTheDocument();
+    // No fatal error banner from the expected not-a-repo case.
+    expect(screen.queryByText(/Repository not found/)).toBeNull();
+  });
+
+  it("the ErrorBoundary degrades an unexpected throw to a recovery state, not a blank close", () => {
+    function Boom(): never {
+      throw { kind: "CommandFailed", message: "boom from the shell" };
+    }
+    // Silence the expected React error log for this case.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+    // The message is humanized, not raw JSON.
+    expect(screen.getByText("boom from the shell")).toBeInTheDocument();
+    expect(screen.queryByText(/"kind"/)).toBeNull();
+    spy.mockRestore();
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -81,6 +81,22 @@ function errText(e: unknown): string {
   return JSON.stringify(e);
 }
 
+/**
+ * Is this thrown value lore's "no repository here yet" signal (loregui #331)?
+ *
+ * On a fresh install the working dir is the app-data folder, which is NOT a lore
+ * repo, so `status` (and any repo-scoped op) fails with a `CommandFailed`
+ * carrying "Repository not found". That is the EXPECTED first-run state — the
+ * user simply hasn't opened/created/connected a repo yet — so the startup probe
+ * must treat it as "no repo open," render onboarding, and NEVER surface it as a
+ * fatal error or let it crash the shell.
+ */
+function isNotARepoError(e: unknown): boolean {
+  return /repository not found|not a (lore )?repository|no repository/i.test(
+    errText(e),
+  );
+}
+
 function useAsyncError() {
   const [error, setError] = useState<string | null>(null);
   const run = useCallback(async (fn: () => Promise<void>) => {
@@ -207,13 +223,37 @@ export default function App() {
   const [diffLoading, setDiffLoading] = useState(false);
 
   const refresh = useCallback(async () => {
-    await run(async () => {
+    // currentRepository() always resolves (it's just the working-dir path).
+    try {
       setRepo(await api.currentRepository());
-      setStatus(await api.status());
+    } catch {
+      /* non-fatal: leave repo label as-is */
+    }
+
+    // Probe the repo. On a fresh install the working dir is the app-data folder,
+    // which is NOT a lore repo, so this throws "Repository not found" — the
+    // EXPECTED first-run state (loregui #331). Treat that as "no repo open":
+    // clear repo-scoped state so onboarding renders, and DON'T set the fatal
+    // error banner or rethrow (which, with no repo open, would otherwise leave
+    // the user staring at a raw CommandFailed with no way forward).
+    try {
+      setError(null);
+      const s = await api.status();
+      setStatus(s);
       setBranches(await api.branches());
       setHistory(await api.log(50));
-    });
-  }, [run]);
+    } catch (e) {
+      if (isNotARepoError(e)) {
+        setStatus(null);
+        setBranches([]);
+        setHistory([]);
+        return;
+      }
+      // A genuine error (corrupt repo, backend down): surface it, but the shell
+      // stays usable so the user can still reach onboarding / settings.
+      setError(errText(e));
+    }
+  }, [setError]);
 
   useEffect(() => {
     void refresh();
@@ -236,6 +276,19 @@ export default function App() {
     void refresh();
   }, [refresh]);
 
+  // Re-enter onboarding from the main shell (loregui #331). If a previously
+  // onboarded user has no repo open — e.g. they moved/deleted it, or the
+  // app-data dir was the working dir — they must still be able to get back to
+  // the setup flow to connect/create/host a repo.
+  const restartOnboarding = useCallback(() => {
+    localStorage.removeItem("loregui.onboarded");
+    setOnboarded(false);
+  }, []);
+
+  // A real repository is open iff status resolved with a repo id (the working
+  // dir always has a default path, so it can't be the signal).
+  const repoOpen = Boolean(status?.repo_id);
+
   const staged = status?.changes.filter((c) => c.staged) ?? [];
   const unstaged = status?.changes.filter((c) => !c.staged) ?? [];
 
@@ -256,21 +309,25 @@ export default function App() {
   }, [status?.changes.length, syncHasConflicts, syncLoading]);
 
   useEffect(() => {
-    void api.traySyncState({
-      branch: status?.branch ?? "",
-      dirtyCount: status?.changes.length ?? 0,
-      status: trayStatus,
-      // Gate the tray quick actions on live state so disabled items reflect
-      // what's actually possible (SBAI-4042). A real repo is signalled by a
-      // resolved repo_id (the working dir always has a default path).
-      repoOpen: Boolean(status?.repo_id),
-      stagedCount: staged.length,
-      canReleaseLock: selectedFilePath != null,
-    });
+    // Fire-and-forget, but swallow rejections so a tray-update failure never
+    // becomes an unhandled promise rejection that could crash the shell (#331).
+    void api
+      .traySyncState({
+        branch: status?.branch ?? "",
+        dirtyCount: status?.changes.length ?? 0,
+        status: trayStatus,
+        // Gate the tray quick actions on live state so disabled items reflect
+        // what's actually possible (SBAI-4042). A real repo is signalled by a
+        // resolved repo_id (the working dir always has a default path).
+        repoOpen,
+        stagedCount: staged.length,
+        canReleaseLock: selectedFilePath != null,
+      })
+      .catch(() => {});
   }, [
     status?.branch,
     status?.changes.length,
-    status?.repo_id,
+    repoOpen,
     trayStatus,
     staged.length,
     selectedFilePath,
@@ -577,8 +634,18 @@ export default function App() {
         <div className="brand">
           Lore<span>GUI</span>
         </div>
-        <div className="repo">{repo || "no repository open"}</div>
+        <div className="repo">
+          {repoOpen ? repo : "no repository open"}
+        </div>
         <div className="actions">
+          {!repoOpen && (
+            <button
+              onClick={restartOnboarding}
+              title="No repository is open. Connect to a server, or create/host one."
+            >
+              Set Up Repository
+            </button>
+          )}
           <button
             onClick={() => window.dispatchEvent(new Event(OPEN_PALETTE_EVENT))}
             title="Command palette (Ctrl/Cmd-K)"

--- a/frontend/src/ErrorBoundary.tsx
+++ b/frontend/src/ErrorBoundary.tsx
@@ -1,0 +1,103 @@
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+
+/** Extract a human-readable message from a thrown value (a LoreError is
+ * serialized as `{ kind, message }`; plain strings and Errors pass through).
+ * Mirrors App.tsx's `errText` so a thrown command error never reaches the user
+ * as raw `{"kind":...}` JSON (loregui #331). */
+function errText(e: unknown): string {
+  if (typeof e === "string") return e;
+  if (e instanceof Error) return e.message;
+  if (e && typeof e === "object") {
+    const o = e as { message?: unknown; kind?: unknown };
+    if (typeof o.message === "string") return o.message;
+    if (typeof o.kind === "string") return o.kind;
+  }
+  try {
+    return JSON.stringify(e);
+  } catch {
+    return String(e);
+  }
+}
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: unknown;
+}
+
+/**
+ * App-shell error boundary (loregui #331).
+ *
+ * Before this existed, ANY thrown error on the first-run path — most acutely a
+ * `lore status` "Repository not found" surfacing as an uncaught `CommandFailed`
+ * on a fresh install where the working dir is the app-data folder, not a repo —
+ * would unmount the whole React tree to a blank window, leaving the user no way
+ * to reach onboarding, settings, or server config. The app "flashed then closed."
+ *
+ * This boundary catches that throw and renders a calm, themeable recovery state
+ * instead of a crash-close, so the window stays usable. It uses the semantic
+ * `--surface-*` tokens (DESIGN-SYSTEM) so it re-themes with the rest of the app.
+ */
+export default class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo): void {
+    // Surface to the console for diagnostics; never re-throw.
+    console.error("LoreGUI app shell error:", error, info.componentStack);
+  }
+
+  private reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.error == null) return this.props.children;
+
+    return (
+      <div className="onboarding" role="alert">
+        <div className="onboarding-card">
+          <h2>Something went wrong</h2>
+          <p className="onboarding-description">
+            LoreGUI hit an unexpected error and paused to keep the window open.
+            You can retry, or open a repository / configure a server from the
+            main view.
+          </p>
+          <pre
+            style={{
+              margin: "0 0 16px",
+              padding: "12px 14px",
+              borderRadius: 8,
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+              background: "var(--surface-error-bg, rgba(248,81,73,0.12))",
+              color: "var(--surface-error-text, var(--red))",
+              border:
+                "1px solid var(--surface-error-border, var(--border))",
+              fontSize: 13,
+            }}
+          >
+            {errText(this.state.error)}
+          </pre>
+          <div className="onboarding-nav">
+            <button
+              className="onboarding-button onboarding-button--primary"
+              onClick={this.reset}
+            >
+              Try again
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { invoke } from "@tauri-apps/api/core";
 import App from "./App";
+import ErrorBoundary from "./ErrorBoundary";
 import { ThemeProvider } from "./theme/ThemeProvider";
 import { bootstrapEntitlements } from "./commercial/entitlement";
 // Commercial overlay entry (SBAI-4061 / SBAI-4068): imported once for its side
@@ -27,7 +28,9 @@ function mount(): void {
   ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>
       <ThemeProvider>
-        <App />
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>
       </ThemeProvider>
     </React.StrictMode>,
   );


### PR DESCRIPTION
Fixes #331 — **P0: fresh Windows installs were unusable.**

## Symptom
Installed via the Windows installer. On launch the onboarding page flashes, then the app crash-closes leaving no way to interact, set a server, or reach settings. The only thing shown is the raw error:

```
{"kind":"CommandFailed","message":"`lore status` exited 1: [Error] Repository not found: C:/Users/MyUser/AppData/Local/LoreGUI"}
```

## Root cause
On an installed Windows launch the process working dir is the **app-data folder** (`C:/Users/<user>/AppData/Local/LoreGUI`), which is **not** a lore repository. `App.tsx` eagerly probes `api.status()` at startup; `lore` correctly returns `Repository not found` exit 1, which surfaces as a `CommandFailed` `LoreError`. With **no React error boundary**, that throw on the first-run path unmounted the whole React tree to a blank window — the "flash then close." A fresh install with no repo is the **expected** first-run state, not a fatal error.

(The Rust side already returns a clean typed `LoreError`; the bug was purely the frontend not tolerating it. No Rust changes were needed.)

## Fix
1. **`App.refresh()` treats the not-a-repo `CommandFailed` as the normal "no repo open" state** — it clears repo-scoped state so onboarding renders, and never sets the fatal error banner or rethrows. Genuine errors (corrupt repo, backend down) still surface but the shell stays usable.
2. **New themeable `ErrorBoundary`** (semantic `--surface-*` tokens, reuses the onboarding card visual language) wraps the app shell in `main.tsx`, so any unexpected throw degrades to a recovery card with a humanized message + **Try again**, instead of a blank crash-close.
3. **Always-reachable setup**: when previously onboarded but no repo is open, the topbar shows a **Set Up Repository** button that re-enters onboarding; Settings / Account / Storage stay reachable.
4. **Hardened the fire-and-forget tray-sync effect** with `.catch()` so a tray update can't become an unhandled rejection.

## Tests
`frontend/src/App.spec.tsx` (new):
- fresh install, status-on-non-repo → **onboarding renders**, no crash, no raw `CommandFailed`/`Repository not found` JSON leak.
- onboarded but no repo open → usable shell + **Set Up Repository** + Settings reachable.
- ErrorBoundary degrades an unexpected throw to a recovery state (humanized, not raw JSON).

## Verification
- `cargo check -p loregui` — ok
- `cargo fmt --all --check` — ok
- `npm --prefix frontend run build` — ok
- `node frontend/scripts/palette-parity.mjs` — `palette parity OK` (108/135)
- Full frontend suite — **103/103 passing** (3 new)

## Coherence / design review
Empty/error states use semantic surface tokens (themeable), `role="alert"`, calm actionable copy, and reuse the established onboarding components — no hardcoded colors, no new palette surface needed (this is a defensive shell fix, not a new op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)