### PR TITLE
SBAI-4488: storage rename storage_get to get

### DIFF
--- a/crates/lore-vm/src/ops/storage/get.rs
+++ b/crates/lore-vm/src/ops/storage/get.rs
@@ -43,7 +43,7 @@ pub struct GetItem {
     pub local_cache: bool,
 }
 
-/// Arguments for [`storage_get`].
+/// Arguments for [`get`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageGetArgs {
     /// Handle id returned by a prior `storage open` call.
@@ -137,7 +137,7 @@ struct GetCollector {
 /// Calls the upstream `lore::storage::get` in-process with a specialised
 /// callback that copies binary payloads during the callback window (the
 /// `LoreBytes` raw-pointer view is only valid for that duration).
-pub async fn storage_get(api: &LoreApi, args: StorageGetArgs) -> Result<StorageGetResult> {
+pub async fn get(api: &LoreApi, args: StorageGetArgs) -> Result<StorageGetResult> {
     let lore_args = args.into_lore()?;
 
     let collector: Arc<Mutex<GetCollector>> = Arc::new(Mutex::new(GetCollector::default()));

--- a/crates/lore-vm/tests/integration_roundtrip.rs
+++ b/crates/lore-vm/tests/integration_roundtrip.rs
@@ -261,7 +261,7 @@ async fn storage_roundtrip_against_real_lore() {
     );
 
     // ---- 3. get it back and assert the bytes round-trip ---------------------
-    let got = ops::storage::get::storage_get(
+    let got = ops::storage::get::get(
         &api,
         ops::storage::get::StorageGetArgs {
             handle,


### PR DESCRIPTION
Resolves SBAI-4488

## Summary
Rename `pub async fn storage_get` to `pub async fn get` in the storage::get module to match the domain-relative naming convention used by all sibling storage ops (open, close, put, put_file, get_file). This is the same fix as SBAI-4486 for `storage_get_file`.

## Files Changed
- `crates/lore-vm/src/ops/storage/get.rs` — Renamed function `storage_get` → `get`, updated doc comment reference
- `crates/lore-vm/tests/integration_roundtrip.rs` — Updated sole caller from `ops::storage::get::storage_get` → `ops::storage::get::get`

## Testing
- `cargo check -p lore-vm` — green
- `cargo test -p lore-vm` — 706+ tests pass, 0 failures