### PR TITLE
SBAI-5465: preserve typed authless/connection semantics before next pin

### DIFF
--- a/crates/lore-vm/examples/live_server_client.rs
+++ b/crates/lore-vm/examples/live_server_client.rs
@@ -71,11 +71,16 @@ async fn run(repo_url: &str, dir_a: &Path, dir_b: &Path) -> Result<(), String> {
         Err(lore_vm::error::LoreError::CommandFailed(message))
             if message == "No authentication configured on server" =>
         {
-            println!("[auth] verified exact no-auth server response");
+            println!("[auth] verified exact no-auth server response (v0.8.5 legacy)");
+        }
+        Err(lore_vm::error::LoreError::CommandFailed(message))
+            if message == "Operation not supported" =>
+        {
+            println!("[auth] verified exact no-auth server response (nightly f20ef0d7d+, NotSupported code 18)");
         }
         other => {
             return Err(format!(
-                "auth compatibility probe returned {other:?}, expected exact no-auth response"
+                "auth compatibility probe returned {other:?}, expected exact no-auth response (v0.8.5 or nightly)"
             ));
         }
     }

--- a/crates/lore-vm/examples/live_server_client.rs
+++ b/crates/lore-vm/examples/live_server_client.rs
@@ -74,7 +74,7 @@ async fn run(repo_url: &str, dir_a: &Path, dir_b: &Path) -> Result<(), String> {
             println!("[auth] verified exact no-auth server response (v0.8.5 legacy)");
         }
         Err(lore_vm::error::LoreError::CommandFailed(message))
-            if message == "Operation not supported" =>
+            if message == "Operation not supported: No authentication configured on server" =>
         {
             println!("[auth] verified exact no-auth server response (nightly f20ef0d7d+, NotSupported code 18)");
         }

--- a/frontend/src/AccountPanel.spec.tsx
+++ b/frontend/src/AccountPanel.spec.tsx
@@ -27,7 +27,7 @@ beforeEach(() => {
 });
 
 describe("auth-disabled connection from the account panel (#404)", () => {
-  it("shows a successful no-auth connection instead of the raw command error", async () => {
+  it("shows a successful no-auth connection for v0.8.5 legacy error", async () => {
     routeCommands({
       kind: "CommandFailed",
       message: "No authentication configured on server",
@@ -48,5 +48,48 @@ describe("auth-disabled connection from the account panel (#404)", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText(/CommandFailed/)).toBeNull();
     expect(screen.queryByText(/No authentication configured/)).toBeNull();
+  });
+
+  it("shows a successful no-auth connection for nightly (f20ef0d7d+) NotSupported code 18", async () => {
+    routeCommands({
+      kind: "CommandFailed",
+      message: "Operation not supported",
+    });
+
+    render(<AccountPanel onClose={vi.fn()} />);
+    await screen.findByText(/Not signed in/);
+
+    fireEvent.change(screen.getByLabelText("Server URL"), {
+      target: { value: "lore://192.0.2.10/repo" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    });
+
+    expect(
+      screen.getByText("Connected without authentication"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/CommandFailed/)).toBeNull();
+  });
+
+  it("rejects near-miss NotSupported messages with qualifiers", async () => {
+    routeCommands({
+      kind: "CommandFailed",
+      message: "Operation not supported: disk full",
+    });
+
+    render(<AccountPanel onClose={vi.fn()} />);
+    await screen.findByText(/Not signed in/);
+
+    fireEvent.change(screen.getByLabelText("Server URL"), {
+      target: { value: "lore://192.0.2.10/repo" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    });
+
+    // Should show the error, NOT the "Connected without authentication" success
+    expect(screen.queryByText("Connected without authentication")).toBeNull();
+    expect(screen.queryByText(/disk full/)).not.toBeNull();
   });
 });

--- a/frontend/src/AccountPanel.spec.tsx
+++ b/frontend/src/AccountPanel.spec.tsx
@@ -53,7 +53,8 @@ describe("auth-disabled connection from the account panel (#404)", () => {
   it("shows a successful no-auth connection for nightly (f20ef0d7d+) NotSupported code 18", async () => {
     routeCommands({
       kind: "CommandFailed",
-      message: "Operation not supported",
+      message:
+        "Operation not supported: No authentication configured on server",
     });
 
     render(<AccountPanel onClose={vi.fn()} />);
@@ -91,5 +92,25 @@ describe("auth-disabled connection from the account panel (#404)", () => {
     // Should show the error, NOT the "Connected without authentication" success
     expect(screen.queryByText("Connected without authentication")).toBeNull();
     expect(screen.queryByText(/disk full/)).not.toBeNull();
+  });
+
+  it("rejects the bare NotSupported prefix without the auth operation", async () => {
+    routeCommands({
+      kind: "CommandFailed",
+      message: "Operation not supported",
+    });
+
+    render(<AccountPanel onClose={vi.fn()} />);
+    await screen.findByText(/Not signed in/);
+
+    fireEvent.change(screen.getByLabelText("Server URL"), {
+      target: { value: "lore://192.0.2.10/repo" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    });
+
+    expect(screen.queryByText("Connected without authentication")).toBeNull();
+    expect(screen.queryByText(/Operation not supported/)).not.toBeNull();
   });
 });

--- a/frontend/src/api.spec.ts
+++ b/frontend/src/api.spec.ts
@@ -32,6 +32,8 @@ import {
   workingFileApi,
   desktopSettingsApi,
   isNoAuthConfigured,
+  OPERATION_NOT_SUPPORTED,
+  NO_AUTH_CONFIGURED,
 } from "./api";
 
 /** The (name, args) pair passed to the most recent invoke call. */
@@ -94,13 +96,35 @@ describe("core repo-loop wrappers", () => {
 });
 
 describe("auth + onboarding wrappers", () => {
-  it("recognizes only Epic Lore's exact auth-disabled error contract", () => {
+  it("recognizes v0.8.5 auth-disabled error contract", () => {
     const message = "No authentication configured on server";
     expect(isNoAuthConfigured(message)).toBe(true);
     expect(isNoAuthConfigured(new Error(message))).toBe(true);
     expect(isNoAuthConfigured({ kind: "CommandFailed", message })).toBe(true);
     expect(isNoAuthConfigured({ message: `${message}.` })).toBe(false);
     expect(isNoAuthConfigured({ kind: "CommandFailed" })).toBe(false);
+  });
+
+  it("recognizes nightly (f20ef0d7d+) NotSupported code 18 authless signal", () => {
+    const message = "Operation not supported";
+    expect(isNoAuthConfigured(message)).toBe(true);
+    expect(isNoAuthConfigured(new Error(message))).toBe(true);
+    expect(isNoAuthConfigured({ kind: "CommandFailed", message })).toBe(true);
+  });
+
+  it("does NOT broadly swallow other NotSupported messages", () => {
+    // Near-miss: a legitimate NotSupported error with a qualifier should NOT match
+    expect(isNoAuthConfigured("Operation not supported: disk full")).toBe(false);
+    expect(isNoAuthConfigured("Operation not supported on this platform")).toBe(false);
+    expect(isNoAuthConfigured(new Error("Operation not supported: read-only filesystem"))).toBe(false);
+    // Suffix/prefix variants should NOT match
+    expect(isNoAuthConfigured({ kind: "CommandFailed", message: "Operation not supported." })).toBe(false);
+    expect(isNoAuthConfigured({ kind: "NotSupported", message: "Operation not supported" })).toBe(true); // exact match still accepted regardless of kind
+  });
+
+  it("exports the canonical constants for external use", () => {
+    expect(NO_AUTH_CONFIGURED).toBe("No authentication configured on server");
+    expect(OPERATION_NOT_SUPPORTED).toBe("Operation not supported");
   });
 
   it("authLoginWithToken maps remoteUrl + token", () => {

--- a/frontend/src/api.spec.ts
+++ b/frontend/src/api.spec.ts
@@ -106,25 +106,35 @@ describe("auth + onboarding wrappers", () => {
   });
 
   it("recognizes nightly (f20ef0d7d+) NotSupported code 18 authless signal", () => {
-    const message = "Operation not supported";
+    const message =
+      "Operation not supported: No authentication configured on server";
     expect(isNoAuthConfigured(message)).toBe(true);
     expect(isNoAuthConfigured(new Error(message))).toBe(true);
     expect(isNoAuthConfigured({ kind: "CommandFailed", message })).toBe(true);
   });
 
   it("does NOT broadly swallow other NotSupported messages", () => {
+    expect(isNoAuthConfigured("Operation not supported")).toBe(false);
     // Near-miss: a legitimate NotSupported error with a qualifier should NOT match
     expect(isNoAuthConfigured("Operation not supported: disk full")).toBe(false);
     expect(isNoAuthConfigured("Operation not supported on this platform")).toBe(false);
     expect(isNoAuthConfigured(new Error("Operation not supported: read-only filesystem"))).toBe(false);
     // Suffix/prefix variants should NOT match
     expect(isNoAuthConfigured({ kind: "CommandFailed", message: "Operation not supported." })).toBe(false);
-    expect(isNoAuthConfigured({ kind: "NotSupported", message: "Operation not supported" })).toBe(true); // exact match still accepted regardless of kind
+    expect(
+      isNoAuthConfigured({
+        kind: "NotSupported",
+        message:
+          "Operation not supported: No authentication configured on server",
+      }),
+    ).toBe(true); // exact match still accepted regardless of kind
   });
 
   it("exports the canonical constants for external use", () => {
     expect(NO_AUTH_CONFIGURED).toBe("No authentication configured on server");
-    expect(OPERATION_NOT_SUPPORTED).toBe("Operation not supported");
+    expect(OPERATION_NOT_SUPPORTED).toBe(
+      "Operation not supported: No authentication configured on server",
+    );
   });
 
   it("authLoginWithToken maps remoteUrl + token", () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -68,19 +68,39 @@ export interface UserInfo {
 }
 
 /**
- * Epic Lore currently reports a reachable auth-disabled server as a failed
- * login with this exact message. Keep the compatibility contract centralized
- * so every connection surface makes the same narrow decision.
+ * Epic Lore reports a reachable auth-disabled server as a failed login with
+ * one of these exact messages. Keep the compatibility contract centralized so
+ * every connection surface makes the same narrow decision.
+ *
+ * - v0.8.5 (pinned): "No authentication configured on server"
+ * - f20ef0d7d+ (nightly, NotSupported code 18): "Operation not supported"
  */
 export const NO_AUTH_CONFIGURED = "No authentication configured on server";
 
+/**
+ * Nightly (f20ef0d7d+) authless signal — typed NotSupported code 18 rendered
+ * as this exact error text. Must NOT broadly swallow other NotSupported failures
+ * (e.g. "Operation not supported: disk full"); only the exact bare message
+ * indicates authless-server compatibility.
+ */
+export const OPERATION_NOT_SUPPORTED = "Operation not supported";
+
+/** Returns true if the error indicates a reachable server with auth disabled.
+ *  Accepts BOTH the legacy v0.8.5 text and the nightly "Operation not supported"
+ *  text (Epic Lore NotSupported code 18). */
 export function isNoAuthConfigured(error: unknown): boolean {
-  if (error === NO_AUTH_CONFIGURED) return true;
-  if (error instanceof Error) return error.message === NO_AUTH_CONFIGURED;
+  if (error === NO_AUTH_CONFIGURED || error === OPERATION_NOT_SUPPORTED) return true;
+  if (error instanceof Error) {
+    return (
+      error.message === NO_AUTH_CONFIGURED ||
+      error.message === OPERATION_NOT_SUPPORTED
+    );
+  }
   if (typeof error !== "object" || error === null || !("message" in error)) {
     return false;
   }
-  return (error as { message?: unknown }).message === NO_AUTH_CONFIGURED;
+  const msg = (error as { message?: unknown }).message;
+  return msg === NO_AUTH_CONFIGURED || msg === OPERATION_NOT_SUPPORTED;
 }
 
 export interface ServiceStopResult {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -73,21 +73,23 @@ export interface UserInfo {
  * every connection surface makes the same narrow decision.
  *
  * - v0.8.5 (pinned): "No authentication configured on server"
- * - f20ef0d7d+ (nightly, NotSupported code 18): "Operation not supported"
+ * - f20ef0d7d+ (nightly, NotSupported code 18):
+ *   "Operation not supported: No authentication configured on server"
  */
 export const NO_AUTH_CONFIGURED = "No authentication configured on server";
 
 /**
  * Nightly (f20ef0d7d+) authless signal — typed NotSupported code 18 rendered
  * as this exact error text. Must NOT broadly swallow other NotSupported failures
- * (e.g. "Operation not supported: disk full"); only the exact bare message
- * indicates authless-server compatibility.
+ * (e.g. "Operation not supported: disk full"); only the exact auth operation
+ * message indicates authless-server compatibility.
  */
-export const OPERATION_NOT_SUPPORTED = "Operation not supported";
+export const OPERATION_NOT_SUPPORTED =
+  "Operation not supported: No authentication configured on server";
 
 /** Returns true if the error indicates a reachable server with auth disabled.
- *  Accepts BOTH the legacy v0.8.5 text and the nightly "Operation not supported"
- *  text (Epic Lore NotSupported code 18). */
+ *  Accepts BOTH the legacy v0.8.5 text and the nightly typed NotSupported
+ *  message (Epic Lore code 18). */
 export function isNoAuthConfigured(error: unknown): boolean {
   if (error === NO_AUTH_CONFIGURED || error === OPERATION_NOT_SUPPORTED) return true;
   if (error instanceof Error) {

--- a/frontend/src/onboarding/ClientConnect.spec.tsx
+++ b/frontend/src/onboarding/ClientConnect.spec.tsx
@@ -56,7 +56,8 @@ describe("auth-disabled server connection (#404)", () => {
   it("accepts the nightly (f20ef0d7d+) NotSupported code 18 authless signal", async () => {
     routeAuthFailure({
       kind: "CommandFailed",
-      message: "Operation not supported",
+      message:
+        "Operation not supported: No authentication configured on server",
     });
 
     await connect();
@@ -84,6 +85,18 @@ describe("auth-disabled server connection (#404)", () => {
     routeAuthFailure({
       kind: "CommandFailed",
       message: "Operation not supported: disk full",
+    });
+
+    await connect();
+
+    expect(await screen.findByRole("button", { name: "Retry" })).toBeInTheDocument();
+    expect(screen.queryByText("Connected without authentication")).toBeNull();
+  });
+
+  it("rejects the bare NotSupported prefix without the auth operation", async () => {
+    routeAuthFailure({
+      kind: "CommandFailed",
+      message: "Operation not supported",
     });
 
     await connect();

--- a/frontend/src/onboarding/ClientConnect.spec.tsx
+++ b/frontend/src/onboarding/ClientConnect.spec.tsx
@@ -38,10 +38,25 @@ beforeEach(() => {
 });
 
 describe("auth-disabled server connection (#404)", () => {
-  it("accepts a reachable server that explicitly has no authentication configured", async () => {
+  it("accepts a reachable server that explicitly has no authentication configured (v0.8.5)", async () => {
     routeAuthFailure({
       kind: "CommandFailed",
       message: "No authentication configured on server",
+    });
+
+    await connect();
+
+    expect(
+      await screen.findByText("Connected without authentication"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    expect(screen.queryByText(/CommandFailed/)).toBeNull();
+  });
+
+  it("accepts the nightly (f20ef0d7d+) NotSupported code 18 authless signal", async () => {
+    routeAuthFailure({
+      kind: "CommandFailed",
+      message: "Operation not supported",
     });
 
     await connect();
@@ -57,6 +72,18 @@ describe("auth-disabled server connection (#404)", () => {
     routeAuthFailure({
       kind: "CommandFailed",
       message: "Server refused the connection",
+    });
+
+    await connect();
+
+    expect(await screen.findByRole("button", { name: "Retry" })).toBeInTheDocument();
+    expect(screen.queryByText("Connected without authentication")).toBeNull();
+  });
+
+  it("rejects near-miss NotSupported messages with qualifiers", async () => {
+    routeAuthFailure({
+      kind: "CommandFailed",
+      message: "Operation not supported: disk full",
     });
 
     await connect();


### PR DESCRIPTION
Resolves SBAI-5465

## Summary
Forward-compatibility layer for LoreGUI to accept BOTH the current v0.8.5 authless error text and the nightly f20ef0d7d+ NotSupported code 18 signal, without broadly swallowing unrelated NotSupported failures. Production remains pinned to v0.8.5; this is pre-work for the next pin.

## Files Changed
- `frontend/src/api.ts` — Added `OPERATION_NOT_SUPPORTED` constant; extended `isNoAuthConfigured()` to accept both v0.8.5 legacy text and nightly NotSupported code 18 text (exact-match only)
- `frontend/src/api.spec.ts` — Split auth test into v0.8.5 + nightly; added 3 negative near-miss tests; added constant export test
- `frontend/src/onboarding/ClientConnect.spec.tsx` — Added test for nightly signal acceptance + near-miss rejection
- `frontend/src/AccountPanel.spec.tsx` — Added test for nightly signal acceptance + near-miss rejection
- `crates/lore-vm/examples/live_server_client.rs` — Extended auth compatibility probe to accept EITHER message and log which version matched

## Testing
- 127 tests passed across 15 test files (frontend)
- cargo check clean (lore-vm)
- All new tests cover both v0.8.5 legacy behavior and nightly f20ef0d7d+ behavior, plus near-miss negative cases

Generated with Qwen Code