### PR TITLE
SBAI-5438: fix React act() warnings in frontend tests

### DIFF
--- a/frontend/src/RepositoryPanel.spec.tsx
+++ b/frontend/src/RepositoryPanel.spec.tsx
@@ -107,5 +107,7 @@ describe("RepositoryPanel", () => {
     expect(
       screen.getByRole("dialog", { name: /Repository management/i }),
     ).toBeInTheDocument();
+    // Await the mount-time identity load so it doesn't fire act() warnings.
+    await waitFor(() => expect(screen.queryByText("Loading…")).not.toBeInTheDocument());
   });
 });

--- a/frontend/src/theme/ThemeProvider.spec.tsx
+++ b/frontend/src/theme/ThemeProvider.spec.tsx
@@ -95,7 +95,9 @@ describe("ThemeProvider", () => {
   it("exportBundle produces a re-importable JSON bundle", () => {
     renderProvider();
     const json = ctx.exportBundle("RoundTrip");
-    expect(() => ctx.importBundle(json)).not.toThrow();
+    act(() => {
+      expect(() => ctx.importBundle(json)).not.toThrow();
+    });
     const parsed = JSON.parse(json);
     expect(parsed.kind).toBe("loregui-theme");
     expect(parsed.name).toBe("RoundTrip");


### PR DESCRIPTION
Resolves SBAI-5438

## Summary
Fixed React `act(...)` warnings in frontend test suites by ensuring state updates are wrapped in `act()` and async operations are awaited before tests finish.

## Files Changed
- `frontend/src/theme/ThemeProvider.spec.tsx`: Wrapped `importBundle` call in `act()` in the exportBundle test.
- `frontend/src/RepositoryPanel.spec.tsx`: Added `waitFor` to ensure the mount-time loading state settles in the accessibility test.

## Testing
- Verified by running `npm --prefix frontend test`. All 116 tests pass with zero `act()` warnings.