### PR TITLE
SBAI-4490: LoreGUI licenses CI installs cargo-about with cli feature

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -35,9 +35,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config
 
       - name: Install cargo-about
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-about
+        run: cargo install cargo-about --locked --features cli
 
       - name: Install frontend deps
         run: npm --prefix frontend ci || npm --prefix frontend install

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -17,7 +17,7 @@ ships.
 ## Regenerating
 
 ```bash
-# Rust (needs cargo-about: cargo install cargo-about)
+# Rust (needs cargo-about: cargo install cargo-about --features cli)
 cargo about generate --all-features about.hbs -o THIRD-PARTY-LICENSES-RUST.md
 
 # Frontend (needs frontend deps installed: npm --prefix frontend ci)


### PR DESCRIPTION
Resolves SBAI-4490

## Summary
Updated the license attribution CI workflow to install `cargo-about` with the `cli` feature enabled. This fixes an issue where the `cargo-about` binary was missing from the default installation, causing CI failures.

## Files Changed
- `.github/workflows/licenses.yml`: Replaced `taiki-e/install-action@v2` with an explicit `cargo install cargo-about --locked --features cli` step.
- `THIRD-PARTY-LICENSES.md`: Updated manual installation instructions to include `--features cli`.
- `scripts/gen-licenses.sh`: Already contained the fix (verified against `origin/main`).

## Testing
- Verified that `cargo check -p lore-vm` and `cargo test -p lore-vm` remain green.
- Manually inspected the workflow file change.