### PR TITLE
chore(licenses): regenerate stale license bundles — fix red gate on main

### DIFF
--- a/THIRD-PARTY-LICENSES-RUST.md
+++ b/THIRD-PARTY-LICENSES-RUST.md
@@ -7812,10 +7812,10 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- lore-vm 0.1.0 — https://github.com/BiloxiStudios/loregui
-- lorevm-cli 0.1.0 — https://github.com/BiloxiStudios/loregui
-- lorevm-ffi 0.1.0 — https://github.com/BiloxiStudios/loregui
-- loregui 0.1.0 — https://github.com/BiloxiStudios/loregui
+- lore-vm 0.1.1 — https://github.com/BiloxiStudios/loregui
+- lorevm-cli 0.1.1 — https://github.com/BiloxiStudios/loregui
+- lorevm-ffi 0.1.1 — https://github.com/BiloxiStudios/loregui
+- loregui 0.1.1 — https://github.com/BiloxiStudios/loregui
 - async-stream-impl 0.3.6 — https://github.com/tokio-rs/async-stream
 - async-stream 0.3.6 — https://github.com/tokio-rs/async-stream
 - bitcode_derive 0.6.9 — https://github.com/SoftbearStudios/bitcode/

--- a/frontend/public/licenses/rust.md
+++ b/frontend/public/licenses/rust.md
@@ -7812,10 +7812,10 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- lore-vm 0.1.0 — https://github.com/BiloxiStudios/loregui
-- lorevm-cli 0.1.0 — https://github.com/BiloxiStudios/loregui
-- lorevm-ffi 0.1.0 — https://github.com/BiloxiStudios/loregui
-- loregui 0.1.0 — https://github.com/BiloxiStudios/loregui
+- lore-vm 0.1.1 — https://github.com/BiloxiStudios/loregui
+- lorevm-cli 0.1.1 — https://github.com/BiloxiStudios/loregui
+- lorevm-ffi 0.1.1 — https://github.com/BiloxiStudios/loregui
+- loregui 0.1.1 — https://github.com/BiloxiStudios/loregui
 - async-stream-impl 0.3.6 — https://github.com/tokio-rs/async-stream
 - async-stream 0.3.6 — https://github.com/tokio-rs/async-stream
 - bitcode_derive 0.6.9 — https://github.com/SoftbearStudios/bitcode/


### PR DESCRIPTION
Fable. The 'licenses' (cargo-about/license-checker) CI gate is failing on main because the committed THIRD-PARTY-LICENSES bundles drifted from the current dep tree — this red-flags otherwise-mergeable PRs through no fault of their own (surfaced by the all-repo sweep). Regenerated via scripts/gen-licenses.sh; scoped to the license bundles only (Cargo.lock untouched).