### PR TITLE
SBAI-5488: preserve caller roots at Epic lore 9179c6d

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,8 @@ name: integration
 #      (add → update → delete → restore → revert + history audit) against a real
 #      on-disk repo, plus a two-repo shared-store sync (CI-headless server↔client
 #      stand-in).
+#   3. exact-pin service CWD — builds the pinned Epic `lore` CLI and proves a
+#      service in cwd A resolves a relative repository against caller root B.
 # Kept SEPARATE from the fast `ci.yml` so it never blocks normal op PRs — `ci.yml`
 # runs only the fast unit tests (`cargo test -p lore-vm`, no feature).
 on:
@@ -17,6 +19,12 @@ on:
   pull_request:
     paths:
       - "crates/lore-vm/**"
+      - "crates/lorevm-cli/**"
+      - "crates/lorevm-ffi/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "scripts/exact-pin-service-cwd-canary.sh"
+      - "scripts/exact-pin-service-cwd-canary.test.sh"
       - ".github/workflows/integration.yml"
   workflow_dispatch:
 
@@ -38,3 +46,7 @@ jobs:
       # the job — no continue-on-error, no `|| true`.
       - name: E2E revision lifecycle against a real on-disk lore instance
         run: cargo test -p lore-vm --features integration-tests --test e2e_lifecycle
+      - name: Exact-pin service fixture fails closed on missing or wrong binary
+        run: scripts/exact-pin-service-cwd-canary.test.sh
+      - name: Exact-pin service resolves relative repository against caller root
+        run: scripts/exact-pin-service-cwd-canary.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1416,7 +1416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2226,7 +2226,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2761,7 +2761,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 [[package]]
 name = "lore"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=437e727dd81da8931f39cea88e07dedd77e867f5#437e727dd81da8931f39cea88e07dedd77e867f5"
+source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
 dependencies = [
  "anyhow",
  "bitcode",
@@ -2796,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "lore-base"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=437e727dd81da8931f39cea88e07dedd77e867f5#437e727dd81da8931f39cea88e07dedd77e867f5"
+source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -2825,7 +2825,7 @@ dependencies = [
 [[package]]
 name = "lore-credential"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=437e727dd81da8931f39cea88e07dedd77e867f5#437e727dd81da8931f39cea88e07dedd77e867f5"
+source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
@@ -2846,7 +2846,7 @@ dependencies = [
 [[package]]
 name = "lore-error-set"
 version = "0.1.0"
-source = "git+https://github.com/EpicGames/lore.git?rev=437e727dd81da8931f39cea88e07dedd77e867f5#437e727dd81da8931f39cea88e07dedd77e867f5"
+source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
 dependencies = [
  "lore-error-set-macro",
 ]
@@ -2854,7 +2854,7 @@ dependencies = [
 [[package]]
 name = "lore-error-set-macro"
 version = "0.1.0"
-source = "git+https://github.com/EpicGames/lore.git?rev=437e727dd81da8931f39cea88e07dedd77e867f5#437e727dd81da8931f39cea88e07dedd77e867f5"
+source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "lore-macro"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=437e727dd81da8931f39cea88e07dedd77e867f5#437e727dd81da8931f39cea88e07dedd77e867f5"
+source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "lore-notification"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=437e727dd81da8931f39cea88e07dedd77e867f5#437e727dd81da8931f39cea88e07dedd77e867f5"
+source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
 dependencies = [
  "async-trait",
  "lore-base",
@@ -2890,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "lore-proto"
 version = "0.1.60"
-source = "git+https://github.com/EpicGames/lore.git?rev=437e727dd81da8931f39cea88e07dedd77e867f5#437e727dd81da8931f39cea88e07dedd77e867f5"
+source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
 dependencies = [
  "lore-base",
  "prost",
@@ -2903,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "lore-revision"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=437e727dd81da8931f39cea88e07dedd77e867f5#437e727dd81da8931f39cea88e07dedd77e867f5"
+source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2963,7 +2963,7 @@ dependencies = [
 [[package]]
 name = "lore-storage"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=437e727dd81da8931f39cea88e07dedd77e867f5#437e727dd81da8931f39cea88e07dedd77e867f5"
+source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -3000,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "lore-telemetry"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=437e727dd81da8931f39cea88e07dedd77e867f5#437e727dd81da8931f39cea88e07dedd77e867f5"
+source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
 dependencies = [
  "axum",
  "http",
@@ -3023,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "lore-transport"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=437e727dd81da8931f39cea88e07dedd77e867f5#437e727dd81da8931f39cea88e07dedd77e867f5"
+source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3360,7 +3360,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4114,7 +4114,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools",
  "log",
  "multimap",
@@ -4223,7 +4223,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.11.13"
-source = "git+https://github.com/EpicGames/lore.git?rev=437e727dd81da8931f39cea88e07dedd77e867f5#437e727dd81da8931f39cea88e07dedd77e867f5"
+source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -4260,9 +4260,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4574,7 +4574,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4632,7 +4632,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5718,7 +5718,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6679,7 +6679,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,15 @@ tokio = { version = "1", features = ["process", "rt-multi-thread", "macros", "io
 tracing = "0.1"
 
 # Lore's own API library — pinned by exact rev. Pre-1.0, so any bump is a
-# deliberate, manager-owned PR. SBAI-3685 / SBAI-3700 / SBAI-5434 / SBAI-5473.
-# 437e727d = post-v0.8.5 nightly: Linux/macOS Unix-domain-socket service process
-# support + clean shutdown. No public operation signature changes vs 2d86d1dd.
-lore = { git = "https://github.com/EpicGames/lore.git", rev = "437e727dd81da8931f39cea88e07dedd77e867f5" }
+# deliberate, manager-owned PR. SBAI-3685 / SBAI-3700 / SBAI-5434 / SBAI-5473 / SBAI-5488.
+# 9179c6dc = post-v0.8.5 nightly: service calls carry their caller working
+# directory so relative paths never resolve against the service process cwd.
+lore = { git = "https://github.com/EpicGames/lore.git", rev = "9179c6dc7cd14931af5b66beb3b2e186907f6360" }
 
 # REQUIRED: upstream `lore` patches quinn-proto to a vendored fork that adds
 # `TransportErrorCode::is_crypto()`. A [patch] does NOT propagate through a git
 # dependency, so without replicating it here `lore-transport` fails to compile
 # ("no method named `is_crypto`"). Same fork, same exact commit, inside the
-# lore repo. Every consumer of the `lore` crate needs this. SBAI-3685 / SBAI-5434 / SBAI-5473.
+# lore repo. Every consumer of the `lore` crate needs this. SBAI-3685 / SBAI-5434 / SBAI-5473 / SBAI-5488.
 [patch.crates-io]
-quinn-proto = { git = "https://github.com/EpicGames/lore.git", rev = "437e727dd81da8931f39cea88e07dedd77e867f5" }
+quinn-proto = { git = "https://github.com/EpicGames/lore.git", rev = "9179c6dc7cd14931af5b66beb3b2e186907f6360" }

--- a/crates/lore-vm/src/api.rs
+++ b/crates/lore-vm/src/api.rs
@@ -40,7 +40,7 @@ impl LoreApi {
 
     /// Change the working directory (e.g. after opening a different repo).
     pub fn set_working_dir(&mut self, path: PathBuf) {
-        self.global.repository_path = path;
+        self.global.set_repository_path(path);
     }
 
     /// Set the global identity after construction. Uses interior mutability on

--- a/crates/lore-vm/src/global.rs
+++ b/crates/lore-vm/src/global.rs
@@ -129,6 +129,11 @@ impl LoreGlobal {
     pub fn build(&self) -> LoreGlobalArgs {
         LoreGlobalArgs {
             repository_path: LoreString::from_path(&self.repository_path),
+            // LoreGUI already owns the authoritative repository/lifecycle root.
+            // Send it explicitly so an out-of-process Lore service resolves
+            // relative paths against the product-selected root, never against
+            // either process's ambient current directory.
+            working_directory: LoreString::from_path(&self.repository_path),
             correlation_id: LoreString::default(),
             identity: LoreString::from_str(&self.identity.read().unwrap()),
             force: u8::from(self.force),
@@ -187,5 +192,22 @@ mod tests {
         g.set_identity("frank");
         let args2 = g.build();
         assert_eq!(args2.identity.as_str(), "frank");
+    }
+
+    #[test]
+    fn build_uses_repository_root_as_explicit_working_directory() {
+        let repository_root = PathBuf::from("/authoritative/repository/root");
+        let args = LoreGlobal::new(repository_root.clone()).build();
+
+        assert_eq!(
+            args.repository_path.as_str(),
+            repository_root.to_str().unwrap()
+        );
+        assert_eq!(
+            args.working_directory.as_str(),
+            repository_root.to_str().unwrap(),
+            "LoreGUI must send its authoritative lifecycle/repository root; \
+             relative paths must never inherit the service process cwd"
+        );
     }
 }

--- a/crates/lore-vm/src/global.rs
+++ b/crates/lore-vm/src/global.rs
@@ -62,6 +62,7 @@ impl Clone for LoreGlobal {
 
 impl LoreGlobal {
     pub fn new(repository_path: PathBuf) -> Self {
+        let repository_path = authoritative_repository_path(repository_path);
         Self {
             repository_path,
             identity: RwLock::new(String::new()),
@@ -72,6 +73,10 @@ impl LoreGlobal {
             remote: false,
             local: false,
         }
+    }
+
+    pub(crate) fn set_repository_path(&mut self, repository_path: PathBuf) {
+        self.repository_path = authoritative_repository_path(repository_path);
     }
 
     pub fn identity(self, id: impl Into<String>) -> Self {
@@ -154,6 +159,23 @@ impl LoreGlobal {
     }
 }
 
+/// Convert a caller-selected repository path to an explicit absolute lifecycle
+/// root without touching the filesystem. Upstream resolves a relative
+/// `repository_path` against `working_directory`; sending the same relative
+/// value in both fields would therefore turn `repo` into `repo/repo` in the
+/// out-of-process service. Empty paths retain their special store-only meaning.
+fn authoritative_repository_path(repository_path: PathBuf) -> PathBuf {
+    if repository_path.as_os_str().is_empty() || repository_path.is_absolute() {
+        return repository_path;
+    }
+    std::path::absolute(&repository_path).unwrap_or_else(|error| {
+        panic!(
+            "failed to resolve relative repository path `{}` against the caller root: {error}",
+            repository_path.display()
+        )
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -209,5 +231,18 @@ mod tests {
             "LoreGUI must send its authoritative lifecycle/repository root; \
              relative paths must never inherit the service process cwd"
         );
+    }
+
+    #[test]
+    fn relative_repository_path_is_made_absolute_without_double_joining() {
+        let relative = PathBuf::from("relative-repository-that-need-not-exist");
+        let expected = std::path::absolute(&relative).expect("absolute caller path");
+        let args = LoreGlobal::new(relative).build();
+
+        assert_eq!(args.repository_path.as_str(), expected.to_str().unwrap());
+        assert_eq!(args.working_directory.as_str(), expected.to_str().unwrap());
+        assert!(!args.repository_path.as_str().ends_with(
+            "relative-repository-that-need-not-exist/relative-repository-that-need-not-exist"
+        ));
     }
 }

--- a/crates/lore-vm/tests/service_unix_smoke.rs
+++ b/crates/lore-vm/tests/service_unix_smoke.rs
@@ -6,12 +6,12 @@
 //! **compatibility-only**: it proves the new upstream path can start, serve a
 //! readiness probe, resolve a relative operation against the caller rather
 //! than the service process, and shut down cleanly when an **exact-pin** `lore`
-//! binary is available.
+//! binary is available. The caller-CWD canary is a required PR integration
+//! gate and fails closed when that binary is unavailable.
 //!
-//! Soft-skips **only** when no exact-pin `lore` binary is resolved (contributors
-//! without the heavy lore build are never blocked). Once a binary is resolved,
-//! boot / readiness / shutdown failures **must fail** the test — never convert
-//! into a soft skip (that previously masked older sibling-checkout binaries).
+//! The basic start/stop smoke remains contributor-friendly, but the behavioral
+//! caller-CWD canary never skips: CI provisions the exact pin first, and missing
+//! or wrong-provenance input is a hard failure.
 //!
 //! ```sh
 //! LOREVM_LORE_BIN=/path/to/lore-from-exact-pin \
@@ -100,9 +100,33 @@ fn exact_pin_lore_candidates() -> Vec<PathBuf> {
 
 /// Resolve a `lore` CLI binary without building one and without sibling fallback.
 fn resolve_lore_binary() -> Option<PathBuf> {
-    exact_pin_lore_candidates()
-        .into_iter()
-        .find(|cand| cand.is_file())
+    let explicit = std::env::var_os("LOREVM_LORE_BIN").map(PathBuf::from);
+    resolve_lore_binary_from(explicit, lore_checkout())
+}
+
+fn resolve_lore_binary_from(
+    explicit: Option<PathBuf>,
+    checkout: Option<PathBuf>,
+) -> Option<PathBuf> {
+    if let Some(path) = explicit {
+        return path.is_file().then_some(path);
+    }
+    checkout.and_then(|root| {
+        ["release", "debug"]
+            .into_iter()
+            .map(|profile| root.join("target").join(profile).join("lore"))
+            .find(|candidate| candidate.is_file())
+    })
+}
+
+#[test]
+fn explicit_missing_binary_fixture_never_falls_back_to_checkout_artifact() {
+    let missing = PathBuf::from("/definitely/missing/exact-pin-lore");
+    assert_eq!(
+        resolve_lore_binary_from(Some(missing), lore_checkout()),
+        None,
+        "an explicit required fixture must fail closed instead of falling back"
+    );
 }
 
 /// UDS socket lives under `$XDG_RUNTIME_DIR` (or `$TMPDIR`/`/tmp`) in a
@@ -337,10 +361,9 @@ fn unix_service_run_start_stop_smoke() {
 /// resolving it under A proves the service inherited its own process cwd.
 #[test]
 fn unix_service_resolves_relative_repository_against_caller_root() {
-    let Some(lore_bin) = resolve_lore_binary() else {
-        eprintln!("[SKIP] no exact-pin `lore` CLI binary resolved — caller-cwd canary not run");
-        return;
-    };
+    let lore_bin = resolve_lore_binary().expect(
+        "REQUIRED exact-pin caller-CWD canary has no lore binary; provision the pinned CLI or set LOREVM_LORE_BIN",
+    );
     assert_binary_built_from_exact_pin(&lore_bin);
 
     let sandbox = tempfile::tempdir().expect("canary sandbox");

--- a/crates/lore-vm/tests/service_unix_smoke.rs
+++ b/crates/lore-vm/tests/service_unix_smoke.rs
@@ -4,8 +4,9 @@
 //! LoreGUI's architecture still uses in-process lore bindings + standalone
 //! `loreserver` (not the background CLI service), so this suite is
 //! **compatibility-only**: it proves the new upstream path can start, serve a
-//! readiness probe, and shut down cleanly when an **exact-pin** `lore` binary
-//! is available.
+//! readiness probe, resolve a relative operation against the caller rather
+//! than the service process, and shut down cleanly when an **exact-pin** `lore`
+//! binary is available.
 //!
 //! Soft-skips **only** when no exact-pin `lore` binary is resolved (contributors
 //! without the heavy lore build are never blocked). Once a binary is resolved,
@@ -99,12 +100,9 @@ fn exact_pin_lore_candidates() -> Vec<PathBuf> {
 
 /// Resolve a `lore` CLI binary without building one and without sibling fallback.
 fn resolve_lore_binary() -> Option<PathBuf> {
-    for cand in exact_pin_lore_candidates() {
-        if cand.is_file() {
-            return Some(cand);
-        }
-    }
-    None
+    exact_pin_lore_candidates()
+        .into_iter()
+        .find(|cand| cand.is_file())
 }
 
 /// UDS socket lives under `$XDG_RUNTIME_DIR` (or `$TMPDIR`/`/tmp`) in a
@@ -132,6 +130,7 @@ fn libc_uid() -> u32 {
 struct ServiceProc {
     child: Child,
     runtime_dir: tempfile::TempDir,
+    global_dir: tempfile::TempDir,
 }
 
 impl Drop for ServiceProc {
@@ -142,13 +141,27 @@ impl Drop for ServiceProc {
 }
 
 fn boot_service(lore_bin: &Path) -> Result<ServiceProc, String> {
+    boot_service_in_directory(lore_bin, None)
+}
+
+fn boot_service_in_directory(
+    lore_bin: &Path,
+    service_directory: Option<&Path>,
+) -> Result<ServiceProc, String> {
     let runtime_dir = tempfile::tempdir().map_err(|e| format!("tempdir: {e}"))?;
-    let mut child = Command::new(lore_bin)
+    let global_dir = tempfile::tempdir().map_err(|e| format!("global tempdir: {e}"))?;
+    let mut command = Command::new(lore_bin);
+    command
         .args(["service", "run"])
         .env("XDG_RUNTIME_DIR", runtime_dir.path())
         .env("TMPDIR", runtime_dir.path())
+        .env("LORE_GLOBAL_PATH", global_dir.path())
         .stdout(Stdio::null())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(directory) = service_directory {
+        command.current_dir(directory);
+    }
+    let mut child = command
         .spawn()
         .map_err(|e| format!("spawn lore service run: {e}"))?;
 
@@ -158,10 +171,10 @@ fn boot_service(lore_bin: &Path) -> Result<ServiceProc, String> {
             let err = child
                 .stderr
                 .as_mut()
-                .and_then(|s| {
+                .map(|s| {
                     let mut buf = String::new();
                     let _ = std::io::Read::read_to_string(s, &mut buf);
-                    Some(buf)
+                    buf
                 })
                 .unwrap_or_default();
             return Err(format!(
@@ -176,7 +189,11 @@ fn boot_service(lore_bin: &Path) -> Result<ServiceProc, String> {
                         let p = e.path();
                         // Try connect as a readiness probe (matches upstream's connect probe).
                         if std::os::unix::net::UnixStream::connect(&p).is_ok() {
-                            return Ok(ServiceProc { child, runtime_dir });
+                            return Ok(ServiceProc {
+                                child,
+                                runtime_dir,
+                                global_dir,
+                            });
                         }
                     }
                 }
@@ -189,6 +206,51 @@ fn boot_service(lore_bin: &Path) -> Result<ServiceProc, String> {
         }
         std::thread::sleep(Duration::from_millis(100));
     }
+}
+
+fn assert_binary_built_from_exact_pin(lore_bin: &Path) {
+    let expected = pinned_rev().expect("workspace pinned lore rev");
+    let checkout = lore_bin
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+        .unwrap_or_else(|| panic!("unexpected lore binary path: {}", lore_bin.display()));
+    let output = Command::new("git")
+        .args([
+            "-C",
+            checkout.to_str().expect("utf-8 checkout"),
+            "rev-parse",
+            "HEAD",
+        ])
+        .output()
+        .unwrap_or_else(|e| panic!("inspect lore checkout revision: {e}"));
+    assert!(
+        output.status.success(),
+        "exact-pin canary requires a lore binary built inside its git checkout: {}",
+        lore_bin.display()
+    );
+    let actual = String::from_utf8(output.stdout)
+        .expect("git revision utf-8")
+        .trim()
+        .to_string();
+    assert_eq!(
+        actual, expected,
+        "client/service binary must match Cargo.toml pin"
+    );
+
+    let version = Command::new(lore_bin)
+        .arg("--version")
+        .output()
+        .expect("run exact-pin lore --version");
+    assert!(
+        version.status.success(),
+        "exact-pin lore --version must succeed"
+    );
+    let version = String::from_utf8(version.stdout).expect("lore version utf-8");
+    assert!(
+        version.starts_with("lore 0.8.6-nightly"),
+        "unexpected client/service version for pin {expected}: {version}"
+    );
 }
 
 /// SIGTERM the service and require a clean exit (upstream clean-shutdown path).
@@ -266,6 +328,63 @@ fn unix_service_run_start_stop_smoke() {
         );
     });
     eprintln!("[service] clean shutdown verified");
+}
+
+/// Behavioral exact-pin canary for Epic 9179c6d.
+///
+/// A background service is started from A while the client performs a relative
+/// repository operation from B. The repository must be created only under B;
+/// resolving it under A proves the service inherited its own process cwd.
+#[test]
+fn unix_service_resolves_relative_repository_against_caller_root() {
+    let Some(lore_bin) = resolve_lore_binary() else {
+        eprintln!("[SKIP] no exact-pin `lore` CLI binary resolved — caller-cwd canary not run");
+        return;
+    };
+    assert_binary_built_from_exact_pin(&lore_bin);
+
+    let sandbox = tempfile::tempdir().expect("canary sandbox");
+    let service_a = sandbox.path().join("service-a");
+    let caller_b = sandbox.path().join("caller-b");
+    std::fs::create_dir_all(&service_a).expect("service cwd A");
+    std::fs::create_dir_all(&caller_b).expect("caller/root B");
+
+    let proc = boot_service_in_directory(&lore_bin, Some(&service_a))
+        .unwrap_or_else(|e| panic!("boot exact-pin service in cwd A: {e}"));
+    let relative_repo = "relative-service-canary";
+    let output = Command::new(&lore_bin)
+        .args([
+            "--repository",
+            relative_repo,
+            "--offline",
+            "repository",
+            "create",
+            "cwd-canary",
+        ])
+        .current_dir(&caller_b)
+        .env("XDG_RUNTIME_DIR", proc.runtime_dir.path())
+        .env("TMPDIR", proc.runtime_dir.path())
+        .env("LORE_GLOBAL_PATH", proc.global_dir.path())
+        .env("LORE_USE_SERVICE", "1")
+        .output()
+        .expect("run exact-pin client against exact-pin service");
+
+    assert!(
+        output.status.success(),
+        "relative repository create through service failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        caller_b.join(relative_repo).join(".lore").is_dir(),
+        "relative repository must land under authoritative caller/root B"
+    );
+    assert!(
+        !service_a.join(relative_repo).exists(),
+        "relative repository must never land under service cwd A"
+    );
+
+    stop_service(proc).expect("clean exact-pin service shutdown");
 }
 
 /// Regression: candidate discovery never walks sibling short-rev checkouts.

--- a/crates/lorevm-cli/tests/cli_plumbing.rs
+++ b/crates/lorevm-cli/tests/cli_plumbing.rs
@@ -180,6 +180,36 @@ fn explicit_dir_to_non_repo_is_a_clean_engine_error() {
     assert_ne!(kind, "cli");
 }
 
+#[test]
+fn relative_dir_repository_create_resolves_once_against_caller_root() {
+    let caller = tempfile::tempdir().expect("caller root");
+    let relative_repo = "relative-cli-repository";
+    let run = run_cli_in(
+        Some(caller.path()),
+        &[
+            "repository.create",
+            "--dir",
+            relative_repo,
+            "--args",
+            r#"{"repository_url":"lore://localhost/relative-cli"}"#,
+            "--offline",
+        ],
+    );
+    assert!(run.success, "relative create failed: {}", run.stdout);
+    assert!(
+        caller.path().join(relative_repo).join(".lore").is_dir(),
+        "relative --dir must resolve exactly once under the caller root"
+    );
+    assert!(
+        !caller
+            .path()
+            .join(relative_repo)
+            .join(relative_repo)
+            .exists(),
+        "relative --dir must never become repo/repo"
+    );
+}
+
 /// Every failure path prints valid JSON to stdout AND exits non-zero — the
 /// invariant `lore-mcp` depends on to distinguish success from failure without
 /// parsing prose. Spot-checks several distinct failure classes at once.

--- a/crates/lorevm-ffi/tests/smoke.rs
+++ b/crates/lorevm-ffi/tests/smoke.rs
@@ -95,6 +95,41 @@ fn warm_handle_create_then_status_then_status_roundtrips() {
 }
 
 #[test]
+fn relative_dir_repository_create_resolves_once_over_ffi() {
+    let caller = std::env::current_dir().expect("caller root");
+    let relative = format!("target/ffi-relative-repository-{}", std::process::id());
+    let expected = caller.join(&relative);
+    let _ = std::fs::remove_dir_all(&expected);
+
+    let handle = open(&serde_json::json!({
+        "dir": relative,
+        "offline": true,
+    }));
+    let created = call(
+        handle,
+        "repository.create",
+        &serde_json::json!({
+            "repository_url": format!("lore://localhost/relative-ffi-{}", std::process::id())
+        }),
+    );
+    assert!(
+        created.get("error").is_none(),
+        "relative repository.create errored over FFI: {created}"
+    );
+    assert!(
+        expected.join(".lore").is_dir(),
+        "relative FFI dir must resolve exactly once under the caller root"
+    );
+    assert!(
+        !expected.join("target").exists(),
+        "relative FFI dir must never be joined to itself"
+    );
+
+    unsafe { lorevm_ffi_close(handle) };
+    std::fs::remove_dir_all(expected).expect("clean relative FFI repository");
+}
+
+#[test]
 fn unknown_op_returns_structured_error_not_null() {
     let handle = open(&serde_json::json!({ "dir": ".", "offline": true }));
     let resp = call(handle, "nope.nope", &serde_json::json!({}));

--- a/scripts/exact-pin-service-cwd-canary.sh
+++ b/scripts/exact-pin-service-cwd-canary.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Required exact-pin Epic Lore service/caller-CWD compatibility proof (SBAI-5488).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+REV="$(grep -oE 'rev = "[0-9a-f]{40}"' Cargo.toml | head -1 | grep -oE '[0-9a-f]{40}')"
+if [[ ! "$REV" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "FATAL: could not read exact Epic Lore pin from Cargo.toml" >&2
+  exit 1
+fi
+SHORT="${REV:0:7}"
+
+# An explicit fixture is a contract, not a hint: missing input must not fall
+# through to a cached checkout artifact and accidentally green the proof.
+if [[ -n "${LOREVM_LORE_BIN:-}" && ! -x "$LOREVM_LORE_BIN" ]]; then
+  echo "FATAL: required LOREVM_LORE_BIN is missing or not executable: $LOREVM_LORE_BIN" >&2
+  exit 1
+fi
+
+cargo fetch --locked
+CARGO_HOME_DIR="${CARGO_HOME:-$HOME/.cargo}"
+CHECKOUT=""
+while IFS= read -r candidate; do
+  if [[ "$(git -C "$candidate" rev-parse HEAD 2>/dev/null || true)" == "$REV" ]]; then
+    CHECKOUT="$candidate"
+    break
+  fi
+done < <(find "$CARGO_HOME_DIR/git/checkouts" -mindepth 2 -maxdepth 2 -type d -name "$SHORT" 2>/dev/null | sort)
+
+if [[ -z "$CHECKOUT" ]]; then
+  echo "FATAL: exact Epic Lore checkout $REV was not provisioned by cargo fetch" >&2
+  exit 1
+fi
+
+if [[ -n "${LOREVM_LORE_BIN:-}" ]]; then
+  BIN="$LOREVM_LORE_BIN"
+else
+  cargo build --manifest-path "$CHECKOUT/Cargo.toml" -p lore-client --bin lore
+  BIN="$CHECKOUT/target/debug/lore"
+fi
+
+BIN_REAL="$(realpath "$BIN")"
+CHECKOUT_REAL="$(realpath "$CHECKOUT")"
+case "$BIN_REAL" in
+  "$CHECKOUT_REAL"/target/debug/lore|"$CHECKOUT_REAL"/target/release/lore) ;;
+  *)
+    echo "FATAL: lore binary lacks exact-pin checkout provenance: $BIN_REAL" >&2
+    exit 1
+    ;;
+esac
+
+ACTUAL_REV="$(git -C "$CHECKOUT_REAL" rev-parse HEAD)"
+if [[ "$ACTUAL_REV" != "$REV" ]]; then
+  echo "FATAL: lore binary checkout is $ACTUAL_REV, expected $REV" >&2
+  exit 1
+fi
+VERSION="$($BIN_REAL --version)"
+if [[ "$VERSION" != lore\ 0.8.6-nightly* ]]; then
+  echo "FATAL: unexpected lore binary version for $REV: $VERSION" >&2
+  exit 1
+fi
+
+echo "exact-pin lore fixture: rev=$ACTUAL_REV binary=$BIN_REAL version=$VERSION"
+if [[ "${1:-}" == "--verify-only" ]]; then
+  exit 0
+fi
+if [[ $# -ne 0 ]]; then
+  echo "FATAL: unsupported argument: $1" >&2
+  exit 1
+fi
+
+LOREVM_LORE_BIN="$BIN_REAL" \
+  cargo test -p lore-vm --features integration-tests \
+    --test service_unix_smoke \
+    unix_service_resolves_relative_repository_against_caller_root \
+    -- --exact --nocapture

--- a/scripts/exact-pin-service-cwd-canary.test.sh
+++ b/scripts/exact-pin-service-cwd-canary.test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Demonstrate that the required service-CWD proof fails closed on bad fixtures.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNNER="$ROOT/scripts/exact-pin-service-cwd-canary.sh"
+
+if LOREVM_LORE_BIN="$ROOT/target/definitely-missing-lore" "$RUNNER" --verify-only; then
+  echo "FAIL: missing explicit lore fixture was accepted" >&2
+  exit 1
+fi
+
+if LOREVM_LORE_BIN=/bin/true "$RUNNER" --verify-only; then
+  echo "FAIL: executable without exact-pin checkout provenance was accepted" >&2
+  exit 1
+fi
+
+echo "exact-pin service-CWD negative fixture tests passed"

--- a/scripts/upstream-lore-parity.mjs
+++ b/scripts/upstream-lore-parity.mjs
@@ -4,7 +4,9 @@
  *
  * Keeps LoreGUI in parity with Epic's `lore` crate: it enumerates the op surface
  * of the upstream `lore` source (every `pub async fn` in `lore/src/`) and diffs
- * it against our `crates/lore-vm/src/ops/<domain>/<op>.rs` bindings.
+ * it against our `crates/lore-vm/src/ops/<domain>/<op>.rs` bindings. It also
+ * records shared interfaces consumed by every operation (currently
+ * `LoreGlobalArgs`) so schema-only changes cannot hide outside op signatures.
  *
  * It also supports comparing a "head" source (e.g. latest lore HEAD) against
  * the "pinned" source (the version we currently use) to detect signature drift.
@@ -20,6 +22,14 @@ import { homedir } from "node:os";
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, ".."); // scripts -> repo root
 const opsDir = join(repoRoot, "crates", "lore-vm", "src", "ops");
+
+/**
+ * Shared interfaces consumed by every bound operation. These do not appear in
+ * op argument signatures, so a field added here used to evade parity checks.
+ */
+const SHARED_SCHEMA_SOURCES = {
+  LoreGlobalArgs: ["lore-revision", "src", "interface.rs"],
+};
 
 /** Internal upstream fns that are not user-facing ops (excluded from the diff). */
 const UPSTREAM_IGNORE = new Set([
@@ -186,6 +196,37 @@ function collectSignatures(srcDir) {
   return signatures;
 }
 
+/** Extract selected shared structs from the upstream checkout containing lore/src. */
+function collectSharedSchemas(srcDir) {
+  const upstreamRoot = resolve(srcDir, "..", "..");
+  const schemas = new Map();
+
+  for (const [id, segments] of Object.entries(SHARED_SCHEMA_SOURCES)) {
+    const sourcePath = join(upstreamRoot, ...segments);
+    if (!existsSync(sourcePath)) {
+      schemas.set(id, { source: segments.join("/"), fields: null });
+      continue;
+    }
+    const source = readFileSync(sourcePath, "utf8");
+    const struct = source.match(
+      new RegExp(`pub\\s+struct\\s+${id}\\s*\\{([\\s\\S]*?)^\\}`, "m"),
+    );
+    if (!struct) {
+      schemas.set(id, { source: segments.join("/"), fields: null });
+      continue;
+    }
+    const fields = {};
+    const fieldRegex = /^\s*pub\s+([a-z_][a-z0-9_]*)\s*:\s*([^,\n]+),/gm;
+    let field;
+    while ((field = fieldRegex.exec(struct[1])) !== null) {
+      fields[field[1]] = field[2].trim();
+    }
+    schemas.set(id, { source: segments.join("/"), fields });
+  }
+
+  return schemas;
+}
+
 /** Enumerate our bindings as a set of "<domain>.<op>". */
 function ourOps() {
   const ops = new Set();
@@ -218,11 +259,16 @@ if (!pinnedDir) {
 
 const pinnedSigs = collectSignatures(pinnedDir);
 const headSigs = headSrcPath ? collectSignatures(headSrcPath) : pinnedSigs;
+const pinnedSharedSchemas = collectSharedSchemas(pinnedDir);
+const headSharedSchemas = headSrcPath
+  ? collectSharedSchemas(headSrcPath)
+  : pinnedSharedSchemas;
 const ours = ourOps();
 
 const newOps = [];
 const driftedOps = [];
 const orphanedBindings = [];
+const driftedSharedSchemas = [];
 
 // Compare head vs ours
 for (const [id, sig] of headSigs) {
@@ -252,6 +298,13 @@ for (const id of ours) {
   }
 }
 
+for (const [id, newSchema] of headSharedSchemas) {
+  const oldSchema = pinnedSharedSchemas.get(id);
+  if (oldSchema && JSON.stringify(oldSchema) !== JSON.stringify(newSchema)) {
+    driftedSharedSchemas.push({ id, oldSchema, newSchema });
+  }
+}
+
 const report = {
   rev,
   pinnedOpCount: pinnedSigs.size,
@@ -261,6 +314,10 @@ const report = {
   driftedOps: driftedOps.sort((a, b) => a.id.localeCompare(b.id)),
   orphanedBindings: orphanedBindings.sort(),
   intentionalOrphans: intentionalOrphans.sort((a, b) => a.id.localeCompare(b.id)),
+  sharedSchemas: Object.fromEntries(headSharedSchemas),
+  driftedSharedSchemas: driftedSharedSchemas.sort((a, b) =>
+    a.id.localeCompare(b.id),
+  ),
 };
 
 if (process.argv.includes("--json")) {
@@ -275,6 +332,11 @@ if (process.argv.includes("--json")) {
 
   console.error(`  DRIFTED ops signatures (${driftedOps.length}):`);
   for (const o of driftedOps) console.error(`    ! ${o.id} (signature changed)`);
+
+  console.error(`  DRIFTED shared schemas (${driftedSharedSchemas.length}):`);
+  for (const schema of driftedSharedSchemas) {
+    console.error(`    ! ${schema.id} (shared schema changed)`);
+  }
 
   console.error(`  bindings with no upstream match (${orphanedBindings.length}):`);
   for (const o of orphanedBindings) console.error(`    ? ${o}`);

--- a/scripts/upstream-lore-parity.test.mjs
+++ b/scripts/upstream-lore-parity.test.mjs
@@ -8,11 +8,20 @@
  *   - revision.activity_report is classified derived-composite
  *   - real unbound upstream ops still appear in newOps
  *   - unknown orphans still appear in orphanedBindings (no blanket ignore)
+ *   - shared LoreGlobalArgs schema drift is reported and enforcement-tested
  */
 import { spawnSync } from "node:child_process";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { readFileSync } from "node:fs";
+import {
+  cpSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const script = join(here, "upstream-lore-parity.mjs");
@@ -86,6 +95,80 @@ for (const id of [
   "storage.mutable_compare_and_swap",
 ]) {
   assert(!newIds.includes(id), `${id} is bound (not in newOps)`);
+}
+
+const globalSchema = report.sharedSchemas?.LoreGlobalArgs;
+assert(globalSchema, "live report records shared LoreGlobalArgs schema");
+assert(
+  globalSchema.fields?.working_directory === "LoreString",
+  "live report records LoreGlobalArgs.working_directory",
+);
+assert(
+  (report.driftedSharedSchemas || []).length === 0,
+  "pinned source has no shared-schema drift against itself",
+);
+
+// Demonstrate enforcement: remove only working_directory from a copy of the
+// exact pinned shared interface. The scanner must report the shared-schema
+// change even though no operation signature changed.
+function pinnedLoreRoot(rev) {
+  if (process.env.LORE_SRC) {
+    return resolve(process.env.LORE_SRC);
+  }
+  const checkouts = join(homedir(), ".cargo", "git", "checkouts");
+  for (const repository of readdirSync(checkouts)) {
+    if (!repository.startsWith("lore-")) continue;
+    for (const checkout of readdirSync(join(checkouts, repository))) {
+      if (rev.startsWith(checkout)) {
+        return join(checkouts, repository, checkout);
+      }
+    }
+  }
+  return null;
+}
+
+const pinnedRoot = pinnedLoreRoot(report.rev);
+assert(pinnedRoot, "located exact pinned checkout for seeded schema drift");
+const fixtureRoot = mkdtempSync(join(tmpdir(), "lore-parity-schema-"));
+try {
+  const fixtureLoreSrc = join(fixtureRoot, "lore", "src");
+  const fixtureRevisionSrc = join(fixtureRoot, "lore-revision", "src");
+  cpSync(join(pinnedRoot, "lore", "src"), fixtureLoreSrc, { recursive: true });
+  cpSync(
+    join(pinnedRoot, "lore-revision", "src"),
+    fixtureRevisionSrc,
+    { recursive: true },
+  );
+  const interfacePath = join(fixtureRevisionSrc, "interface.rs");
+  const originalInterface = readFileSync(interfacePath, "utf8");
+  const seededInterface = originalInterface.replace(
+    /\n\s*\/\/\/ Directory that relative paths[\s\S]*?\n\s*pub working_directory:\s*LoreString,\n/,
+    "\n",
+  );
+  assert(
+    seededInterface !== originalInterface,
+    "seed removed LoreGlobalArgs.working_directory from fixture",
+  );
+  writeFileSync(interfacePath, seededInterface);
+
+  const seededRun = spawnSync(
+    process.execPath,
+    [script, "--head-src", fixtureLoreSrc, "--json"],
+    { encoding: "utf8", env: process.env },
+  );
+  assert(seededRun.status === 0, "seeded shared-schema scan completes");
+  const seededReport = JSON.parse(seededRun.stdout);
+  const globalDrift = (seededReport.driftedSharedSchemas || []).find(
+    (entry) => entry.id === "LoreGlobalArgs",
+  );
+  assert(globalDrift, "seeded LoreGlobalArgs drift is reported");
+  assert(
+    globalDrift.oldSchema.fields.working_directory === "LoreString" &&
+      !("working_directory" in globalDrift.newSchema.fields),
+    "seeded drift identifies removed working_directory field",
+  );
+} finally {
+  rmSync(fixtureRoot, { recursive: true, force: true });
 }
 
 console.error("upstream-lore-parity policy tests passed");


### PR DESCRIPTION
## Summary

- pin both `lore` and the required `quinn-proto` patch to exact Epic revision `9179c6dc7cd14931af5b66beb3b2e186907f6360`
- populate the new `LoreGlobalArgs.working_directory` from LoreGUI's authoritative repository/lifecycle root rather than ambient process cwd
- add an exact-revision Unix service canary proving a relative repository operation from caller B lands only under B, never service cwd A
- extend upstream parity to track shared `LoreGlobalArgs` schema changes, with a seeded field-removal enforcement test
- regenerate `Cargo.lock` and attribution bundles via `scripts/gen-licenses.sh`

## TDD evidence

RED before implementation:
- `LoreGlobalArgs` at the prior pin had no `working_directory` field
- parity report omitted shared schemas
- the prior exact-pin service created `relative-service-canary` under service cwd A instead of caller/root B

GREEN at `ce0304d026f0c67a16a2d31cbbc2ba7dce35ca87`:
- `cargo test -p lore-vm`: 754 passed
- `cargo test -p lore-vm --features integration-tests`: 755 unit + all real lifecycle/storage integration tests passed
- exact `9179c6d` release CLI service suite: 5/5 passed, including revision verification and caller-B-only filesystem assertion
- `cargo test -p lorevm-cli`: 26 passed
- `cargo test -p lorevm-ffi`: 5 passed
- `cargo test -p loregui --lib`: 53 passed, 2 live-only ignored
- `cargo check --workspace`
- `cargo clippy -p lore-vm --all-targets --features integration-tests -- -D warnings`
- `cargo fmt --all --check`
- parity policy + seeded-negative: passed; live scan 140/140, zero new/drifted/orphaned ops and zero shared-schema drift
- boundary guard, command-registration, palette parity: passed
- `scripts/gen-licenses.sh` regenerated cleanly; `git diff --check` passed

## Compatibility

No LoreGUI op-signature compatibility issue was found. The only upstream contract addition is the shared `LoreGlobalArgs.working_directory` field, now explicitly populated and watched for future drift.
