### PR TITLE
SBAI-5436: fix auto-release lockfile guard — verify workspace versions after bump

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -80,7 +80,13 @@ jobs:
           # tauri.conf.json's explicit copy both track it).
           sed -i -E "0,/^version = \"[0-9.]+\"/s//version = \"$V\"/" Cargo.toml
           sed -i -E "s/\"version\": \"[0-9.]+\"/\"version\": \"$V\"/" src-tauri/tauri.conf.json
-          cargo update -w --offline 2>/dev/null || true # refresh lockfile version stamps if possible
+          # SBAI-5436: refresh lockfile version stamps — fail if it doesn't match.
+          cargo update -w --offline
+          LOCK_VERSIONS=$(grep -A1 'name = "lore-vm"\|name = "loregui"\|name = "lorevm-cli"\|name = "lorevm-ffi"' Cargo.lock | grep 'version = ' | grep -oE '[0-9.]+' | sort -u)
+          if [ "$LOCK_VERSIONS" != "$V" ]; then
+            echo "::error::Cargo.lock still has stale versions after cargo update -w (expected $V, got $LOCK_VERSIONS)"
+            exit 1
+          fi
           git config user.name "loregui-auto-release"
           git config user.email "brandon.f@graeinc.co"
           git add Cargo.toml Cargo.lock src-tauri/tauri.conf.json 2>/dev/null || true


### PR DESCRIPTION
Resolves SBAI-5436

## Summary
The auto-release workflow had a silent failure path for Cargo.lock version updates: `cargo update -w --offline 2>/dev/null || true`. When the lockfile update failed, the release would proceed with stale 0.1.2 versions in Cargo.lock while Cargo.toml declared 0.1.3.

This PR removes the error suppression (`|| true`) and adds a post-update verification step that checks all four workspace member crates (lore-vm, loregui, lorevm-cli, lorevm-ffi) have the expected version in Cargo.lock before the release commit is made.

## Files Changed
- `.github/workflows/auto-release.yml` — Removed `2>/dev/null || true` from `cargo update -w`, added version verification guard that fails the workflow if Cargo.lock doesn't match the bumped version

## Testing
- `cargo test -p lore-vm --lib --locked` — 733 passed
- `cargo check -p lore-vm` — green
- Cargo.lock already regenerated to 0.1.3 by prior worker commit (ae8325b)

Generated with Qwen Code