### PR TITLE
SBAI-4206: fix PR gate CI — disable updater artifacts on windows-build + build-crossplatform

### DIFF
--- a/.github/workflows/build-crossplatform.yml
+++ b/.github/workflows/build-crossplatform.yml
@@ -77,7 +77,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           projectPath: .
-          args: ${{ matrix.args }}
+          args: ${{ matrix.args }} --config src-tauri/tauri.ci.conf.json
 
       - name: Upload bundle artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -41,6 +41,8 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --config src-tauri/tauri.ci.conf.json
 
       - name: Upload installer artifact
         uses: actions/upload-artifact@v4

--- a/src-tauri/tauri.ci.conf.json
+++ b/src-tauri/tauri.ci.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "createUpdaterArtifacts": false
+  }
+}


### PR DESCRIPTION
Resolves SBAI-4206

## Summary
Both PR gate workflows (windows-build.yml, build-crossplatform.yml) have been failing since SBAI-4040 added updater pubkey + createUpdaterArtifacts=true to tauri.conf.json. When pubkey is set, `tauri build` hard-fails without `TAURI_SIGNING_PRIVATE_KEY` — it doesn't silently skip signing. The release workflow passes this secret; the PR gates do not.

## Fix
- Added `src-tauri/tauri.ci.conf.json`: a committed config override that sets `bundle.createUpdaterArtifacts: false`
- Both PR gate workflows now pass `--config src-tauri/tauri.ci.conf.json` to `tauri build`
- release.yml is unchanged — it still builds + signs the real updater artifacts with the secret

## Files Changed
- `src-tauri/tauri.ci.conf.json` (new) — CI override disabling updater artifacts
- `.github/workflows/windows-build.yml` — added `--config` arg to tauri-action
- `.github/workflows/build-crossplatform.yml` — added `--config` arg to tauri-action

## Testing
- Config override is valid JSON matching Tauri config schema
- Deep-merge via `--config` is the standard Tauri mechanism (also used by release.yml's Windows signing override)
- No Rust/TypeScript code changed — no `cargo check` or `npm build` needed