### PR TITLE
SBAI-4683: publish raw loregui + loreserver sidecar binaries on releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,3 +285,66 @@ jobs:
           releaseBody: ${{ startsWith(github.ref, 'refs/tags/') && steps.notes.outputs.body || 'Rolling build of the latest `main`. Current Windows / Linux / macOS installers. Pre-alpha — CI refreshes this on each push to main.' }}
           releaseDraft: ${{ startsWith(github.ref, 'refs/tags/') }}
           prerelease: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
+      # ── Raw sidecar binaries for StudioBrain desktop bundling (SBAI-4683) ──
+      # The StudioBrain desktop app (BiloxiStudios/studiobrain-app) bundles
+      # loregui + loreserver as Tauri externalBin sidecars. Its
+      # scripts/download-loregui.sh / download-loreserver.sh fetch RAW
+      # executables (not installers) from this release under the artifact
+      # names below (pinned via packages/desktop/satellites.lock.json).
+      # Installers alone are useless for that flow — upload the raw binaries
+      # alongside them. Non-fatal on tag drafts: uploads target the same
+      # release tauri-action just created/updated.
+      - name: Upload raw sidecar binaries (StudioBrain externalBin contract)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'nightly' }}"
+
+          case "${{ matrix.triple }}" in
+            x86_64-unknown-linux-gnu)
+              GUI_ART="LoreGUI_Linux_x64";      SRV_ART="loreserver_Linux_x64" ;;
+            aarch64-apple-darwin)
+              GUI_ART="LoreGUI_MacOS_arm64";    SRV_ART="loreserver_MacOS_arm64" ;;
+            x86_64-pc-windows-msvc)
+              GUI_ART="LoreGUI_Windows_x64.exe"; SRV_ART="loreserver_Windows_x64.exe" ;;
+            *)
+              echo "No raw-binary artifact mapping for ${{ matrix.triple }} — skipping"; exit 0 ;;
+          esac
+
+          # Locate the built loregui executable. Linux/Windows build without
+          # --target (target/release); macOS builds with --target
+          # (target/<triple>/release). Tauri may also emit a productName-cased
+          # copy — prefer the cargo bin name.
+          GUI_BIN=""
+          for CAND in \
+            "src-tauri/target/${{ matrix.triple }}/release/loregui${{ matrix.sidecar_ext }}" \
+            "src-tauri/target/release/loregui${{ matrix.sidecar_ext }}" \
+            "src-tauri/target/${{ matrix.triple }}/release/LoreGUI${{ matrix.sidecar_ext }}" \
+            "src-tauri/target/release/LoreGUI${{ matrix.sidecar_ext }}"; do
+            if [ -s "$CAND" ]; then GUI_BIN="$CAND"; break; fi
+          done
+
+          SRV_BIN="src-tauri/binaries/loreserver-${{ matrix.triple }}${{ matrix.sidecar_ext }}"
+
+          STAGE="$(mktemp -d)"
+          UPLOADS=()
+          if [ -n "$GUI_BIN" ]; then
+            cp "$GUI_BIN" "$STAGE/$GUI_ART"
+            UPLOADS+=("$STAGE/$GUI_ART")
+          else
+            echo "WARNING: built loregui binary not found — raw GUI artifact skipped" >&2
+          fi
+          if [ -s "$SRV_BIN" ]; then
+            cp "$SRV_BIN" "$STAGE/$SRV_ART"
+            UPLOADS+=("$STAGE/$SRV_ART")
+          else
+            echo "WARNING: staged loreserver sidecar not found at $SRV_BIN — raw server artifact skipped" >&2
+          fi
+
+          if [ "${#UPLOADS[@]}" -eq 0 ]; then
+            echo "Nothing to upload."; exit 0
+          fi
+          gh release upload "$TAG" "${UPLOADS[@]}" --clobber --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Why

StudioBrain desktop bundles loregui + loreserver as Tauri externalBin sidecars and downloads **raw executables** (`LoreGUI_<Platform>`, `loreserver_<Platform>`) per `packages/desktop/satellites.lock.json`. No loregui release has ever carried raw binaries — only installers — so those downloads 404 and StudioBrain CI ships zero-byte stubs: bundled lore hosting and the tray LoreGUI launcher are silently dead in every StudioBrain install.

## What

After the tauri-action build/publish in `release.yml`, upload per-leg:
- built loregui executable → `LoreGUI_{Linux_x64|MacOS_arm64|Windows_x64.exe}`
- staged loreserver sidecar → `loreserver_{Linux_x64|MacOS_arm64|Windows_x64.exe}`

to the same release (rolling `nightly` on main pushes, version tag on tag pushes), `--clobber` for nightly refreshes. Missing binaries warn-and-skip — never blocks the release.

Companion: BiloxiStudios/studiobrain-app#855 repoints its download scripts at `BiloxiStudios/loregui@nightly` (the old pins referenced `Lore-Foundation/LoreGUI` and tags that never existed).

**Note for reviewer:** left unmerged deliberately — this file also contains the signing steps (policy: nothing signing-adjacent merges unattended). The added step itself only reads build outputs and calls `gh release upload` with the default `GITHUB_TOKEN`.

Follow-up (tracked in JIRA): cut a versioned loregui release with these raw assets so studiobrain-app can move off the rolling `nightly` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJCxaiDfiqQso3ikbUSFnz