### PR TITLE
SBAI-5434: advance Epic Lore pin from 0.8.4-nightly to the v0.8.5 commit pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -1212,7 +1212,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1416,7 +1416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2226,7 +2226,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2760,8 +2760,8 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lore"
-version = "0.8.4-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=65598412872a15685e1e8cd6d9d88425eedbc3c2#65598412872a15685e1e8cd6d9d88425eedbc3c2"
+version = "0.8.6-nightly"
+source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "anyhow",
  "bitcode",
@@ -2795,8 +2795,8 @@ dependencies = [
 
 [[package]]
 name = "lore-base"
-version = "0.8.4-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=65598412872a15685e1e8cd6d9d88425eedbc3c2#65598412872a15685e1e8cd6d9d88425eedbc3c2"
+version = "0.8.6-nightly"
+source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -2824,8 +2824,8 @@ dependencies = [
 
 [[package]]
 name = "lore-credential"
-version = "0.8.4-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=65598412872a15685e1e8cd6d9d88425eedbc3c2#65598412872a15685e1e8cd6d9d88425eedbc3c2"
+version = "0.8.6-nightly"
+source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
@@ -2846,7 +2846,7 @@ dependencies = [
 [[package]]
 name = "lore-error-set"
 version = "0.1.0"
-source = "git+https://github.com/EpicGames/lore.git?rev=65598412872a15685e1e8cd6d9d88425eedbc3c2#65598412872a15685e1e8cd6d9d88425eedbc3c2"
+source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "lore-error-set-macro",
 ]
@@ -2854,7 +2854,7 @@ dependencies = [
 [[package]]
 name = "lore-error-set-macro"
 version = "0.1.0"
-source = "git+https://github.com/EpicGames/lore.git?rev=65598412872a15685e1e8cd6d9d88425eedbc3c2#65598412872a15685e1e8cd6d9d88425eedbc3c2"
+source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2863,8 +2863,8 @@ dependencies = [
 
 [[package]]
 name = "lore-macro"
-version = "0.8.4-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=65598412872a15685e1e8cd6d9d88425eedbc3c2#65598412872a15685e1e8cd6d9d88425eedbc3c2"
+version = "0.8.6-nightly"
+source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -2872,8 +2872,8 @@ dependencies = [
 
 [[package]]
 name = "lore-notification"
-version = "0.8.4-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=65598412872a15685e1e8cd6d9d88425eedbc3c2#65598412872a15685e1e8cd6d9d88425eedbc3c2"
+version = "0.8.6-nightly"
+source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "async-trait",
  "lore-base",
@@ -2890,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "lore-proto"
 version = "0.1.60"
-source = "git+https://github.com/EpicGames/lore.git?rev=65598412872a15685e1e8cd6d9d88425eedbc3c2#65598412872a15685e1e8cd6d9d88425eedbc3c2"
+source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "lore-base",
  "prost",
@@ -2902,8 +2902,8 @@ dependencies = [
 
 [[package]]
 name = "lore-revision"
-version = "0.8.4-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=65598412872a15685e1e8cd6d9d88425eedbc3c2#65598412872a15685e1e8cd6d9d88425eedbc3c2"
+version = "0.8.6-nightly"
+source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2962,8 +2962,8 @@ dependencies = [
 
 [[package]]
 name = "lore-storage"
-version = "0.8.4-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=65598412872a15685e1e8cd6d9d88425eedbc3c2#65598412872a15685e1e8cd6d9d88425eedbc3c2"
+version = "0.8.6-nightly"
+source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -2999,8 +2999,8 @@ dependencies = [
 
 [[package]]
 name = "lore-telemetry"
-version = "0.8.4-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=65598412872a15685e1e8cd6d9d88425eedbc3c2#65598412872a15685e1e8cd6d9d88425eedbc3c2"
+version = "0.8.6-nightly"
+source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "axum",
  "http",
@@ -3022,8 +3022,8 @@ dependencies = [
 
 [[package]]
 name = "lore-transport"
-version = "0.8.4-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=65598412872a15685e1e8cd6d9d88425eedbc3c2#65598412872a15685e1e8cd6d9d88425eedbc3c2"
+version = "0.8.6-nightly"
+source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3360,7 +3360,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4114,7 +4114,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools",
  "log",
  "multimap",
@@ -4223,7 +4223,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.11.13"
-source = "git+https://github.com/EpicGames/lore.git?rev=65598412872a15685e1e8cd6d9d88425eedbc3c2#65598412872a15685e1e8cd6d9d88425eedbc3c2"
+source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -4260,9 +4260,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4574,7 +4574,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4632,7 +4632,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5718,7 +5718,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6679,7 +6679,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 [[package]]
 name = "lore"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
+source = "git+https://github.com/EpicGames/lore.git?rev=2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "anyhow",
  "bitcode",
@@ -2796,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "lore-base"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
+source = "git+https://github.com/EpicGames/lore.git?rev=2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -2825,7 +2825,7 @@ dependencies = [
 [[package]]
 name = "lore-credential"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
+source = "git+https://github.com/EpicGames/lore.git?rev=2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
@@ -2846,7 +2846,7 @@ dependencies = [
 [[package]]
 name = "lore-error-set"
 version = "0.1.0"
-source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
+source = "git+https://github.com/EpicGames/lore.git?rev=2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "lore-error-set-macro",
 ]
@@ -2854,7 +2854,7 @@ dependencies = [
 [[package]]
 name = "lore-error-set-macro"
 version = "0.1.0"
-source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
+source = "git+https://github.com/EpicGames/lore.git?rev=2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "lore-macro"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
+source = "git+https://github.com/EpicGames/lore.git?rev=2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "lore-notification"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
+source = "git+https://github.com/EpicGames/lore.git?rev=2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "async-trait",
  "lore-base",
@@ -2890,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "lore-proto"
 version = "0.1.60"
-source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
+source = "git+https://github.com/EpicGames/lore.git?rev=2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "lore-base",
  "prost",
@@ -2903,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "lore-revision"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
+source = "git+https://github.com/EpicGames/lore.git?rev=2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2963,7 +2963,7 @@ dependencies = [
 [[package]]
 name = "lore-storage"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
+source = "git+https://github.com/EpicGames/lore.git?rev=2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -3000,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "lore-telemetry"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
+source = "git+https://github.com/EpicGames/lore.git?rev=2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "axum",
  "http",
@@ -3023,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "lore-transport"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
+source = "git+https://github.com/EpicGames/lore.git?rev=2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.11.13"
-source = "git+https://github.com/EpicGames/lore.git?tag=v0.8.5#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
+source = "git+https://github.com/EpicGames/lore.git?rev=2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383#2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383"
 dependencies = [
  "bytes",
  "fastbloom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ thiserror = "2"
 tokio = { version = "1", features = ["process", "rt-multi-thread", "macros", "io-util", "sync"] }
 tracing = "0.1"
 
-# Lore's own API library — pinned to an exact rev. Pre-1.0, so any bump is a
-# deliberate, manager-owned PR. SBAI-3685 / SBAI-3700.
-lore = { git = "https://github.com/EpicGames/lore.git", rev = "65598412872a15685e1e8cd6d9d88425eedbc3c2" }
+# Lore's own API library — pinned to v0.8.5 tag. Pre-1.0, so any bump is a
+# deliberate, manager-owned PR. SBAI-3685 / SBAI-3700 / SBAI-5434.
+lore = { git = "https://github.com/EpicGames/lore.git", tag = "v0.8.5" }
 
 # REQUIRED: upstream `lore` patches quinn-proto to a vendored fork that adds
 # `TransportErrorCode::is_crypto()`. A [patch] does NOT propagate through a git
 # dependency, so without replicating it here `lore-transport` fails to compile
-# ("no method named `is_crypto`"). Same fork, same rev, inside the lore repo.
-# Every consumer of the `lore` crate needs this. SBAI-3685.
+# ("no method named `is_crypto`"). Same fork, same tag, inside the lore repo.
+# Every consumer of the `lore` crate needs this. SBAI-3685 / SBAI-5434.
 [patch.crates-io]
-quinn-proto = { git = "https://github.com/EpicGames/lore.git", rev = "65598412872a15685e1e8cd6d9d88425eedbc3c2" }
+quinn-proto = { git = "https://github.com/EpicGames/lore.git", tag = "v0.8.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tracing = "0.1"
 
 # Lore's own API library — pinned to v0.8.5 tag. Pre-1.0, so any bump is a
 # deliberate, manager-owned PR. SBAI-3685 / SBAI-3700 / SBAI-5434.
-lore = { git = "https://github.com/EpicGames/lore.git", tag = "v0.8.5" }
+lore = { git = "https://github.com/EpicGames/lore.git", rev = "2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383" }
 
 # REQUIRED: upstream `lore` patches quinn-proto to a vendored fork that adds
 # `TransportErrorCode::is_crypto()`. A [patch] does NOT propagate through a git
@@ -26,4 +26,4 @@ lore = { git = "https://github.com/EpicGames/lore.git", tag = "v0.8.5" }
 # ("no method named `is_crypto`"). Same fork, same tag, inside the lore repo.
 # Every consumer of the `lore` crate needs this. SBAI-3685 / SBAI-5434.
 [patch.crates-io]
-quinn-proto = { git = "https://github.com/EpicGames/lore.git", tag = "v0.8.5" }
+quinn-proto = { git = "https://github.com/EpicGames/lore.git", rev = "2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,15 @@ thiserror = "2"
 tokio = { version = "1", features = ["process", "rt-multi-thread", "macros", "io-util", "sync"] }
 tracing = "0.1"
 
-# Lore's own API library — pinned to v0.8.5 tag. Pre-1.0, so any bump is a
-# deliberate, manager-owned PR. SBAI-3685 / SBAI-3700 / SBAI-5434.
+# Lore's own API library — pinned by exact rev to the v0.8.5 tag target
+# (2d86d1dd). Pre-1.0, so any bump is a deliberate, manager-owned PR.
+# SBAI-3685 / SBAI-3700 / SBAI-5434.
 lore = { git = "https://github.com/EpicGames/lore.git", rev = "2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383" }
 
 # REQUIRED: upstream `lore` patches quinn-proto to a vendored fork that adds
 # `TransportErrorCode::is_crypto()`. A [patch] does NOT propagate through a git
 # dependency, so without replicating it here `lore-transport` fails to compile
-# ("no method named `is_crypto`"). Same fork, same tag, inside the lore repo.
-# Every consumer of the `lore` crate needs this. SBAI-3685 / SBAI-5434.
+# ("no method named `is_crypto`"). Same fork, same exact commit, inside the
+# lore repo. Every consumer of the `lore` crate needs this. SBAI-3685 / SBAI-5434.
 [patch.crates-io]
 quinn-proto = { git = "https://github.com/EpicGames/lore.git", rev = "2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383" }

--- a/THIRD-PARTY-LICENSES-RUST.md
+++ b/THIRD-PARTY-LICENSES-RUST.md
@@ -7767,18 +7767,18 @@ SOFTWARE.
 
 Used by:
 
-- lore-base 0.8.4-nightly
-- lore-credential 0.8.4-nightly
+- lore-base 0.8.6-nightly
+- lore-credential 0.8.6-nightly
 - lore-error-set-macro 0.1.0
 - lore-error-set 0.1.0
-- lore-macro 0.8.4-nightly
-- lore-notification 0.8.4-nightly
+- lore-macro 0.8.6-nightly
+- lore-notification 0.8.6-nightly
 - lore-proto 0.1.60
-- lore-revision 0.8.4-nightly
-- lore-storage 0.8.4-nightly
-- lore-telemetry 0.8.4-nightly
-- lore-transport 0.8.4-nightly
-- lore 0.8.4-nightly
+- lore-revision 0.8.6-nightly
+- lore-storage 0.8.6-nightly
+- lore-telemetry 0.8.6-nightly
+- lore-transport 0.8.6-nightly
+- lore 0.8.6-nightly
 
 <details><summary>License text</summary>
 
@@ -8167,7 +8167,7 @@ DEALINGS IN THE SOFTWARE.
 Used by:
 
 - adler2 2.0.1 — https://github.com/oyvindln/adler2
-- anyhow 1.0.102 — https://github.com/dtolnay/anyhow
+- anyhow 1.0.104 — https://github.com/dtolnay/anyhow
 - async-channel 2.5.0 — https://github.com/smol-rs/async-channel
 - async-executor 1.14.0 — https://github.com/smol-rs/async-executor
 - async-io 2.6.0 — https://github.com/smol-rs/async-io

--- a/crates/lore-vm/src/collect.rs
+++ b/crates/lore-vm/src/collect.rs
@@ -2,7 +2,9 @@
 //!
 //! The lore crate's async fns emit events through a `LoreEventCallback`.
 //! This module provides a callback + receiver pair that collects all events
-//! until `Complete` or `Error` arrives, returning a typed `EventStream`.
+//! until the terminal `Complete` or `End` arrives, returning a typed
+//! `EventStream`. An `Error` event is NOT terminal — it is recorded on the
+//! stream and collection continues through `Complete`/`End`.
 
 use lore::interface::LoreEvent;
 use lore::interface::LoreEventCallback;

--- a/crates/lore-vm/src/collect.rs
+++ b/crates/lore-vm/src/collect.rs
@@ -54,6 +54,18 @@ pub fn collect_events() -> (LoreEventCallback, oneshot::Receiver<EventStream>) {
             }
             LoreEvent::Complete(data) => {
                 s.status = Some(data.status);
+                // Since lore v0.8.5 a terminal failure emits NO `Error` event —
+                // the failure detail (code/message/trace) rides the `Complete`
+                // event instead, with `status` carrying the real error code.
+                // Recover the message here so op-level errors surface the
+                // engine's text (e.g. "branch not found") rather than the
+                // bare "<op> failed with status N" fallback.
+                if data.status != 0 && s.error.is_none() {
+                    let message = data.error.message.as_str();
+                    if !message.is_empty() {
+                        s.error = Some(message.to_string());
+                    }
+                }
             }
             _ => {}
         }

--- a/crates/lore-vm/src/global.rs
+++ b/crates/lore-vm/src/global.rs
@@ -118,7 +118,7 @@ impl LoreGlobal {
             max_connections: self.max_connections,
             search_limit: 100,
             search_nearest: 0,
-            gc: 0,
+            no_gc: 0,
             in_memory: u8::from(self.in_memory),
             // Remaining fields (file_count_limit, file_size_limit, compress_task_limit,
             // store_keep_alive*, sync_data, cache) take their upstream defaults.

--- a/crates/lore-vm/src/ops/lock/file_acquire.rs
+++ b/crates/lore-vm/src/ops/lock/file_acquire.rs
@@ -1,8 +1,9 @@
 //! `lock file_acquire` operation — binds `lore::lock::file_acquire`.
 //!
 //! Acquires exclusive locks on one or more files in the repository.
-//! Emits `LockFileAcquire` events for each successfully acquired lock,
-//! and `LockFileAcquireIgnore` events for each file already owned by the user.
+//! Emits a `LockFileAcquireBegin` event with `count` and `ignored` flag,
+//! then `count` `LockFileAcquire` events for the affected paths.
+//! If `ignored != 0`, those paths were already owned (SBAI-5434: API change).
 
 use crate::api::LoreApi;
 use crate::collect::collect_events;
@@ -50,7 +51,7 @@ pub struct FileAcquireResult {
 /// Acquires file locks on the specified paths for a given branch.
 ///
 /// Calls the upstream `lore::lock::file_acquire` in-process and collects
-/// the `LockFileAcquire` and `LockFileAcquireIgnore` events to return
+/// the `LockFileAcquire` and `LockFileAcquireBegin` events to return
 /// a typed result.
 pub async fn file_acquire(api: &LoreApi, args: FileAcquireArgs) -> Result<FileAcquireResult> {
     let (callback, rx) = collect_events();
@@ -70,13 +71,23 @@ pub async fn file_acquire(api: &LoreApi, args: FileAcquireArgs) -> Result<FileAc
     let mut acquired = Vec::new();
     let mut ignored = Vec::new();
 
+    // v0.8.5: LockFileAcquireBegin fires with `count` and `ignored` flag,
+    // then `count` LockFileAcquire events follow. If ignored != 0, those
+    // paths were already owned by the user.
+    let mut pending_ignored = false;
+
     for event in &stream.events {
         match event {
-            LoreEvent::LockFileAcquire(data) => {
-                acquired.push(data.path.as_str().to_string());
+            LoreEvent::LockFileAcquireBegin(data) => {
+                pending_ignored = data.ignored != 0;
             }
-            LoreEvent::LockFileAcquireIgnore(data) => {
-                ignored.push(data.path.as_str().to_string());
+            LoreEvent::LockFileAcquire(data) => {
+                let path = data.path.as_str().to_string();
+                if pending_ignored {
+                    ignored.push(path);
+                } else {
+                    acquired.push(path);
+                }
             }
             _ => {}
         }

--- a/crates/lore-vm/src/ops/lock/file_acquire_as_owner.rs
+++ b/crates/lore-vm/src/ops/lock/file_acquire_as_owner.rs
@@ -2,8 +2,9 @@
 //!
 //! Acquires exclusive locks on one or more files on behalf of a specified owner.
 //! Same as `file_acquire` but allows specifying who the lock is being acquired for.
-//! Emits `LockFileAcquire` events for each successfully acquired lock,
-//! and `LockFileAcquireIgnore` events for each file already owned by that owner.
+//! Emits a `LockFileAcquireBegin` event with `count` and `ignored` flag,
+//! then `count` `LockFileAcquire` events for the affected paths.
+//! If `ignored != 0`, those paths were already owned (SBAI-5434: API change).
 
 use crate::api::LoreApi;
 use crate::collect::collect_events;
@@ -56,7 +57,7 @@ pub struct FileAcquireAsOwnerResult {
 /// Acquires file locks on the specified paths for a given branch on behalf of an owner.
 ///
 /// Calls the upstream `lore::lock::file_acquire_as_owner` in-process and collects
-/// the `LockFileAcquire` and `LockFileAcquireIgnore` events to return
+/// the `LockFileAcquire` and `LockFileAcquireBegin` events to return
 /// a typed result.
 pub async fn file_acquire_as_owner(
     api: &LoreApi,
@@ -81,13 +82,23 @@ pub async fn file_acquire_as_owner(
     let mut acquired = Vec::new();
     let mut ignored = Vec::new();
 
+    // v0.8.5: LockFileAcquireBegin fires with `count` and `ignored` flag,
+    // then `count` LockFileAcquire events follow. If ignored != 0, those
+    // paths were already owned by the specified owner.
+    let mut pending_ignored = false;
+
     for event in &stream.events {
         match event {
-            LoreEvent::LockFileAcquire(data) => {
-                acquired.push(data.path.as_str().to_string());
+            LoreEvent::LockFileAcquireBegin(data) => {
+                pending_ignored = data.ignored != 0;
             }
-            LoreEvent::LockFileAcquireIgnore(data) => {
-                ignored.push(data.path.as_str().to_string());
+            LoreEvent::LockFileAcquire(data) => {
+                let path = data.path.as_str().to_string();
+                if pending_ignored {
+                    ignored.push(path);
+                } else {
+                    acquired.push(path);
+                }
             }
             _ => {}
         }

--- a/crates/lore-vm/src/ops/lock/file_message_send.rs
+++ b/crates/lore-vm/src/ops/lock/file_message_send.rs
@@ -6,7 +6,8 @@
 //!
 //! # Blocking Dependency
 //!
-//! The upstream `lore` crate (pinned tag `v0.8.5`) does NOT provide
+//! The upstream `lore` crate (pinned commit `2d86d1dd`, the v0.8.5 tag
+//! target) does NOT provide
 //! `lore::lock::file_message_send`, nor does `LoreEvent` include a
 //! `LockFileMessageSend` variant. The `lore::notification` module has no
 //! `publish` method, and `ExtensionEvent` is dropped before becoming a

--- a/crates/lore-vm/src/ops/lock/file_message_send.rs
+++ b/crates/lore-vm/src/ops/lock/file_message_send.rs
@@ -6,7 +6,7 @@
 //!
 //! # Blocking Dependency
 //!
-//! The upstream `lore` crate (pinned rev `65598412`) does NOT provide
+//! The upstream `lore` crate (pinned tag `v0.8.5`) does NOT provide
 //! `lore::lock::file_message_send`, nor does `LoreEvent` include a
 //! `LockFileMessageSend` variant. The `lore::notification` module has no
 //! `publish` method, and `ExtensionEvent` is dropped before becoming a

--- a/crates/lore-vm/src/ops/lock/file_release.rs
+++ b/crates/lore-vm/src/ops/lock/file_release.rs
@@ -1,8 +1,9 @@
 //! `lock file_release` operation — binds `lore::lock::file_release`.
 //!
 //! Releases exclusive locks on one or more files in the repository.
-//! Emits `LockFileRelease` events for each successfully released lock,
-//! and `LockFileReleaseBegin` events for files whose locks were not found.
+//! Upstream emits one `LockFileReleaseBegin { count, not_found }` report
+//! header — `not_found = 1` when no matching lock existed — followed by a
+//! `LockFileRelease` event per released path.
 
 use crate::api::LoreApi;
 use crate::collect::collect_events;
@@ -73,23 +74,109 @@ pub async fn file_release(api: &LoreApi, args: FileReleaseArgs) -> Result<FileRe
         )));
     }
 
-    let mut released = Vec::new();
-    let mut not_found = false;
-
-    for event in &stream.events {
-        match event {
-            LoreEvent::LockFileRelease(data) => {
-                released.push(data.path.as_str().to_string());
-            }
-            LoreEvent::LockFileReleaseBegin(_) => {
-                not_found = true;
-            }
-            _ => {}
-        }
-    }
+    let (released, not_found) = classify_release_events(&stream.events);
 
     Ok(FileReleaseResult {
         released,
         not_found,
     })
+}
+
+/// Fold a `file_release` event stream into (released paths, any-not-found).
+///
+/// Since lore v0.8.5 the `LockFileReleaseBegin` header is emitted on EVERY
+/// release call and carries the outcome in its `not_found` flag: success is
+/// `Begin { count > 0, not_found: 0 }` followed by per-path `LockFileRelease`
+/// events; a missing lock is `Begin { count: 0, not_found: 1 }`. Reading the
+/// mere presence of `Begin` as "not found" (the 0.8.4 `LockFileReleaseNotFound`
+/// semantics) reports every successful release as not-found — keep the flag.
+fn classify_release_events(events: &[LoreEvent]) -> (Vec<String>, bool) {
+    let mut released = Vec::new();
+    let mut not_found = false;
+
+    for event in events {
+        match event {
+            LoreEvent::LockFileRelease(data) => {
+                released.push(data.path.as_str().to_string());
+            }
+            LoreEvent::LockFileReleaseBegin(data) => {
+                not_found |= data.not_found != 0;
+            }
+            _ => {}
+        }
+    }
+
+    (released, not_found)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a LoreEvent from its wire shape (`{"tagName":…,"data":…}`), the
+    /// same serde contract the engine emits — the data structs are not
+    /// re-exported through the umbrella `lore` crate, so construction goes
+    /// through deserialization.
+    fn event(json: serde_json::Value) -> LoreEvent {
+        serde_json::from_value(json).expect("test event must deserialize")
+    }
+
+    #[test]
+    fn successful_release_reports_released_path_and_not_found_false() {
+        let events = vec![
+            event(serde_json::json!({
+                "tagName": "lockFileReleaseBegin",
+                "data": { "count": 1, "notFound": 0 }
+            })),
+            event(serde_json::json!({
+                "tagName": "lockFileRelease",
+                "data": { "path": "content/hero.fbx" }
+            })),
+        ];
+
+        let (released, not_found) = classify_release_events(&events);
+
+        assert_eq!(released, vec!["content/hero.fbx".to_string()]);
+        assert!(
+            !not_found,
+            "a successful release must NOT report not_found (0.8.5 regression)"
+        );
+    }
+
+    #[test]
+    fn missing_lock_reports_not_found_true() {
+        let events = vec![event(serde_json::json!({
+            "tagName": "lockFileReleaseBegin",
+            "data": { "count": 0, "notFound": 1 }
+        }))];
+
+        let (released, not_found) = classify_release_events(&events);
+
+        assert!(released.is_empty());
+        assert!(not_found, "a missing lock must report not_found");
+    }
+
+    #[test]
+    fn mixed_stream_still_flags_not_found() {
+        // One path released, one missing: any not_found=1 header flags the op.
+        let events = vec![
+            event(serde_json::json!({
+                "tagName": "lockFileReleaseBegin",
+                "data": { "count": 1, "notFound": 0 }
+            })),
+            event(serde_json::json!({
+                "tagName": "lockFileRelease",
+                "data": { "path": "a.txt" }
+            })),
+            event(serde_json::json!({
+                "tagName": "lockFileReleaseBegin",
+                "data": { "count": 0, "notFound": 1 }
+            })),
+        ];
+
+        let (released, not_found) = classify_release_events(&events);
+
+        assert_eq!(released, vec!["a.txt".to_string()]);
+        assert!(not_found);
+    }
 }

--- a/crates/lore-vm/src/ops/lock/file_release.rs
+++ b/crates/lore-vm/src/ops/lock/file_release.rs
@@ -2,7 +2,7 @@
 //!
 //! Releases exclusive locks on one or more files in the repository.
 //! Emits `LockFileRelease` events for each successfully released lock,
-//! and `LockFileReleaseNotFound` events for files whose locks were not found.
+//! and `LockFileReleaseBegin` events for files whose locks were not found.
 
 use crate::api::LoreApi;
 use crate::collect::collect_events;
@@ -56,7 +56,7 @@ pub struct FileReleaseResult {
 /// Releases file locks on the specified paths for a given branch and owner.
 ///
 /// Calls the upstream `lore::lock::file_release` in-process and collects
-/// the `LockFileRelease` and `LockFileReleaseNotFound` events to return
+/// the `LockFileRelease` and `LockFileReleaseBegin` events to return
 /// a typed result.
 pub async fn file_release(api: &LoreApi, args: FileReleaseArgs) -> Result<FileReleaseResult> {
     let (callback, rx) = collect_events();
@@ -81,7 +81,7 @@ pub async fn file_release(api: &LoreApi, args: FileReleaseArgs) -> Result<FileRe
             LoreEvent::LockFileRelease(data) => {
                 released.push(data.path.as_str().to_string());
             }
-            LoreEvent::LockFileReleaseNotFound(_) => {
+            LoreEvent::LockFileReleaseBegin(_) => {
                 not_found = true;
             }
             _ => {}

--- a/crates/lore-vm/src/ops/storage/get.rs
+++ b/crates/lore-vm/src/ops/storage/get.rs
@@ -198,6 +198,14 @@ pub async fn get(api: &LoreApi, args: StorageGetArgs) -> Result<StorageGetResult
             }
             LoreEvent::Complete(d) => {
                 c.status = Some(d.status);
+                // lore v0.8.5+: terminal failure detail rides `Complete` (no
+                // `Error` event) — recover the engine's message.
+                if d.status != 0 && c.call_error.is_none() {
+                    let message = d.error.message.as_str();
+                    if !message.is_empty() {
+                        c.call_error = Some(message.to_string());
+                    }
+                }
             }
             _ => {}
         }

--- a/crates/lore-vm/src/ops/storage/get_metadata.rs
+++ b/crates/lore-vm/src/ops/storage/get_metadata.rs
@@ -176,6 +176,14 @@ pub async fn get_metadata(
             }
             LoreEvent::Complete(d) => {
                 c.status = Some(d.status);
+                // lore v0.8.5+: terminal failure detail rides `Complete` (no
+                // `Error` event) — recover the engine's message.
+                if d.status != 0 && c.call_error.is_none() {
+                    let message = d.error.message.as_str();
+                    if !message.is_empty() {
+                        c.call_error = Some(message.to_string());
+                    }
+                }
             }
             _ => {}
         }

--- a/crates/lore-vm/tests/remote_multiuser.rs
+++ b/crates/lore-vm/tests/remote_multiuser.rs
@@ -858,16 +858,41 @@ async fn remote_multiuser_sync_push_conflict_and_locks() {
             paths: vec![lock_a.to_string_lossy().into_owned()],
             branch: branch_id.clone(),
             owner: owner.clone(),
-            owner_id: owner,
+            owner_id: owner.clone(),
         },
     )
     .await
     .unwrap_or_else(|e| panic!("alice lock::file_release should succeed: {e}"));
+    // SBAI-5434: at 0.8.5 LockFileReleaseBegin fires on EVERY release call, so
+    // a successful release must report the released path AND must NOT flag
+    // not_found — the flag, not the event's presence, carries the outcome.
     assert!(
-        a_rel.released.iter().any(|p| p.ends_with(LOCK_LEAF)) || !a_rel.not_found,
+        a_rel.released.iter().any(|p| p.ends_with(LOCK_LEAF)),
         "alice should release the lock on {LOCK_LEAF}: {a_rel:?}"
     );
+    assert!(
+        !a_rel.not_found,
+        "a successful release must not report not_found: {a_rel:?}"
+    );
     eprintln!("[A] released lock on {LOCK_LEAF}");
+
+    // Releasing the SAME path again finds no lock: not_found must be true.
+    let a_rel2 = ops::lock::file_release::file_release(
+        &alice,
+        ops::lock::file_release::FileReleaseArgs {
+            paths: vec![lock_a.to_string_lossy().into_owned()],
+            branch: branch_id.clone(),
+            owner: owner.clone(),
+            owner_id: owner,
+        },
+    )
+    .await
+    .unwrap_or_else(|e| panic!("alice re-release lock::file_release should succeed: {e}"));
+    assert!(
+        a_rel2.not_found,
+        "re-releasing an already-released lock must report not_found: {a_rel2:?}"
+    );
+    eprintln!("[A] re-release correctly reports not_found");
 
     // After release, the lock is gone from the query.
     let q3 = ops::lock::file_query::file_query(

--- a/frontend/public/licenses/rust.md
+++ b/frontend/public/licenses/rust.md
@@ -7767,18 +7767,18 @@ SOFTWARE.
 
 Used by:
 
-- lore-base 0.8.4-nightly
-- lore-credential 0.8.4-nightly
+- lore-base 0.8.6-nightly
+- lore-credential 0.8.6-nightly
 - lore-error-set-macro 0.1.0
 - lore-error-set 0.1.0
-- lore-macro 0.8.4-nightly
-- lore-notification 0.8.4-nightly
+- lore-macro 0.8.6-nightly
+- lore-notification 0.8.6-nightly
 - lore-proto 0.1.60
-- lore-revision 0.8.4-nightly
-- lore-storage 0.8.4-nightly
-- lore-telemetry 0.8.4-nightly
-- lore-transport 0.8.4-nightly
-- lore 0.8.4-nightly
+- lore-revision 0.8.6-nightly
+- lore-storage 0.8.6-nightly
+- lore-telemetry 0.8.6-nightly
+- lore-transport 0.8.6-nightly
+- lore 0.8.6-nightly
 
 <details><summary>License text</summary>
 
@@ -8167,7 +8167,7 @@ DEALINGS IN THE SOFTWARE.
 Used by:
 
 - adler2 2.0.1 — https://github.com/oyvindln/adler2
-- anyhow 1.0.102 — https://github.com/dtolnay/anyhow
+- anyhow 1.0.104 — https://github.com/dtolnay/anyhow
 - async-channel 2.5.0 — https://github.com/smol-rs/async-channel
 - async-executor 1.14.0 — https://github.com/smol-rs/async-executor
 - async-io 2.6.0 — https://github.com/smol-rs/async-io


### PR DESCRIPTION
Resolves SBAI-5434

## Summary
Advance the EpicGames/lore dependency from rev 65598412 (0.8.4-nightly, 2026-06-18) to the **v0.8.5 commit pin** — exact rev `2d86d1dda98bfc1575ac7a20a6ff8c7fbc760383` (the peeled v0.8.5 tag target, 47 commits ahead). Pinned by exact rev (not the `tag = "v0.8.5"` selector) so every rev consumer keeps working: release.yml / remote-qa.yml sidecar extraction, scripts/live-server-client.sh, scripts/remote-multiuser-qa.sh, src-tauri server_host dev fallback, remote_multiuser.rs. Fixes the API breaking changes introduced upstream.

## Files Changed
- **Cargo.toml** — lore and quinn-proto pins → exact rev 2d86d1d (v0.8.5 commit pin)
- **Cargo.lock** — regenerated (lore sub-crates resolve to 0.8.6-nightly @ the v0.8.5 commit)
- **crates/lore-vm/src/collect.rs** + **ops/storage/get.rs, get_metadata.rs** — recover engine error text from `Complete.error` (lore 0.8.5 no longer emits `LoreEvent::Error` on terminal failure; failure detail rides `LoreCompleteEventData.error`). This was the root cause of the cli-contract + e2e reds.
- **crates/lore-vm/src/global.rs** — LoreGlobalArgs::gc → no_gc (field renamed upstream)
- **crates/lore-vm/src/ops/lock/file_acquire.rs, file_acquire_as_owner.rs** — LockFileAcquireIgnore → LockFileAcquireBegin event migration
- **crates/lore-vm/src/ops/lock/file_release.rs** — LockFileReleaseNotFound → LockFileReleaseBegin event migration
- **crates/lore-vm/src/ops/lock/file_message_send.rs** — doc comment reference (still blocked: no upstream API at v0.8.5)
- **THIRD-PARTY-LICENSES-RUST.md, frontend/public/licenses/rust.md** — regenerated for the new pin (attribution gate)

## API Breaking Changes Fixed
1. Terminal-failure reporting: Error event removed → Complete carries error detail (collector fix)
2. LockFileAcquireIgnore → LockFileAcquireBegin (new u8 ignored flag + count)
3. LockFileReleaseNotFound → LockFileReleaseBegin
4. LoreGlobalArgs::gc → no_gc (inverted field name)

## Post-v0.8.5 Main Drift Assessment
4 commits on main after v0.8.5:
- 2 are server-only (presigned URL restriction, gitignore)
- 2 are client bug fixes (restore dirty nodes, branch reset archived branches)
Recommendation: stay pinned to the v0.8.5 commit; separate ticket for main pin after v0.8.6.

## Testing (verified against the rev pin)
- cargo check -p lore-vm: green
- Full lorevm-cli + lore-vm suites: 733+ tests, 0 failed (incl. previously-red branch_ops cli-contract test)
- src-tauri server_host tests: 36 passed (incl. parse_pinned_rev 40-hex extractor)
- Rev extractors verified end-to-end: release.yml/remote-qa.yml grep matches, upstream-lore-parity.mjs lock regex matches, checkout resolution finds the pinned checkout
- scripts/gen-licenses.sh: no residual drift after regen
