### PR TITLE
SBAI-4239: interactive dark→light theme-swap in website screenshot gallery

### DIFF
--- a/website/src/components/Screenshots.tsx
+++ b/website/src/components/Screenshots.tsx
@@ -1,50 +1,121 @@
-import Image from "next/image";
 import { Container } from "@/components/ui/Container";
 import { Button } from "@/components/ui/Button";
-import { AppWindow } from "@/components/mockups/AppWindow";
+import { ThemeSwapShot } from "@/components/ThemeSwapShot";
 import { ArrowRightIcon } from "@/components/icons";
 
-/** A captioned surface in the feature gallery. All shots are 1440×900. */
-const surfaces: {
+interface Shot {
   src: string;
   alt: string;
+}
+
+interface Caption {
   title: string;
-  caption: string;
+  body: string;
+}
+
+/**
+ * A captioned surface in the feature gallery. Each shows the DARK theme by
+ * default and crossfades to a LIGHT shot on hover.
+ *
+ * - If `light` is the SAME surface re-themed → omit `captionHover`; the image
+ *   swaps and the caption stays.
+ * - If `light` is a DIFFERENT object/function → provide `captionHover` so the
+ *   title + description flip to describe what's now on screen.
+ */
+const surfaces: {
+  windowTitle: string;
+  dark: Shot;
+  light: Shot;
+  hint?: string;
+  caption: Caption;
+  captionHover?: Caption;
+  className?: string;
+  sizes?: string;
 }[] = [
   {
-    src: "/screenshots/main-view-dark.png",
-    alt: "LoreGUI main view: branches on the left, staged and unstaged changes with a commit box in the center, and revision history on the right.",
-    title: "Branches · Changes · History",
-    caption:
-      "The whole repository in one window — pick a branch, stage and commit changes, and read the history without ever touching the command line.",
+    windowTitle: "LoreGUI — Branches · Changes · History",
+    className: "lg:col-span-2",
+    sizes: "(min-width: 1024px) 1024px, 100vw",
+    dark: {
+      src: "/screenshots/main-view-dark.png",
+      alt: "LoreGUI main view in the dark theme: branches on the left, staged and unstaged changes with a commit box in the center, and revision history on the right.",
+    },
+    light: {
+      src: "/screenshots/main-view-light.png",
+      alt: "The same LoreGUI main view rendered in the light theme — identical layout, re-themed surfaces.",
+    },
+    caption: {
+      title: "Branches · Changes · History",
+      body: "The whole repository in one window — pick a branch, stage and commit changes, and read the history without ever touching the command line.",
+    },
   },
   {
-    src: "/screenshots/panel-branches-dark.png",
-    alt: "LoreGUI branches panel showing the branch list and a guided merge flow.",
-    title: "Branches & merging",
-    caption:
-      "Create, protect, reset and archive branches, then drive a guided three-way merge with conflict resolution built in.",
+    windowTitle: "LoreGUI — Branches & merging",
+    dark: {
+      src: "/screenshots/panel-branches-dark.png",
+      alt: "LoreGUI branches panel in the dark theme showing the branch list and a guided merge flow.",
+    },
+    light: {
+      src: "/screenshots/panel-branches-light.png",
+      alt: "The same LoreGUI branches panel rendered in the light theme.",
+    },
+    caption: {
+      title: "Branches & merging",
+      body: "Create, protect, reset and archive branches, then drive a guided three-way merge with conflict resolution built in.",
+    },
   },
   {
-    src: "/screenshots/panel-history-dark.png",
-    alt: "LoreGUI history panel listing revisions with diffs and a revert action.",
-    title: "Revisions & diff",
-    caption:
-      "Walk every revision, compare any two side by side, and cherry-pick or revert a change with a single action.",
+    windowTitle: "LoreGUI — Revisions & diff",
+    dark: {
+      src: "/screenshots/panel-history-dark.png",
+      alt: "LoreGUI history panel in the dark theme listing revisions with diffs and a revert action.",
+    },
+    light: {
+      src: "/screenshots/panel-history-light.png",
+      alt: "The same LoreGUI history panel rendered in the light theme.",
+    },
+    caption: {
+      title: "Revisions & diff",
+      body: "Walk every revision, compare any two side by side, and cherry-pick or revert a change with a single action.",
+    },
   },
   {
-    src: "/screenshots/panel-storage-dark.png",
-    alt: "LoreGUI storage panel showing the configured backend and connectivity status.",
-    title: "Storage backends",
-    caption:
-      "See which backend a repository is bound to and confirm connectivity at a glance — local disk, an S3 bucket, or a hosted server.",
+    // Different function on hover: the storage-backend picker (dark) flips to
+    // the real Windows "Host Server" wizard (light), so the caption flips too.
+    windowTitle: "LoreGUI — Storage & self-hosting",
+    hint: "See it on Windows",
+    dark: {
+      src: "/screenshots/panel-storage-dark.png",
+      alt: "LoreGUI storage panel in the dark theme: choose a backend — local packfiles, Amazon S3, MinIO or Garage.",
+    },
+    light: {
+      src: "/screenshots/windows/cropped/hosting.png",
+      alt: "The LoreGUI desktop app running on Windows in the light theme, showing the Host Server step with a live lore:// connection URL to share with a team.",
+    },
+    caption: {
+      title: "Storage backends",
+      body: "Point a repository at local packfiles, an S3 bucket, MinIO or Garage — and confirm connectivity before you ever commit.",
+    },
+    captionHover: {
+      title: "Host your own server",
+      body: "Hover to jump into the real Windows app: start a Lore server over that same store and share a lore:// URL so your whole team can clone and push.",
+    },
   },
   {
-    src: "/screenshots/panel-theme-dark.png",
-    alt: "LoreGUI theme editor exposing semantic surface tokens for light and dark themes.",
-    title: "Theme editor",
-    caption:
-      "Every surface is a semantic token. Build a theme, save it, and share it — the whole app re-themes instantly, light or dark.",
+    windowTitle: "LoreGUI — Theme editor",
+    hint: "Re-theme it live",
+    dark: {
+      src: "/screenshots/panel-theme-dark.png",
+      alt: "LoreGUI theme editor in the dark theme, exposing semantic surface tokens for light and dark variants.",
+    },
+    light: {
+      src: "/screenshots/panel-theme-light.png",
+      alt: "The same LoreGUI theme editor re-themed to the light variant — the editor themes itself.",
+    },
+    caption: {
+      title: "Theme editor",
+      body: "Every surface is a semantic token. Build a theme, save it, and share it — the whole app re-themes instantly, light or dark. (Hover this one and watch the editor re-theme itself.)",
+    },
   },
 ];
 
@@ -61,58 +132,56 @@ export function Screenshots() {
             that runs any operation. Purpose-built for projects where the
             binaries are bigger than the code.
           </p>
+          <p className="mt-4 inline-flex items-center gap-2 rounded-full border border-brand-muted/20 bg-brand-surface-light/60 px-3.5 py-1.5 text-sm text-brand-muted">
+            <span aria-hidden="true">☀️</span>
+            Hover (or tap) any window to flip it into the light theme — every
+            pixel is a semantic token.
+          </p>
         </div>
 
-        {/* Hero shot: the command palette */}
+        {/* Hero shot: the command palette — dark by default, light on hover. */}
         <div className="relative mx-auto mt-16 max-w-5xl">
-          <AppWindow title="LoreGUI — ⌘K command palette">
-            <Image
-              src="/screenshots/palette-query-dark.png"
-              alt="LoreGUI command palette open with a fuzzy search for 'branch', listing matching operations."
-              width={1440}
-              height={900}
-              className="w-full"
-              priority
-            />
-          </AppWindow>
+          <ThemeSwapShot
+            windowTitle="LoreGUI — ⌘K command palette"
+            priority
+            sizes="(min-width: 1024px) 1024px, 100vw"
+            dark={{
+              src: "/screenshots/palette-query-dark.png",
+              alt: "LoreGUI command palette in the dark theme, open with a fuzzy search for 'branch', listing matching operations.",
+            }}
+            light={{
+              src: "/screenshots/palette-query-light.png",
+              alt: "The same LoreGUI command palette and fuzzy search rendered in the light theme.",
+            }}
+          >
+            <p className="mt-4 text-center text-sm text-brand-muted">
+              Press{" "}
+              <kbd className="rounded border border-brand-muted/30 bg-brand-surface-light px-1.5 py-0.5 font-mono text-xs text-brand-text">
+                ⌘K
+              </kbd>{" "}
+              to fuzzy-search and run any operation in the app.
+            </p>
+          </ThemeSwapShot>
           <div
             className="pointer-events-none absolute -inset-4 -z-10 rounded-xl bg-vapor-pink/10 blur-2xl"
             aria-hidden="true"
           />
-          <p className="mt-4 text-center text-sm text-brand-muted">
-            Press{" "}
-            <kbd className="rounded border border-brand-muted/30 bg-brand-surface-light px-1.5 py-0.5 font-mono text-xs text-brand-text">
-              ⌘K
-            </kbd>{" "}
-            to fuzzy-search and run any operation in the app.
-          </p>
         </div>
 
         {/* Captioned surface gallery */}
         <div className="mt-16 grid gap-8 lg:grid-cols-2">
-          {surfaces.map((surface, i) => (
-            <figure
-              key={surface.src}
-              className={i === 0 ? "lg:col-span-2" : ""}
-            >
-              <AppWindow title={`LoreGUI — ${surface.title}`}>
-                <Image
-                  src={surface.src}
-                  alt={surface.alt}
-                  width={1440}
-                  height={900}
-                  className="w-full"
-                />
-              </AppWindow>
-              <figcaption className="mt-4">
-                <h3 className="font-heading text-base font-semibold text-brand-text-bright">
-                  {surface.title}
-                </h3>
-                <p className="mt-1 text-sm leading-relaxed text-brand-muted">
-                  {surface.caption}
-                </p>
-              </figcaption>
-            </figure>
+          {surfaces.map((surface) => (
+            <ThemeSwapShot
+              key={surface.dark.src}
+              windowTitle={surface.windowTitle}
+              dark={surface.dark}
+              light={surface.light}
+              hint={surface.hint}
+              caption={surface.caption}
+              captionHover={surface.captionHover}
+              className={surface.className}
+              sizes={surface.sizes}
+            />
           ))}
         </div>
 

--- a/website/src/components/ThemeSwapShot.tsx
+++ b/website/src/components/ThemeSwapShot.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { AppWindow } from "@/components/mockups/AppWindow";
+
+interface Shot {
+  src: string;
+  alt: string;
+}
+
+interface Caption {
+  title: string;
+  body: string;
+}
+
+interface ThemeSwapShotProps {
+  /** Title shown in the faux desktop-window chrome. */
+  windowTitle: string;
+  /** Default (dark-theme) screenshot — establishes the aspect box. */
+  dark: Shot;
+  /** Light-theme screenshot that crossfades in on hover / focus / tap. */
+  light: Shot;
+  /** Short affordance label, e.g. "Light theme" or "See it on Windows". */
+  hint?: string;
+  /** Intrinsic size of the dark shot (defaults to the 1440×900 gallery size). */
+  width?: number;
+  height?: number;
+  /** next/image responsive `sizes` hint. */
+  sizes?: string;
+  priority?: boolean;
+  /** Figure className — e.g. a column span. */
+  className?: string;
+  /** Default caption. Omit for an image-only shot (e.g. the hero). */
+  caption?: Caption;
+  /**
+   * Flipped caption — provide ONLY when the light shot is a *different*
+   * surface/function than the dark one. When present the caption text
+   * crossfades along with the image; when absent the caption stays put.
+   */
+  captionHover?: Caption;
+  /** Extra content rendered under the frame (e.g. the hero's ⌘K hint). */
+  children?: React.ReactNode;
+}
+
+/**
+ * A captioned screenshot that shows the DARK theme by default and crossfades to
+ * the LIGHT theme on hover — a live demo that the app is fully themeable.
+ *
+ * - Same-surface pair (just re-themed): pass `caption` only → image swaps, caption stays.
+ * - Different surface/function: also pass `captionHover` → caption text flips too.
+ *
+ * Accessibility: both images carry alt text; the reveal is CSS-driven via
+ * `group-hover` / `group-focus-within`, honours `prefers-reduced-motion`
+ * (instant swap, no fade), and exposes a real toggle button so touch and
+ * keyboard users can flip the theme without a pointer hover.
+ */
+export function ThemeSwapShot({
+  windowTitle,
+  dark,
+  light,
+  hint = "Light theme",
+  width = 1440,
+  height = 900,
+  sizes = "(min-width: 1024px) 50vw, 100vw",
+  priority,
+  className = "",
+  caption,
+  captionHover,
+  children,
+}: ThemeSwapShotProps) {
+  const [revealed, setRevealed] = useState(false);
+  const Wrapper = caption ? "figure" : "div";
+
+  return (
+    <Wrapper
+      className={`group ${revealed ? "is-revealed" : ""} ${className}`.trim()}
+    >
+      <div className="relative">
+        <AppWindow title={windowTitle}>
+          <div className="relative">
+            {/* Default: dark theme. Sets the box height the light shot fills. */}
+            <Image
+              src={dark.src}
+              alt={dark.alt}
+              width={width}
+              height={height}
+              sizes={sizes}
+              className="w-full"
+              priority={priority}
+            />
+            {/* On hover/focus/tap: light theme crossfades over the same box. */}
+            <Image
+              src={light.src}
+              alt={light.alt}
+              fill
+              sizes={sizes}
+              aria-hidden={!revealed}
+              className="object-cover object-center opacity-0 transition-opacity duration-500 ease-out group-hover:opacity-100 group-focus-within:opacity-100 group-[.is-revealed]:opacity-100 motion-reduce:transition-none"
+            />
+          </div>
+        </AppWindow>
+
+        {/* Affordance + touch/keyboard toggle. */}
+        <button
+          type="button"
+          onClick={() => setRevealed((v) => !v)}
+          aria-pressed={revealed}
+          aria-label={
+            revealed
+              ? "Show the dark theme screenshot"
+              : "Show the light theme screenshot"
+          }
+          className="absolute top-3 right-3 z-10 inline-flex items-center gap-1.5 rounded-full border border-brand-muted/30 bg-brand-deep-light/80 px-2.5 py-1 font-mono text-[11px] leading-none text-brand-muted shadow-sm backdrop-blur-sm transition-colors group-hover:border-brand-accent/40 group-hover:text-brand-text hover:border-brand-accent/50 hover:text-brand-text-bright focus-visible:ring-2 focus-visible:ring-brand-accent/60 focus-visible:outline-none"
+        >
+          <span aria-hidden="true">{revealed ? "🌙" : "☀️"}</span>
+          <span>{revealed ? "Dark theme" : hint}</span>
+        </button>
+      </div>
+
+      {caption && (
+        <figcaption className="mt-4 grid">
+          <div
+            className={`col-start-1 row-start-1 ${
+              captionHover
+                ? "transition-opacity duration-500 ease-out group-hover:opacity-0 group-focus-within:opacity-0 group-[.is-revealed]:opacity-0 motion-reduce:transition-none"
+                : ""
+            }`}
+          >
+            <h3 className="font-heading text-base font-semibold text-brand-text-bright">
+              {caption.title}
+            </h3>
+            <p className="mt-1 text-sm leading-relaxed text-brand-muted">
+              {caption.body}
+            </p>
+          </div>
+          {captionHover && (
+            <div className="col-start-1 row-start-1 opacity-0 transition-opacity duration-500 ease-out group-hover:opacity-100 group-focus-within:opacity-100 group-[.is-revealed]:opacity-100 motion-reduce:transition-none">
+              <h3 className="font-heading text-base font-semibold text-brand-text-bright">
+                {captionHover.title}
+              </h3>
+              <p className="mt-1 text-sm leading-relaxed text-brand-muted">
+                {captionHover.body}
+              </p>
+            </div>
+          )}
+        </figcaption>
+      )}
+
+      {children}
+    </Wrapper>
+  );
+}


### PR DESCRIPTION
## What

Turns the marketing-site screenshot gallery into a **live demo that LoreGUI is fully themeable**: every screenshot shows the **dark** theme by default and crossfades to the **light** theme on hover (and on tap / keyboard focus).

The rule, applied per pair:
- **Same surface, just re-themed → image-only swap** (caption stays).
- **Different object/function → caption flips too** (title + description describe what's now shown).

## Pairs wired

| Card | Dark (default) | Light (hover) | Kind |
|---|---|---|---|
| Hero | `palette-query-dark` | `palette-query-light` | Same surface — image only |
| Branches · Changes · History | `main-view-dark` | `main-view-light` | Same surface — image only |
| Branches & merging | `panel-branches-dark` | `panel-branches-light` | Same surface — image only |
| Revisions & diff | `panel-history-dark` | `panel-history-light` | Same surface — image only |
| **Storage backends → Host your own server** | `panel-storage-dark` | `windows/cropped/hosting.png` | **Different function — caption flips** |
| Theme editor | `panel-theme-dark` | `panel-theme-light` | Same surface — image only (the editor re-themes itself ✨) |

The storage card is the deliberate "different function" example: the dark **storage-backend picker** flips on hover to the **real-install Windows "Host Server" wizard** (light theme), so the caption flips from *Storage backends* to *Host your own server*.

## How the effect works

- New client component `website/src/components/ThemeSwapShot.tsx`. The dark `next/image` sits in normal flow and establishes the aspect box; the light image is `fill` + `object-cover`, `opacity-0`, and crossfades to `opacity-100` via `group-hover` / `group-focus-within`.
- Caption-flip uses a CSS grid stack (both blocks in the same cell) so the box sizes to the taller caption — no layout shift, no clipping.
- Matches the existing `AppWindow` chrome, Tailwind brand tokens, and responsive 2-col grid.

## Affordance

- A subtle ☀/🌙 **toggle pill** on each window (brand tokens, `backdrop-blur`), plus a global "Hover (or tap) any window to flip it into the light theme" hint under the section heading.

## Accessibility

- `alt` text on **both** the dark and light images.
- Reveal is **CSS-driven** (`group-hover` / `group-focus-within`).
- **`prefers-reduced-motion`** honored (`motion-reduce:transition-none` → instant swap, no fade).
- The pill is a **real `<button>`** with `aria-pressed` — touch and keyboard users can flip the theme with no pointer hover; on touch the default dark shot stands alone until tapped.

## Verify

`npm install` + `npm run build` in `website/` succeed — no TS errors, no broken image refs, lint clean.

**Please review the hover/crossfade on the Vercel preview** before merging.

Ticket: SBAI-4239

🤖 Generated with [Claude Code](https://claude.com/claude-code)