### PR TITLE
fix(ci): unbreak installer PR gates — disable updater signing on build-only gate (SBAI-4206)

### DIFF
--- a/.github/workflows/build-crossplatform.yml
+++ b/.github/workflows/build-crossplatform.yml
@@ -71,13 +71,23 @@ jobs:
       # placeholder for the current triple so the bundler is satisfied and the gate
       # keeps proving the installer/config still builds per OS. The placeholder is
       # never shipped.
+      #
+      # SBAI-4206: `tauri.conf.json` sets plugins.updater.pubkey +
+      # bundle.createUpdaterArtifacts=true (SBAI-4040). When a pubkey is present
+      # and updater artifacts are enabled, `tauri build` SIGNS those artifacts and
+      # HARD-FAILS if TAURI_SIGNING_PRIVATE_KEY is unset — it does NOT silently
+      # emit unsigned artifacts. This build-only gate intentionally carries no
+      # signing secret, so we deep-merge `tauri.ci.conf.json` to flip
+      # createUpdaterArtifacts off. The .dmg/.app/.deb/.AppImage bundles are
+      # unaffected; release.yml still produces + signs the real updater artifacts
+      # with the secret.
       - name: Build (Tauri → bundle)
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           projectPath: .
-          args: ${{ matrix.args }}
+          args: ${{ matrix.args }} --config src-tauri/tauri.ci.conf.json
 
       - name: Upload bundle artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -37,10 +37,22 @@ jobs:
       # for the current triple so the bundler is satisfied and the gate keeps
       # proving the installer/config still builds. The placeholder is never
       # shipped; release.yml stages the real binary, which build.rs leaves intact.
+      #
+      # SBAI-4206: `tauri.conf.json` sets plugins.updater.pubkey +
+      # bundle.createUpdaterArtifacts=true (SBAI-4040). When a pubkey is present
+      # and updater artifacts are enabled, `tauri build` SIGNS those artifacts and
+      # HARD-FAILS if TAURI_SIGNING_PRIVATE_KEY is unset — it does NOT silently
+      # emit unsigned artifacts. This build-only gate intentionally carries no
+      # signing secret, so we deep-merge `tauri.ci.conf.json` to flip
+      # createUpdaterArtifacts off. The NSIS + MSI installers are unaffected
+      # (updater artifacts are a separate output); release.yml still produces +
+      # signs the real updater artifacts with the secret.
       - name: Build (Tauri → NSIS + MSI)
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --config src-tauri/tauri.ci.conf.json
 
       - name: Upload installer artifact
         uses: actions/upload-artifact@v4

--- a/src-tauri/tauri.ci.conf.json
+++ b/src-tauri/tauri.ci.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "createUpdaterArtifacts": false
+  }
+}


### PR DESCRIPTION
## Problem

Both installer PR gates — `windows-build.yml` (`build-windows`, step *Build (Tauri → NSIS + MSI)*) and `build-crossplatform.yml` (macOS `aarch64-apple-darwin` job) — have failed on **every PR** since SBAI-4040 (#332) merged on 2026-06-24. `main` is not branch-protected, so PRs (including the #331 onboarding-crash fix) merged over the red gate and no installable build can be produced.

Failing runs: #331 (`28186152669`/`28186152677`), `spike/ew0`, `adr/0002`, `hosting-certs`, `tray`, etc.

## Root cause (identical on both platforms)

SBAI-4040 added `plugins.updater.pubkey` + `bundle.createUpdaterArtifacts: true` to `src-tauri/tauri.conf.json`. When a pubkey is present **and** updater artifacts are enabled, `tauri build` signs the updater artifacts and **hard-fails** with:

```
A public key has been found, but no private key. Make sure to set `TAURI_SIGNING_PRIVATE_KEY` environment variable.
##[error]Command "tauri ["build"]" failed with exit code 1
```

…when `TAURI_SIGNING_PRIVATE_KEY` is unset. It does **not** silently emit unsigned artifacts. `release.yml` passes the secret, so it's fine; the two build-only PR gates intentionally carry no secret beyond `GITHUB_TOKEN`, so they exit 1 **after** successfully producing every bundle (NSIS + MSI on Windows; `.app` / `.dmg` / `.app.tar.gz` on macOS aarch64 — logs show `Finished 2 bundles at:` immediately before the error).

**The `macos-latest` → macOS 26 image migration (2026-06-15) is a red herring.** The macOS aarch64 build compiles and bundles cleanly on macOS 26; it dies at the same signing step. No runner pinning needed. The `externalBin` loreserver placeholder staging (build.rs) also works correctly — both platforms reach the bundling stage.

## Fix

These gates are build-only (no signing, no publishing). Add `src-tauri/tauri.ci.conf.json` that deep-merges `bundle.createUpdaterArtifacts: false`, and pass it via `tauri build --config src-tauri/tauri.ci.conf.json` on both gates. The installers/bundles are unaffected (updater artifacts are a separate output); `release.yml` still produces and signs the real updater artifacts with `TAURI_SIGNING_PRIVATE_KEY`. Keeps the gates secret-free and fork-safe per their stated design.

## Verification

CI on this branch must show `build-windows` and the macOS `build-crossplatform` job **green**, producing the NSIS + MSI / `.dmg` artifacts.

Jira: SBAI-4206

🤖 Generated with [Claude Code](https://claude.com/claude-code)