### PR TITLE
SBAI-4487: storage get_metadata — rename fn storage_get_metadata → get_metadata

### DIFF
--- a/crates/lore-vm/src/ops/storage/get_metadata.rs
+++ b/crates/lore-vm/src/ops/storage/get_metadata.rs
@@ -37,7 +37,7 @@ pub struct GetMetadataItem {
     pub address: String,
 }
 
-/// Arguments for [`storage_get_metadata`].
+/// Arguments for [`get_metadata`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageGetMetadataArgs {
     /// Handle id returned by a prior `storage open` call.
@@ -136,7 +136,7 @@ struct GetMetadataCollector {
 /// Calls the upstream `lore::storage::get_metadata::get_metadata` in-process
 /// with a callback that captures per-item `StorageGetMetadataItemComplete`
 /// events. No binary payload is transferred — only fragment metadata.
-pub async fn storage_get_metadata(
+pub async fn get_metadata(
     api: &LoreApi,
     args: StorageGetMetadataArgs,
 ) -> Result<StorageGetMetadataResult> {

--- a/crates/lore-vm/src/ops/storage/get_metadata.rs
+++ b/crates/lore-vm/src/ops/storage/get_metadata.rs
@@ -232,6 +232,18 @@ pub async fn get_metadata(
     Ok(StorageGetMetadataResult { items })
 }
 
+/// Backwards-compatible command symbol for existing Tauri/frontend wiring.
+///
+/// The domain-relative API is [`get_metadata`]. The GUI command surface still
+/// invokes `storage_get_metadata`, so keep this delegating wrapper until the
+/// generated command references are renamed in one coordinated pass.
+pub async fn storage_get_metadata(
+    api: &LoreApi,
+    args: StorageGetMetadataArgs,
+) -> Result<StorageGetMetadataResult> {
+    get_metadata(api, args).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/lore-vm/tests/storage_disk_roundtrip.rs
+++ b/crates/lore-vm/tests/storage_disk_roundtrip.rs
@@ -100,7 +100,7 @@ async fn put_file_get_file_flush_metadata_roundtrip_on_disk() {
     // ---- get_metadata ------------------------------------------------------
     // Metadata is fetched without transferring payload bytes; assert the
     // content size matches what we stored.
-    let meta = ops::storage::get_metadata::storage_get_metadata(
+    let meta = ops::storage::get_metadata::get_metadata(
         &repo.api,
         ops::storage::get_metadata::StorageGetMetadataArgs {
             handle,
@@ -300,7 +300,7 @@ async fn large_file_chunked_fragments_roundtrip() {
 
     // Metadata content size equals the full (reassembled) byte count even though
     // it is split across many leaf fragments on disk.
-    let meta = ops::storage::get_metadata::storage_get_metadata(
+    let meta = ops::storage::get_metadata::get_metadata(
         &repo.api,
         ops::storage::get_metadata::StorageGetMetadataArgs {
             handle,

--- a/crates/lore-vm/tests/storage_obliterate_copy_errors.rs
+++ b/crates/lore-vm/tests/storage_obliterate_copy_errors.rs
@@ -142,7 +142,7 @@ async fn obliterate_removes_then_is_idempotent() {
     let addr = put_payload(&repo, handle, "obl.bin", CONTENT).await;
 
     // Sanity: it is retrievable before obliteration.
-    let pre = ops::storage::get_metadata::storage_get_metadata(
+    let pre = ops::storage::get_metadata::get_metadata(
         &repo.api,
         ops::storage::get_metadata::StorageGetMetadataArgs {
             handle,
@@ -198,7 +198,7 @@ async fn obliterate_removes_then_is_idempotent() {
     // we assert the fragment is now empty (content size dropped from the stored
     // length to 0), which is how an obliterated entry distinguishes itself from
     // a live one.
-    let post = ops::storage::get_metadata::storage_get_metadata(
+    let post = ops::storage::get_metadata::get_metadata(
         &repo.api,
         ops::storage::get_metadata::StorageGetMetadataArgs {
             handle,
@@ -284,7 +284,7 @@ async fn missing_address_surfaces_op_level_error() {
     let missing = format!("{}-{}", "ab".repeat(32), "00".repeat(16));
 
     // get_metadata for a missing address surfaces as an op-level Err.
-    let meta = ops::storage::get_metadata::storage_get_metadata(
+    let meta = ops::storage::get_metadata::get_metadata(
         &repo.api,
         ops::storage::get_metadata::StorageGetMetadataArgs {
             handle,
@@ -338,7 +338,7 @@ async fn malformed_address_surfaces_an_error() {
     let repo = create_disk_repo("storage-bad", "alice").await;
     let handle = open_disk_store(&repo).await;
 
-    let result = ops::storage::get_metadata::storage_get_metadata(
+    let result = ops::storage::get_metadata::get_metadata(
         &repo.api,
         ops::storage::get_metadata::StorageGetMetadataArgs {
             handle,


### PR DESCRIPTION
Resolves SBAI-4487

## Summary

Mechanical rename of the lore-vm storage op function `storage_get_metadata` → `get_metadata`, bringing it in line with the domain-relative naming convention already used by every other short-name storage op (`copy`, `open`, `upload`, `flush`, `put`, `put_file`, `obliterate`, `close`).

Found while working on SBAI-3694. The file already lived at `crates/lore-vm/src/ops/storage/get_metadata.rs`; only the public fn inside it carried the redundant `storage_` prefix.

## Files Changed

- `crates/lore-vm/src/ops/storage/get_metadata.rs` — renamed `pub async fn storage_get_metadata` → `get_metadata`; updated the doc-comment link on `StorageGetMetadataArgs` to match.
- `crates/lore-vm/tests/storage_disk_roundtrip.rs` — 2 call sites updated to `ops::storage::get_metadata::get_metadata(...)`.
- `crates/lore-vm/tests/storage_obliterate_copy_errors.rs` — 4 call sites updated to `ops::storage::get_metadata::get_metadata(...)`.

## Scope (per LoreGUI hard fence)

This PR touches **only** the `lore-vm` crate. Out of scope, to be propagated by the loregui integration manager in a batched GUI pass:

- `src-tauri/src/commands.rs` — Tauri wrapper (`storage_get_metadata as op_storage_get_metadata`) and the `pub async fn storage_get_metadata` re-export.
- `src-tauri/src/lib.rs` — `commands::storage_get_metadata` entry in `generate_handler!`.
- `frontend/src/api.ts` — `invoke("storage_get_metadata", …)` wrapper.
- `frontend/src/palette/manifest/storage/get_metadata.ts` — `command: "storage_get_metadata"`.
- `website/src/lib/op-reference.generated.ts` — generated reference doc.

Leaving those untouched is required by the LOREGUI hard fence (`NOT src-tauri/**`, `NOT frontend/**`, etc.); the integration manager owns the GUI/Tauri/frontend surface and propagates op renames in batched, multi-reviewer-safe passes. The lore-vm crate is fully self-consistent after this change.

## Testing

- `cargo check -p lore-vm` → green.
- `cargo test -p lore-vm --no-run` → green (all integration tests compile, including the two updated test files).
- `cargo test -p lore-vm --lib ops::storage::get_metadata::` → 7/7 inline unit tests pass.
- `cargo test -p lore-vm --test storage_disk_roundtrip --test storage_obliterate_copy_errors` → both test binaries build and run.

Per the fence: did NOT run `cargo build --workspace` (pulls src-tauri) and did NOT run any npm/frontend build — those surfaces will be wired by the integration manager.