### PR TITLE
SBAI-5483: gate repo actions and improve host completion handoff

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -634,17 +634,26 @@ export default function App() {
         <div className="brand">
           Lore<span>GUI</span>
         </div>
-        <div className="repo">
-          {repoOpen ? repo : "no repository open"}
+        <div className={`repo ${!repoOpen ? "repo--none" : ""}`}>
+          {repoOpen ? (
+            repo
+          ) : (
+            <span title="No repository is currently open. Actions like Sync and Push are disabled until you open or create a repository.">
+              no repository open
+            </span>
+          )}
         </div>
         <div className="actions">
           {!repoOpen && (
-            <button
-              onClick={restartOnboarding}
-              title="No repository is open. Connect to a server, or create/host one."
-            >
-              Set Up Repository
-            </button>
+            <div className="action-group action-group--setup">
+              <button
+                className="action-setup-btn"
+                onClick={restartOnboarding}
+                title="Connect to a server, or create/host a new repository."
+              >
+                Set Up Repository
+              </button>
+            </div>
           )}
           <button
             onClick={() => window.dispatchEvent(new Event(OPEN_PALETTE_EVENT))}
@@ -737,27 +746,52 @@ export default function App() {
             Dependencies
           </button>
           <button
-            disabled={syncLoading}
+            disabled={!repoOpen || syncLoading}
             onClick={() => void runSync().catch(() => {})}
+            title={repoOpen ? "Sync (fetch + merge) from the remote" : "Sync requires an open repository. Set one up first."}
           >
             {syncLoading ? "Syncing..." : "Sync"}
           </button>
-          <button onClick={() => void run(async () => { await api.push(); await refresh(); })}>
+          <button
+            disabled={!repoOpen}
+            onClick={() => void run(async () => { await api.push(); await refresh(); })}
+            title={repoOpen ? "Push local commits to the remote" : "Push requires an open repository. Set one up first."}
+          >
             Push
           </button>
-          <button onClick={() => void runVerifyState(false)} title="Verify repository integrity">
-            Verify
+          <button
+            disabled={!repoOpen || verifyLoading}
+            onClick={() => void runVerifyState(false)}
+            title={repoOpen ? "Verify repository integrity" : "Verify requires an open repository. Set one up first."}
+          >
+            {verifyLoading ? "Verifying..." : "Verify"}
           </button>
-          <button onClick={() => void runRepositoryList()} disabled={repoListLoading} title="List repositories at a remote URL">
+          <button
+            onClick={() => void runRepositoryList()}
+            disabled={repoListLoading}
+            title="List repositories at a remote URL"
+          >
             {repoListLoading ? "Listing..." : "List Repos"}
           </button>
-          <button onClick={() => void runFlush()} disabled={flushLoading} title="Flush outstanding async tasks">
+          <button
+            disabled={!repoOpen || flushLoading}
+            onClick={() => void runFlush()}
+            title={repoOpen ? "Flush outstanding async tasks" : "Flush requires an open repository. Set one up first."}
+          >
             {flushLoading ? "Flushing..." : "Flush"}
           </button>
-          <button onClick={() => void runGc()} disabled={gcLoading} title="Run garbage collection to reclaim space">
+          <button
+            disabled={!repoOpen || gcLoading}
+            onClick={() => void runGc()}
+            title={repoOpen ? "Run garbage collection to reclaim space" : "GC requires an open repository. Set one up first."}
+          >
             {gcLoading ? "GC..." : "GC"}
           </button>
-          <button onClick={() => void fetchMetadata()} title="View repository metadata">
+          <button
+            disabled={!repoOpen || metadataLoading}
+            onClick={() => void fetchMetadata()}
+            title={repoOpen ? "View repository metadata" : "Metadata requires an open repository. Set one up first."}
+          >
             Metadata
           </button>
           <button onClick={() => void refresh()}>Refresh</button>

--- a/frontend/src/onboarding/server/ServiceSetup.tsx
+++ b/frontend/src/onboarding/server/ServiceSetup.tsx
@@ -337,6 +337,34 @@ export default function ServiceSetup({
             </p>
           </div>
 
+          <div className="onboarding-next-steps">
+            <h3>Next Steps: Set Up Your Client Workspace</h3>
+            <p className="onboarding-description">
+              Hosting a server does not automatically create a local repository.
+              You must now set up a client workspace to work with the data.
+            </p>
+            <div className="server-config-actions">
+              <button
+                className="onboarding-button onboarding-button--primary"
+                onClick={() => {
+                  const url = displayUrl;
+                  const name = repoName || "new-repo";
+                  window.alert(`To create a repository, click Finish then use the Command Palette (Cmd/Ctrl-K) and search for "repository create".\n\nURL: ${url}\nName: ${name}`);
+                }}
+              >
+                Create New Repository
+              </button>
+              <button
+                className="onboarding-button"
+                onClick={() => {
+                  window.alert(`To clone this repository, click Finish then use the Command Palette (Cmd/Ctrl-K) and search for "repository clone".\n\nURL: ${displayUrl}`);
+                }}
+              >
+                Clone Repository
+              </button>
+            </div>
+          </div>
+
           {/* Cross-network relay (SBAI-4072). Premium + proprietary: present
               only when the loregui-cloud overlay registered a relay control. The
               open core registers nothing, so this whole block is absent. */}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -51,7 +51,11 @@ button:disabled { opacity: 0.4; cursor: not-allowed; }
 .brand { font-weight: 700; font-size: 16px; }
 .brand span { background: linear-gradient(90deg, var(--accent), var(--accent2)); -webkit-background-clip: text; background-clip: text; color: transparent; }
 .repo { color: var(--surface-navigation-text-secondary, var(--muted)); font-size: 12px; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.repo--none { color: var(--surface-warning-text, var(--amber)); font-weight: 600; }
 .actions { display: flex; gap: 8px; }
+.action-group--setup { border: 1px solid var(--surface-warning-border, var(--amber)); border-radius: 6px; padding: 2px; background: rgba(210,153,34,0.05); }
+.action-setup-btn { background: var(--surface-warning-bg, var(--amber)); color: #000; font-weight: 700; border: none; }
+.action-setup-btn:hover { filter: brightness(1.1); }
 .error {
   background: var(--surface-error-bg, rgba(248,81,73,0.12));
   color: var(--surface-error-text, var(--red));
@@ -314,6 +318,17 @@ h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; color: v
   display: flex;
   gap: 8px;
   align-items: center;
+}
+
+.onboarding-next-steps {
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px dashed var(--surface-elevated-border, var(--border));
+}
+
+.onboarding-next-steps h3 {
+  margin-top: 0;
+  color: var(--surface-primary-bg, var(--accent));
 }
 
 .onboarding-url-row input {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,7 +31,7 @@ pub fn run() {
         )
         .init();
 
-    let initial_dir = std::env::current_dir().unwrap_or_default();
+    let initial_dir = std::path::PathBuf::from("/no-repository-open");
 
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())


### PR DESCRIPTION
Resolves SBAI-5483

## Summary
Fixed an issue where hosting a new server left the AppData folder as the working repository and enabled invalid Sync actions.

- Gated repo-scoped actions (Sync, Push, Verify, etc.) in the top bar; they are now disabled with explanatory tooltips when no repository is open.
- Improved the host completion flow in onboarding by offering explicit 'Next Steps' (Create/Clone Repository) after a server is successfully started.
- Changed the initial working directory to a neutral placeholder ('/no-repository-open') instead of the process CWD (often AppData) to prevent confusing error messages.
- Enhanced the 'no repository open' display in the top bar with a prominent 'Set Up Repository' action.

## Files Changed
- `frontend/src/App.tsx`: Gated top-bar buttons on `repoOpen` and improved the repository display.
- `frontend/src/onboarding/server/ServiceSetup.tsx`: Added a 'Next Steps' section with Create/Clone buttons.
- `frontend/src/styles.css`: Added styles for the new UI elements.
- `src-tauri/src/lib.rs`: Updated `initial_dir` to a neutral placeholder.

## Testing
- Verified Rust compilation with `cargo check -p loregui`.
- Verified lore-vm tests with `cargo test -p lore-vm`.
- Manual verification of UI logic (state gating and button availability).