### PR TITLE
SBAI-4605 (loregui): theme-bridge import — apply StudioBrain theme + custom colors, origin-gated

### DIFF
--- a/frontend/src/theme/ThemeProvider.tsx
+++ b/frontend/src/theme/ThemeProvider.tsx
@@ -16,6 +16,11 @@ import {
   resolveIsDark,
   toBundle,
 } from "./theme";
+import {
+  detectBridgeTheme,
+  listenForBridgeTheme,
+  payloadToSettings,
+} from "./bridge";
 import type {
   FontSize,
   SemanticTheme,
@@ -54,6 +59,15 @@ interface ThemeContextValue {
   downloadBundle: (name: string, author?: string) => void;
   /** Parse + apply an imported bundle JSON. Throws on bad input. */
   importBundle: (json: string) => void;
+  /**
+   * True when the active theme came from StudioBrain via the theme bridge
+   * (SBAI-4605: URL fragment, studiobrain.ai cookie, or host postMessage).
+   * Bridged themes are runtime-only — they are never persisted, so the
+   * user's own standalone theme survives untouched.
+   */
+  bridgeActive: boolean;
+  /** Drop the bridged StudioBrain theme and return to the local theme. */
+  clearBridgeTheme: () => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
@@ -105,16 +119,28 @@ function structuredCloneSettings(s: ThemeSettings): ThemeSettings {
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [settings, setSettings] = useState<ThemeSettings>(() => loadSettings());
+  // SBAI-4605: theme handed off by StudioBrain (fragment / cookie /
+  // postMessage). Runtime-only override — never written to localStorage —
+  // so standalone launches keep the user's own LoreGUI theme.
+  const [bridged, setBridged] = useState<ThemeSettings | null>(() => {
+    const payload = detectBridgeTheme();
+    return payload ? payloadToSettings(payload) : null;
+  });
+  const effective = bridged ?? settings;
   const [isDark, setIsDark] = useState<boolean>(() =>
     resolveIsDark(loadSettings().mode),
   );
   const firstRender = useRef(true);
 
-  // Apply on mount + whenever settings change; persist (skip the very first
-  // apply-only pass so we don't rewrite identical storage on boot).
+  // Apply on mount + whenever the effective (bridged or local) theme changes.
   useEffect(() => {
-    applyTheme(settings);
-    setIsDark(resolveIsDark(settings.mode));
+    applyTheme(effective);
+    setIsDark(resolveIsDark(effective.mode));
+  }, [effective]);
+
+  // Persist LOCAL settings only (skip the very first pass so we don't
+  // rewrite identical storage on boot). Bridged themes are never persisted.
+  useEffect(() => {
     if (firstRender.current) {
       firstRender.current = false;
       return;
@@ -126,34 +152,46 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     }
   }, [settings]);
 
+  // Live theme updates from an embedding StudioBrain host. Origin-gated in
+  // listenForBridgeTheme (only *.studiobrain.ai / Tauri / Capacitor shells).
+  useEffect(
+    () =>
+      listenForBridgeTheme((payload) => setBridged(payloadToSettings(payload))),
+    [],
+  );
+
   // React to OS dark-mode changes while in "system" mode.
   useEffect(() => {
-    if (settings.mode !== "system" || !window.matchMedia) return;
+    if (effective.mode !== "system" || !window.matchMedia) return;
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     const onChange = () => {
-      applyTheme(settings);
-      setIsDark(resolveIsDark(settings.mode));
+      applyTheme(effective);
+      setIsDark(resolveIsDark(effective.mode));
     };
     mq.addEventListener("change", onChange);
     return () => mq.removeEventListener("change", onChange);
-  }, [settings]);
+  }, [effective]);
 
-  const setMode = useCallback(
-    (mode: ThemeMode) => setSettings((s) => ({ ...s, mode })),
-    [],
-  );
-  const setFontSize = useCallback(
-    (fontSize: FontSize) => setSettings((s) => ({ ...s, fontSize })),
-    [],
-  );
-  const setFontFamily = useCallback(
-    (fontFamily: string) => setSettings((s) => ({ ...s, fontFamily })),
-    [],
-  );
-  const setCustomCSS = useCallback(
-    (customCSS: string) => setSettings((s) => ({ ...s, customCSS })),
-    [],
-  );
+  const clearBridgeTheme = useCallback(() => setBridged(null), []);
+
+  // Any explicit local theme interaction takes over from a bridged theme so
+  // the user's edits are immediately visible.
+  const setMode = useCallback((mode: ThemeMode) => {
+    setBridged(null);
+    setSettings((s) => ({ ...s, mode }));
+  }, []);
+  const setFontSize = useCallback((fontSize: FontSize) => {
+    setBridged(null);
+    setSettings((s) => ({ ...s, fontSize }));
+  }, []);
+  const setFontFamily = useCallback((fontFamily: string) => {
+    setBridged(null);
+    setSettings((s) => ({ ...s, fontFamily }));
+  }, []);
+  const setCustomCSS = useCallback((customCSS: string) => {
+    setBridged(null);
+    setSettings((s) => ({ ...s, customCSS }));
+  }, []);
 
   const updateSurfaceSlot = useCallback(
     (
@@ -162,6 +200,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       slot: keyof ThemeSurface,
       value: string,
     ) => {
+      setBridged(null);
       setSettings((s) => {
         const key = variant === "dark" ? "darkTheme" : "lightTheme";
         const next = cloneTheme(s[key]);
@@ -174,6 +213,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   const setVariant = useCallback(
     (variant: "light" | "dark", theme: SemanticTheme) => {
+      setBridged(null);
       setSettings((s) => ({
         ...s,
         [variant === "dark" ? "darkTheme" : "lightTheme"]: cloneTheme(theme),
@@ -182,15 +222,15 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     [],
   );
 
-  const replaceSettings = useCallback(
-    (next: ThemeSettings) => setSettings(structuredCloneSettings(next)),
-    [],
-  );
+  const replaceSettings = useCallback((next: ThemeSettings) => {
+    setBridged(null);
+    setSettings(structuredCloneSettings(next));
+  }, []);
 
-  const resetToDefaults = useCallback(
-    () => setSettings(structuredCloneSettings(DEFAULT_THEME_SETTINGS)),
-    [],
-  );
+  const resetToDefaults = useCallback(() => {
+    setBridged(null);
+    setSettings(structuredCloneSettings(DEFAULT_THEME_SETTINGS));
+  }, []);
 
   const exportBundle = useCallback(
     (name: string, author?: string) =>
@@ -215,6 +255,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   const importBundle = useCallback((json: string) => {
     const bundle = parseBundle(json);
+    setBridged(null);
     setSettings((s) => ({
       ...s,
       lightTheme: cloneTheme(bundle.lightTheme),
@@ -238,10 +279,13 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       exportBundle,
       downloadBundle,
       importBundle,
+      bridgeActive: bridged !== null,
+      clearBridgeTheme,
     }),
     [
       settings,
       isDark,
+      bridged,
       setMode,
       setFontSize,
       setFontFamily,
@@ -253,6 +297,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       exportBundle,
       downloadBundle,
       importBundle,
+      clearBridgeTheme,
     ],
   );
 

--- a/frontend/src/theme/bridge.spec.tsx
+++ b/frontend/src/theme/bridge.spec.tsx
@@ -1,0 +1,304 @@
+/**
+ * SBAI-4605 — StudioBrain → LoreGUI theme bridge tests.
+ *
+ * Covers: payload round-trip incl. user-customized colors, allowed-origin
+ * gating (postMessage), fragment hand-off, cookie-shape conversion, and the
+ * standalone fallback to LoreGUI's own theme.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, cleanup, act } from "@testing-library/react";
+import { ThemeProvider, useTheme } from "./ThemeProvider";
+import {
+  BRIDGE_MESSAGE_TYPE,
+  BRIDGE_FRAGMENT_KEY,
+  cookieJsonToPayload,
+  isAllowedBridgeOrigin,
+  parseBridgePayload,
+  payloadToSettings,
+  varMapToVariant,
+  type SbThemeBridgePayload,
+} from "./bridge";
+import {
+  DEFAULT_THEME_SETTINGS,
+  SURFACE_NAMES,
+  cloneTheme,
+} from "./theme";
+import type { SemanticTheme } from "./theme";
+
+// ---------------------------------------------------------------------------
+// Helpers — simulate StudioBrain's export side (surfaces → CSS-var map)
+// ---------------------------------------------------------------------------
+
+const SLOT_TO_VAR: [string, string][] = [
+  ["background", "bg"],
+  ["text", "text"],
+  ["textSecondary", "text-secondary"],
+  ["border", "border"],
+  ["hover", "hover"],
+  ["active", "active"],
+  ["shadow", "shadow"],
+];
+
+function exportVarMap(variant: SemanticTheme): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const name of SURFACE_NAMES) {
+    for (const [slot, suffix] of SLOT_TO_VAR) {
+      vars[`--surface-${name}-${suffix}`] = (
+        variant[name] as unknown as Record<string, string>
+      )[slot];
+    }
+  }
+  return vars;
+}
+
+function makeStudioBrainPayload(): SbThemeBridgePayload {
+  // A StudioBrain user's CUSTOMIZED theme: start from defaults, override.
+  const dark = cloneTheme(DEFAULT_THEME_SETTINGS.darkTheme);
+  const light = cloneTheme(DEFAULT_THEME_SETTINGS.lightTheme);
+  dark.primary.background = "#ff0088"; // user-picked brand color
+  dark.base.background = "#101820";
+  light.accent.text = "#123456";
+  return {
+    kind: "sb-theme-bridge",
+    version: 1,
+    base: "studiobrain",
+    mode: "dark",
+    fontSize: "large",
+    fontFamily: "Inter, sans-serif",
+    light: exportVarMap(light),
+    dark: exportVarMap(dark),
+  };
+}
+
+function encodeFragment(payload: SbThemeBridgePayload): string {
+  return btoa(unescape(encodeURIComponent(JSON.stringify(payload))))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function Probe({ onCtx }: { onCtx: (ctx: ReturnType<typeof useTheme>) => void }) {
+  onCtx(useTheme());
+  return null;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  window.location.hash = "";
+  // Wipe any CSS vars left by a previous applyTheme.
+  document.documentElement.removeAttribute("style");
+});
+
+afterEach(() => {
+  cleanup();
+  window.location.hash = "";
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip: export → import → tokens match (incl. custom overrides)
+// ---------------------------------------------------------------------------
+
+describe("payload round-trip", () => {
+  it("reproduces StudioBrain's customized tokens exactly", () => {
+    const payload = makeStudioBrainPayload();
+    const parsed = parseBridgePayload(payload);
+    expect(parsed).not.toBeNull();
+    const settings = payloadToSettings(parsed!);
+    expect(settings.mode).toBe("dark");
+    expect(settings.fontSize).toBe("large");
+    expect(settings.fontFamily).toBe("Inter, sans-serif");
+    // Custom overrides survive.
+    expect(settings.darkTheme.primary.background).toBe("#ff0088");
+    expect(settings.darkTheme.base.background).toBe("#101820");
+    expect(settings.lightTheme.accent.text).toBe("#123456");
+    // Non-overridden tokens equal StudioBrain's export bit-for-bit.
+    expect(settings.darkTheme.info).toEqual(DEFAULT_THEME_SETTINGS.darkTheme.info);
+    // Remote CSS injection is never accepted.
+    expect(settings.customCSS).toBe("");
+  });
+
+  it("applies bridged tokens to the DOM via the provider (fragment boot)", () => {
+    const payload = makeStudioBrainPayload();
+    window.location.hash = `#${BRIDGE_FRAGMENT_KEY}=${encodeFragment(payload)}`;
+    let ctx!: ReturnType<typeof useTheme>;
+    render(
+      <ThemeProvider>
+        <Probe onCtx={(c) => (ctx = c)} />
+      </ThemeProvider>,
+    );
+    const style = document.documentElement.style;
+    expect(style.getPropertyValue("--surface-primary-bg")).toBe("#ff0088");
+    expect(style.getPropertyValue("--surface-base-bg")).toBe("#101820");
+    expect(ctx.bridgeActive).toBe(true);
+    expect(ctx.isDark).toBe(true);
+    // Fragment is stripped after being read (accounts #token= discipline).
+    expect(window.location.hash).not.toContain(BRIDGE_FRAGMENT_KEY);
+    // Bridged theme is never persisted over the user's local theme.
+    expect(localStorage.getItem("loregui.theme.v1")).toBeNull();
+  });
+
+  it("merges partial var maps over LoreGUI defaults", () => {
+    const variant = varMapToVariant(
+      { "--surface-primary-bg": "#abcdef", "--unknown-var": "#000" },
+      DEFAULT_THEME_SETTINGS.darkTheme,
+    );
+    expect(variant.primary.background).toBe("#abcdef");
+    expect(variant.primary.text).toBe(
+      DEFAULT_THEME_SETTINGS.darkTheme.primary.text,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Allowed-origin gating
+// ---------------------------------------------------------------------------
+
+describe("origin gating", () => {
+  it("accepts only StudioBrain origins (+ loopback in dev builds)", () => {
+    expect(isAllowedBridgeOrigin("https://app.studiobrain.ai")).toBe(true);
+    expect(isAllowedBridgeOrigin("https://studiobrain.ai")).toBe(true);
+    expect(isAllowedBridgeOrigin("https://foo.studiobrain.ai")).toBe(true);
+    expect(isAllowedBridgeOrigin("tauri://localhost")).toBe(true);
+    expect(isAllowedBridgeOrigin("capacitor://localhost")).toBe(true);
+    expect(isAllowedBridgeOrigin("https://evil.example.com")).toBe(false);
+    expect(isAllowedBridgeOrigin("https://studiobrain.ai.evil.com")).toBe(false);
+    expect(isAllowedBridgeOrigin("http://studiobrain.ai", { dev: false })).toBe(
+      false, // http (not https) is not a StudioBrain origin
+    );
+    expect(isAllowedBridgeOrigin("http://localhost:1420", { dev: false })).toBe(
+      false,
+    );
+    expect(isAllowedBridgeOrigin("http://localhost:1420", { dev: true })).toBe(
+      true,
+    );
+    expect(isAllowedBridgeOrigin("")).toBe(false);
+  });
+
+  it("applies postMessage themes from allowed origins and drops others", () => {
+    let ctx!: ReturnType<typeof useTheme>;
+    render(
+      <ThemeProvider>
+        <Probe onCtx={(c) => (ctx = c)} />
+      </ThemeProvider>,
+    );
+    const payload = makeStudioBrainPayload();
+
+    // Disallowed origin → ignored.
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: BRIDGE_MESSAGE_TYPE, payload },
+          origin: "https://evil.example.com",
+        }),
+      );
+    });
+    expect(ctx.bridgeActive).toBe(false);
+    expect(
+      document.documentElement.style.getPropertyValue("--surface-primary-bg"),
+    ).not.toBe("#ff0088");
+
+    // Allowed origin → applied live.
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: BRIDGE_MESSAGE_TYPE, payload },
+          origin: "https://app.studiobrain.ai",
+        }),
+      );
+    });
+    expect(ctx.bridgeActive).toBe(true);
+    expect(
+      document.documentElement.style.getPropertyValue("--surface-primary-bg"),
+    ).toBe("#ff0088");
+  });
+
+  it("rejects malformed payloads even from allowed origins", () => {
+    let ctx!: ReturnType<typeof useTheme>;
+    render(
+      <ThemeProvider>
+        <Probe onCtx={(c) => (ctx = c)} />
+      </ThemeProvider>,
+    );
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: BRIDGE_MESSAGE_TYPE, payload: { kind: "nope" } },
+          origin: "https://app.studiobrain.ai",
+        }),
+      );
+    });
+    expect(ctx.bridgeActive).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cookie-shape conversion (SettingsContext's sb_theme_sync_v1)
+// ---------------------------------------------------------------------------
+
+describe("cookie conversion", () => {
+  it("converts the SettingsContext cookie JSON (surface objects) to a payload", () => {
+    const dark = cloneTheme(DEFAULT_THEME_SETTINGS.darkTheme);
+    dark.accent.background = "#00ffcc";
+    const cookieJson = JSON.stringify({
+      theme: {
+        mode: "dark",
+        fontSize: "small",
+        fontFamily: "JetBrains Mono",
+        lightTheme: DEFAULT_THEME_SETTINGS.lightTheme,
+        darkTheme: { ...dark, primaryColor: "#legacy-ignored" },
+      },
+      display: { uiScale: 1.25 },
+    });
+    const payload = cookieJsonToPayload(cookieJson);
+    expect(payload).not.toBeNull();
+    expect(payload!.dark["--surface-accent-bg"]).toBe("#00ffcc");
+    expect(payload!.fontFamily).toBe("JetBrains Mono");
+    const settings = payloadToSettings(payload!);
+    expect(settings.darkTheme.accent.background).toBe("#00ffcc");
+  });
+
+  it("returns null for junk cookies", () => {
+    expect(cookieJsonToPayload("not json")).toBeNull();
+    expect(cookieJsonToPayload("{}")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Standalone fallback
+// ---------------------------------------------------------------------------
+
+describe("standalone fallback", () => {
+  it("uses LoreGUI's own theme when no bridge payload is present", () => {
+    let ctx!: ReturnType<typeof useTheme>;
+    render(
+      <ThemeProvider>
+        <Probe onCtx={(c) => (ctx = c)} />
+      </ThemeProvider>,
+    );
+    expect(ctx.bridgeActive).toBe(false);
+    // matchMedia stub says light; system mode resolves to LIGHT defaults.
+    expect(
+      document.documentElement.style.getPropertyValue("--surface-base-bg"),
+    ).toBe(DEFAULT_THEME_SETTINGS.lightTheme.base.background);
+  });
+
+  it("local edits take over from a bridged theme and persist locally only", () => {
+    const payload = makeStudioBrainPayload();
+    window.location.hash = `#${BRIDGE_FRAGMENT_KEY}=${encodeFragment(payload)}`;
+    let ctx!: ReturnType<typeof useTheme>;
+    render(
+      <ThemeProvider>
+        <Probe onCtx={(c) => (ctx = c)} />
+      </ThemeProvider>,
+    );
+    expect(ctx.bridgeActive).toBe(true);
+    act(() => {
+      ctx.updateSurfaceSlot("light", "primary", "background", "#111111");
+    });
+    expect(ctx.bridgeActive).toBe(false);
+    const saved = JSON.parse(localStorage.getItem("loregui.theme.v1")!);
+    expect(saved.lightTheme.primary.background).toBe("#111111");
+    // The bridged StudioBrain color was never written to storage.
+    expect(saved.darkTheme.primary.background).not.toBe("#ff0088");
+  });
+});

--- a/frontend/src/theme/bridge.ts
+++ b/frontend/src/theme/bridge.ts
@@ -1,0 +1,352 @@
+/**
+ * StudioBrain → LoreGUI theme bridge (SBAI-4605).
+ *
+ * LoreGUI's surface model was ported from StudioBrain, so the two apps share
+ * the same 12 surfaces × 7 slots and the same `--surface-{name}-{prop}` CSS
+ * custom properties. This module lets LoreGUI *import* StudioBrain's resolved
+ * theme — including user-customized colors — so it renders visually identical
+ * whether launched standalone or alongside/inside StudioBrain.
+ *
+ * Accepted transports (in priority order):
+ *  1. URL fragment  `#sbtheme=<base64url(JSON)>` — set by StudioBrain when it
+ *     launches or embeds LoreGUI (same pattern as the accounts-iframe JWT
+ *     fragment, SBAI-1935: read once, stripped from the URL, never logged).
+ *  2. Cookie        `sb_theme_sync_v1` on `.studiobrain.ai` — present when the
+ *     LoreGUI web build is served from a *.studiobrain.ai origin.
+ *  3. postMessage   `sb-theme-update` — live updates while embedded; ONLY
+ *     accepted from allowed StudioBrain origins (mirrors the accounts
+ *     frame-ancestors allowlist). Arbitrary cross-origin injection is
+ *     rejected.
+ *
+ * When no payload is present, LoreGUI falls back to its own saved/default
+ * theme — standalone use is unaffected.
+ */
+
+import {
+  DEFAULT_THEME_SETTINGS,
+  SURFACE_NAMES,
+  cloneTheme,
+} from "./theme";
+import type {
+  FontSize,
+  SemanticTheme,
+  SurfaceName,
+  ThemeMode,
+  ThemeSettings,
+  ThemeSurface,
+} from "./theme";
+
+// ---------------------------------------------------------------------------
+// Wire format (shared contract with studiobrain-core `lib/theme-bridge.ts`)
+// ---------------------------------------------------------------------------
+
+export interface SbThemeBridgePayload {
+  kind: "sb-theme-bridge";
+  version: 1;
+  /** Base theme identity (informational; colors are fully resolved). */
+  base?: string;
+  mode: ThemeMode;
+  fontSize?: FontSize;
+  fontFamily?: string;
+  /** Flat CSS-var maps keyed `--surface-{surface}-{prop}`. */
+  light: Record<string, string>;
+  dark: Record<string, string>;
+}
+
+export const BRIDGE_MESSAGE_TYPE = "sb-theme-update";
+export const BRIDGE_FRAGMENT_KEY = "sbtheme";
+export const BRIDGE_COOKIE_NAME = "sb_theme_sync_v1";
+
+/** CSS-var suffix → ThemeSurface slot. */
+const VAR_TO_SLOT: [string, keyof ThemeSurface][] = [
+  // Longest suffixes first so "text-secondary" wins over "text".
+  ["text-secondary", "textSecondary"],
+  ["bg", "background"],
+  ["text", "text"],
+  ["border", "border"],
+  ["hover", "hover"],
+  ["active", "active"],
+  ["shadow", "shadow"],
+];
+
+// ---------------------------------------------------------------------------
+// Origin allowlist (mirror of the accounts CSP frame-ancestors, SBAI-1952)
+// ---------------------------------------------------------------------------
+
+const ALLOWED_EXACT_ORIGINS = new Set([
+  "https://app.studiobrain.ai",
+  "https://studiobrain.ai",
+  // Desktop (Tauri) and mobile (Capacitor) StudioBrain shells.
+  "tauri://localhost",
+  "https://tauri.localhost",
+  "capacitor://localhost",
+]);
+
+/** Is `origin` an allowed StudioBrain host for theme injection? */
+export function isAllowedBridgeOrigin(
+  origin: string,
+  opts: { dev?: boolean } = {},
+): boolean {
+  if (!origin) return false;
+  if (ALLOWED_EXACT_ORIGINS.has(origin)) return true;
+  try {
+    const url = new URL(origin);
+    if (
+      url.protocol === "https:" &&
+      (url.hostname === "studiobrain.ai" ||
+        url.hostname.endsWith(".studiobrain.ai"))
+    ) {
+      return true;
+    }
+    // Local development only (vite dev / tauri dev): loopback hosts.
+    const dev = opts.dev ?? isDevBuild();
+    if (
+      dev &&
+      (url.hostname === "localhost" || url.hostname === "127.0.0.1")
+    ) {
+      return true;
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+function isDevBuild(): boolean {
+  try {
+    return Boolean(import.meta.env?.DEV);
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Payload validation + conversion to LoreGUI theme settings
+// ---------------------------------------------------------------------------
+
+function isVarMap(v: unknown): v is Record<string, string> {
+  return (
+    !!v &&
+    typeof v === "object" &&
+    !Array.isArray(v) &&
+    Object.entries(v as Record<string, unknown>).every(
+      ([k, val]) => k.startsWith("--") && typeof val === "string",
+    )
+  );
+}
+
+/** Validate an untrusted value as a bridge payload. Returns null on junk. */
+export function parseBridgePayload(raw: unknown): SbThemeBridgePayload | null {
+  if (!raw || typeof raw !== "object") return null;
+  const p = raw as Partial<SbThemeBridgePayload>;
+  if (p.kind !== "sb-theme-bridge" || p.version !== 1) return null;
+  if (!isVarMap(p.light) || !isVarMap(p.dark)) return null;
+  const mode: ThemeMode =
+    p.mode === "light" || p.mode === "dark" || p.mode === "system"
+      ? p.mode
+      : "system";
+  return {
+    kind: "sb-theme-bridge",
+    version: 1,
+    base: typeof p.base === "string" ? p.base : undefined,
+    mode,
+    fontSize:
+      p.fontSize === "small" || p.fontSize === "medium" || p.fontSize === "large"
+        ? p.fontSize
+        : undefined,
+    fontFamily: typeof p.fontFamily === "string" ? p.fontFamily : undefined,
+    light: { ...p.light },
+    dark: { ...p.dark },
+  };
+}
+
+/**
+ * Merge a flat CSS-var map onto a variant. Unknown vars are ignored; missing
+ * vars keep the fallback's value so partial payloads degrade gracefully.
+ */
+export function varMapToVariant(
+  vars: Record<string, string>,
+  fallback: SemanticTheme,
+): SemanticTheme {
+  const out = cloneTheme(fallback);
+  for (const [key, value] of Object.entries(vars)) {
+    if (!key.startsWith("--surface-") || typeof value !== "string" || !value)
+      continue;
+    const rest = key.slice("--surface-".length); // "{surface}-{suffix}"
+    for (const name of SURFACE_NAMES) {
+      if (!rest.startsWith(`${name}-`)) continue;
+      const suffix = rest.slice(name.length + 1);
+      const slot = VAR_TO_SLOT.find(([s]) => s === suffix)?.[1];
+      if (slot) out[name as SurfaceName][slot] = value;
+      break;
+    }
+  }
+  return out;
+}
+
+/** Convert a validated payload into full LoreGUI theme settings. */
+export function payloadToSettings(
+  payload: SbThemeBridgePayload,
+  base: ThemeSettings = DEFAULT_THEME_SETTINGS,
+): ThemeSettings {
+  return {
+    mode: payload.mode,
+    lightTheme: varMapToVariant(payload.light, base.lightTheme),
+    darkTheme: varMapToVariant(payload.dark, base.darkTheme),
+    fontSize: payload.fontSize ?? base.fontSize,
+    fontFamily: payload.fontFamily ?? base.fontFamily,
+    // Never accept remote CSS injection — customCSS stays local-only.
+    customCSS: base.customCSS,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cookie-shape conversion (SettingsContext writes surface OBJECTS, not vars)
+// ---------------------------------------------------------------------------
+
+interface CookieShape {
+  theme?: {
+    mode?: ThemeMode;
+    fontSize?: FontSize;
+    fontFamily?: string;
+    lightTheme?: Partial<Record<SurfaceName, Partial<ThemeSurface>>>;
+    darkTheme?: Partial<Record<SurfaceName, Partial<ThemeSurface>>>;
+  };
+}
+
+const SLOT_TO_VAR: [keyof ThemeSurface, string][] = [
+  ["background", "bg"],
+  ["text", "text"],
+  ["textSecondary", "text-secondary"],
+  ["border", "border"],
+  ["hover", "hover"],
+  ["active", "active"],
+  ["shadow", "shadow"],
+];
+
+function variantObjectToVarMap(
+  variant: Partial<Record<SurfaceName, Partial<ThemeSurface>>>,
+): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const name of SURFACE_NAMES) {
+    const s = variant[name];
+    if (!s || typeof s !== "object") continue;
+    for (const [slot, suffix] of SLOT_TO_VAR) {
+      const v = (s as Record<string, unknown>)[slot];
+      if (typeof v === "string" && v)
+        vars[`--surface-${name}-${suffix}`] = v;
+    }
+  }
+  return vars;
+}
+
+/** Convert the `sb_theme_sync_v1` cookie JSON into a bridge payload. */
+export function cookieJsonToPayload(raw: string): SbThemeBridgePayload | null {
+  try {
+    const parsed = JSON.parse(raw) as CookieShape;
+    const t = parsed?.theme;
+    if (!t?.lightTheme || !t.darkTheme) return null;
+    return parseBridgePayload({
+      kind: "sb-theme-bridge",
+      version: 1,
+      base: "studiobrain",
+      mode: t.mode ?? "system",
+      fontSize: t.fontSize,
+      fontFamily: t.fontFamily,
+      light: variantObjectToVarMap(t.lightTheme),
+      dark: variantObjectToVarMap(t.darkTheme),
+    });
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Transport readers
+// ---------------------------------------------------------------------------
+
+function fromBase64Url(value: string): string {
+  const b64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+  return decodeURIComponent(escape(atob(padded)));
+}
+
+/**
+ * Read `#sbtheme=...` from the current URL, then strip it (never logged,
+ * never persisted in history — same discipline as the accounts `#token=`).
+ */
+export function readFragmentTheme(): SbThemeBridgePayload | null {
+  if (typeof window === "undefined") return null;
+  const hash = window.location.hash.replace(/^#/, "");
+  if (!hash) return null;
+  const params = new URLSearchParams(hash);
+  const value = params.get(BRIDGE_FRAGMENT_KEY);
+  if (!value) return null;
+  params.delete(BRIDGE_FRAGMENT_KEY);
+  try {
+    const remaining = params.toString();
+    window.history.replaceState(
+      null,
+      "",
+      window.location.pathname +
+        window.location.search +
+        (remaining ? `#${remaining}` : ""),
+    );
+  } catch {
+    /* history may be unavailable; payload still applies */
+  }
+  try {
+    return parseBridgePayload(JSON.parse(fromBase64Url(value)));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the StudioBrain theme-sync cookie. Only meaningful when LoreGUI is
+ * served from a *.studiobrain.ai origin (the cookie is domain-scoped there,
+ * so its presence already implies an allowed origin).
+ */
+export function readCookieTheme(): SbThemeBridgePayload | null {
+  if (typeof document === "undefined" || typeof window === "undefined")
+    return null;
+  const host = window.location.hostname.toLowerCase();
+  if (host !== "studiobrain.ai" && !host.endsWith(".studiobrain.ai"))
+    return null;
+  const match = document.cookie
+    .split("; ")
+    .find((c) => c.startsWith(`${BRIDGE_COOKIE_NAME}=`));
+  if (!match) return null;
+  try {
+    return cookieJsonToPayload(
+      decodeURIComponent(match.slice(BRIDGE_COOKIE_NAME.length + 1)),
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** Boot-time detection: fragment first (explicit hand-off), then cookie. */
+export function detectBridgeTheme(): SbThemeBridgePayload | null {
+  return readFragmentTheme() ?? readCookieTheme();
+}
+
+/**
+ * Listen for live `sb-theme-update` postMessages from an embedding
+ * StudioBrain host. Messages from non-allowed origins are silently dropped.
+ * Returns an unsubscribe function.
+ */
+export function listenForBridgeTheme(
+  onTheme: (payload: SbThemeBridgePayload) => void,
+): () => void {
+  if (typeof window === "undefined") return () => {};
+  const handler = (event: MessageEvent) => {
+    if (!isAllowedBridgeOrigin(event.origin)) return;
+    const data = event.data as { type?: string; payload?: unknown } | null;
+    if (!data || data.type !== BRIDGE_MESSAGE_TYPE) return;
+    const payload = parseBridgePayload(data.payload);
+    if (payload) onTheme(payload);
+  };
+  window.addEventListener("message", handler);
+  return () => window.removeEventListener("message", handler);
+}


### PR DESCRIPTION
In-house (Fable-reviewed, vitest 116/116 + tsc clean). theme/bridge.ts: accept StudioBrain resolved theme via fragment/cookie/postMessage (origin allowlist mirrors accounts frame-ancestors: *.studiobrain.ai https + tauri/capacitor localhost; arbitrary origins rejected; remote customCSS never accepted). Bridged theme is runtime-only override; no payload -> loregui own theme (standalone unchanged); local edit takes over. Part 2 of SBAI-4605. RECOMMENDATION: keep loregui STANDALONE with this bridge (not wrapped) — OSS/build-trust boundary + it is a native Tauri app, and the accounts-1935 embed pattern already provides feels-integrated without merging trust zones.