### PR TITLE
SBAI-5432: connect to auth-disabled Lore servers

### DIFF
--- a/crates/lore-vm/examples/live_server_client.rs
+++ b/crates/lore-vm/examples/live_server_client.rs
@@ -6,6 +6,7 @@
 //! no live server). Here we drive the REAL loop against a running `loreserver`
 //! QUIC/gRPC process:
 //!
+//!   auth probe: verify the server's explicit no-auth compatibility signal
 //!   client A:  repository::create  (lore://host/<repo>)
 //!              → write file → file::stage → revision::commit
 //!              → branch::push          (uploads revision to the server OVER THE WIRE)
@@ -55,6 +56,29 @@ fn write_file(path: &Path, contents: &[u8]) {
 
 async fn run(repo_url: &str, dir_a: &Path, dir_b: &Path) -> Result<(), String> {
     let alice = online_api(dir_a, "alice");
+
+    // ---- compatibility probe: reachable server intentionally has no auth ---
+    println!("[auth] login_interactive against no-auth server");
+    let login = ops::auth::login_interactive::login_interactive(
+        &alice,
+        ops::auth::login_interactive::LoginInteractiveArgs {
+            remote_url: repo_url.to_string(),
+            no_browser: true,
+        },
+    )
+    .await;
+    match login {
+        Err(lore_vm::error::LoreError::CommandFailed(message))
+            if message == "No authentication configured on server" =>
+        {
+            println!("[auth] verified exact no-auth server response");
+        }
+        other => {
+            return Err(format!(
+                "auth compatibility probe returned {other:?}, expected exact no-auth response"
+            ));
+        }
+    }
 
     // ---- client A: create a repo tracking the remote URL --------------------
     println!("[A] repository::create {repo_url}");

--- a/frontend/src/AccountPanel.spec.tsx
+++ b/frontend/src/AccountPanel.spec.tsx
@@ -1,0 +1,52 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import AccountPanel from "./AccountPanel";
+
+function routeCommands(authError: unknown) {
+  invokeMock.mockImplementation((command: string) => {
+    if (command === "auth_user_info") return Promise.resolve(null);
+    if (command === "auth_local_user_info") {
+      return Promise.resolve({ users: [], tokens: [] });
+    }
+    if (command === "auth_login_interactive") {
+      return Promise.reject(authError);
+    }
+    return Promise.reject(new Error(`unexpected command ${command}`));
+  });
+}
+
+beforeEach(() => {
+  invokeMock.mockReset();
+});
+
+describe("auth-disabled connection from the account panel (#404)", () => {
+  it("shows a successful no-auth connection instead of the raw command error", async () => {
+    routeCommands({
+      kind: "CommandFailed",
+      message: "No authentication configured on server",
+    });
+
+    render(<AccountPanel onClose={vi.fn()} />);
+    await screen.findByText(/Not signed in/);
+
+    fireEvent.change(screen.getByLabelText("Server URL"), {
+      target: { value: "lore://192.0.2.10/repo" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    });
+
+    expect(
+      screen.getByText("Connected without authentication"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/CommandFailed/)).toBeNull();
+    expect(screen.queryByText(/No authentication configured/)).toBeNull();
+  });
+});

--- a/frontend/src/AccountPanel.tsx
+++ b/frontend/src/AccountPanel.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { api, authLocalUserInfoApi, type LocalUserInfo, type UserInfo } from "./api";
+import {
+  api,
+  authLocalUserInfoApi,
+  isNoAuthConfigured,
+  type LocalUserInfo,
+  type UserInfo,
+} from "./api";
 
 /**
  * Account / identity panel (top-bar identity surface) — the curated home for the
@@ -49,6 +55,7 @@ export default function AccountPanel({ onClose }: { onClose: () => void }) {
   const [token, setToken] = useState("");
   const [connectStep, setConnectStep] = useState<ConnectStep>("idle");
   const [connectError, setConnectError] = useState<string | null>(null);
+  const [connectedWithoutAuth, setConnectedWithoutAuth] = useState(false);
 
   const loadRemote = useCallback(async () => {
     setRemoteLoading(true);
@@ -120,17 +127,26 @@ export default function AccountPanel({ onClose }: { onClose: () => void }) {
     if (mode === "token" && !token) return;
     setConnectStep("authenticating");
     setConnectError(null);
+    setConnectedWithoutAuth(false);
     try {
       const user =
         mode === "interactive"
           ? await api.authLoginInteractive(url)
           : await api.authLoginWithToken(url, token);
       setRemoteUser(user);
+      setConnectedWithoutAuth(false);
       setToken(""); // never retain the token in component state
       setConnectStep("idle");
       // Refresh the local identity list — a successful login caches a token.
       void loadLocal();
     } catch (e) {
+      if (isNoAuthConfigured(e)) {
+        setRemoteUser(null);
+        setToken("");
+        setConnectedWithoutAuth(true);
+        setConnectStep("idle");
+        return;
+      }
       setConnectError(typeof e === "string" ? e : JSON.stringify(e));
       setConnectStep("error");
     }
@@ -233,8 +249,8 @@ export default function AccountPanel({ onClose }: { onClose: () => void }) {
         <section className="storage-section">
           <h3>Connect to a server</h3>
           <p className="storage-help">
-            Sign in to a remote lore server. Authenticate in your browser, or
-            paste a token if you already have one.
+            Connect to a remote lore server. Authenticate in your browser or
+            paste a token when the server requires it.
           </p>
 
           <div className="onboarding-field">
@@ -291,6 +307,15 @@ export default function AccountPanel({ onClose }: { onClose: () => void }) {
             <div className="error storage-inline-error">{connectError}</div>
           )}
 
+          {connectedWithoutAuth && (
+            <div className="onboarding-success">
+              <div className="success-message">
+                <span className="success-icon">&#10003;</span>
+                <span>Connected without authentication</span>
+              </div>
+            </div>
+          )}
+
           <button
             className="storage-primary"
             disabled={
@@ -302,7 +327,7 @@ export default function AccountPanel({ onClose }: { onClose: () => void }) {
               ? "Connecting…"
               : connectStep === "error"
                 ? "Retry connect"
-                : signedIn
+                : signedIn || connectedWithoutAuth
                   ? "Connect to another server"
                   : "Connect"}
           </button>

--- a/frontend/src/api.spec.ts
+++ b/frontend/src/api.spec.ts
@@ -31,6 +31,7 @@ import {
   storageApi,
   workingFileApi,
   desktopSettingsApi,
+  isNoAuthConfigured,
 } from "./api";
 
 /** The (name, args) pair passed to the most recent invoke call. */
@@ -93,6 +94,15 @@ describe("core repo-loop wrappers", () => {
 });
 
 describe("auth + onboarding wrappers", () => {
+  it("recognizes only Epic Lore's exact auth-disabled error contract", () => {
+    const message = "No authentication configured on server";
+    expect(isNoAuthConfigured(message)).toBe(true);
+    expect(isNoAuthConfigured(new Error(message))).toBe(true);
+    expect(isNoAuthConfigured({ kind: "CommandFailed", message })).toBe(true);
+    expect(isNoAuthConfigured({ message: `${message}.` })).toBe(false);
+    expect(isNoAuthConfigured({ kind: "CommandFailed" })).toBe(false);
+  });
+
   it("authLoginWithToken maps remoteUrl + token", () => {
     api.authLoginWithToken("lore://srv/repo", "tok123");
     expect(lastCall()).toEqual([

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -67,6 +67,22 @@ export interface UserInfo {
   name: string;
 }
 
+/**
+ * Epic Lore currently reports a reachable auth-disabled server as a failed
+ * login with this exact message. Keep the compatibility contract centralized
+ * so every connection surface makes the same narrow decision.
+ */
+export const NO_AUTH_CONFIGURED = "No authentication configured on server";
+
+export function isNoAuthConfigured(error: unknown): boolean {
+  if (error === NO_AUTH_CONFIGURED) return true;
+  if (error instanceof Error) return error.message === NO_AUTH_CONFIGURED;
+  if (typeof error !== "object" || error === null || !("message" in error)) {
+    return false;
+  }
+  return (error as { message?: unknown }).message === NO_AUTH_CONFIGURED;
+}
+
 export interface ServiceStopResult {
   log_messages: string[];
 }

--- a/frontend/src/onboarding/ClientConnect.spec.tsx
+++ b/frontend/src/onboarding/ClientConnect.spec.tsx
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+const invokeMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: () => Promise.resolve(() => {}),
+}));
+
+import ClientConnect from "./ClientConnect";
+
+function routeAuthFailure(error: unknown) {
+  invokeMock.mockImplementation((command: string) => {
+    if (command === "lan_discover_browse") return Promise.resolve([]);
+    if (command === "lan_discover_stop") return Promise.resolve();
+    if (command === "auth_login_interactive") return Promise.reject(error);
+    return Promise.reject(new Error(`unexpected command ${command}`));
+  });
+}
+
+async function connect() {
+  render(<ClientConnect />);
+  await screen.findByText(/No servers found yet/);
+  fireEvent.change(screen.getByLabelText("Remote Server URL"), {
+    target: { value: "lore://192.0.2.10/repo" },
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+  });
+}
+
+beforeEach(() => {
+  invokeMock.mockReset();
+});
+
+describe("auth-disabled server connection (#404)", () => {
+  it("accepts a reachable server that explicitly has no authentication configured", async () => {
+    routeAuthFailure({
+      kind: "CommandFailed",
+      message: "No authentication configured on server",
+    });
+
+    await connect();
+
+    expect(
+      await screen.findByText("Connected without authentication"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    expect(screen.queryByText(/CommandFailed/)).toBeNull();
+  });
+
+  it("continues to reject unrelated authentication failures", async () => {
+    routeAuthFailure({
+      kind: "CommandFailed",
+      message: "Server refused the connection",
+    });
+
+    await connect();
+
+    expect(await screen.findByRole("button", { name: "Retry" })).toBeInTheDocument();
+    expect(screen.queryByText("Connected without authentication")).toBeNull();
+  });
+});

--- a/frontend/src/onboarding/ClientConnect.tsx
+++ b/frontend/src/onboarding/ClientConnect.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   api,
+  isNoAuthConfigured,
   LAN_DISCOVERED_EVENT,
   type DiscoveredServer,
   type UserInfo,
@@ -10,17 +11,6 @@ import { listen } from "@tauri-apps/api/event";
 type Step = "input" | "authenticating" | "success" | "error";
 type DiscoveryStep = "loading" | "ready" | "error";
 type ConnectionMode = "authenticated" | "no-auth";
-
-const NO_AUTH_CONFIGURED = "No authentication configured on server";
-
-function isNoAuthConfigured(error: unknown): boolean {
-  if (error === NO_AUTH_CONFIGURED) return true;
-  if (error instanceof Error) return error.message === NO_AUTH_CONFIGURED;
-  if (typeof error !== "object" || error === null || !("message" in error)) {
-    return false;
-  }
-  return (error as { message?: unknown }).message === NO_AUTH_CONFIGURED;
-}
 
 /**
  * Connect-to-server onboarding (SBAI-3841 + SBAI-4073).

--- a/frontend/src/onboarding/ClientConnect.tsx
+++ b/frontend/src/onboarding/ClientConnect.tsx
@@ -9,6 +9,18 @@ import { listen } from "@tauri-apps/api/event";
 
 type Step = "input" | "authenticating" | "success" | "error";
 type DiscoveryStep = "loading" | "ready" | "error";
+type ConnectionMode = "authenticated" | "no-auth";
+
+const NO_AUTH_CONFIGURED = "No authentication configured on server";
+
+function isNoAuthConfigured(error: unknown): boolean {
+  if (error === NO_AUTH_CONFIGURED) return true;
+  if (error instanceof Error) return error.message === NO_AUTH_CONFIGURED;
+  if (typeof error !== "object" || error === null || !("message" in error)) {
+    return false;
+  }
+  return (error as { message?: unknown }).message === NO_AUTH_CONFIGURED;
+}
 
 /**
  * Connect-to-server onboarding (SBAI-3841 + SBAI-4073).
@@ -24,6 +36,7 @@ export default function ClientConnect() {
   const [remoteUrl, setRemoteUrl] = useState("");
   const [step, setStep] = useState<Step>("input");
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  const [connectionMode, setConnectionMode] = useState<ConnectionMode | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   // --- LAN discovery state ---
@@ -101,8 +114,18 @@ export default function ClientConnect() {
       setError(null);
       const user = await api.authLoginInteractive(remoteUrl.trim());
       setUserInfo(user);
+      setConnectionMode("authenticated");
       setStep("success");
     } catch (e) {
+      // Epic Lore uses this exact result after successfully contacting a server
+      // whose administrator intentionally disabled authentication. Connectivity
+      // succeeded; there is no identity to synthesize or token flow to retry.
+      if (isNoAuthConfigured(e)) {
+        setUserInfo(null);
+        setConnectionMode("no-auth");
+        setStep("success");
+        return;
+      }
       setError(errMsg(e));
       setStep("error");
     }
@@ -111,6 +134,7 @@ export default function ClientConnect() {
   const handleRetry = useCallback(() => {
     setStep("input");
     setError(null);
+    setConnectionMode(null);
   }, []);
 
   return (
@@ -118,7 +142,7 @@ export default function ClientConnect() {
       <h2>Connect to Server</h2>
       <p className="onboarding-description">
         Pick a server discovered on your network, or enter the URL of a remote
-        StudioBrain server. You will be prompted to authenticate.
+        StudioBrain server. You will be prompted to authenticate when required.
       </p>
 
       {error && <div className="error">{error}</div>}
@@ -205,7 +229,16 @@ export default function ClientConnect() {
         </div>
       )}
 
-      {step === "success" && userInfo && (
+      {step === "success" && connectionMode === "no-auth" && (
+        <div className="onboarding-success">
+          <div className="success-message">
+            <span className="success-icon">&#10003;</span>
+            <span>Connected without authentication</span>
+          </div>
+        </div>
+      )}
+
+      {step === "success" && connectionMode === "authenticated" && userInfo && (
         <div className="onboarding-success">
           <div className="success-message">
             <span className="success-icon">&#10003;</span>


### PR DESCRIPTION
## Summary
- centralize Epic Lore exact no-auth compatibility contract
- accept auth-disabled servers in both onboarding and Account Panel surfaces
- preserve failures for every unrelated authentication error
- show an explicit no-auth success state without inventing a user identity or token
- extend the live-server harness to verify the exact auth signal plus a real network create/commit/push/clone round trip

## Verification
- npm test (25 Node + 120 Vitest tests pass)
- npm run typecheck
- npm run build
- cargo fmt --check
- LORE_PORT=42337 scripts/live-server-client.sh (real pinned no-auth loreserver; exact auth response verified; separate-client network round trip verified)
- git diff --check

Closes #404