### PR TITLE
SBAI-5478: Account panel neutral no-auth identity state

### DIFF
--- a/frontend/src/AccountPanel.spec.tsx
+++ b/frontend/src/AccountPanel.spec.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const invokeMock = vi.fn();
@@ -9,14 +9,31 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 import AccountPanel from "./AccountPanel";
 
-function routeCommands(authError: unknown) {
+/** Real EROS QA payload (SBAI-5478): identity loaders on auth-disabled server. */
+const NO_AUTH_ENDPOINT = {
+  kind: "CommandFailed",
+  message: "No auth endpoint available",
+} as const;
+
+function routeCommands(opts: {
+  loginError?: unknown;
+  userInfo?: unknown;
+  localInfo?: unknown;
+  userInfoError?: unknown;
+  localInfoError?: unknown;
+}) {
   invokeMock.mockImplementation((command: string) => {
-    if (command === "auth_user_info") return Promise.resolve(null);
+    if (command === "auth_user_info") {
+      if (opts.userInfoError !== undefined) return Promise.reject(opts.userInfoError);
+      return Promise.resolve(opts.userInfo ?? null);
+    }
     if (command === "auth_local_user_info") {
-      return Promise.resolve({ users: [], tokens: [] });
+      if (opts.localInfoError !== undefined) return Promise.reject(opts.localInfoError);
+      return Promise.resolve(opts.localInfo ?? { users: [], tokens: [] });
     }
     if (command === "auth_login_interactive") {
-      return Promise.reject(authError);
+      if (opts.loginError !== undefined) return Promise.reject(opts.loginError);
+      return Promise.resolve({ id: "u1", name: "User" });
     }
     return Promise.reject(new Error(`unexpected command ${command}`));
   });
@@ -29,8 +46,10 @@ beforeEach(() => {
 describe("auth-disabled connection from the account panel (#404)", () => {
   it("shows a successful no-auth connection for v0.8.5 legacy error", async () => {
     routeCommands({
-      kind: "CommandFailed",
-      message: "No authentication configured on server",
+      loginError: {
+        kind: "CommandFailed",
+        message: "No authentication configured on server",
+      },
     });
 
     render(<AccountPanel onClose={vi.fn()} />);
@@ -52,9 +71,11 @@ describe("auth-disabled connection from the account panel (#404)", () => {
 
   it("shows a successful no-auth connection for nightly (f20ef0d7d+) NotSupported code 18", async () => {
     routeCommands({
-      kind: "CommandFailed",
-      message:
-        "Operation not supported: No authentication configured on server",
+      loginError: {
+        kind: "CommandFailed",
+        message:
+          "Operation not supported: No authentication configured on server",
+      },
     });
 
     render(<AccountPanel onClose={vi.fn()} />);
@@ -75,8 +96,10 @@ describe("auth-disabled connection from the account panel (#404)", () => {
 
   it("rejects near-miss NotSupported messages with qualifiers", async () => {
     routeCommands({
-      kind: "CommandFailed",
-      message: "Operation not supported: disk full",
+      loginError: {
+        kind: "CommandFailed",
+        message: "Operation not supported: disk full",
+      },
     });
 
     render(<AccountPanel onClose={vi.fn()} />);
@@ -96,8 +119,10 @@ describe("auth-disabled connection from the account panel (#404)", () => {
 
   it("rejects the bare NotSupported prefix without the auth operation", async () => {
     routeCommands({
-      kind: "CommandFailed",
-      message: "Operation not supported",
+      loginError: {
+        kind: "CommandFailed",
+        message: "Operation not supported",
+      },
     });
 
     render(<AccountPanel onClose={vi.fn()} />);
@@ -112,5 +137,107 @@ describe("auth-disabled connection from the account panel (#404)", () => {
 
     expect(screen.queryByText("Connected without authentication")).toBeNull();
     expect(screen.queryByText(/Operation not supported/)).not.toBeNull();
+  });
+});
+
+/**
+ * SBAI-5478 — real EROS Account dialog after successful no-auth connect showed
+ * green Connect success while Signed in + This device rendered red raw
+ * CommandFailed JSON ("No auth endpoint available"). Identity loaders must
+ * treat no-auth signals as neutral empty states, not errors.
+ */
+describe("Account identity loaders on auth-disabled server (SBAI-5478)", () => {
+  it("on open, No auth endpoint available is neutral on both surfaces (not red JSON)", async () => {
+    routeCommands({
+      userInfoError: NO_AUTH_ENDPOINT,
+      localInfoError: NO_AUTH_ENDPOINT,
+    });
+
+    render(<AccountPanel onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Not signed in/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/No local identities on this device/)).toBeInTheDocument();
+    expect(screen.queryByText(/CommandFailed/)).toBeNull();
+    expect(screen.queryByText(/No auth endpoint available/)).toBeNull();
+    // No red inline error containers for identity sections.
+    expect(document.querySelectorAll(".storage-inline-error").length).toBe(0);
+  });
+
+  it("on open, legacy + nightly no-auth signals are neutral on both surfaces", async () => {
+    routeCommands({
+      userInfoError: {
+        kind: "CommandFailed",
+        message: "No authentication configured on server",
+      },
+      localInfoError: {
+        kind: "CommandFailed",
+        message:
+          "Operation not supported: No authentication configured on server",
+      },
+    });
+
+    render(<AccountPanel onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Not signed in/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/No local identities on this device/)).toBeInTheDocument();
+    expect(screen.queryByText(/CommandFailed/)).toBeNull();
+    expect(screen.queryByText(/No authentication configured/)).toBeNull();
+  });
+
+  it("successful no-auth connect keeps identity sections neutral (EROS contradiction)", async () => {
+    routeCommands({
+      userInfoError: NO_AUTH_ENDPOINT,
+      localInfoError: NO_AUTH_ENDPOINT,
+      loginError: {
+        kind: "CommandFailed",
+        message: "No authentication configured on server",
+      },
+    });
+
+    render(<AccountPanel onClose={vi.fn()} />);
+    await screen.findByText(/Not signed in/);
+
+    fireEvent.change(screen.getByLabelText("Server URL"), {
+      target: { value: "lore://10.15.1.167:41337/eros-noauth" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    });
+
+    expect(
+      screen.getByText("Connected without authentication"),
+    ).toBeInTheDocument();
+    // Both identity surfaces stay neutral — no red CommandFailed JSON.
+    expect(screen.getByText(/Not signed in/)).toBeInTheDocument();
+    expect(screen.getByText(/No local identities on this device/)).toBeInTheDocument();
+    expect(screen.queryByText(/CommandFailed/)).toBeNull();
+    expect(screen.queryByText(/No auth endpoint available/)).toBeNull();
+  });
+
+  it("unrelated identity loader errors remain fail-closed and visible", async () => {
+    routeCommands({
+      userInfoError: {
+        kind: "CommandFailed",
+        message: "network unreachable",
+      },
+      localInfoError: {
+        kind: "CommandFailed",
+        message: "disk I/O error",
+      },
+    });
+
+    render(<AccountPanel onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/network unreachable/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/disk I\/O error/)).toBeInTheDocument();
+    expect(screen.queryByText("Connected without authentication")).toBeNull();
+    // Unrelated failures must still surface as errors (not swallowed as no-auth).
+    expect(document.querySelectorAll(".storage-inline-error").length).toBe(2);
   });
 });

--- a/frontend/src/AccountPanel.tsx
+++ b/frontend/src/AccountPanel.tsx
@@ -4,6 +4,7 @@ import {
   api,
   authLocalUserInfoApi,
   isNoAuthConfigured,
+  isNoAuthIdentityUnavailable,
   type LocalUserInfo,
   type UserInfo,
 } from "./api";
@@ -64,7 +65,12 @@ export default function AccountPanel({ onClose }: { onClose: () => void }) {
       setRemoteUser(await api.authUserInfo());
     } catch (e) {
       setRemoteUser(null);
-      setRemoteError(typeof e === "string" ? e : JSON.stringify(e));
+      // SBAI-5478: auth-disabled / no-endpoint is "not signed in", not a red error.
+      if (isNoAuthIdentityUnavailable(e)) {
+        setRemoteError(null);
+      } else {
+        setRemoteError(typeof e === "string" ? e : JSON.stringify(e));
+      }
     } finally {
       setRemoteLoading(false);
     }
@@ -79,7 +85,12 @@ export default function AccountPanel({ onClose }: { onClose: () => void }) {
       setLocalUsers(result.users);
     } catch (e) {
       setLocalUsers([]);
-      setLocalError(typeof e === "string" ? e : JSON.stringify(e));
+      // SBAI-5478: no local auth endpoint → empty device list, not red JSON.
+      if (isNoAuthIdentityUnavailable(e)) {
+        setLocalError(null);
+      } else {
+        setLocalError(typeof e === "string" ? e : JSON.stringify(e));
+      }
     } finally {
       setLocalLoading(false);
     }
@@ -142,6 +153,8 @@ export default function AccountPanel({ onClose }: { onClose: () => void }) {
     } catch (e) {
       if (isNoAuthConfigured(e)) {
         setRemoteUser(null);
+        setRemoteError(null);
+        setLocalError(null);
         setToken("");
         setConnectedWithoutAuth(true);
         setConnectStep("idle");

--- a/frontend/src/api.spec.ts
+++ b/frontend/src/api.spec.ts
@@ -32,8 +32,10 @@ import {
   workingFileApi,
   desktopSettingsApi,
   isNoAuthConfigured,
+  isNoAuthIdentityUnavailable,
   OPERATION_NOT_SUPPORTED,
   NO_AUTH_CONFIGURED,
+  NO_AUTH_ENDPOINT_AVAILABLE,
 } from "./api";
 
 /** The (name, args) pair passed to the most recent invoke call. */
@@ -135,6 +137,29 @@ describe("auth + onboarding wrappers", () => {
     expect(OPERATION_NOT_SUPPORTED).toBe(
       "Operation not supported: No authentication configured on server",
     );
+    expect(NO_AUTH_ENDPOINT_AVAILABLE).toBe("No auth endpoint available");
+  });
+
+  it("recognizes identity-loader No auth endpoint available (SBAI-5478)", () => {
+    const message = "No auth endpoint available";
+    expect(isNoAuthIdentityUnavailable(message)).toBe(true);
+    expect(isNoAuthIdentityUnavailable(new Error(message))).toBe(true);
+    expect(
+      isNoAuthIdentityUnavailable({ kind: "CommandFailed", message }),
+    ).toBe(true);
+    // Login-path signals also count as identity-unavailable.
+    expect(isNoAuthIdentityUnavailable(NO_AUTH_CONFIGURED)).toBe(true);
+    expect(isNoAuthIdentityUnavailable(OPERATION_NOT_SUPPORTED)).toBe(true);
+    // Unrelated failures stay fail-closed.
+    expect(isNoAuthIdentityUnavailable("network unreachable")).toBe(false);
+    expect(
+      isNoAuthIdentityUnavailable({
+        kind: "CommandFailed",
+        message: "No auth endpoint available.",
+      }),
+    ).toBe(false);
+    // Connect classifier does NOT broaden to the identity-loader message.
+    expect(isNoAuthConfigured(message)).toBe(false);
   });
 
   it("authLoginWithToken maps remoteUrl + token", () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -89,22 +89,42 @@ export const NO_AUTH_CONFIGURED = "No authentication configured on server";
 export const OPERATION_NOT_SUPPORTED =
   "Operation not supported: No authentication configured on server";
 
+/**
+ * Identity-loader signal when no auth endpoint is configured (SBAI-5478).
+ * Real EROS Account panel evidence: `auth_user_info` / `auth_local_user_info`
+ * reject with this exact `CommandFailed` message while Connect can still
+ * succeed as "Connected without authentication". Exact match only.
+ */
+export const NO_AUTH_ENDPOINT_AVAILABLE = "No auth endpoint available";
+
+function loreErrorMessage(error: unknown): string | null {
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  if (typeof error === "object" && error !== null && "message" in error) {
+    const msg = (error as { message?: unknown }).message;
+    return typeof msg === "string" ? msg : null;
+  }
+  return null;
+}
+
 /** Returns true if the error indicates a reachable server with auth disabled.
  *  Accepts BOTH the legacy v0.8.5 text and the nightly typed NotSupported
  *  message (Epic Lore code 18). */
 export function isNoAuthConfigured(error: unknown): boolean {
-  if (error === NO_AUTH_CONFIGURED || error === OPERATION_NOT_SUPPORTED) return true;
-  if (error instanceof Error) {
-    return (
-      error.message === NO_AUTH_CONFIGURED ||
-      error.message === OPERATION_NOT_SUPPORTED
-    );
-  }
-  if (typeof error !== "object" || error === null || !("message" in error)) {
-    return false;
-  }
-  const msg = (error as { message?: unknown }).message;
+  const msg = loreErrorMessage(error);
   return msg === NO_AUTH_CONFIGURED || msg === OPERATION_NOT_SUPPORTED;
+}
+
+/**
+ * True when an identity loader (`auth_user_info` / `auth_local_user_info`)
+ * failed because the environment has no auth endpoint / auth is disabled.
+ * These must render as **neutral empty state**, not red raw CommandFailed JSON
+ * (SBAI-5478). Includes login no-auth signals plus the exact identity-loader
+ * "No auth endpoint available" message. Unrelated failures stay fail-closed.
+ */
+export function isNoAuthIdentityUnavailable(error: unknown): boolean {
+  if (isNoAuthConfigured(error)) return true;
+  return loreErrorMessage(error) === NO_AUTH_ENDPOINT_AVAILABLE;
 }
 
 export interface ServiceStopResult {


### PR DESCRIPTION
## Summary
Fixes the real EROS Account dialog contradiction: Connect shows **Connected without authentication** while **Signed in** / **This device** render red `CommandFailed` JSON (`No auth endpoint available`).

Evidence: `/srv/AI_Stuff/lorecrew/evidence/SBAI-5470/02-noauth-gui-connected-account.png` (SHA-256 `753eaf8f…4164`).

## Change
- `isNoAuthIdentityUnavailable` + `NO_AUTH_ENDPOINT_AVAILABLE` in `api.ts` (exact match; includes legacy/nightly login no-auth signals)
- `AccountPanel` identity loaders treat no-auth as neutral empty state
- Successful no-auth connect clears any residual identity errors
- Unrelated errors remain fail-closed red

## Tests (TDD)
- Account open with endpoint-unavailable on both surfaces
- Legacy + nightly no-auth signals on both surfaces
- Connect success + identity neutrality (EROS contradiction)
- Unrelated error negatives
- api.spec classifier unit coverage

```
npx vitest run src/AccountPanel.spec.tsx src/api.spec.ts  # 38 passed
```

## Out of scope
- No merge / no Jira transition from this PR
- Does not touch SBAI-5476 / USDC work

Base: durable main `21842b1f` (post-#416).