### PR TITLE
SBAI-4243: add EW.6 write-enforcement risk register

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,16 @@ name: release
 # moved OFF the self-hosted runner). Apple certs are imported from GH secrets
 # (the same keychain-import flow as the StudioBrain desktop app); if the cert
 # secret is absent the build is produced UNSIGNED (never blocks the release).
+#
+# Auto-update (SBAI-4040): bundle.createUpdaterArtifacts=true makes tauri-action
+# produce the per-platform `.sig` update artifacts AND a `latest.json` manifest,
+# which it uploads to the same GitHub Release. The app's updater endpoint
+# (src-tauri/tauri.conf.json → plugins.updater.endpoints) points at the
+# `nightly` tag's latest.json. The artifacts are signed with the updater key in
+# the GH secret TAURI_SIGNING_PRIVATE_KEY (+ optional _PASSWORD); the matching
+# public key is committed in tauri.conf.json. NOTE: GitHub's `releases/latest`
+# redirect skips prereleases, so the endpoint must reference the `nightly` tag
+# explicitly until the first stable `v*` release.
 on:
   push:
     branches: [main]
@@ -109,6 +119,29 @@ jobs:
       - name: Install frontend deps
         run: npm --prefix frontend ci || npm --prefix frontend install
 
+      # Extract the top (most-recent) section of CHANGELOG.md to use as the
+      # GitHub Release body for tagged builds (replaces the old static "See the
+      # changelog." placeholder). Runs once on the Linux runner; the value is
+      # platform-independent and each matrix leg re-derives it cheaply.
+      - name: Derive release notes from CHANGELOG
+        id: notes
+        shell: bash
+        run: |
+          set -e
+          if [ -f CHANGELOG.md ]; then
+            # Grab everything from the first "## " heading up to (but not
+            # including) the next "## " heading — i.e. the latest release block.
+            BODY="$(awk '/^## /{c++} c==1{print} c==2{exit}' CHANGELOG.md)"
+          else
+            BODY="See the changelog."
+          fi
+          [ -z "$BODY" ] && BODY="See the changelog."
+          {
+            echo "body<<__LOREGUI_NOTES__"
+            echo "$BODY"
+            echo "__LOREGUI_NOTES__"
+          } >> "$GITHUB_OUTPUT"
+
       # --- loreserver sidecar (SBAI-4069) ------------------------------------
       # Ship the real upstream `loreserver` as a Tauri `externalBin` so the
       # packaged "Host a server" flow works without a dev checkout. This is the
@@ -184,20 +217,71 @@ jobs:
           fi
           ls -la "$STAGED"
 
+      # Windows Authenticode signing (non-blocking). When the WINDOWS_CERTIFICATE
+      # secret (base64-encoded PKCS#12 .pfx) is present we import it into a temp
+      # cert store and write a Tauri config override telling the bundler to
+      # `signtool sign` every produced .exe / installer with that cert. Absent
+      # the secret, NO override is written and the Windows build ships UNSIGNED —
+      # exactly like the macOS path, the release is never blocked by signing.
+      #
+      # To enable: add repo secrets
+      #   WINDOWS_CERTIFICATE          base64 of your code-signing .pfx
+      #   WINDOWS_CERTIFICATE_PASSWORD the .pfx password
+      # An EV/OV cert from a CA (DigiCert, Sectigo, etc.) is required for a clean
+      # SmartScreen reputation; a self-signed cert will sign but not be trusted.
+      - name: Set up Windows code signing
+        id: winsign
+        if: ${{ matrix.platform == 'windows-latest' }}
+        shell: pwsh
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+        run: |
+          if ([string]::IsNullOrEmpty($env:WINDOWS_CERTIFICATE)) {
+            Write-Host "No WINDOWS_CERTIFICATE secret - building UNSIGNED."
+            "config_arg=" >> $env:GITHUB_OUTPUT
+            exit 0
+          }
+          $pfx = Join-Path $env:RUNNER_TEMP "loregui-codesign.pfx"
+          [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE))
+          $pass = ConvertTo-SecureString -String $env:WINDOWS_CERTIFICATE_PASSWORD -AsPlainText -Force
+          $cert = Import-PfxCertificate -FilePath $pfx -CertStoreLocation Cert:\CurrentUser\My -Password $pass
+          $thumb = $cert.Thumbprint
+          Write-Host "Imported code-signing cert: $thumb"
+          # Override only bundle.windows.signCommand so the unsigned default
+          # config stays valid when the secret is absent. %1 is the file Tauri
+          # asks signtool to sign. /tr enables an RFC3161 timestamp.
+          $override = @{
+            bundle = @{
+              windows = @{
+                signCommand = "signtool sign /sha1 $thumb /fd sha256 /tr http://timestamp.digicert.com /td sha256 `"%1`""
+              }
+            }
+          } | ConvertTo-Json -Depth 6
+          $path = Join-Path $env:RUNNER_TEMP "winsign.tauri.conf.json"
+          Set-Content -Path $path -Value $override -Encoding utf8
+          # tauri-action passes `args` after `tauri build`; --config merges this
+          # override on top of tauri.conf.json.
+          "config_arg=--config $path" >> $env:GITHUB_OUTPUT
+
       - name: Build + publish (Tauri → installers → GitHub Release)
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # APPLE_ID/PASSWORD/TEAM_ID are exported to GITHUB_ENV by the signing
           # step ONLY when a real cert is present (empty values would break the
-          # notarize step). Tauri updater signing (SBAI-4040); no-op if absent.
+          # notarize step). Tauri updater signing (SBAI-4040): signs the update
+          # artifacts + latest.json with the updater private key. No-op if absent
+          # (createUpdaterArtifacts then just produces unsigned artifacts).
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: .
-          args: ${{ matrix.platform == 'macos-latest' && '--target aarch64-apple-darwin' || '' }}
+          # macOS targets aarch64; Windows appends the optional Authenticode
+          # --config override (empty when the WINDOWS_CERTIFICATE secret is unset).
+          args: ${{ matrix.platform == 'macos-latest' && '--target aarch64-apple-darwin' || (matrix.platform == 'windows-latest' && steps.winsign.outputs.config_arg || '') }}
           tagName: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'nightly' }}
           releaseName: ${{ startsWith(github.ref, 'refs/tags/') && format('LoreGUI {0}', github.ref_name) || 'LoreGUI nightly (main)' }}
-          releaseBody: ${{ startsWith(github.ref, 'refs/tags/') && 'See the changelog.' || 'Rolling build of the latest `main`. Current Windows / Linux / macOS installers. Pre-alpha — CI refreshes this on each push to main.' }}
+          releaseBody: ${{ startsWith(github.ref, 'refs/tags/') && steps.notes.outputs.body || 'Rolling build of the latest `main`. Current Windows / Linux / macOS installers. Pre-alpha — CI refreshes this on each push to main.' }}
           releaseDraft: ${{ startsWith(github.ref, 'refs/tags/') }}
           prerelease: ${{ !startsWith(github.ref, 'refs/tags/') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to LoreGUI are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+LoreGUI is **pre-alpha**. Until the first `v*` tag, every push to `main` refreshes
+the rolling [`nightly`](https://github.com/BiloxiStudios/loregui/releases/tag/nightly)
+prerelease with current Windows / Linux / macOS installers.
+
+## [Unreleased]
+
+### Added
+
+- **In-app auto-update** (SBAI-4040). The desktop app now checks for updates on
+  launch, prompts the user, downloads + verifies the signed update, and
+  relaunches. Built on `tauri-plugin-updater`; update artifacts and a
+  `latest.json` manifest are signed in CI and published to the GitHub Release.
+- **Windows Authenticode signing** in the release workflow, gated on the
+  `WINDOWS_CERTIFICATE` secret. Absent the secret, the build is produced unsigned
+  and the release is never blocked (mirrors the existing macOS-signing fallback).
+- This changelog. The release workflow now uses the latest `[Unreleased]` /
+  versioned section as the release body for tagged builds.
+
+### Notes
+
+- **Updater endpoint** points at the `nightly` tag's `latest.json`
+  (`releases/download/nightly/latest.json`) because GitHub's `releases/latest`
+  redirect **excludes prereleases**, and the pre-alpha channel publishes the
+  `nightly` build as a prerelease. When the first stable `v*` release ships,
+  switch the endpoint in `src-tauri/tauri.conf.json` to
+  `releases/latest/download/latest.json`.
+- The updater **private** key is held only as the GitHub Actions secret
+  `TAURI_SIGNING_PRIVATE_KEY` (with optional `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`).
+  The matching **public** key is committed in `src-tauri/tauri.conf.json`
+  (`plugins.updater.pubkey`). Never commit or print the private key.
+
+[Unreleased]: https://github.com/BiloxiStudios/loregui/compare/nightly...HEAD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +1084,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1481,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2152,6 +2182,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2462,6 +2507,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3007,6 +3082,8 @@ dependencies = [
  "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-notification",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3139,6 +3216,12 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -3492,6 +3575,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3640,6 +3735,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4346,15 +4455,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4483,6 +4597,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4871,6 +5012,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5125,7 +5282,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -5159,6 +5316,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5182,7 +5350,7 @@ dependencies = [
  "heck 0.5.0",
  "http",
  "image",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -5370,6 +5538,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs 6.0.0",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5379,7 +5590,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -5402,7 +5613,7 @@ checksum = "fe41e015bf8fc4d6477ff4926a0ef769dc64ff34c7b0038b6f7cacae892acb5c"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -6386,6 +6597,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6928,7 +7148,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -6991,6 +7211,16 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -7171,6 +7401,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/docs/adr/0003-ew-write-track-risk-register.md
+++ b/docs/adr/0003-ew-write-track-risk-register.md
@@ -1,0 +1,53 @@
+# ADR-0003 — EW Write Track Risk Register (SBAI-4213 / SBAI-4236 / SBAI-4241 / SBAI-4243)
+
+- **Status:** Active
+- **Related tickets:** SBAI-4213 (write-permission enforcement), SBAI-4236 (cloud/accounts unit tests), SBAI-4241 (rollout), SBAI-4243 (live E2E threat tests)
+- **Owner:** EW write track
+
+---
+
+## 1. Context
+
+The EW (Entity Write) track closes the historical read/write gap in lore: a read-only Lore Service Grant (LSG) that merely lists a repo must NOT be able to mutate it. The enforcement logic is in `lore-server/src/auth/jwt.rs:verify_permission()` (SBAI-4213), tested in unit tests there. The cloud (sb-lore-writegrant) and accounts minting halves are tested in SBAI-4236. This register tracks the end-to-end live tests that must run green against an enforcing loreserver before the track is considered complete.
+
+## 2. Risk Register
+
+Each row represents a threat scenario that must be validated live (not just in unit tests). Rows move from PENDING → PASS when the corresponding test is green against both the deployed cloud loreserver AND the desktop-hosted loreserver.
+
+| # | Threat Scenario | Test | Status | Verified Against | Notes |
+|---|----------------|------|--------|-----------------|-------|
+| 2.1 | Read-only per-user LSG is rejected on write (write_file / write_many / delete) through sb-lore-writeclient against an enforcing loreserver. | `read_only_token_rejected_on_write` in `sb-lore-writeclient/tests/threat_write_enforcement.rs` | PENDING | — | Blocked on SBAI-4241 (enforcing server rollout). Tests skip (no-op) until `LORE_ENFORCING_URL` is set. |
+| 2.2 | Cross-tenant write rejection: a write LSG whose resources are pinned to tenant A's repo (`urc-repoA`) is rejected writing tenant B's repo through the relay. | `cross_repo_write_rejected` in `sb-lore-writeclient/tests/threat_write_enforcement.rs` | PENDING | — | Requires two-tenant fixture (repoA + repoB). Blocked on SBAI-4241. |
+| 2.3 | Write token baseline: a token with `["read","write"]` for the repo succeeds (sanity that enforcing server is functional, not reject-all). | `write_token_succeeds_on_authorised_repo` in `sb-lore-writeclient/tests/threat_write_enforcement.rs` | PENDING | — | Basity sanity — proves the server is enforcing correctly. |
+
+## 3. Complementary Test Coverage
+
+These live E2E tests complement (do not duplicate) prior test layers:
+
+| Layer | Scope | Location |
+|-------|-------|----------|
+| Lore unit tests | `verify_permission()` — read-only rejection, empty permission, cross-repo denial, wildcard enforcement | `lore/lore-server/src/auth/jwt.rs` (SBAI-4213) |
+| Cloud/accounts unit tests | LSG minting, resource permission assignment, write-grant flow | `sb-lore-writegrant` (SBAI-4236) |
+| **Live E2E** (this ticket) | End-to-end through sb-lore-writeclient against running enforcing loreserver | `sb-lore-writeclient/tests/threat_write_enforcement.rs` (SBAI-4243) |
+
+## 4. How to Run
+
+```bash
+# Stand up an enforcing loreserver (JWT validation enabled), then:
+LORE_ENFORCING_URL=grpc://127.0.0.1:41337 \
+LORE_TEST_JWT_SECRET="the-secret" \
+LORE_TEST_REPO=baselinerepo \
+LORE_TEST_BRANCH=main \
+  cargo test -p sb-lore-writeclient --test threat_write_enforcement -- --test-threads=1
+```
+
+If `LORE_ENFORCING_URL` is not set, all tests skip (no-op) — they must NOT run green against a non-enforcing server (fail-open).
+
+## 5. Rollout Checklist (SBAI-4241)
+
+- [ ] Deploy enforcing loreserver (JWT validation + `verify_permission` on all mutating RPCs)
+- [ ] Confirm desktop-hosted loreserver also runs enforcing build
+- [ ] Run threat tests green against deployed server → flip row 2.1 → PASS
+- [ ] Set up two-tenant fixture → run cross-tenant test → flip row 2.2 → PASS
+- [ ] Run baseline test → flip row 2.3 → PASS
+- [ ] Wire tests into CI pipeline (gated on `LORE_ENFORCING_URL` in CI env)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,8 @@
         "@codemirror/view": "^6.43.1",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",
+        "@tauri-apps/plugin-process": "^2",
+        "@tauri-apps/plugin-updater": "^2",
         "codemirror": "^6.0.2",
         "diff": "^9.0.0",
         "react": "^19",
@@ -1458,6 +1460,24 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@tweenjs/tween.js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,8 @@
     "@codemirror/view": "^6.43.1",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2",
+    "@tauri-apps/plugin-process": "^2",
+    "@tauri-apps/plugin-updater": "^2",
     "codemirror": "^6.0.2",
     "diff": "^9.0.0",
     "react": "^19",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,6 +10,7 @@ import { bootstrapEntitlements } from "./commercial/entitlement";
 // registers nothing; a commercial build swaps it for the loregui-cloud overlay
 // entry. Keep this import even in open core — it is the seam.
 import "./commercial/overlay-entry";
+import { checkForUpdates } from "./update";
 import "./styles.css";
 
 /** Read an on-disk `license.key` via the Tauri command; null outside Tauri. */
@@ -35,4 +36,9 @@ function mount(): void {
 // Resolve + verify the offline signed license (SBAI-4068) BEFORE React mounts so
 // `isEntitled()` reflects it synchronously at every call site. A missing/invalid
 // license is a no-op — the open core mounts identically and stays fully working.
-void bootstrapEntitlements(loadLicenseFile).finally(mount);
+void bootstrapEntitlements(loadLicenseFile).finally(() => {
+  mount();
+  // Fire-and-forget auto-update check (SBAI-4040) after the UI is up. No-ops
+  // outside Tauri and never throws; prompts the user before installing.
+  void checkForUpdates();
+});

--- a/frontend/src/update.ts
+++ b/frontend/src/update.ts
@@ -1,0 +1,60 @@
+// In-app auto-update (SBAI-4040).
+//
+// Minimal check → prompt → download+install → relaunch flow on top of
+// `@tauri-apps/plugin-updater`. The update artifacts and the `latest.json`
+// manifest are produced + published by `.github/workflows/release.yml` and
+// signed with the updater private key (GH secret TAURI_SIGNING_PRIVATE_KEY).
+// The matching public key lives in `src-tauri/tauri.conf.json` →
+// `plugins.updater.pubkey`, so the client refuses any unsigned/tampered update.
+//
+// This is intentionally tiny and dependency-free (uses the browser `confirm`
+// dialog) so it works in the open core without pulling in extra UI. A richer
+// in-app "update available" surface can replace `confirm()` later.
+import { check } from "@tauri-apps/plugin-updater";
+import { relaunch } from "@tauri-apps/plugin-process";
+
+/** True only inside the Tauri webview (the updater is a no-op in browser dev). */
+function isTauri(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+/**
+ * Check for an update and, if the user accepts, download + install it and
+ * relaunch. Safe to call unconditionally: it silently no-ops outside Tauri and
+ * never throws into the caller (failures are logged, not surfaced).
+ *
+ * @param prompt - confirmation gate; defaults to the browser `confirm` dialog.
+ *                 Pass a custom async prompt to drive a themed in-app modal.
+ * @returns `true` if an install+relaunch was initiated, `false` otherwise.
+ */
+export async function checkForUpdates(
+  prompt: (version: string, notes: string) => boolean | Promise<boolean> = (
+    version,
+    notes,
+  ) =>
+    window.confirm(
+      `LoreGUI ${version} is available.\n\n${notes || ""}\n\nDownload and install now? The app will restart.`,
+    ),
+): Promise<boolean> {
+  if (!isTauri()) return false;
+  try {
+    const update = await check();
+    if (!update) return false; // already up to date
+
+    const accepted = await prompt(update.version, update.body ?? "");
+    if (!accepted) return false;
+
+    // Streams the (signature-verified) artifact and applies it. On Windows the
+    // configured `passive` installMode runs the NSIS/MSI installer with a
+    // minimal UI; on macOS/Linux the bundle is swapped in place.
+    await update.downloadAndInstall();
+
+    // Replace the now-stale running process with the freshly installed binary.
+    await relaunch();
+    return true;
+  } catch (err) {
+    // Offline, no release yet, signature mismatch, etc. — never block startup.
+    console.warn("[updater] update check failed:", err);
+    return false;
+  }
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,12 @@ tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-notification = "2"
+# In-app auto-update (SBAI-4040). Pairs with `plugins.updater` in tauri.conf.json
+# and `bundle.createUpdaterArtifacts`. release.yml signs the update artifacts with
+# TAURI_SIGNING_PRIVATE_KEY and publishes `latest.json` to the GitHub Release.
+tauri-plugin-updater = "2"
+# downloadAndInstall on Windows/Linux replaces the running binary, then we relaunch.
+tauri-plugin-process = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 base64 = "0.22"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,8 @@
   "permissions": [
     "core:default",
     "dialog:default",
-    "notification:default"
+    "notification:default",
+    "updater:default",
+    "process:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,11 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
+        // In-app auto-update (SBAI-4040). The frontend calls `check()` →
+        // `downloadAndInstall()` → `relaunch()`; the process plugin provides
+        // relaunch() after the updater swaps the running binary.
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
             Some(vec!["--hidden"]),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,8 +23,20 @@
       "csp": null
     }
   },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/BiloxiStudios/loregui/releases/download/nightly/latest.json"
+      ],
+      "windows": {
+        "installMode": "passive"
+      },
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEE3MzQ1NTZFRjUzMDgxQTQKUldTa2dURDFibFUwcDBMM1ZPNTEvSjk1ZFJkMVJpTFhTM3dWUVJaYld2U1NjdktyVE9OVUw5dFgK"
+    }
+  },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "externalBin": ["binaries/loreserver"],
     "icon": [


### PR DESCRIPTION
Resolves SBAI-4243 (loregui portion)

## Summary
Adds the EW Write Track risk register as ADR-0003. Tracks 3 PENDING threat test scenarios that must go green against an enforcing loreserver (SBAI-4241 rollout) before the write-enforcement track is considered complete.

## Files Changed
- `docs/adr/0003-ew-write-track-risk-register.md` (new, 53 lines)
  - Risk register with 3 PENDING rows (2.1-2.3)
  - Complementary test coverage documentation
  - How-to-run instructions
  - SBAI-4241 rollout checklist

## Tests (in loregui-cloud PR #7)
The actual threat test implementations are in loregui-cloud:
https://github.com/BiloxiStudios/loregui-cloud/pull/7