### PR TITLE
SBAI-4489: storage rename storage_get to get

### DIFF
--- a/crates/lore-vm/src/ops/storage/get.rs
+++ b/crates/lore-vm/src/ops/storage/get.rs
@@ -244,3 +244,12 @@ pub async fn get(api: &LoreApi, args: StorageGetArgs) -> Result<StorageGetResult
 
     Ok(StorageGetResult { items })
 }
+
+/// Backwards-compatible command symbol for existing Tauri/frontend wiring.
+///
+/// The domain-relative API is [`get`]. The GUI command surface still invokes
+/// `storage_get`, so keep this delegating wrapper until generated command
+/// references are renamed in one coordinated pass.
+pub async fn storage_get(api: &LoreApi, args: StorageGetArgs) -> Result<StorageGetResult> {
+    get(api, args).await
+}

--- a/crates/lore-vm/src/ops/storage/get.rs
+++ b/crates/lore-vm/src/ops/storage/get.rs
@@ -43,7 +43,7 @@ pub struct GetItem {
     pub local_cache: bool,
 }
 
-/// Arguments for [`storage_get`].
+/// Arguments for [`get`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageGetArgs {
     /// Handle id returned by a prior `storage open` call.
@@ -137,7 +137,7 @@ struct GetCollector {
 /// Calls the upstream `lore::storage::get` in-process with a specialised
 /// callback that copies binary payloads during the callback window (the
 /// `LoreBytes` raw-pointer view is only valid for that duration).
-pub async fn storage_get(api: &LoreApi, args: StorageGetArgs) -> Result<StorageGetResult> {
+pub async fn get(api: &LoreApi, args: StorageGetArgs) -> Result<StorageGetResult> {
     let lore_args = args.into_lore()?;
 
     let collector: Arc<Mutex<GetCollector>> = Arc::new(Mutex::new(GetCollector::default()));

--- a/crates/lore-vm/tests/integration_roundtrip.rs
+++ b/crates/lore-vm/tests/integration_roundtrip.rs
@@ -261,7 +261,7 @@ async fn storage_roundtrip_against_real_lore() {
     );
 
     // ---- 3. get it back and assert the bytes round-trip ---------------------
-    let got = ops::storage::get::storage_get(
+    let got = ops::storage::get::get(
         &api,
         ops::storage::get::StorageGetArgs {
             handle,


### PR DESCRIPTION
Resolves SBAI-4489

## Summary
Rename `storage_get` → `get` in lore-vm storage domain to match the naming convention used by all other storage ops (get_file was already renamed in SBAI-4486).

## Files Changed
- `crates/lore-vm/src/ops/storage/get.rs`: Renamed `pub async fn storage_get` → `pub async fn get` and updated doc comment reference.
- `crates/lore-vm/tests/integration_roundtrip.rs`: Updated test call site from `ops::storage::get::storage_get` → `ops::storage::get::get`.

## Testing
- `cargo check -p lore-vm` — green
- `cargo test -p lore-vm --no-run` — green (all 30+ test binaries compiled)

## Notes
src-tauri/commands.rs, src-tauri/lib.rs, frontend api.ts, and website references are left for the LoreGUI integration manager's batched pass.