### PR TITLE
SBAI-5460: RUNNERS_V1 T1 — self-hosted-first runs-on with fork-safety gate (Linux plain workflows)

### DIFF
--- a/.github/scripts/.gitignore
+++ b/.github/scripts/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/.github/scripts/.gitignore
+++ b/.github/scripts/.gitignore
@@ -1,2 +1,1 @@
 node_modules/
-package-lock.json

--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "loregui-ci-scripts",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "loregui-ci-scripts",
+      "dependencies": {
+        "@actions/expressions": "0.3.60"
+      }
+    },
+    "node_modules/@actions/expressions": {
+      "version": "0.3.60",
+      "resolved": "https://registry.npmjs.org/@actions/expressions/-/expressions-0.3.60.tgz",
+      "integrity": "sha512-9Go4zz77GbM6iUkullgo0tN7AHgUNRLkw66C6k3mHEc/QScweRNffjSluS0jcip+ULGkDYzBnyMvY9RjnFjEMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    }
+  }
+}

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "loregui-ci-scripts",
+  "private": true,
+  "type": "module",
+  "description": "CI policy verification scripts (RUNNERS_V1 / SBAI-5460)",
+  "dependencies": {
+    "@actions/expressions": "0.3.60"
+  }
+}

--- a/.github/scripts/runner-policy-truth-table.mjs
+++ b/.github/scripts/runner-policy-truth-table.mjs
@@ -18,7 +18,7 @@ import * as ex from "@actions/expressions";
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 const CANON =
-  "(github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '[\"ubuntu-latest\"]')";
+  "(github.event_name == 'pull_request' || github.ref != 'refs/heads/main') && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '[\"ubuntu-latest\"]')";
 
 const T1_WORKFLOWS = {
   "auto-release.yml": 1,
@@ -112,26 +112,34 @@ const prEvent = (headRepo, actor = "team-member") => ({
   event_name: "pull_request",
   repository: REPO,
   actor,
+  ref: "refs/pull/123/merge",
   event: { pull_request: { head: { repo: { full_name: headRepo } } } },
 });
-const bareEvent = (name) => ({
+const bareEvent = (name, ref) => ({
   event_name: name,
   repository: REPO,
   actor: "team-member",
+  ref,
   event: {},
 });
 
-// "untrusted" rows must resolve to GitHub-hosted regardless of the variable:
-// fork PRs (attacker-controlled code), and Dependabot PRs — same head repo,
-// but GitHub runs them with fork-like trust and they execute updated deps.
+// Only CANONICAL-MAIN events (push/schedule/workflow_dispatch on
+// refs/heads/main) may consult the self-hosted variable. Every pull_request
+// (any origin) and every non-main ref (branch push, tag, branch dispatch)
+// must resolve hosted: those runs execute that ref's workflow definitions —
+// the mutation vector — and the main-pinned runner group would deny their
+// jobs anyway (queue deadlock, not safety, but still a policy violation).
 const EVENTS = [
-  ["fork PR", prEvent("outside-user/loregui"), "untrusted"],
-  ["dependabot fork PR", prEvent("outside-user/loregui", "dependabot[bot]"), "untrusted"],
-  ["dependabot PR", prEvent(REPO, "dependabot[bot]"), "untrusted"],
-  ["same-repo PR", prEvent(REPO), "trusted"],
-  ["push", bareEvent("push"), "trusted"],
-  ["schedule", bareEvent("schedule"), "trusted"],
-  ["workflow_dispatch", bareEvent("workflow_dispatch"), "trusted"],
+  ["fork PR", prEvent("outside-user/loregui"), "hosted-only"],
+  ["dependabot fork PR", prEvent("outside-user/loregui", "dependabot[bot]"), "hosted-only"],
+  ["dependabot PR", prEvent(REPO, "dependabot[bot]"), "hosted-only"],
+  ["same-repo PR", prEvent(REPO), "hosted-only"],
+  ["push main", bareEvent("push", "refs/heads/main"), "canonical-main"],
+  ["push branch", bareEvent("push", "refs/heads/feature-x"), "hosted-only"],
+  ["push tag", bareEvent("push", "refs/tags/v9.9.9"), "hosted-only"],
+  ["schedule (main)", bareEvent("schedule", "refs/heads/main"), "canonical-main"],
+  ["dispatch main", bareEvent("workflow_dispatch", "refs/heads/main"), "canonical-main"],
+  ["dispatch branch", bareEvent("workflow_dispatch", "refs/heads/feature-x"), "hosted-only"],
 ];
 const VARS = [
   ["unset", {}, JSON.parse(HOSTED)],
@@ -146,12 +154,12 @@ for (const [eventName, github, trust] of EVENTS) {
   for (const [varName, vars, trustedExpectation] of VARS) {
     rows++;
     const resolved = resolveRunsOn(github, vars);
-    const expected = trust === "untrusted" ? "ubuntu-latest" : trustedExpectation;
+    const expected = trust === "hosted-only" ? "ubuntu-latest" : trustedExpectation;
     const ok = JSON.stringify(resolved) === JSON.stringify(expected);
     const selfHostedLeak =
-      trust === "untrusted" && JSON.stringify(resolved).toLowerCase().includes("self-hosted");
+      trust === "hosted-only" && JSON.stringify(resolved).toLowerCase().includes("self-hosted");
     if (!ok) fail(`${eventName} / var=${varName}: resolved ${JSON.stringify(resolved)}, expected ${JSON.stringify(expected)}`);
-    if (selfHostedLeak) fail(`${eventName} / var=${varName}: UNTRUSTED CONTEXT REACHED SELF-HOSTED`);
+    if (selfHostedLeak) fail(`${eventName} / var=${varName}: NON-CANONICAL-MAIN CONTEXT REACHED SELF-HOSTED`);
     console.log(
       `${eventName.padEnd(18)} | ${varName.padEnd(20)} | ${JSON.stringify(resolved).padEnd(37)} | ${ok && !selfHostedLeak ? "ok" : "VIOLATION"}`,
     );
@@ -163,5 +171,5 @@ if (failures > 0) {
   process.exit(1);
 }
 console.log(
-  `\nRUNNERS_V1 truth table: all ${rows} rows match policy; untrusted contexts (fork + Dependabot PRs) never reach self-hosted`,
+  `\nRUNNERS_V1 truth table: all ${rows} rows match policy; only canonical-main events can reach self-hosted`,
 );

--- a/.github/scripts/runner-policy-truth-table.mjs
+++ b/.github/scripts/runner-policy-truth-table.mjs
@@ -53,6 +53,13 @@ for (const [name, expected] of Object.entries(T1_WORKFLOWS)) {
 }
 console.log(`drift gate: ${totalSites} runs-on sites checked against the canonical expression`);
 
+// The policy doc's Mechanism code block must match the canon verbatim — the
+// versioned policy text is not allowed to drift from the executable mechanism.
+const policyDoc = readFileSync(join(ROOT, "docs", "RUNNERS_V1.md"), "utf8");
+if (!policyDoc.includes(`runs-on: \${{ ${CANON} }}`)) {
+  fail("docs/RUNNERS_V1.md: Mechanism code block no longer matches the canonical expression");
+}
+
 // The preflight workflow must embed the same inner expression, and its own
 // jobs must be pinned to GitHub-hosted (the observer is never the subject).
 const preflight = readFileSync(

--- a/.github/scripts/runner-policy-truth-table.mjs
+++ b/.github/scripts/runner-policy-truth-table.mjs
@@ -18,7 +18,7 @@ import * as ex from "@actions/expressions";
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 const CANON =
-  "(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '[\"ubuntu-latest\"]')";
+  "(github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '[\"ubuntu-latest\"]')";
 
 const T1_WORKFLOWS = {
   "auto-release.yml": 1,
@@ -101,15 +101,26 @@ const REPO = "BiloxiStudios/loregui";
 const SELF_HOSTED = '["self-hosted","linux","proxmox"]';
 const HOSTED = '["ubuntu-latest"]';
 
-const prEvent = (headRepo) => ({
+const prEvent = (headRepo, actor = "team-member") => ({
   event_name: "pull_request",
   repository: REPO,
+  actor,
   event: { pull_request: { head: { repo: { full_name: headRepo } } } },
 });
-const bareEvent = (name) => ({ event_name: name, repository: REPO, event: {} });
+const bareEvent = (name) => ({
+  event_name: name,
+  repository: REPO,
+  actor: "team-member",
+  event: {},
+});
 
+// "untrusted" rows must resolve to GitHub-hosted regardless of the variable:
+// fork PRs (attacker-controlled code), and Dependabot PRs — same head repo,
+// but GitHub runs them with fork-like trust and they execute updated deps.
 const EVENTS = [
-  ["fork PR", prEvent("outside-user/loregui"), "fork"],
+  ["fork PR", prEvent("outside-user/loregui"), "untrusted"],
+  ["dependabot fork PR", prEvent("outside-user/loregui", "dependabot[bot]"), "untrusted"],
+  ["dependabot PR", prEvent(REPO, "dependabot[bot]"), "untrusted"],
   ["same-repo PR", prEvent(REPO), "trusted"],
   ["push", bareEvent("push"), "trusted"],
   ["schedule", bareEvent("schedule"), "trusted"],
@@ -123,15 +134,17 @@ const VARS = [
 
 console.log("\nevent              | LOREGUI_LINUX_RUNNER | resolved runs-on                      | verdict");
 console.log("-------------------|----------------------|---------------------------------------|--------");
+let rows = 0;
 for (const [eventName, github, trust] of EVENTS) {
   for (const [varName, vars, trustedExpectation] of VARS) {
+    rows++;
     const resolved = resolveRunsOn(github, vars);
-    const expected = trust === "fork" ? "ubuntu-latest" : trustedExpectation;
+    const expected = trust === "untrusted" ? "ubuntu-latest" : trustedExpectation;
     const ok = JSON.stringify(resolved) === JSON.stringify(expected);
     const selfHostedLeak =
-      trust === "fork" && JSON.stringify(resolved).toLowerCase().includes("self-hosted");
+      trust === "untrusted" && JSON.stringify(resolved).toLowerCase().includes("self-hosted");
     if (!ok) fail(`${eventName} / var=${varName}: resolved ${JSON.stringify(resolved)}, expected ${JSON.stringify(expected)}`);
-    if (selfHostedLeak) fail(`${eventName} / var=${varName}: FORK CONTEXT REACHED SELF-HOSTED`);
+    if (selfHostedLeak) fail(`${eventName} / var=${varName}: UNTRUSTED CONTEXT REACHED SELF-HOSTED`);
     console.log(
       `${eventName.padEnd(18)} | ${varName.padEnd(20)} | ${JSON.stringify(resolved).padEnd(37)} | ${ok && !selfHostedLeak ? "ok" : "VIOLATION"}`,
     );
@@ -142,4 +155,6 @@ if (failures > 0) {
   console.error(`\n${failures} policy violation(s) — RUNNERS_V1 gate failed`);
   process.exit(1);
 }
-console.log("\nRUNNERS_V1 truth table: all 15 rows match policy; fork contexts never reach self-hosted");
+console.log(
+  `\nRUNNERS_V1 truth table: all ${rows} rows match policy; untrusted contexts (fork + Dependabot PRs) never reach self-hosted`,
+);

--- a/.github/scripts/runner-policy-truth-table.mjs
+++ b/.github/scripts/runner-policy-truth-table.mjs
@@ -1,0 +1,145 @@
+// RUNNERS_V1 static truth table (SBAI-5460).
+//
+// The live preflight job can only witness the event it actually runs under —
+// a same-repo PR run never exercises the fork branch of the runner-selection
+// expression. This script closes that gap: it extracts the REAL expression
+// from every migrated workflow (failing on any drift), then evaluates it with
+// GitHub's own expression engine (@actions/expressions, the engine behind
+// actions/languageservices) across the full event-context matrix, including
+// the fork rows CI cannot produce against itself.
+//
+// Exit non-zero on: expression drift between workflows, a fork context that
+// resolves to anything but GitHub-hosted, or any row not matching policy.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import * as ex from "@actions/expressions";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const CANON =
+  "(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '[\"ubuntu-latest\"]')";
+
+const T1_WORKFLOWS = {
+  "auto-release.yml": 1,
+  "boundary-guard.yml": 1,
+  "ci.yml": 2,
+  "frontend-test.yml": 1,
+  "integration.yml": 1,
+  "licenses.yml": 1,
+  "remote-qa.yml": 1,
+  "upstream-parity.yml": 2,
+  "vscode-test.yml": 2,
+};
+
+let failures = 0;
+const fail = (msg) => {
+  failures++;
+  console.error(`FAIL: ${msg}`);
+};
+
+// ---- 1. Drift gate: every migrated runs-on carries the canonical expression.
+let totalSites = 0;
+for (const [name, expected] of Object.entries(T1_WORKFLOWS)) {
+  const src = readFileSync(join(ROOT, ".github", "workflows", name), "utf8");
+  const sites = [...src.matchAll(/^\s*runs-on:\s*\$\{\{\s*(.*?)\s*\}\}\s*$/gm)];
+  if (sites.length !== expected) {
+    fail(`${name}: expected ${expected} expression runs-on site(s), found ${sites.length}`);
+  }
+  for (const m of sites) {
+    totalSites++;
+    if (m[1] !== CANON) fail(`${name}: runs-on expression drifted from canon:\n  ${m[1]}`);
+  }
+}
+console.log(`drift gate: ${totalSites} runs-on sites checked against the canonical expression`);
+
+// The preflight workflow must embed the same inner expression, and its own
+// jobs must be pinned to GitHub-hosted (the observer is never the subject).
+const preflight = readFileSync(
+  join(ROOT, ".github", "workflows", "runner-policy-preflight.yml"),
+  "utf8",
+);
+if (!preflight.includes(`toJSON(${CANON})`)) {
+  fail("runner-policy-preflight.yml: RESOLVED_RUNS_ON no longer embeds the canonical expression");
+}
+for (const m of preflight.matchAll(/^\s*runs-on:\s*(.*?)\s*$/gm)) {
+  if (m[1] !== "ubuntu-latest") {
+    fail(`runner-policy-preflight.yml: preflight jobs must be pinned to ubuntu-latest, found '${m[1]}'`);
+  }
+}
+
+// ---- 2. Full-matrix evaluation with GitHub's own expression engine.
+function toData(v) {
+  if (v === null || v === undefined) return new ex.data.Null();
+  if (typeof v === "string") return new ex.data.StringData(v);
+  if (typeof v === "boolean") return new ex.data.BooleanData(v);
+  if (typeof v === "object") {
+    const d = new ex.data.Dictionary();
+    for (const [k, val] of Object.entries(v)) d.add(k, toData(val));
+    return d;
+  }
+  throw new Error(`unsupported context value: ${typeof v}`);
+}
+
+function toJs(result) {
+  if (result instanceof ex.data.StringData) return result.coerceString();
+  if (result instanceof ex.data.Array) return result.values().map(toJs);
+  if (result instanceof ex.data.Null) return null;
+  return result.coerceString();
+}
+
+function resolveRunsOn(github, vars) {
+  const tokens = new ex.Lexer(CANON).lex().tokens;
+  const tree = new ex.Parser(tokens, ["github", "vars"], []).parse();
+  const ctx = new ex.data.Dictionary();
+  ctx.add("github", toData(github));
+  ctx.add("vars", toData(vars));
+  return toJs(new ex.Evaluator(tree, ctx).evaluate());
+}
+
+const REPO = "BiloxiStudios/loregui";
+const SELF_HOSTED = '["self-hosted","linux","proxmox"]';
+const HOSTED = '["ubuntu-latest"]';
+
+const prEvent = (headRepo) => ({
+  event_name: "pull_request",
+  repository: REPO,
+  event: { pull_request: { head: { repo: { full_name: headRepo } } } },
+});
+const bareEvent = (name) => ({ event_name: name, repository: REPO, event: {} });
+
+const EVENTS = [
+  ["fork PR", prEvent("outside-user/loregui"), "fork"],
+  ["same-repo PR", prEvent(REPO), "trusted"],
+  ["push", bareEvent("push"), "trusted"],
+  ["schedule", bareEvent("schedule"), "trusted"],
+  ["workflow_dispatch", bareEvent("workflow_dispatch"), "trusted"],
+];
+const VARS = [
+  ["unset", {}, JSON.parse(HOSTED)],
+  ["hosted", { LOREGUI_LINUX_RUNNER: HOSTED }, JSON.parse(HOSTED)],
+  ["self-hosted", { LOREGUI_LINUX_RUNNER: SELF_HOSTED }, JSON.parse(SELF_HOSTED)],
+];
+
+console.log("\nevent              | LOREGUI_LINUX_RUNNER | resolved runs-on                      | verdict");
+console.log("-------------------|----------------------|---------------------------------------|--------");
+for (const [eventName, github, trust] of EVENTS) {
+  for (const [varName, vars, trustedExpectation] of VARS) {
+    const resolved = resolveRunsOn(github, vars);
+    const expected = trust === "fork" ? "ubuntu-latest" : trustedExpectation;
+    const ok = JSON.stringify(resolved) === JSON.stringify(expected);
+    const selfHostedLeak =
+      trust === "fork" && JSON.stringify(resolved).toLowerCase().includes("self-hosted");
+    if (!ok) fail(`${eventName} / var=${varName}: resolved ${JSON.stringify(resolved)}, expected ${JSON.stringify(expected)}`);
+    if (selfHostedLeak) fail(`${eventName} / var=${varName}: FORK CONTEXT REACHED SELF-HOSTED`);
+    console.log(
+      `${eventName.padEnd(18)} | ${varName.padEnd(20)} | ${JSON.stringify(resolved).padEnd(37)} | ${ok && !selfHostedLeak ? "ok" : "VIOLATION"}`,
+    );
+  }
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} policy violation(s) — RUNNERS_V1 gate failed`);
+  process.exit(1);
+}
+console.log("\nRUNNERS_V1 truth table: all 15 rows match policy; fork contexts never reach self-hosted");

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   cut:
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   cut:
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' || github.ref != 'refs/heads/main') && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   cut:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/boundary-guard.yml
+++ b/.github/workflows/boundary-guard.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   boundary:
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
       - name: Accounts / PII / proprietary boundary guard

--- a/.github/workflows/boundary-guard.yml
+++ b/.github/workflows/boundary-guard.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   boundary:
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' || github.ref != 'refs/heads/main') && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
       - name: Accounts / PII / proprietary boundary guard

--- a/.github/workflows/boundary-guard.yml
+++ b/.github/workflows/boundary-guard.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   boundary:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
       - name: Accounts / PII / proprietary boundary guard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   core-check:
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' || github.ref != 'refs/heads/main') && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     env:
       # Drop debug info in CI so the lore-vm test-binary link stays under the
       # github-hosted runner's ~7GB ceiling. With debuginfo the linker OOM'd
@@ -40,7 +40,7 @@ jobs:
     # command palette (a manifest entry) or explicitly allowlisted. Fails when a
     # new lore op is wired without a GUI affordance — keeping the GUI in lock-step
     # with the API surface. See frontend/scripts/palette-parity.mjs.
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' || github.ref != 'refs/heads/main') && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   core-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     env:
       # Drop debug info in CI so the lore-vm test-binary link stays under the
       # github-hosted runner's ~7GB ceiling. With debuginfo the linker OOM'd
@@ -40,7 +40,7 @@ jobs:
     # command palette (a manifest entry) or explicitly allowlisted. Fails when a
     # new lore op is wired without a GUI affordance — keeping the GUI in lock-step
     # with the API surface. See frontend/scripts/palette-parity.mjs.
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   core-check:
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     env:
       # Drop debug info in CI so the lore-vm test-binary link stays under the
       # github-hosted runner's ~7GB ceiling. With debuginfo the linker OOM'd
@@ -40,7 +40,7 @@ jobs:
     # command palette (a manifest entry) or explicitly allowlisted. Fails when a
     # new lore op is wired without a GUI affordance — keeping the GUI in lock-step
     # with the API surface. See frontend/scripts/palette-parity.mjs.
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' || github.ref != 'refs/heads/main') && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   integration:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   integration:
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' || github.ref != 'refs/heads/main') && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   integration:
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   attribution:
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   attribution:
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' || github.ref != 'refs/heads/main') && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   attribution:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/remote-qa.yml
+++ b/.github/workflows/remote-qa.yml
@@ -34,7 +34,7 @@ on:
 
 jobs:
   remote-multiuser:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/remote-qa.yml
+++ b/.github/workflows/remote-qa.yml
@@ -34,7 +34,7 @@ on:
 
 jobs:
   remote-multiuser:
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' || github.ref != 'refs/heads/main') && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/remote-qa.yml
+++ b/.github/workflows/remote-qa.yml
@@ -34,7 +34,7 @@ on:
 
 jobs:
   remote-multiuser:
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/runner-policy-preflight.yml
+++ b/.github/workflows/runner-policy-preflight.yml
@@ -20,22 +20,25 @@ jobs:
     env:
       # The same expression T1 workflows use for runs-on, so the assertion
       # below exercises the real policy rather than a re-implementation.
-      RESOLVED_RUNS_ON: ${{ toJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]')) }}
-      IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+      # Untrusted = fork PR, or a Dependabot PR (same head repo, but GitHub
+      # runs it with fork-like trust and it executes updated dependency code).
+      RESOLVED_RUNS_ON: ${{ toJSON((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]')) }}
+      IS_UNTRUSTED_PR: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]') }}
     steps:
       - name: Print event-context truth table
         run: |
           echo "event_name:                ${{ github.event_name }}"
           echo "repository:                ${{ github.repository }}"
+          echo "actor:                     ${{ github.actor }}"
           echo "pr head repo:              ${{ github.event.pull_request.head.repo.full_name || '(not a pull_request event)' }}"
-          echo "is_fork_pr:                ${IS_FORK_PR}"
+          echo "is_untrusted_pr:           ${IS_UNTRUSTED_PR}"
           echo "vars.LOREGUI_LINUX_RUNNER: '${{ vars.LOREGUI_LINUX_RUNNER }}' (empty = hosted default)"
           echo "resolved runs-on:          ${RESOLVED_RUNS_ON}"
 
-      - name: Assert fork PRs never resolve to self-hosted
+      - name: Assert untrusted PRs never resolve to self-hosted
         run: |
-          if [ "${IS_FORK_PR}" = "true" ] && printf '%s' "${RESOLVED_RUNS_ON}" | grep -qi 'self-hosted'; then
-            echo "::error::POLICY VIOLATION: a fork PR resolved to a self-hosted runner"
+          if [ "${IS_UNTRUSTED_PR}" = "true" ] && printf '%s' "${RESOLVED_RUNS_ON}" | grep -qi 'self-hosted'; then
+            echo "::error::POLICY VIOLATION: an untrusted PR resolved to a self-hosted runner"
             exit 1
           fi
           echo "fork-safety gate holds for this event context"
@@ -52,9 +55,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: Install GitHub's expression engine (pinned)
+      - name: Install GitHub's expression engine (pinned via lockfile)
         working-directory: .github/scripts
-        run: npm install
+        run: npm ci
       - name: Evaluate full runner-policy truth table
         working-directory: .github/scripts
         run: node runner-policy-truth-table.mjs

--- a/.github/workflows/runner-policy-preflight.yml
+++ b/.github/workflows/runner-policy-preflight.yml
@@ -1,0 +1,41 @@
+# RUNNERS_V1 preflight — proves the fork-safety gate with the LIVE expression.
+#
+# loregui is a PUBLIC repo: workflow runs triggered by fork PRs execute
+# attacker-controlled code and must NEVER land on self-hosted runners. Every
+# T1 workflow selects its runner with the exact expression evaluated into
+# RESOLVED_RUNS_ON below; this job prints the event-context truth table and
+# hard-fails if a fork-PR event would ever resolve to self-hosted. Policy:
+# docs/RUNNERS_V1.md (SBAI-5460).
+name: runner-policy-preflight
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  truth-table:
+    # Always GitHub-hosted: this job is the observer, never the subject.
+    runs-on: ubuntu-latest
+    env:
+      # The same expression T1 workflows use for runs-on, so the assertion
+      # below exercises the real policy rather than a re-implementation.
+      RESOLVED_RUNS_ON: ${{ toJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]')) }}
+      IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+    steps:
+      - name: Print event-context truth table
+        run: |
+          echo "event_name:                ${{ github.event_name }}"
+          echo "repository:                ${{ github.repository }}"
+          echo "pr head repo:              ${{ github.event.pull_request.head.repo.full_name || '(not a pull_request event)' }}"
+          echo "is_fork_pr:                ${IS_FORK_PR}"
+          echo "vars.LOREGUI_LINUX_RUNNER: '${{ vars.LOREGUI_LINUX_RUNNER }}' (empty = hosted default)"
+          echo "resolved runs-on:          ${RESOLVED_RUNS_ON}"
+
+      - name: Assert fork PRs never resolve to self-hosted
+        run: |
+          if [ "${IS_FORK_PR}" = "true" ] && printf '%s' "${RESOLVED_RUNS_ON}" | grep -qi 'self-hosted'; then
+            echo "::error::POLICY VIOLATION: a fork PR resolved to a self-hosted runner"
+            exit 1
+          fi
+          echo "fork-safety gate holds for this event context"

--- a/.github/workflows/runner-policy-preflight.yml
+++ b/.github/workflows/runner-policy-preflight.yml
@@ -39,3 +39,22 @@ jobs:
             exit 1
           fi
           echo "fork-safety gate holds for this event context"
+
+  # The job above can only witness the event it runs under — a same-repo PR
+  # never exercises the fork branch of the expression. This job evaluates the
+  # REAL expression (extracted from the workflows, drift-checked) with
+  # GitHub's own expression engine across the full event/variable matrix,
+  # fork rows included. See .github/scripts/runner-policy-truth-table.mjs.
+  truth-table-static:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install GitHub's expression engine (pinned)
+        working-directory: .github/scripts
+        run: npm install
+      - name: Evaluate full runner-policy truth table
+        working-directory: .github/scripts
+        run: node runner-policy-truth-table.mjs

--- a/.github/workflows/runner-policy-preflight.yml
+++ b/.github/workflows/runner-policy-preflight.yml
@@ -20,10 +20,14 @@ jobs:
     env:
       # The same expression T1 workflows use for runs-on, so the assertion
       # below exercises the real policy rather than a re-implementation.
-      # Untrusted = fork PR, or a Dependabot PR (same head repo, but GitHub
-      # runs it with fork-like trust and it executes updated dependency code).
-      RESOLVED_RUNS_ON: ${{ toJSON((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]')) }}
-      IS_UNTRUSTED_PR: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]') }}
+      # Only CANONICAL-MAIN events (push/schedule/workflow_dispatch on
+      # refs/heads/main) may consult the self-hosted variable. Everything
+      # else — any pull_request, and any non-main ref (branch push, tag,
+      # branch dispatch) — runs hosted: PR/branch runs execute that ref's
+      # workflow definitions (the mutation vector), and the runner group is
+      # pinned to workflows@main, which would deny non-main jobs anyway.
+      RESOLVED_RUNS_ON: ${{ toJSON((github.event_name == 'pull_request' || github.ref != 'refs/heads/main') && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]')) }}
+      IS_HOSTED_ONLY_CONTEXT: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
     steps:
       - name: Print event-context truth table
         run: |
@@ -31,17 +35,18 @@ jobs:
           echo "repository:                ${{ github.repository }}"
           echo "actor:                     ${{ github.actor }}"
           echo "pr head repo:              ${{ github.event.pull_request.head.repo.full_name || '(not a pull_request event)' }}"
-          echo "is_untrusted_pr:           ${IS_UNTRUSTED_PR}"
+          echo "ref:                       ${{ github.ref }}"
+          echo "is_hosted_only_context:    ${IS_HOSTED_ONLY_CONTEXT}"
           echo "vars.LOREGUI_LINUX_RUNNER: '${{ vars.LOREGUI_LINUX_RUNNER }}' (empty = hosted default)"
           echo "resolved runs-on:          ${RESOLVED_RUNS_ON}"
 
-      - name: Assert untrusted PRs never resolve to self-hosted
+      - name: Assert non-canonical-main contexts never resolve to self-hosted
         run: |
-          if [ "${IS_UNTRUSTED_PR}" = "true" ] && printf '%s' "${RESOLVED_RUNS_ON}" | grep -qi 'self-hosted'; then
-            echo "::error::POLICY VIOLATION: an untrusted PR resolved to a self-hosted runner"
+          if [ "${IS_HOSTED_ONLY_CONTEXT}" = "true" ] && printf '%s' "${RESOLVED_RUNS_ON}" | grep -qi 'self-hosted'; then
+            echo "::error::POLICY VIOLATION: a pull_request or non-main-ref event resolved to a self-hosted runner"
             exit 1
           fi
-          echo "fork-safety gate holds for this event context"
+          echo "runner policy holds for this event context"
 
   # The job above can only witness the event it runs under — a same-repo PR
   # never exercises the fork branch of the expression. This job evaluates the

--- a/.github/workflows/upstream-parity.yml
+++ b/.github/workflows/upstream-parity.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   detect:
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     outputs:
       rev_changed: ${{ steps.check.outputs.changed }}
       old_rev: ${{ steps.pinned.outputs.rev }}
@@ -127,7 +127,7 @@ jobs:
   canary:
     needs: detect
     if: needs.detect.outputs.rev_changed == 'true'
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/upstream-parity.yml
+++ b/.github/workflows/upstream-parity.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   detect:
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' || github.ref != 'refs/heads/main') && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     outputs:
       rev_changed: ${{ steps.check.outputs.changed }}
       old_rev: ${{ steps.pinned.outputs.rev }}
@@ -127,7 +127,7 @@ jobs:
   canary:
     needs: detect
     if: needs.detect.outputs.rev_changed == 'true'
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' || github.ref != 'refs/heads/main') && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/upstream-parity.yml
+++ b/.github/workflows/upstream-parity.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   detect:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     outputs:
       rev_changed: ${{ steps.check.outputs.changed }}
       old_rev: ${{ steps.pinned.outputs.rev }}
@@ -127,7 +127,7 @@ jobs:
   canary:
     needs: detect
     if: needs.detect.outputs.rev_changed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/vscode-test.yml
+++ b/.github/workflows/vscode-test.yml
@@ -33,7 +33,7 @@ jobs:
   # the same path triggers as the e2e job (a lore-vm / lorevm-cli change can break
   # the contract), and gates this workflow before the heavier headless E2E.
   cli-contract:
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -44,7 +44,7 @@ jobs:
         run: cargo test -p lorevm-cli
 
   e2e:
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/vscode-test.yml
+++ b/.github/workflows/vscode-test.yml
@@ -33,7 +33,7 @@ jobs:
   # the same path triggers as the e2e job (a lore-vm / lorevm-cli change can break
   # the contract), and gates this workflow before the heavier headless E2E.
   cli-contract:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -44,7 +44,7 @@ jobs:
         run: cargo test -p lorevm-cli
 
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/vscode-test.yml
+++ b/.github/workflows/vscode-test.yml
@@ -33,7 +33,7 @@ jobs:
   # the same path triggers as the e2e job (a lore-vm / lorevm-cli change can break
   # the contract), and gates this workflow before the heavier headless E2E.
   cli-contract:
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' || github.ref != 'refs/heads/main') && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -44,7 +44,7 @@ jobs:
         run: cargo test -p lorevm-cli
 
   e2e:
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' || github.ref != 'refs/heads/main') && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/RUNNERS_V1.md
+++ b/docs/RUNNERS_V1.md
@@ -66,7 +66,7 @@ if a fork-PR context ever resolves to self-hosted.
 
 | Tier | Scope | Target labels | State |
 |------|-------|---------------|-------|
-| T1 | Linux plain: auto-release, boundary-guard, ci, frontend-test, integration, licenses, remote-qa, upstream-parity, vscode-test | `["self-hosted","linux","proxmox"]` — dedicated group gets **CT147/148** (2/2 split with model-manager per infra capacity call: pve1 is CPU-saturated, so runners are repartitioned, never added there; all four CT145–148 verified Tauri-v2-ready — lorecrew board record 2026-07-21) | Mechanism landed; variable stays UNSET (hosted default) until the dedicated runner group exists, fork-safety proof and failover drill pass, and the lead signs off. Two runners ⇒ cap/stagger matrices and avoid overlapping model-manager release builds; durable contention fix is runners on a different host |
+| T1 | Linux plain: auto-release, boundary-guard, ci, frontend-test, integration, licenses, remote-qa, upstream-parity, vscode-test | `["self-hosted","linux","proxmox"]` — matches the two **dedicated loregui runners `actions-linux-5` (id 32) and `actions-linux-6` (id 33)**, labels `[self-hosted, Linux, X64, proxmox, vm3]`, in org runner group **`loregui-public` (id 7)**: `allows_public_repositories=true`, visibility=selected → this repo only. Hosts: CT158/159 on **vm3** (16 vCPU / 32G each) — additive capacity per owner directive, deliberately OFF the CPU-saturated pve1; the earlier 2/2-split plan is superseded and model-manager's four pve1 runners are untouched | Mechanism landed; runners live and group verified on the org API (lorecrew record 2026-07-21). Variable stays UNSET (hosted default) until the Tauri toolchain install completes on both CTs, the failover drill passes, and the lead signs off. The extra `vm3` label lets the drill drain a specific runner |
 | T2 | Linux GUI/Tauri: tauri-e2e, build-crossplatform (linux), release (linux) | same as T1 (Tauri v2 deps verified on all four runners) | Pending T1; stagger matrix concurrency — runners are shared with model-manager CI |
 | T3 | Windows: windows-build, release (win), publish-vscode (win32) | `["self-hosted","Windows","X64"]` (bx-w11-build01) | Pending; single runner → serialized. Never use the retired `Windows, proxmox` label (dead VM150) |
 | T4 | macOS: release, build-crossplatform, publish-vscode (darwin) | TBD | Last; blocked on macOS runner health + signing keychain (macOS was deliberately moved off self-hosted before — see release.yml header). GitHub-hosted remains the supported path until proven |
@@ -74,9 +74,15 @@ if a fork-PR context ever resolves to self-hosted.
 ## Rollout / operations
 
 1. T1 lands with the **hosted default** — behavior is unchanged until the flip.
-2. Infra confirms org runner-group admission for this repo (group policy: public
-   repos OFF), then sets `LOREGUI_LINUX_RUNNER='["self-hosted","linux","proxmox"]'`.
-3. Failover drill (required before relying on self-hosted): drain or stop a
-   runner, flip the variable back to hosted, re-run a workflow, confirm green.
-4. Each subsequent tier repeats this pattern with its own variable
+2. Infra provisions the dedicated group + runners (done: `loregui-public` id 7,
+   `actions-linux-5/6` on vm3) and confirms build toolchain on both runners.
+3. **Failover drill** (required before relying on self-hosted): set
+   `LOREGUI_LINUX_RUNNER='["self-hosted","linux","proxmox"]'`, dispatch a light
+   workflow and confirm it lands on actions-linux-5/6; drain one runner
+   mid-queue and confirm the other picks up; flip the variable back to hosted
+   and confirm green on GitHub-hosted; then unset until the lead signs off.
+4. Decommission/rollback: remove the runner from the org + destroy CT158/159 on
+   vm3; deleting group 7 rolls membership back to Default. The variable flip is
+   always the fastest escape hatch.
+5. Each subsequent tier repeats this pattern with its own variable
    (`LOREGUI_WINDOWS_RUNNER`, `LOREGUI_MACOS_RUNNER`) and its own drill.

--- a/docs/RUNNERS_V1.md
+++ b/docs/RUNNERS_V1.md
@@ -35,10 +35,23 @@ if a fork-PR context ever resolves to self-hosted.
 ## Fork-safety: defense in depth (four layers)
 
 1. The `runs-on` expression above (workflow level) — fork PRs → hosted, always.
-2. Org runner group keeps **“allow public repositories” OFF**; loregui uses the
-   group only for trusted-event runs (org-admin action, applied by infra).
+   Proven two ways: the live preflight assertion, and the static truth table
+   (`.github/scripts/runner-policy-truth-table.mjs`) which evaluates the real,
+   drift-checked expression with GitHub's own expression engine across every
+   event/variable combination — fork rows included.
+2. A **dedicated org runner group for this repository alone**. GitHub blocks
+   public repositories from runner groups unless the group opts in, so the
+   group must set `allows_public_repositories=true` — which is exactly why it
+   must contain **only loregui** (selected-repositories) and, where the org
+   plan supports it, be restricted to **selected workflows** pinned to this
+   repo's workflow files. The group is never a shared pool: opting a shared
+   group into public repos would expose every repo's runners. Containment for
+   fork code itself is layers 1, 3, and 4 — the group scoping bounds the blast
+   radius to runners this repo was explicitly granted. Live org-admin state
+   and group creation: infra (brain-chat), pending admin credential unlock.
 3. Repo setting **“require approval for all outside collaborators”** for fork
-   PR workflows; `GITHUB_TOKEN` stays read-only for fork PRs (repo-admin action).
+   PR workflows — **set and verified by the lead (2026-07-21,
+   `all_external_contributors`)**; `GITHUB_TOKEN` stays read-only for fork PRs.
 4. Never `pull_request_target` with a checkout of the fork head — and never on
    self-hosted. This combination is the canonical RCE and is banned outright.
 
@@ -46,7 +59,7 @@ if a fork-PR context ever resolves to self-hosted.
 
 | Tier | Scope | Target labels | State |
 |------|-------|---------------|-------|
-| T1 | Linux plain: auto-release, boundary-guard, ci, frontend-test, integration, licenses, remote-qa, upstream-parity, vscode-test | `["self-hosted","linux","proxmox"]` (CT145–148, pve1) | Mechanism landed; variable stays at hosted default until org runner-group admission is confirmed by infra |
+| T1 | Linux plain: auto-release, boundary-guard, ci, frontend-test, integration, licenses, remote-qa, upstream-parity, vscode-test | `["self-hosted","linux","proxmox"]` (CT145–148, pve1; all four verified Tauri-v2-ready by infra — webkit2gtk-4.1 + gtk3 + xvfb, lorecrew board record 2026-07-21) | Mechanism landed; variable stays UNSET (hosted default) until the dedicated runner group exists, fork-safety proof and failover drill pass, and the lead signs off |
 | T2 | Linux GUI/Tauri: tauri-e2e, build-crossplatform (linux), release (linux) | same as T1 (Tauri v2 deps verified on all four runners) | Pending T1; stagger matrix concurrency — runners are shared with model-manager CI |
 | T3 | Windows: windows-build, release (win), publish-vscode (win32) | `["self-hosted","Windows","X64"]` (bx-w11-build01) | Pending; single runner → serialized. Never use the retired `Windows, proxmox` label (dead VM150) |
 | T4 | macOS: release, build-crossplatform, publish-vscode (darwin) | TBD | Last; blocked on macOS runner health + signing keychain (macOS was deliberately moved off self-hosted before — see release.yml header). GitHub-hosted remains the supported path until proven |

--- a/docs/RUNNERS_V1.md
+++ b/docs/RUNNERS_V1.md
@@ -6,11 +6,16 @@ Tracking: SBAI-5460 (T1). Adopted by lorecrew lead ruling, 2026-07-21.
 ## The rule
 
 CI runs **self-hosted-first** with GitHub-hosted Actions as failover — except
-that **untrusted pull-request runs always run GitHub-hosted**: fork PRs
-(attacker-controlled code) and Dependabot PRs (same head repo, but GitHub runs
-them with fork-like trust and they execute freshly-updated dependency code).
-loregui is a public repository; untrusted code never reaches studio
-infrastructure. No exceptions, no overrides.
+that **only canonical-main events (push / schedule / workflow_dispatch on
+`refs/heads/main`) may consult the self-hosted variable. Everything else runs
+GitHub-hosted**: every `pull_request` of any origin, and every non-main ref
+(branch push, tag push, branch dispatch). The reason is structural, not about
+who triggered the run: non-main runs execute **that ref's workflow
+definitions**, so any PR or branch can mutate a workflow file (including
+`runs-on` itself) — and the runner group is pinned to workflows@main, which
+would deny non-main jobs anyway (a queue deadlock, not a safety event, but
+still wrong). loregui is a public repository; unreviewed code never reaches
+studio infrastructure. No exceptions, no overrides.
 
 Tooling note: the truth-table validator depends on `@actions/expressions`
 (MIT, GitHub's own expression engine), pinned by `.github/scripts/package-lock.json`.
@@ -22,16 +27,18 @@ does not belong in the THIRD-PARTY-LICENSES bundles, whose scope is shipped code
 Every migrated job selects its runner with this expression:
 
 ```yaml
-runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+runs-on: ${{ (github.event_name == 'pull_request' || github.ref != 'refs/heads/main') && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
 ```
 
 This block is drift-checked: the static truth-table validator fails CI if it
 ever differs from the expression in the workflows.
 
-- **Fork-PR events** (head repo ≠ this repo) → `ubuntu-latest`, unconditionally.
-- **Trusted events** (push, same-repo PR, schedule, workflow_dispatch) → the
-  JSON label array in the repo variable `LOREGUI_LINUX_RUNNER`; if the variable
-  is unset, the hosted default `["ubuntu-latest"]`.
+- **Any `pull_request` event, or any non-main ref** (branch push, tag,
+  branch dispatch) → `ubuntu-latest`, unconditionally (see The rule).
+- **Canonical-main events** (push/schedule/workflow_dispatch on
+  `refs/heads/main`) → the JSON label array in the repo variable
+  `LOREGUI_LINUX_RUNNER`; if the variable is unset, the hosted default
+  `["ubuntu-latest"]`.
 
 **Failover is a variable flip, not a commit:** set `LOREGUI_LINUX_RUNNER` to
 `["ubuntu-latest"]` (or delete it) and every migrated workflow is back on
@@ -44,22 +51,27 @@ if an untrusted PR context (fork or Dependabot) ever resolves to self-hosted.
 
 ## Fork-safety: defense in depth (four layers)
 
-1. The `runs-on` expression above (workflow level) — fork PRs → hosted, always.
-   Proven two ways: the live preflight assertion, and the static truth table
+1. The `runs-on` expression above (workflow level) — every `pull_request`
+   and every non-main ref → hosted, always. Proven two ways: the live
+   preflight assertion, and the static truth table
    (`.github/scripts/runner-policy-truth-table.mjs`) which evaluates the real,
    drift-checked expression with GitHub's own expression engine across every
-   event/variable combination — fork rows included.
-2. A **dedicated org runner group for this repository alone**. GitHub blocks
-   public repositories from runner groups unless the group opts in, so the
-   group must set `allows_public_repositories=true` — which is exactly why it
-   must contain **only loregui** (selected-repositories) and, where the org
-   plan supports it, be restricted to **selected workflows** pinned to this
-   repo's workflow files. The group is never a shared pool: opting a shared
-   group into public repos would expose every repo's runners. Containment for
-   fork code itself is layers 1, 3, and 4 — the group scoping bounds the blast
-   radius to runners this repo was explicitly granted. **Live**: group
-   `loregui-public` (id 7) exists with exactly this shape — verified on the
-   org API by infra, 2026-07-21.
+   event/ref/variable combination — fork, Dependabot, same-repo PR, branch
+   push, tag, and branch-dispatch rows all asserted hosted.
+2. A **dedicated org runner group for this repository alone**, with
+   **selected-workflows restriction pinned to this repo's workflows at
+   `refs/heads/main`** — this is REQUIRED, not optional (lead security
+   ruling): it makes a workflow-mutation attack inert at the group level,
+   because a PR-ref workflow that hardcodes self-hosted labels is not on the
+   group's allowlist and cannot acquire its runners. GitHub blocks public
+   repositories from runner groups unless the group opts in
+   (`allows_public_repositories=true`) — which is exactly why the group must
+   contain **only loregui** and is never a shared pool. **Live**: group
+   `loregui-public` (id 7) exists (org-API-verified 2026-07-21); the
+   main-pinned workflow restriction and the **ephemeral-runner conversion**
+   (residual-risk control: each job gets a fresh runner instance, so nothing
+   persists across jobs) are being applied by infra and are drill
+   prerequisites.
 3. Repo setting **“require approval for all outside collaborators”** for fork
    PR workflows — **set and verified by the lead (2026-07-21,
    `all_external_contributors`)**; `GITHUB_TOKEN` stays read-only for fork PRs.
@@ -80,13 +92,22 @@ if an untrusted PR context (fork or Dependabot) ever resolves to self-hosted.
 1. T1 lands with the **hosted default** — behavior is unchanged until the flip.
 2. Infra provisions the dedicated group + runners (done: `loregui-public` id 7,
    `actions-linux-5/6` on vm3) and confirms build toolchain on both runners.
-3. **Failover drill** (required before relying on self-hosted): set
+3. **Seeded-violation proof** (gated on infra completing the main-pinned
+   workflow restriction + ephemeral conversion, and on security sign-off;
+   planned, not yet launched): a real fork PR edits a workflow's `runs-on` to
+   hardcode the self-hosted labels. Expected: the mutated PR-ref workflow is
+   not on group 7's main-pinned allowlist and **cannot acquire its runners**
+   (queues indefinitely / fails), the unmutated workflows run hosted, and the
+   org audit shows zero job assignments to actions-linux-5/6 from the PR.
+   Rollback: close the PR — the variable is never involved.
+4. **Failover drill** (required before relying on self-hosted): set
    `LOREGUI_LINUX_RUNNER='["self-hosted","linux","proxmox"]'`, dispatch a light
-   workflow and confirm it lands on actions-linux-5/6; drain one runner
-   mid-queue and confirm the other picks up; flip the variable back to hosted
-   and confirm green on GitHub-hosted; then unset until the lead signs off.
-4. Decommission/rollback: remove the runner from the org + destroy CT158/159 on
+   **main-ref** workflow (workflow_dispatch) and confirm it lands on
+   actions-linux-5/6; drain one runner mid-queue and confirm the other picks
+   up; flip the variable back to hosted and confirm green on GitHub-hosted;
+   then unset until the lead signs off.
+5. Decommission/rollback: remove the runner from the org + destroy CT158/159 on
    vm3; deleting group 7 rolls membership back to Default. The variable flip is
    always the fastest escape hatch.
-5. Each subsequent tier repeats this pattern with its own variable
+6. Each subsequent tier repeats this pattern with its own variable
    (`LOREGUI_WINDOWS_RUNNER`, `LOREGUI_MACOS_RUNNER`) and its own drill.

--- a/docs/RUNNERS_V1.md
+++ b/docs/RUNNERS_V1.md
@@ -1,0 +1,62 @@
+# RUNNERS_V1 — CI runner policy (self-hosted-first, Actions failover)
+
+Versioned policy. Changes ship as `RUNNERS_V2`, never as silent edits.
+Tracking: SBAI-5460 (T1). Adopted by lorecrew lead ruling, 2026-07-21.
+
+## The rule
+
+CI runs **self-hosted-first** with GitHub-hosted Actions as failover — except
+that **workflow runs triggered by fork pull requests always run GitHub-hosted**.
+loregui is a public repository; fork PRs execute untrusted code, and untrusted
+code never reaches studio infrastructure. No exceptions, no overrides.
+
+## Mechanism
+
+Every migrated job selects its runner with this expression:
+
+```yaml
+runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+```
+
+- **Fork-PR events** (head repo ≠ this repo) → `ubuntu-latest`, unconditionally.
+- **Trusted events** (push, same-repo PR, schedule, workflow_dispatch) → the
+  JSON label array in the repo variable `LOREGUI_LINUX_RUNNER`; if the variable
+  is unset, the hosted default `["ubuntu-latest"]`.
+
+**Failover is a variable flip, not a commit:** set `LOREGUI_LINUX_RUNNER` to
+`["ubuntu-latest"]` (or delete it) and every migrated workflow is back on
+GitHub-hosted immediately. Restore `["self-hosted","linux","proxmox"]` to
+return. Variable changes are audit-logged by GitHub.
+
+`.github/workflows/runner-policy-preflight.yml` evaluates the same expression
+on every PR and push, prints the event-context truth table, and fails the run
+if a fork-PR context ever resolves to self-hosted.
+
+## Fork-safety: defense in depth (four layers)
+
+1. The `runs-on` expression above (workflow level) — fork PRs → hosted, always.
+2. Org runner group keeps **“allow public repositories” OFF**; loregui uses the
+   group only for trusted-event runs (org-admin action, applied by infra).
+3. Repo setting **“require approval for all outside collaborators”** for fork
+   PR workflows; `GITHUB_TOKEN` stays read-only for fork PRs (repo-admin action).
+4. Never `pull_request_target` with a checkout of the fork head — and never on
+   self-hosted. This combination is the canonical RCE and is banned outright.
+
+## Tiers and current state
+
+| Tier | Scope | Target labels | State |
+|------|-------|---------------|-------|
+| T1 | Linux plain: auto-release, boundary-guard, ci, frontend-test, integration, licenses, remote-qa, upstream-parity, vscode-test | `["self-hosted","linux","proxmox"]` (CT145–148, pve1) | Mechanism landed; variable stays at hosted default until org runner-group admission is confirmed by infra |
+| T2 | Linux GUI/Tauri: tauri-e2e, build-crossplatform (linux), release (linux) | same as T1 (Tauri v2 deps verified on all four runners) | Pending T1; stagger matrix concurrency — runners are shared with model-manager CI |
+| T3 | Windows: windows-build, release (win), publish-vscode (win32) | `["self-hosted","Windows","X64"]` (bx-w11-build01) | Pending; single runner → serialized. Never use the retired `Windows, proxmox` label (dead VM150) |
+| T4 | macOS: release, build-crossplatform, publish-vscode (darwin) | TBD | Last; blocked on macOS runner health + signing keychain (macOS was deliberately moved off self-hosted before — see release.yml header). GitHub-hosted remains the supported path until proven |
+
+## Rollout / operations
+
+1. T1 lands with the **hosted default** — behavior is unchanged until the flip.
+2. Infra confirms org runner-group admission for this repo (group policy: public
+   repos OFF), then sets `LOREGUI_LINUX_RUNNER='["self-hosted","linux","proxmox"]'`.
+3. Failover drill (required before relying on self-hosted): drain or stop a
+   runner, flip the variable back to hosted, re-run a workflow, confirm green.
+4. Each subsequent tier repeats this pattern with its own variable
+   (`LOREGUI_WINDOWS_RUNNER`, `LOREGUI_MACOS_RUNNER`) and its own drill.

--- a/docs/RUNNERS_V1.md
+++ b/docs/RUNNERS_V1.md
@@ -22,8 +22,11 @@ does not belong in the THIRD-PARTY-LICENSES bundles, whose scope is shipped code
 Every migrated job selects its runner with this expression:
 
 ```yaml
-runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
+runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '["ubuntu-latest"]') }}
 ```
+
+This block is drift-checked: the static truth-table validator fails CI if it
+ever differs from the expression in the workflows.
 
 - **Fork-PR events** (head repo ≠ this repo) → `ubuntu-latest`, unconditionally.
 - **Trusted events** (push, same-repo PR, schedule, workflow_dispatch) → the
@@ -37,7 +40,7 @@ return. Variable changes are audit-logged by GitHub.
 
 `.github/workflows/runner-policy-preflight.yml` evaluates the same expression
 on every PR and push, prints the event-context truth table, and fails the run
-if a fork-PR context ever resolves to self-hosted.
+if an untrusted PR context (fork or Dependabot) ever resolves to self-hosted.
 
 ## Fork-safety: defense in depth (four layers)
 
@@ -54,8 +57,9 @@ if a fork-PR context ever resolves to self-hosted.
    repo's workflow files. The group is never a shared pool: opting a shared
    group into public repos would expose every repo's runners. Containment for
    fork code itself is layers 1, 3, and 4 — the group scoping bounds the blast
-   radius to runners this repo was explicitly granted. Live org-admin state
-   and group creation: infra (brain-chat), pending admin credential unlock.
+   radius to runners this repo was explicitly granted. **Live**: group
+   `loregui-public` (id 7) exists with exactly this shape — verified on the
+   org API by infra, 2026-07-21.
 3. Repo setting **“require approval for all outside collaborators”** for fork
    PR workflows — **set and verified by the lead (2026-07-21,
    `all_external_contributors`)**; `GITHUB_TOKEN` stays read-only for fork PRs.
@@ -66,8 +70,8 @@ if a fork-PR context ever resolves to self-hosted.
 
 | Tier | Scope | Target labels | State |
 |------|-------|---------------|-------|
-| T1 | Linux plain: auto-release, boundary-guard, ci, frontend-test, integration, licenses, remote-qa, upstream-parity, vscode-test | `["self-hosted","linux","proxmox"]` — matches the two **dedicated loregui runners `actions-linux-5` (id 32) and `actions-linux-6` (id 33)**, labels `[self-hosted, Linux, X64, proxmox, vm3]`, in org runner group **`loregui-public` (id 7)**: `allows_public_repositories=true`, visibility=selected → this repo only. Hosts: CT158/159 on **vm3** (16 vCPU / 32G each) — additive capacity per owner directive, deliberately OFF the CPU-saturated pve1; the earlier 2/2-split plan is superseded and model-manager's four pve1 runners are untouched | Mechanism landed; runners live and group verified on the org API (lorecrew record 2026-07-21). Variable stays UNSET (hosted default) until the Tauri toolchain install completes on both CTs, the failover drill passes, and the lead signs off. The extra `vm3` label lets the drill drain a specific runner |
-| T2 | Linux GUI/Tauri: tauri-e2e, build-crossplatform (linux), release (linux) | same as T1 (Tauri v2 deps verified on all four runners) | Pending T1; stagger matrix concurrency — runners are shared with model-manager CI |
+| T1 | Linux plain: auto-release, boundary-guard, ci, frontend-test, integration, licenses, remote-qa, upstream-parity, vscode-test | `["self-hosted","linux","proxmox"]` — matches the two **dedicated loregui runners `actions-linux-5` (id 32) and `actions-linux-6` (id 33)**, labels `[self-hosted, Linux, X64, proxmox, vm3]`, in org runner group **`loregui-public` (id 7)**: `allows_public_repositories=true`, visibility=selected → this repo only. Hosts: CT158/159 on **vm3** (16 vCPU / 32G each) — additive capacity per owner directive, deliberately OFF the CPU-saturated pve1; the earlier 2/2-split plan is superseded and model-manager's four pve1 runners are untouched | Mechanism landed; runners live and group verified on the org API (lorecrew record 2026-07-21). Toolchain verified on both runners (full Tauri v2 set + rust/node/cmake/protoc — infra record 2026-07-21). Variable stays UNSET (hosted default) until the failover drill passes and the lead signs off. Both runners carry the `vm3` label, so it does not isolate one — draining a single runner means stopping that named runner's service on its CT |
+| T2 | Linux GUI/Tauri: tauri-e2e, build-crossplatform (linux), release (linux) | same as T1 (dedicated runners) | Pending T1. Toolchain proof on actions-linux-5/6 specifically is delivered (webkit2gtk-4.1 + gtk3 + xvfb + full Tauri v2 dep set + rust/node/cmake/protoc — infra record 2026-07-21), so T2 is dep-ready on the dedicated runners. NOT shared with model-manager; stagger only against each other (two runners) |
 | T3 | Windows: windows-build, release (win), publish-vscode (win32) | `["self-hosted","Windows","X64"]` (bx-w11-build01) | Pending; single runner → serialized. Never use the retired `Windows, proxmox` label (dead VM150) |
 | T4 | macOS: release, build-crossplatform, publish-vscode (darwin) | TBD | Last; blocked on macOS runner health + signing keychain (macOS was deliberately moved off self-hosted before — see release.yml header). GitHub-hosted remains the supported path until proven |
 

--- a/docs/RUNNERS_V1.md
+++ b/docs/RUNNERS_V1.md
@@ -6,9 +6,16 @@ Tracking: SBAI-5460 (T1). Adopted by lorecrew lead ruling, 2026-07-21.
 ## The rule
 
 CI runs **self-hosted-first** with GitHub-hosted Actions as failover — except
-that **workflow runs triggered by fork pull requests always run GitHub-hosted**.
-loregui is a public repository; fork PRs execute untrusted code, and untrusted
-code never reaches studio infrastructure. No exceptions, no overrides.
+that **untrusted pull-request runs always run GitHub-hosted**: fork PRs
+(attacker-controlled code) and Dependabot PRs (same head repo, but GitHub runs
+them with fork-like trust and they execute freshly-updated dependency code).
+loregui is a public repository; untrusted code never reaches studio
+infrastructure. No exceptions, no overrides.
+
+Tooling note: the truth-table validator depends on `@actions/expressions`
+(MIT, GitHub's own expression engine), pinned by `.github/scripts/package-lock.json`.
+It is CI-only tooling — it is not part of the distributed LoreGUI binary, so it
+does not belong in the THIRD-PARTY-LICENSES bundles, whose scope is shipped code.
 
 ## Mechanism
 
@@ -59,7 +66,7 @@ if a fork-PR context ever resolves to self-hosted.
 
 | Tier | Scope | Target labels | State |
 |------|-------|---------------|-------|
-| T1 | Linux plain: auto-release, boundary-guard, ci, frontend-test, integration, licenses, remote-qa, upstream-parity, vscode-test | `["self-hosted","linux","proxmox"]` (CT145–148, pve1; all four verified Tauri-v2-ready by infra — webkit2gtk-4.1 + gtk3 + xvfb, lorecrew board record 2026-07-21) | Mechanism landed; variable stays UNSET (hosted default) until the dedicated runner group exists, fork-safety proof and failover drill pass, and the lead signs off |
+| T1 | Linux plain: auto-release, boundary-guard, ci, frontend-test, integration, licenses, remote-qa, upstream-parity, vscode-test | `["self-hosted","linux","proxmox"]` — dedicated group gets **CT147/148** (2/2 split with model-manager per infra capacity call: pve1 is CPU-saturated, so runners are repartitioned, never added there; all four CT145–148 verified Tauri-v2-ready — lorecrew board record 2026-07-21) | Mechanism landed; variable stays UNSET (hosted default) until the dedicated runner group exists, fork-safety proof and failover drill pass, and the lead signs off. Two runners ⇒ cap/stagger matrices and avoid overlapping model-manager release builds; durable contention fix is runners on a different host |
 | T2 | Linux GUI/Tauri: tauri-e2e, build-crossplatform (linux), release (linux) | same as T1 (Tauri v2 deps verified on all four runners) | Pending T1; stagger matrix concurrency — runners are shared with model-manager CI |
 | T3 | Windows: windows-build, release (win), publish-vscode (win32) | `["self-hosted","Windows","X64"]` (bx-w11-build01) | Pending; single runner → serialized. Never use the retired `Windows, proxmox` label (dead VM150) |
 | T4 | macOS: release, build-crossplatform, publish-vscode (darwin) | TBD | Last; blocked on macOS runner health + signing keychain (macOS was deliberately moved off self-hosted before — see release.yml header). GitHub-hosted remains the supported path until proven |


### PR DESCRIPTION
## Summary
Tier 1 of **RUNNERS_V1** (policy adopted by lead ruling on the lorecrew board, 2026-07-21): the nine Linux-plain workflows (12 jobs) select their runner via an expression instead of a hardcoded `ubuntu-latest`:

- **Fork-PR events → GitHub-hosted, unconditionally.** loregui is a public repo; fork code never reaches self-hosted runners.
- **Trusted events** (push / same-repo PR / schedule / dispatch) resolve from the repo variable `LOREGUI_LINUX_RUNNER`, **defaulting to `["ubuntu-latest"]` when unset — behavior is unchanged by this PR** until ops flips the variable to `["self-hosted","linux","proxmox"]` after runner-group admission is confirmed.
- **Failover = flip the variable back. Zero commits**, audit-logged by GitHub.

New `runner-policy-preflight.yml` evaluates the **identical expression** on every PR/push, prints the event-context truth table, and hard-fails if a fork-PR context ever resolves to self-hosted. Policy + tiers + rollout drill recorded as versioned `docs/RUNNERS_V1.md`.

Migrated: auto-release, boundary-guard, ci (×2 jobs), frontend-test, integration, licenses, remote-qa, upstream-parity (×2), vscode-test (×2). Out of scope here: tauri-e2e/build-crossplatform (T2), Windows (T3, label `[self-hosted, Windows, X64]` — the proxmox Windows label is retired), macOS (T4, last).

## Merge gates (per lead ruling — DO NOT MERGE until sb-lore signs off)
- [ ] Lead review (load-bearing CI policy)
- [ ] Preflight truth-table evidence on this PR (same-repo PR context → hosted default, fork gate asserted)
- [ ] Demonstrated hosted failover (variable flip drill — doc §Rollout)
- [ ] Repo setting "require approval for ALL outside collaborators" flipped by a repo admin (parallel track)

## Verification
- All 15 workflow files parse (yaml.safe_load clean).
- This PR's own CI run exercises the new expression in the same-repo PR context: every migrated job must still run on `ubuntu-latest` (hosted default, variable unset).

SBAI-5460

🤖 Generated with [Claude Code](https://claude.com/claude-code)