### PR TITLE
SBAI-4568: add #[deprecated] to lock file_message_send stub

### DIFF
--- a/crates/lore-vm/src/ops/lock/file_message_send.rs
+++ b/crates/lore-vm/src/ops/lock/file_message_send.rs
@@ -16,6 +16,13 @@
 //!   - collect events via `crate::collect::collect_events`
 //!   - map `LoreEvent::LockMessageSend` → typed result
 
+#![deprecated(
+    since = "0.1.0",
+    note = "Stub blocked on SBAI-4072: upstream lore crate lacks `lore::lock::file_message_send`. \
+            Until then this module only returns LoreError::CommandFailed. \
+            Remove from lock/mod.rs or implement when lore upstream adds the binding."
+)]
+
 use crate::api::LoreApi;
 use crate::error::{LoreError, Result};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Resolves SBAI-4568

## Summary
Added `#![deprecated]` module-level attribute to `file_message_send` in the lock domain. This produces compile-time warnings in `dispatch.rs\ whenever the stub is referenced, signaling to workers that this op is blocked on upstream `lore::lock::file_message_send\ (SBAI-4072).

## Files Changed
- `crates/lore-vm/src/ops/lock/file_message_send.rs` — added `#![deprecated(since = "0.1.0", note = "...")]` after module docs

## Testing
- `cargo check -p lore-vm` — green (2 expected deprecation warnings in dispatch.rs)
- `cargo test -p lore-vm file_message_send` — 5/5 pass