### PR TITLE
SBAI-4237: fix local-FS Host-a-server wizard (steps 1 + 3 errored)

### DIFF
--- a/frontend/scripts/palette-parity-allowlist.json
+++ b/frontend/scripts/palette-parity-allowlist.json
@@ -7,6 +7,8 @@
     "unsubscribe_notifications",
     "storage_open",
     "storage_obliterate",
+    "host_store_prepare",
+    "host_store_probe",
     "revision_commit",
     "create_branch",
     "branches",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -418,6 +418,21 @@ export const api = {
     invoke<void>("storage_obliterate", { key }),
   sharedStoreCreate: (path: string) =>
     invoke<string>("shared_store_create", { path }),
+
+  // --- local host-store prepare / probe (first-run "Host a server", local FS) ---
+  // The local-FS host store is a plain directory the standalone `loreserver`
+  // fills with its content-addressed immutable/ + mutable/ layout at launch — it
+  // is NOT a lore repository (no `.lore`) and needs NO remote URL. These replace
+  // `storageOpen`/`sharedStoreCreate` for the local backend in the host wizard.
+  /** Ensure the local store dir (and optional mutable dir) exists; returns the resolved path. */
+  hostStorePrepare: (path: string, mutableStore?: string) =>
+    invoke<string>("host_store_prepare", {
+      path,
+      mutableStore: mutableStore ?? null,
+    }),
+  /** Round-trip writability probe (write → read → delete) for a local store dir. */
+  hostStoreProbe: (path: string) =>
+    invoke<void>("host_store_probe", { path }),
   serviceStart: (installAutorun: boolean) =>
     invoke<void>("service_start", { installAutorun }),
   serviceStop: (all: boolean = false) =>

--- a/frontend/src/onboarding/OnboardingFlow.tsx
+++ b/frontend/src/onboarding/OnboardingFlow.tsx
@@ -96,7 +96,12 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
         );
         break;
       case "init":
-        content = <InitStore onInitialized={setInitResult} />;
+        content = (
+          <InitStore
+            config={backendConfig ?? undefined}
+            onInitialized={setInitResult}
+          />
+        );
         break;
       case "service":
         content = (

--- a/frontend/src/onboarding/server/BackendPicker.tsx
+++ b/frontend/src/onboarding/server/BackendPicker.tsx
@@ -137,7 +137,20 @@ export default function BackendPicker({ onConfigured }: BackendPickerProps = {})
       setStep("connecting");
       setError(null);
       const config = buildConfig();
-      await api.storageOpen(config);
+      if (config.kind === "local") {
+        // A local-FS host store is a plain directory the loreserver populates
+        // when it starts (step 4) — NOT an existing lore repository. Prepare
+        // (create) the directory here instead of opening a `.lore` repo, which
+        // would fail for a brand-new host with "missing .lore". Forward the
+        // resolved absolute path so later steps serve exactly this directory.
+        const resolved = await api.hostStorePrepare(
+          config.path ?? "",
+          config.mutableStore,
+        );
+        config.path = resolved;
+      } else {
+        await api.storageOpen(config);
+      }
       setStep("success");
       onConfigured?.(config);
     } catch (e) {
@@ -228,6 +241,11 @@ export default function BackendPicker({ onConfigured }: BackendPickerProps = {})
             onChange={updateField("path")}
             disabled={step === "connecting"}
           />
+          <span className="onboarding-field-hint">
+            The directory is created if it doesn&rsquo;t exist — no existing
+            repository required. Your server fills it with its content store when
+            it starts.
+          </span>
         </div>
       )}
 
@@ -337,7 +355,7 @@ export default function BackendPicker({ onConfigured }: BackendPickerProps = {})
           disabled={!isValid()}
           onClick={handleConnect}
         >
-          Open Storage
+          {kind === "local" ? "Prepare Store" : "Open Storage"}
         </button>
       )}
 

--- a/frontend/src/onboarding/server/HostFlowLocal.spec.tsx
+++ b/frontend/src/onboarding/server/HostFlowLocal.spec.tsx
@@ -1,0 +1,128 @@
+/**
+ * Fresh local-FS "Host a server" wizard path (loregui host-wizard bug fix).
+ *
+ * A brand-new user hosting a LOCAL filesystem server must get through steps
+ * 1 (Choose Storage Backend), 2 (Validate connectivity) and 3 (Initialize
+ * server / Create store) with NO errors, ending at the working host step.
+ *
+ * The bug: step 1 called `storage_open` (which requires an existing `.lore`
+ * repository → "missing .lore") and step 3 called `shared_store_create` (which
+ * requires a remote URL → "no remote URL"). Both are the wrong abstraction for a
+ * local host store — that store is a plain directory the loreserver fills at
+ * host time. These tests pin the fix: the local path now drives the
+ * `host_store_prepare` / `host_store_probe` filesystem commands and succeeds
+ * without any `.lore` repo or remote URL.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import type { StorageBackendConfig } from "../../api";
+import BackendPicker from "./BackendPicker";
+import ValidateConnectivity from "./ValidateConnectivity";
+import InitStore, { type InitStoreResult } from "./InitStore";
+
+/** All invoked (name, args) pairs, in order. */
+function calls(): Array<[string, Record<string, unknown> | undefined]> {
+  return invokeMock.mock.calls.map((c) => [
+    c[0] as string,
+    c[1] as Record<string, unknown> | undefined,
+  ]);
+}
+function names(): string[] {
+  return calls().map(([n]) => n);
+}
+
+beforeEach(() => {
+  invokeMock.mockReset();
+});
+
+describe("step 1 — Choose Storage Backend (local FS)", () => {
+  it("prepares the store dir via host_store_prepare, never opens a .lore repo", async () => {
+    // host_store_prepare echoes back the resolved absolute path.
+    invokeMock.mockImplementation((cmd: string, args: Record<string, unknown>) => {
+      if (cmd === "host_store_prepare") return Promise.resolve(args.path);
+      return Promise.reject(`unexpected command ${cmd}`);
+    });
+
+    const onConfigured = vi.fn();
+    render(<BackendPicker onConfigured={onConfigured} />);
+
+    fireEvent.change(screen.getByLabelText("Local Storage Path"), {
+      target: { value: "C:/loredata" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Prepare Store" }));
+
+    await waitFor(() => expect(onConfigured).toHaveBeenCalledTimes(1));
+
+    // It used the local-FS prepare command, NOT the repository storage_open that
+    // produced "missing .lore".
+    expect(names()).toContain("host_store_prepare");
+    expect(names()).not.toContain("storage_open");
+    expect(calls()[0]).toEqual([
+      "host_store_prepare",
+      { path: "C:/loredata", mutableStore: null },
+    ]);
+
+    const cfg = onConfigured.mock.calls[0][0] as StorageBackendConfig;
+    expect(cfg.kind).toBe("local");
+    expect(cfg.path).toBe("C:/loredata");
+    expect(screen.getByText(/Storage opened/)).toBeInTheDocument();
+  });
+});
+
+describe("step 2 — Validate connectivity (local FS)", () => {
+  it("round-trips via host_store_probe, not the content-store put/get", async () => {
+    invokeMock.mockResolvedValue(undefined);
+    const config: StorageBackendConfig = { kind: "local", path: "C:/loredata" };
+    render(<ValidateConnectivity config={config} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Run Connectivity Test" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/backend is reachable/)).toBeInTheDocument(),
+    );
+    expect(calls()).toEqual([["host_store_probe", { path: "C:/loredata" }]]);
+    expect(names()).not.toContain("storage_put");
+    expect(names()).not.toContain("storage_open");
+  });
+});
+
+describe("step 3 — Initialize server / Create store (local FS)", () => {
+  it("creates the store locally, never calling shared_store_create / remote", async () => {
+    invokeMock.mockImplementation((cmd: string, args: Record<string, unknown>) => {
+      if (cmd === "host_store_prepare") return Promise.resolve(args.path);
+      return Promise.reject(`unexpected command ${cmd}`);
+    });
+
+    let result: InitStoreResult | null = null;
+    const config: StorageBackendConfig = { kind: "local", path: "C:/loredata" };
+    render(
+      <InitStore config={config} onInitialized={(r) => (result = r)} />,
+    );
+
+    // Store path is prefilled from step 1's config.
+    const pathInput = screen.getByLabelText("Store Path") as HTMLInputElement;
+    expect(pathInput.value).toBe("C:/loredata");
+
+    fireEvent.change(screen.getByLabelText("Repository Name (optional)"), {
+      target: { value: "my-repo" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create Store" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Store ready")).toBeInTheDocument(),
+    );
+
+    expect(names()).toEqual(["host_store_prepare"]);
+    expect(names()).not.toContain("shared_store_create");
+    expect(names()).not.toContain("repository_create");
+    expect(result).toEqual({ storePath: "C:/loredata", repoName: "my-repo" });
+  });
+});

--- a/frontend/src/onboarding/server/InitStore.tsx
+++ b/frontend/src/onboarding/server/InitStore.tsx
@@ -1,133 +1,104 @@
-import { useCallback, useState } from "react";
-import { api } from "../../api";
+import { useCallback, useEffect, useState } from "react";
+import { api, type StorageBackendConfig } from "../../api";
 
-type Step = "store" | "repo" | "done" | "error";
+type Step = "form" | "done" | "error";
 
 export interface InitStoreResult {
-  /** The shared-store directory created — this is what the host server serves. */
+  /** The store directory created — this is what the host server serves. */
   storePath: string;
-  /** The repository name created in that store. */
+  /** Optional repository name advertised in the host server's lore:// URL. */
   repoName: string;
 }
 
 interface InitStoreProps {
   /**
-   * Reports the created store path + repo name up to the onboarding shell so the
-   * next step ("Host server") can serve exactly this store and advertise this
-   * repo in its lore:// URL.
+   * Storage backend config from step 1, used to prefill the store path so the
+   * user doesn't retype it. Optional so the component still renders if the user
+   * jumped here.
+   */
+  config?: StorageBackendConfig;
+  /**
+   * Reports the created store path + (optional) repo name up to the onboarding
+   * shell so the next step ("Host server") serves exactly this store and
+   * advertises this repo in its lore:// URL.
    */
   onInitialized?: (result: InitStoreResult) => void;
 }
 
 /**
- * Onboarding component: initialize a shared store + repository.
- * Wired into the onboarding shell by the integration manager.
+ * Onboarding step 3: create the local store the server will host.
  *
- * Uses `api.sharedStoreCreate` to create the shared storage backend,
- * then `api.repositoryCreate` to create the first repository.
+ * The host flow's store is a plain directory the standalone `loreserver` fills
+ * with its content-addressed immutable/ + mutable/ layout when it starts
+ * (step 4). It is NOT a lore *repository* (no `.lore` marker) and needs NO
+ * remote service, so this step simply ensures the directory exists via
+ * `api.hostStorePrepare` — it does not call `shared_store_create` /
+ * `repository_create`, which require a remote URL and would fail for a fresh
+ * local host with "no remote URL". An optional repository name is collected to
+ * advertise in the connection URL the next step shows clients.
  */
-export default function InitStore({ onInitialized }: InitStoreProps = {}) {
-  const [storePath, setStorePath] = useState("");
-  const [repoPath, setRepoPath] = useState("");
+export default function InitStore({ config, onInitialized }: InitStoreProps = {}) {
+  const [storePath, setStorePath] = useState(config?.path ?? "");
   const [repoName, setRepoName] = useState("");
-  const [step, setStep] = useState<Step>("store");
+  const [step, setStep] = useState<Step>("form");
   const [error, setError] = useState<string | null>(null);
-  const [storeResult, setStoreResult] = useState<string | null>(null);
-  const [repoResult, setRepoResult] = useState<string | null>(null);
+  const [resolvedPath, setResolvedPath] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleCreateStore = useCallback(async () => {
+  // Keep the store path in sync if step 1 reports/updates a resolved path.
+  useEffect(() => {
+    if (config?.path) setStorePath(config.path);
+  }, [config?.path]);
+
+  const handleCreate = useCallback(async () => {
     if (!storePath.trim()) return;
     try {
       setIsSubmitting(true);
       setError(null);
-      const id = await api.sharedStoreCreate(storePath.trim());
-      setStoreResult(id);
-      setStep("repo");
-    } catch (e) {
-      setError(typeof e === "string" ? e : JSON.stringify(e));
-      setStep("error");
-    } finally {
-      setIsSubmitting(false);
-    }
-  }, [storePath]);
-
-  const handleCreateRepo = useCallback(async () => {
-    if (!repoPath.trim() || !repoName.trim()) return;
-    try {
-      setIsSubmitting(true);
-      setError(null);
-      const id = await api.repositoryCreate(repoPath.trim(), repoName.trim());
-      setRepoResult(id);
+      // Ensure the local store directory exists. Idempotent — step 1 may have
+      // already created it. No remote URL, no repository-create here.
+      const resolved = await api.hostStorePrepare(storePath.trim());
+      setResolvedPath(resolved);
       setStep("done");
-      onInitialized?.({ storePath: storePath.trim(), repoName: repoName.trim() });
+      onInitialized?.({ storePath: resolved, repoName: repoName.trim() });
     } catch (e) {
       setError(typeof e === "string" ? e : JSON.stringify(e));
       setStep("error");
     } finally {
       setIsSubmitting(false);
     }
-  }, [repoPath, repoName, storePath, onInitialized]);
-
-  const handleRetry = useCallback(() => {
-    setError(null);
-    // Retry from the step that failed
-    if (storeResult) {
-      setStep("repo");
-    } else {
-      setStep("store");
-    }
-  }, [storeResult]);
+  }, [storePath, repoName, onInitialized]);
 
   return (
     <div className="onboarding-card">
       <h2>Initialize Server</h2>
       <p className="onboarding-description">
-        Set up a shared storage backend and create your first repository.
+        Create the local store your server will host. The server fills it with
+        its content store when it starts — there&rsquo;s nothing else to set up.
+        Optionally name the first repository to advertise in the connection URL.
       </p>
 
       {error && <div className="error">{error}</div>}
 
-      {step === "store" && (
-        <div className="onboarding-field">
-          <label htmlFor="store-path">Shared Store Path</label>
-          <input
-            id="store-path"
-            type="text"
-            placeholder="/path/to/shared/store"
-            value={storePath}
-            onChange={(e) => setStorePath(e.target.value)}
-            disabled={isSubmitting}
-          />
-          <button
-            className="onboarding-button onboarding-button--primary"
-            disabled={!storePath.trim() || isSubmitting}
-            onClick={() => void handleCreateStore()}
-          >
-            Create Store
-          </button>
-        </div>
-      )}
-
-      {step === "repo" && (
+      {(step === "form" || step === "error") && (
         <>
-          <div className="onboarding-success">
-            <span className="success-icon">&#10003;</span>
-            <span>Shared store created (ID: {storeResult})</span>
-          </div>
           <div className="onboarding-field">
-            <label htmlFor="repo-path">Repository Path</label>
+            <label htmlFor="store-path">Store Path</label>
             <input
-              id="repo-path"
+              id="store-path"
               type="text"
-              placeholder="/path/to/repository"
-              value={repoPath}
-              onChange={(e) => setRepoPath(e.target.value)}
+              placeholder="/path/to/store"
+              value={storePath}
+              onChange={(e) => setStorePath(e.target.value)}
               disabled={isSubmitting}
             />
+            <span className="onboarding-field-hint">
+              Prefilled from the storage backend you chose. The directory is
+              created if it doesn&rsquo;t exist.
+            </span>
           </div>
-          <div className="onboarding-field">
-            <label htmlFor="repo-name">Repository Name</label>
+          <div className="onboarding-field onboarding-field--optional">
+            <label htmlFor="repo-name">Repository Name (optional)</label>
             <input
               id="repo-name"
               type="text"
@@ -136,13 +107,17 @@ export default function InitStore({ onInitialized }: InitStoreProps = {}) {
               onChange={(e) => setRepoName(e.target.value)}
               disabled={isSubmitting}
             />
+            <span className="onboarding-field-hint">
+              Advertised in the <code>lore://</code> URL clients clone. Leave
+              blank to set it up later.
+            </span>
           </div>
           <button
             className="onboarding-button onboarding-button--primary"
-            disabled={!repoPath.trim() || !repoName.trim() || isSubmitting}
-            onClick={() => void handleCreateRepo()}
+            disabled={!storePath.trim() || isSubmitting}
+            onClick={() => void handleCreate()}
           >
-            Create Repository
+            {step === "error" ? "Retry" : "Create Store"}
           </button>
         </>
       )}
@@ -151,24 +126,19 @@ export default function InitStore({ onInitialized }: InitStoreProps = {}) {
         <div className="onboarding-success">
           <div className="success-message">
             <span className="success-icon">&#10003;</span>
-            <span>Server initialized</span>
+            <span>Store ready</span>
           </div>
           <div className="onboarding-description">
-            Shared store created (ID: {storeResult})
-          </div>
-          <div className="onboarding-description">
-            Repository created (ID: {repoResult})
+            Store created at <code>{resolvedPath}</code>
+            {repoName.trim() ? (
+              <>
+                {" — repository "}
+                <code>{repoName.trim()}</code>
+              </>
+            ) : null}
+            . Continue to host it.
           </div>
         </div>
-      )}
-
-      {step === "error" && (
-        <button
-          className="onboarding-button onboarding-button--primary"
-          onClick={handleRetry}
-        >
-          Retry
-        </button>
       )}
     </div>
   );

--- a/frontend/src/onboarding/server/ValidateConnectivity.tsx
+++ b/frontend/src/onboarding/server/ValidateConnectivity.tsx
@@ -22,7 +22,18 @@ export default function ValidateConnectivity({
       setStep("testing");
       setError(null);
 
-      // Open the configured storage backend
+      // A local-FS host store is a plain directory the loreserver fills at host
+      // time — NOT a lore repository — so its connectivity check is a real
+      // filesystem round-trip (write → read → delete a probe file) rather than
+      // the content-store put/get/obliterate, which would require an existing
+      // `.lore`. The S3 backend keeps the storage round-trip below.
+      if (config.kind === "local") {
+        await api.hostStoreProbe(config.path ?? "");
+        setStep("pass");
+        return;
+      }
+
+      // Open the configured storage backend (S3-compatible)
       await api.storageOpen(config);
 
       // Put a test key
@@ -45,11 +56,13 @@ export default function ValidateConnectivity({
 
       setStep("pass");
     } catch (e) {
-      // Best-effort cleanup if put succeeded but get/obliterate failed
-      try {
-        await api.storageObliterate(TEST_KEY);
-      } catch {
-        // ignore — the key may not exist or storage may be unreachable
+      // Best-effort cleanup if put succeeded but get/obliterate failed (S3 only).
+      if (config.kind !== "local") {
+        try {
+          await api.storageObliterate(TEST_KEY);
+        } catch {
+          // ignore — the key may not exist or storage may be unreachable
+        }
       }
       const msg = typeof e === "string" ? e : JSON.stringify(e);
       setError(msg);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2169,6 +2169,35 @@ pub async fn shared_store_create(
     Ok(result.path)
 }
 
+// --- onboarding: local host-store prepare / probe ---
+//
+// The first-run "Host a server" flow with a LOCAL filesystem backend does NOT
+// use the lore repository/remote storage abstraction. Its store is a plain
+// directory the standalone `loreserver` fills with its content-addressed
+// `immutable/` + `mutable/` layout at launch (see `server_host`). These commands
+// give the wizard a local-FS-native "prepare store" (steps 1 + 3) and "validate
+// connectivity" (step 2) that never require an existing `.lore` repository or a
+// remote URL — the bug that made `storage_open` ("missing .lore") and
+// `shared_store_create` ("no remote URL") fail for a brand-new local host.
+
+/// Ensure a local host-store directory (and an optional separate mutable-store
+/// directory) exists; returns the resolved store path. Idempotent.
+#[tauri::command]
+pub fn host_store_prepare(
+    path: String,
+    mutable_store: Option<String>,
+) -> Result<String, LoreError> {
+    server_host::prepare_local_store(&path, mutable_store.as_deref())
+        .map(|p| p.to_string_lossy().into_owned())
+}
+
+/// Round-trip writability probe for a local host-store directory (write → read →
+/// delete a probe file). The local-FS equivalent of the connectivity check.
+#[tauri::command]
+pub fn host_store_probe(path: String) -> Result<(), LoreError> {
+    server_host::probe_local_store(&path)
+}
+
 // --- repository clone ---
 
 use lore_vm::ops::repository::clone::{clone as op_repository_clone, CloneArgs};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -179,6 +179,8 @@ pub fn run() {
             commands::storage_copy,
             commands::storage_upload,
             commands::shared_store_create,
+            commands::host_store_prepare,
+            commands::host_store_probe,
             commands::shared_store_info,
             commands::shared_store_set_use_automatically,
             commands::repository_clone,

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -1904,6 +1904,91 @@ pub fn render_config(opts: &HostServerOptions, ctx: &CertContext) -> Result<Stri
     Ok(render_config_toml(&cfg))
 }
 
+/// Probe file written under a local store's `.loregui-host/` dir by
+/// [`probe_local_store`]. Lives alongside the generated `local.toml` so a single
+/// store directory stays self-describing.
+const PROBE_FILE: &str = ".connectivity-probe";
+/// Fixed payload round-tripped by the writability probe.
+const PROBE_PAYLOAD: &[u8] = b"loregui-host-ok";
+
+/// Prepare a **local** filesystem host store directory for the first-run flow.
+///
+/// The host flow's store is a plain directory the standalone `loreserver` fills
+/// with its content-addressed `immutable/` + `mutable/` layout the first time it
+/// launches (see [`prepare`] / [`start`]). It is **not** a lore *repository*:
+/// there is no `.lore` marker and no remote service involved. So this just
+/// ensures the store directory (and an optional separate mutable-store dir)
+/// exists, then returns the store path.
+///
+/// This is the local-FS-native replacement for the onboarding wizard's old step
+/// 1 ("open storage") + step 3 ("create store"), which wrongly routed through the
+/// lore repository/remote storage abstraction (`storage open` requires an
+/// existing `.lore`; `shared_store create` requires a remote URL) and therefore
+/// failed for a brand-new local host. Idempotent: re-running it on an existing
+/// store directory is a no-op that re-returns the path.
+pub fn prepare_local_store(
+    store_dir: &str,
+    mutable_store: Option<&str>,
+) -> Result<PathBuf, LoreError> {
+    let trimmed = store_dir.trim();
+    if trimmed.is_empty() {
+        return Err(LoreError::CommandFailed(
+            "a local storage path is required".into(),
+        ));
+    }
+    let path = PathBuf::from(trimmed);
+    std::fs::create_dir_all(&path).map_err(|e| {
+        LoreError::CommandFailed(format!(
+            "could not create local store directory {}: {e}",
+            path.display()
+        ))
+    })?;
+    if let Some(mut_dir) = mutable_store.map(str::trim).filter(|s| !s.is_empty()) {
+        std::fs::create_dir_all(mut_dir).map_err(|e| {
+            LoreError::CommandFailed(format!(
+                "could not create mutable store directory {mut_dir}: {e}"
+            ))
+        })?;
+    }
+    Ok(path)
+}
+
+/// Round-trip writability probe for a **local** host store directory.
+///
+/// Writes a small probe file under the store's `.loregui-host/` config dir, reads
+/// it back, verifies the bytes, then deletes it. This is the local-FS equivalent
+/// of the onboarding "validate connectivity" round-trip — it never touches the
+/// lore repository/remote abstraction, so it works on a brand-new directory that
+/// has no `.lore` marker (the bug being fixed). Ensures the directory exists
+/// first, so it can run before [`prepare_local_store`] has been called.
+pub fn probe_local_store(store_dir: &str) -> Result<(), LoreError> {
+    let path = prepare_local_store(store_dir, None)?;
+    let probe_dir = path.join(".loregui-host");
+    std::fs::create_dir_all(&probe_dir).map_err(|e| {
+        LoreError::CommandFailed(format!(
+            "could not create probe dir {}: {e}",
+            probe_dir.display()
+        ))
+    })?;
+    let probe = probe_dir.join(PROBE_FILE);
+    std::fs::write(&probe, PROBE_PAYLOAD).map_err(|e| {
+        LoreError::CommandFailed(format!(
+            "store directory is not writable ({}): {e}",
+            path.display()
+        ))
+    })?;
+    let read_back = std::fs::read(&probe)
+        .map_err(|e| LoreError::CommandFailed(format!("could not read back probe file: {e}")))?;
+    // Tidy up before asserting so a mismatch still removes the probe file.
+    let _ = std::fs::remove_file(&probe);
+    if read_back != PROBE_PAYLOAD {
+        return Err(LoreError::CommandFailed(
+            "store directory round-trip mismatch — storage may be unreliable".into(),
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2039,6 +2124,75 @@ mod tests {
         // Secrets are never written into the config TOML (they go via env vars).
         assert!(!toml.contains("AKIAEXAMPLE"));
         assert!(!toml.contains("supersecret"));
+    }
+
+    // --- fresh local-FS host store: prepare + probe (the wizard bug fix) -------
+
+    #[test]
+    fn prepare_local_store_creates_a_fresh_dir_without_requiring_dot_lore() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("fresh-host-store");
+        // A brand-new host: the directory does not exist yet and has no `.lore`
+        // repository marker — exactly the case the old `storage open` rejected.
+        assert!(!store.exists());
+
+        let got = prepare_local_store(store.to_str().unwrap(), None).unwrap();
+        assert_eq!(got, store);
+        assert!(store.is_dir());
+        // No `.lore` marker is created or required (requiring one was the bug).
+        assert!(!store.join(".lore").exists());
+
+        // Idempotent: re-running on the now-existing dir succeeds (wizard step 1
+        // then step 3 both prepare the same path).
+        prepare_local_store(store.to_str().unwrap(), None).unwrap();
+    }
+
+    #[test]
+    fn prepare_local_store_also_creates_an_optional_mutable_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("store");
+        let mutable = tmp.path().join("mutable");
+        prepare_local_store(store.to_str().unwrap(), mutable.to_str()).unwrap();
+        assert!(store.is_dir());
+        assert!(mutable.is_dir());
+    }
+
+    #[test]
+    fn prepare_local_store_rejects_a_blank_path() {
+        assert!(prepare_local_store("   ", None).is_err());
+    }
+
+    #[test]
+    fn probe_local_store_round_trips_and_cleans_up_without_remote_or_dot_lore() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("host-store");
+        // Connectivity validation on a fresh local store must pass with no remote
+        // URL and no `.lore` repository present.
+        probe_local_store(store.to_str().unwrap()).unwrap();
+        // The probe file is removed and nothing repository-shaped is created.
+        assert!(!store.join(".loregui-host").join(PROBE_FILE).exists());
+        assert!(!store.join(".lore").exists());
+    }
+
+    #[test]
+    fn full_fresh_local_host_path_prepare_probe_then_render_config() {
+        // End-to-end of the fixed wizard's local-FS host path: step 1/3 prepare
+        // the store dir, step 2 probes it, step 4 renders the loreserver config —
+        // none of which require an existing `.lore` repo or a remote URL.
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("linear-host-store");
+
+        let resolved = prepare_local_store(store.to_str().unwrap(), None).unwrap();
+        probe_local_store(resolved.to_str().unwrap()).unwrap();
+
+        let toml = render_config(
+            &basic_opts(resolved.to_str().unwrap()),
+            &CertContext::none(),
+        )
+        .expect("render local host config");
+        assert!(toml.contains("[immutable_store.local]"));
+        assert!(toml.contains("[mutable_store.local]"));
+        assert!(!toml.contains("mode = \"aws\""));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes **SBAI-4237**. The first-run **Host a server** wizard errored on two of its four steps for a brand-new **local filesystem** host, so a fresh user would conclude the app is broken — even though hosting actually works via a non-obvious workaround (force-advancing past the errors to step 4 and clicking *Start Hosting*).

### The bug (from real-install testing)
- **Step 1 — Choose Storage Backend (Local FS):** `{"kind":"CommandFailed","message":"no lore repository at <path> (missing .lore)"}`. Step 2 then refuses ("configure a storage backend on the previous step first").
- **Step 3 — Initialize Server → Create Store:** `{"kind":"CommandFailed","message":"Failed to connect to remote URL: no remote URL"}` even with the dir pre-created — it wrongly attempts a **remote** connection for a **local** host.
- **Only working path:** Continue past the step-3 error → step 4 *Host Server* → *Start Hosting* launches `loreserver`, creates the immutable/mutable store, and the main UI loads.

### Root cause
Steps 1 and 3 were wired to the wrong storage abstraction:
- Step 1 (`BackendPicker`) called `storage_open` → `lore::storage::open`, which opens an **existing** lore repository content store and requires a `.lore` marker.
- Step 3 (`InitStore`) called `shared_store_create` → `lore::shared_store::create`, the **remote** shared-store abstraction, which requires a remote URL.

But the local-FS host store has neither — it's a plain directory the standalone `loreserver` fills with its content-addressed `immutable/` + `mutable/` layout (plus `.loregui-host/local.toml`) at host time (`server_host::prepare`). So only step 4 worked.

### Fix
Make the local-FS host path filesystem-native so all four steps complete **linearly with no errors**:
- New Tauri commands **`host_store_prepare`** (create the store dir, idempotent) and **`host_store_probe`** (write → read → delete a probe file).
- **Step 1** local → `host_store_prepare` (not `storage_open`); forwards the resolved absolute path to later steps. Button reads *Prepare Store* for local.
- **Step 2** local → `host_store_probe` (not the content-store put/get/obliterate round-trip).
- **Step 3** → `host_store_prepare` with the store path **prefilled from step 1** + an optional repository name for the `lore://` URL; no `shared_store_create` / `repository_create` / remote URL.
- **S3 backend behavior unchanged.**

### Tests
- Rust: `prepare_local_store` / `probe_local_store` unit tests + a full fresh-local-FS host path (`prepare → probe → render_config`) that needs no `.lore` repo or remote URL.
- Frontend: `HostFlowLocal.spec.tsx` asserts steps 1/2/3 drive the new commands and never call `storage_open` / `shared_store_create` / `repository_create`.

### Verification
- `cargo check -p loregui` ✓
- `cargo fmt --all --check` ✓
- `cargo test -p loregui --lib server_host::tests` ✓ (36 passed)
- `npm --prefix frontend run build` ✓
- `npx vitest run` ✓ (106 passed)
- `node frontend/scripts/palette-parity.mjs` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)