### PR TITLE
SBAI-3698: dependency add/remove/list

### DIFF
--- a/crates/lore-vm/src/ops/dependency/dependency_add.rs
+++ b/crates/lore-vm/src/ops/dependency/dependency_add.rs
@@ -49,7 +49,9 @@ pub struct DependencyAddArgs {
 }
 
 impl DependencyAddArgs {
-    fn into_lore(self) -> LoreFileDependencyAddArgs {
+    /// Convert to the upstream lore args, resolving every incoming path against
+    /// `repo_root`.
+    fn into_lore(self, repo_root: &std::path::Path) -> LoreFileDependencyAddArgs {
         let mut paths = Vec::new();
         let mut dependencies = Vec::new();
         let mut tags = Vec::new();
@@ -57,11 +59,23 @@ impl DependencyAddArgs {
         let mut tag_counts = Vec::new();
 
         for source in &self.sources {
-            paths.push(LoreString::from_str(&source.path));
+            let p = std::path::Path::new(&source.path);
+            if p.is_absolute() {
+                paths.push(LoreString::from_str(&source.path));
+            } else {
+                paths.push(LoreString::from_path(repo_root.join(p)));
+            }
+
             dep_counts.push(source.dependencies.len() as u32);
 
             for entry in &source.dependencies {
-                dependencies.push(LoreString::from_str(&entry.dependency));
+                let dep_p = std::path::Path::new(&entry.dependency);
+                if dep_p.is_absolute() {
+                    dependencies.push(LoreString::from_str(&entry.dependency));
+                } else {
+                    dependencies.push(LoreString::from_path(repo_root.join(dep_p)));
+                }
+
                 tag_counts.push(entry.tags.len() as u32);
 
                 for tag in &entry.tags {
@@ -95,8 +109,11 @@ pub struct DependencyAddResult {
 pub async fn dependency_add(api: &LoreApi, args: DependencyAddArgs) -> Result<DependencyAddResult> {
     let (callback, rx) = collect_events();
 
+    let globals = api.globals();
+    let repo_root = globals.repository_path.clone();
     let status =
-        lore::dependency::dependency_add(api.globals().build(), args.into_lore(), callback).await;
+        lore::dependency::dependency_add(globals.build(), args.into_lore(&repo_root), callback)
+            .await;
 
     let stream = rx
         .await
@@ -169,7 +186,8 @@ mod tests {
             }],
             force: false,
         };
-        let lore_args = args.into_lore();
+        let repo_root = std::path::Path::new("/repo");
+        let lore_args = args.into_lore(repo_root);
         assert_eq!(lore_args.paths.len(), 1);
         assert_eq!(lore_args.dependencies.len(), 1);
         assert_eq!(lore_args.dep_counts.len(), 1);
@@ -191,7 +209,8 @@ mod tests {
             }],
             force: true,
         };
-        let lore_args = args.into_lore();
+        let repo_root = std::path::Path::new("/repo");
+        let lore_args = args.into_lore(repo_root);
         assert_eq!(lore_args.force, 1);
     }
 
@@ -219,7 +238,8 @@ mod tests {
             ],
             force: false,
         };
-        let lore_args = args.into_lore();
+        let repo_root = std::path::Path::new("/repo");
+        let lore_args = args.into_lore(repo_root);
         assert_eq!(lore_args.paths.len(), 2);
         assert_eq!(lore_args.dependencies.len(), 2);
         assert_eq!(lore_args.tags.len(), 3);

--- a/crates/lore-vm/src/ops/dependency/dependency_list.rs
+++ b/crates/lore-vm/src/ops/dependency/dependency_list.rs
@@ -38,12 +38,21 @@ pub struct DependencyListArgs {
 }
 
 impl DependencyListArgs {
-    fn into_lore(self) -> LoreFileDependencyListArgs {
+    /// Convert to the upstream lore args, resolving every incoming path against
+    /// `repo_root`.
+    fn into_lore(self, repo_root: &std::path::Path) -> LoreFileDependencyListArgs {
         LoreFileDependencyListArgs {
             paths: LoreArray::from_vec(
                 self.paths
                     .into_iter()
-                    .map(|s| LoreString::from_str(&s))
+                    .map(|s| {
+                        let path = std::path::Path::new(&s);
+                        if path.is_absolute() {
+                            LoreString::from_str(&s)
+                        } else {
+                            LoreString::from_path(repo_root.join(path))
+                        }
+                    })
                     .collect(),
             ),
             revision: LoreString::from_str(&self.revision),
@@ -101,8 +110,14 @@ pub async fn dependency_list(
 ) -> Result<DependencyListResult> {
     let (callback, rx) = collect_events();
 
-    let status =
-        lore::dependency::dependency_list(api.globals().build(), args.into_lore(), callback).await;
+    let globals = api.globals();
+    let repo_root = globals.repository_path.clone();
+    let status = lore::dependency::dependency_list(
+        api.globals().build(),
+        args.into_lore(&repo_root),
+        callback,
+    )
+    .await;
 
     let stream = rx
         .await
@@ -236,7 +251,8 @@ mod tests {
             tags: vec!["texture".into()],
             depth_limit: 3,
         };
-        let lore_args = args.into_lore();
+        let repo_root = std::path::Path::new("/repo");
+        let lore_args = args.into_lore(repo_root);
         assert_eq!(lore_args.paths.as_slice().len(), 2);
         assert_eq!(lore_args.revision.as_str(), "main");
         assert_eq!(lore_args.recursive, 1);

--- a/crates/lore-vm/src/ops/dependency/dependency_remove.rs
+++ b/crates/lore-vm/src/ops/dependency/dependency_remove.rs
@@ -48,7 +48,9 @@ pub struct DependencyRemoveArgs {
 }
 
 impl DependencyRemoveArgs {
-    fn into_lore(self) -> LoreFileDependencyRemoveArgs {
+    /// Convert to the upstream lore args, resolving every incoming path against
+    /// `repo_root`.
+    fn into_lore(self, repo_root: &std::path::Path) -> LoreFileDependencyRemoveArgs {
         let mut paths = Vec::new();
         let mut dependencies = Vec::new();
         let mut tags = Vec::new();
@@ -56,11 +58,23 @@ impl DependencyRemoveArgs {
         let mut tag_counts = Vec::new();
 
         for source in &self.sources {
-            paths.push(LoreString::from_str(&source.path));
+            let p = std::path::Path::new(&source.path);
+            if p.is_absolute() {
+                paths.push(LoreString::from_str(&source.path));
+            } else {
+                paths.push(LoreString::from_path(repo_root.join(p)));
+            }
+
             dep_counts.push(source.dependencies.len() as u32);
 
             for entry in &source.dependencies {
-                dependencies.push(LoreString::from_str(&entry.dependency));
+                let dep_p = std::path::Path::new(&entry.dependency);
+                if dep_p.is_absolute() {
+                    dependencies.push(LoreString::from_str(&entry.dependency));
+                } else {
+                    dependencies.push(LoreString::from_path(repo_root.join(dep_p)));
+                }
+
                 tag_counts.push(entry.tags.len() as u32);
 
                 for tag in &entry.tags {
@@ -96,8 +110,10 @@ pub async fn dependency_remove(
 ) -> Result<DependencyRemoveResult> {
     let (callback, rx) = collect_events();
 
+    let globals = api.globals();
+    let repo_root = globals.repository_path.clone();
     let status =
-        lore::dependency::dependency_remove(api.globals().build(), args.into_lore(), callback)
+        lore::dependency::dependency_remove(globals.build(), args.into_lore(&repo_root), callback)
             .await;
 
     let stream = rx
@@ -169,7 +185,8 @@ mod tests {
                 }],
             }],
         };
-        let lore_args = args.into_lore();
+        let repo_root = std::path::Path::new("/repo");
+        let lore_args = args.into_lore(repo_root);
         assert_eq!(lore_args.paths.len(), 1);
         assert_eq!(lore_args.dependencies.len(), 1);
         assert_eq!(lore_args.dep_counts.len(), 1);
@@ -201,7 +218,8 @@ mod tests {
                 },
             ],
         };
-        let lore_args = args.into_lore();
+        let repo_root = std::path::Path::new("/repo");
+        let lore_args = args.into_lore(repo_root);
         assert_eq!(lore_args.paths.len(), 2);
         assert_eq!(lore_args.dependencies.len(), 2);
         assert_eq!(lore_args.tags.len(), 3);

--- a/crates/lore-vm/tests/dependency_ops.rs
+++ b/crates/lore-vm/tests/dependency_ops.rs
@@ -1,0 +1,155 @@
+//! Integration tests for dependency operations.
+//!
+//! Tests add, remove, and list operations in the dependency domain.
+
+use std::fs;
+use tempfile::TempDir;
+
+use lore_vm::api::LoreApi;
+use lore_vm::ops::dependency::dependency_add::{
+    dependency_add, DependencyAddArgs, DependencyAddEntry, DependencyAddSource,
+};
+use lore_vm::ops::dependency::dependency_list::{dependency_list, DependencyListArgs};
+use lore_vm::ops::dependency::dependency_remove::{
+    dependency_remove, DependencyRemoveArgs, DependencyRemoveEntry, DependencyRemoveSource,
+};
+use lore_vm::ops::file::stage::{stage, CaseChange, FileStageArgs};
+use lore_vm::ops::repository::create::{create, CreateArgs};
+
+#[tokio::test]
+async fn test_dependency_lifecycle() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let repo_path = fs::canonicalize(temp_dir.path())
+        .expect("canonicalize temp dir")
+        .join("repo");
+    fs::create_dir_all(&repo_path).unwrap();
+
+    let api = LoreApi::new(repo_path.clone());
+
+    // 1. Create a repository with a unique name
+    let repo_name = format!("dep-test-{}", std::process::id());
+    let _ = create(
+        &api,
+        CreateArgs {
+            repository_url: format!("lore://localhost/{}", repo_name),
+            description: "Dependency test repo".into(),
+            id: String::new(),
+            use_shared_store: false,
+            shared_store_path: String::new(),
+        },
+    )
+    .await
+    .expect("repository creation failed");
+
+    // 2. Create some files and stage them
+    let a_path = repo_path.join("a.txt");
+    let b_path = repo_path.join("b.txt");
+    fs::write(&a_path, "source").unwrap();
+    fs::write(&b_path, "dependency").unwrap();
+
+    stage(
+        &api,
+        FileStageArgs {
+            paths: vec!["a.txt".into(), "b.txt".into()],
+            case_change: CaseChange::Error,
+            scan: true,
+        },
+    )
+    .await
+    .expect("staging failed");
+
+    // 3. Add a dependency: a.txt -> b.txt with "test-tag"
+    let add_result = dependency_add(
+        &api,
+        DependencyAddArgs {
+            sources: vec![DependencyAddSource {
+                path: "a.txt".into(),
+                dependencies: vec![DependencyAddEntry {
+                    dependency: "b.txt".into(),
+                    tags: vec!["test-tag".into()],
+                }],
+            }],
+            force: false,
+        },
+    )
+    .await
+    .expect("dependency_add failed");
+    assert_eq!(add_result.added_count, 1);
+
+    // 4. List dependencies for a.txt
+    let list_result = dependency_list(
+        &api,
+        DependencyListArgs {
+            paths: vec!["a.txt".into()],
+            revision: String::new(),
+            recursive: false,
+            reverse: false,
+            tags: vec![],
+            depth_limit: 0,
+        },
+    )
+    .await
+    .expect("dependency_list failed");
+
+    assert_eq!(list_result.file_count, 1);
+    assert_eq!(list_result.files.len(), 1);
+    // The engine returns absolute paths
+    assert!(list_result.files[0].path.ends_with("a.txt"));
+    assert_eq!(list_result.files[0].entries.len(), 1);
+    assert!(list_result.files[0].entries[0].path.ends_with("b.txt"));
+    assert_eq!(list_result.files[0].entries[0].tags, vec!["test-tag"]);
+
+    // 5. List dependents for b.txt (reverse)
+    let reverse_result = dependency_list(
+        &api,
+        DependencyListArgs {
+            paths: vec!["b.txt".into()],
+            revision: String::new(),
+            recursive: false,
+            reverse: true,
+            tags: vec![],
+            depth_limit: 0,
+        },
+    )
+    .await
+    .expect("reverse dependency_list failed");
+
+    assert_eq!(reverse_result.files.len(), 1);
+    assert!(reverse_result.files[0].path.ends_with("b.txt"));
+    assert_eq!(reverse_result.files[0].entries.len(), 1);
+    assert!(reverse_result.files[0].entries[0].path.ends_with("a.txt"));
+
+    // 6. Remove the dependency
+    let remove_result = dependency_remove(
+        &api,
+        DependencyRemoveArgs {
+            sources: vec![DependencyRemoveSource {
+                path: "a.txt".into(),
+                dependencies: vec![DependencyRemoveEntry {
+                    dependency: "b.txt".into(),
+                    tags: vec![], // remove entire edge
+                }],
+            }],
+        },
+    )
+    .await
+    .expect("dependency_remove failed");
+    assert_eq!(remove_result.removed_count, 1);
+
+    // 7. Verify removal
+    let final_list = dependency_list(
+        &api,
+        DependencyListArgs {
+            paths: vec!["a.txt".into()],
+            revision: String::new(),
+            recursive: false,
+            reverse: false,
+            tags: vec![],
+            depth_limit: 0,
+        },
+    )
+    .await
+    .expect("final dependency_list failed");
+
+    assert_eq!(final_list.files[0].entries.len(), 0);
+}


### PR DESCRIPTION
Resolves SBAI-3698

## Summary
- Updated `dependency_add`, `dependency_remove`, and `dependency_list` to correctly resolve repository-relative paths against the repository root.
- Fixed `into_lore` methods to take `repo_root` and use `LoreString::from_path`.
- Added a comprehensive integration test `crates/lore-vm/tests/dependency_ops.rs` covering the full dependency lifecycle.

## Files Changed
- `crates/lore-vm/src/ops/dependency/dependency_add.rs`
- `crates/lore-vm/src/ops/dependency/dependency_remove.rs`
- `crates/lore-vm/src/ops/dependency/dependency_list.rs`
- `crates/lore-vm/tests/dependency_ops.rs`

## Testing
- Ran `cargo test -p lore-vm` (all 706 unit tests passed).
- Ran `cargo test -p lore-vm --test dependency_ops` (integration test passed).
- Verified path resolution for relative paths in a real-world scenario.