### PR TITLE
SBAI-5487: verified backend-owned hosted-server restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3089,6 +3089,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "zeroize",
 ]
 
 [[package]]

--- a/frontend/src/HostedServerCard.spec.tsx
+++ b/frontend/src/HostedServerCard.spec.tsx
@@ -638,6 +638,113 @@ describe("HostedServerCard", () => {
     expect(screen.queryByText("PID 9999 · Process running")).toBeNull();
   });
 
+  it.each(["poll-first", "restart-first"] as const)(
+    "does not let a pre-restart poll overwrite the restart result (%s)",
+    async (completionOrder) => {
+      vi.useFakeTimers();
+      const poll = deferred<HostStatus>();
+      const restart = deferred<HostStatus>();
+      let statusCalls = 0;
+      invokeMock.mockImplementation((command: string) => {
+        if (command === "host_server_status") {
+          statusCalls += 1;
+          return statusCalls === 1 ? Promise.resolve(RUNNING_NO_AUTH) : poll.promise;
+        }
+        if (command === "host_server_restart") return restart.promise;
+        return Promise.resolve(null);
+      });
+      const HostedServerCard = await loadCard();
+      render(
+        <HostedServerCard onBrowseRepositories={() => {}} pollIntervalMs={25} />,
+      );
+      await act(async () => {
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(25);
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Restart" }));
+
+      const restarted = { ...RUNNING_NO_AUTH, pid: 4343, generation: 8 };
+      const stale = { ...RUNNING_NO_AUTH, pid: 1111, generation: 7 };
+      await act(async () => {
+        if (completionOrder === "poll-first") {
+          poll.resolve(stale);
+          await Promise.resolve();
+          restart.resolve(restarted);
+        } else {
+          restart.resolve(restarted);
+          await Promise.resolve();
+          poll.resolve(stale);
+        }
+        await Promise.resolve();
+      });
+
+      expect(screen.getByText("PID 4343 · Process running")).toBeVisible();
+      expect(screen.queryByText("PID 1111 · Process running")).toBeNull();
+    },
+  );
+
+  it("aborts an in-flight Browse when restart begins", async () => {
+    const restart = deferred<HostStatus>();
+    let browseSignal: AbortSignal | undefined;
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "host_server_status") return Promise.resolve(RUNNING_NO_AUTH);
+      if (command === "host_server_restart") return restart.promise;
+      return Promise.resolve(null);
+    });
+    const HostedServerCard = await loadCard();
+    render(
+      <HostedServerCard
+        onBrowseRepositories={(_url, signal) => {
+          browseSignal = signal;
+          return new Promise<void>(() => {});
+        }}
+      />,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Browse repositories" }));
+    expect(browseSignal?.aborted).toBe(false);
+
+    fireEvent.click(screen.getByRole("button", { name: "Restart" }));
+    expect(browseSignal?.aborted).toBe(true);
+    await act(async () => {
+      restart.resolve({ ...RUNNING_NO_AUTH, pid: 4343, generation: 8 });
+      await Promise.resolve();
+    });
+  });
+
+  it.each(["resolve", "reject"] as const)(
+    "suppresses a pending copy %s after restart begins",
+    async (completion) => {
+      const copy = deferred<void>();
+      const restart = deferred<HostStatus>();
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: { writeText: vi.fn(() => copy.promise) },
+      });
+      invokeMock.mockImplementation((command: string) => {
+        if (command === "host_server_status") return Promise.resolve(RUNNING_NO_AUTH);
+        if (command === "host_server_restart") return restart.promise;
+        return Promise.resolve(null);
+      });
+      const HostedServerCard = await loadCard();
+      render(<HostedServerCard onBrowseRepositories={() => {}} />);
+      fireEvent.click(await screen.findByRole("button", { name: "Copy URL" }));
+      fireEvent.click(screen.getByRole("button", { name: "Restart" }));
+
+      await act(async () => {
+        if (completion === "resolve") copy.resolve();
+        else copy.reject(new Error("late clipboard failure"));
+        await Promise.resolve();
+      });
+      expect(screen.queryByText("URL copied.")).toBeNull();
+      expect(screen.queryByText("Could not copy the server URL.")).toBeNull();
+
+      await act(async () => {
+        restart.resolve({ ...RUNNING_NO_AUTH, pid: 4343, generation: 8 });
+        await Promise.resolve();
+      });
+    },
+  );
+
   it("retains last non-secret configuration when stopped and disables running actions", async () => {
     vi.useFakeTimers();
     routeStatus(RUNNING_NO_AUTH, STOPPED);

--- a/frontend/src/HostedServerCard.spec.tsx
+++ b/frontend/src/HostedServerCard.spec.tsx
@@ -35,9 +35,16 @@ const RUNNING_NO_AUTH: HostStatus = {
   storeDir: "E:\\lore",
   serverName: "world-bible",
   authRequired: false,
+  generation: 7,
+  restartSupported: true,
 };
 
-const STOPPED: HostStatus = { running: false };
+const STOPPED: HostStatus = {
+  running: false,
+  restartSupported: false,
+  restartDisabledReason:
+    "Restart is unavailable because no backend-owned hosted server session is running.",
+};
 
 async function loadCard() {
   const module = await import("./HostedServerCard");
@@ -560,6 +567,77 @@ describe("HostedServerCard", () => {
     expect(screen.queryByText("stale-stop")).toBeNull();
   });
 
+  it("restarts with only the observed generation and renders backend-verified status", async () => {
+    const restart = deferred<HostStatus>();
+    invokeMock.mockImplementation((command: string, args?: unknown) => {
+      if (command === "host_server_status") return Promise.resolve(RUNNING_NO_AUTH);
+      if (command === "host_server_restart") {
+        expect(args).toEqual({ expectedGeneration: 7 });
+        return restart.promise;
+      }
+      return Promise.resolve(null);
+    });
+    const HostedServerCard = await loadCard();
+    render(<HostedServerCard onBrowseRepositories={() => {}} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Restart" }));
+
+    expect(screen.getByRole("button", { name: "Restarting…" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Stop" })).toBeDisabled();
+    await act(async () => {
+      restart.resolve({ ...RUNNING_NO_AUTH, pid: 4343, generation: 8 });
+      await Promise.resolve();
+    });
+    expect(screen.getByText("PID 4343 · Process running")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Restart" })).toBeEnabled();
+  });
+
+  it("keeps restart failure visible and re-reads authoritative rollback state", async () => {
+    let statusCalls = 0;
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "host_server_status") {
+        statusCalls += 1;
+        return Promise.resolve(RUNNING_NO_AUTH);
+      }
+      if (command === "host_server_restart") {
+        return Promise.reject("restart failed and the prior server was restored");
+      }
+      return Promise.resolve(null);
+    });
+    const HostedServerCard = await loadCard();
+    render(<HostedServerCard onBrowseRepositories={() => {}} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Restart" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "restart failed and the prior server was restored",
+    );
+    expect(statusCalls).toBe(2);
+    expect(screen.getByText("PID 4242 · Process running")).toBeVisible();
+  });
+
+  it("ignores a deferred restart completion after unmount", async () => {
+    const restart = deferred<HostStatus>();
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "host_server_status") return Promise.resolve(RUNNING_NO_AUTH);
+      if (command === "host_server_restart") return restart.promise;
+      return Promise.resolve(null);
+    });
+    const HostedServerCard = await loadCard();
+    const first = render(<HostedServerCard onBrowseRepositories={() => {}} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Restart" }));
+    first.unmount();
+    await act(async () => {
+      restart.resolve({ ...RUNNING_NO_AUTH, pid: 9999, generation: 8 });
+      await Promise.resolve();
+    });
+
+    invokeMock.mockImplementation((command: string) =>
+      command === "host_server_status" ? Promise.resolve(STOPPED) : Promise.resolve(null),
+    );
+    render(<HostedServerCard onBrowseRepositories={() => {}} />);
+    expect(await screen.findByText("Server stopped")).toBeVisible();
+    expect(screen.queryByText("PID 9999 · Process running")).toBeNull();
+  });
+
   it("retains last non-secret configuration when stopped and disables running actions", async () => {
     vi.useFakeTimers();
     routeStatus(RUNNING_NO_AUTH, STOPPED);
@@ -586,6 +664,6 @@ describe("HostedServerCard", () => {
     expect(screen.getByRole("button", { name: "Copy URL" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Stop" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Restart" })).toBeDisabled();
-    expect(screen.getByText(/backend does not retain a secret-free full launch configuration/i)).toBeVisible();
+    expect(screen.getByText(/no backend-owned hosted server session/i)).toBeVisible();
   });
 });

--- a/frontend/src/HostedServerCard.tsx
+++ b/frontend/src/HostedServerCard.tsx
@@ -2,8 +2,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { api, type HostStatus } from "./api";
 
 const DEFAULT_POLL_INTERVAL_MS = 5_000;
-const RESTART_DISABLED_REASON =
-  "Restart is unavailable because the backend does not retain a secret-free full launch configuration.";
 
 interface HostedServerContext {
   serverName?: string;
@@ -63,9 +61,11 @@ export default function HostedServerCard({
   const [error, setError] = useState<string | null>(null);
   const [copyResult, setCopyResult] = useState<"success" | "error" | null>(null);
   const [stopping, setStopping] = useState(false);
+  const [restarting, setRestarting] = useState(false);
   const mounted = useRef(false);
   const pollGeneration = useRef(0);
   const stopGeneration = useRef(0);
+  const restartGeneration = useRef(0);
   const copyGeneration = useRef(0);
   const browseController = useRef<AbortController | null>(null);
   const activeContextKey = useRef<string | null>(null);
@@ -135,6 +135,7 @@ export default function HostedServerCard({
       mounted.current = false;
       pollGeneration.current += 1;
       stopGeneration.current += 1;
+      restartGeneration.current += 1;
       copyGeneration.current += 1;
       browseController.current?.abort();
       browseController.current = null;
@@ -184,6 +185,45 @@ export default function HostedServerCard({
     }
   }, [applyStatus, invalidateCopyAndBrowse, status?.running]);
 
+  const handleRestart = useCallback(async () => {
+    if (
+      !status?.running ||
+      !status.restartSupported ||
+      typeof status.generation !== "number" ||
+      lifecycleInFlight.current
+    ) return;
+    lifecycleInFlight.current = true;
+    pollGeneration.current += 1;
+    invalidateCopyAndBrowse();
+    const generation = ++restartGeneration.current;
+    const expectedGeneration = status.generation;
+    setRestarting(true);
+    setError(null);
+    try {
+      const next = await api.hostServerRestart(expectedGeneration);
+      if (!mounted.current || generation !== restartGeneration.current) return;
+      applyStatus(next);
+    } catch (caught) {
+      if (!mounted.current || generation !== restartGeneration.current) return;
+      const message = messageFrom(caught);
+      try {
+        const current = await api.hostServerStatus();
+        if (!mounted.current || generation !== restartGeneration.current) return;
+        applyStatus(current);
+      } catch {
+        activeContextKey.current = null;
+        invalidateCopyAndBrowse();
+        setStatus(null);
+      }
+      setError(message);
+    } finally {
+      if (mounted.current && generation === restartGeneration.current) {
+        lifecycleInFlight.current = false;
+        setRestarting(false);
+      }
+    }
+  }, [applyStatus, invalidateCopyAndBrowse, status]);
+
   const handleBrowse = useCallback(() => {
     if (!status?.running || !context?.clientUrl || lifecycleInFlight.current) return;
     browseController.current?.abort();
@@ -204,7 +244,9 @@ export default function HostedServerCard({
   }, [context?.clientUrl, onBrowseRepositories, status?.running]);
 
   const running = status?.running === true;
-  const runningActionsEnabled = running && !stopping;
+  const runningActionsEnabled = running && !stopping && !restarting;
+  const restartDisabledReason = status?.restartDisabledReason ??
+    "Restart is unavailable because no backend-owned replay recipe is active.";
   const stateLabel = running
     ? "Hosted on this device"
     : error
@@ -279,20 +321,31 @@ export default function HostedServerCard({
         >
           Copy URL
         </button>
-        <button type="button" disabled title={RESTART_DISABLED_REASON}>
-          Restart
+        <button
+          type="button"
+          disabled={
+            !runningActionsEnabled ||
+            !status?.restartSupported ||
+            typeof status.generation !== "number"
+          }
+          title={status?.restartSupported ? undefined : restartDisabledReason}
+          onClick={() => void handleRestart()}
+        >
+          {restarting ? "Restarting…" : "Restart"}
         </button>
         <button
           type="button"
-          disabled={!running || stopping}
+          disabled={!running || stopping || restarting}
           onClick={() => void handleStop()}
         >
           {stopping ? "Stopping…" : "Stop"}
         </button>
       </div>
-      <p className="hosted-server-card__restart-reason">
-        {RESTART_DISABLED_REASON}
-      </p>
+      {!status?.restartSupported && (
+        <p className="hosted-server-card__restart-reason">
+          {restartDisabledReason}
+        </p>
+      )}
       {copyResult === "success" && <p role="status">URL copied.</p>}
       {copyResult === "error" && (
         <p role="alert">Could not copy the server URL.</p>

--- a/frontend/src/api.spec.ts
+++ b/frontend/src/api.spec.ts
@@ -233,6 +233,14 @@ describe("auth + onboarding wrappers", () => {
 });
 
 describe("hostServerStart option flattening", () => {
+  it("sends only the backend generation for restart", () => {
+    api.hostServerRestart(73);
+    expect(lastCall()).toEqual([
+      "host_server_restart",
+      { expectedGeneration: 73 },
+    ]);
+  });
+
   it("nulls every optional + nested s3/advanced field when only storeDir is given", () => {
     api.hostServerStart({ storeDir: "/srv/store" });
     const [name, args] = lastCall();

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -458,6 +458,11 @@ export interface HostStatus {
   serverName?: string;
   /** Auth mode from the backend-owned launch configuration; absent when stopped. */
   authRequired?: boolean;
+  /** Backend-owned lifecycle token required for generation-safe restart. */
+  generation?: number;
+  /** True only while the backend retains a complete private replay recipe. */
+  restartSupported?: boolean;
+  restartDisabledReason?: string;
   /**
    * An externally-registered, publicly-reachable URL that supersedes {@link url}
    * for display (SBAI-4072). Set by the proprietary cross-network *relay*
@@ -593,6 +598,8 @@ export const api = {
   hostServerRenderConfig: (opts: HostServerOptions) =>
     invoke<string>("host_server_render_config", { opts }),
   hostServerStop: () => invoke<HostStatus>("host_server_stop"),
+  hostServerRestart: (expectedGeneration: number) =>
+    invoke<HostStatus>("host_server_restart", { expectedGeneration }),
   hostServerStatus: () => invoke<HostStatus>("host_server_status"),
 
   // --- advertised-URL seam for the cross-network relay overlay (SBAI-4072) ---

--- a/frontend/src/palette/manifest/service/host_server_restart.ts
+++ b/frontend/src/palette/manifest/service/host_server_restart.ts
@@ -1,0 +1,26 @@
+import type { OpManifest } from "../../types";
+
+/** Generation-safe restart of the backend-owned hosted-server session. */
+const manifest: OpManifest = {
+  id: "service.host_server_restart",
+  domain: "service",
+  op: "host_server_restart",
+  label: "Host Server: Restart",
+  description:
+    "Restart the active hosted server from its private backend launch recipe. Requires the generation reported by Host Server: Status.",
+  command: "host_server_restart",
+  args: [
+    {
+      name: "expectedGeneration",
+      kind: "number",
+      label: "Expected generation",
+      description:
+        "Exact backend generation from Host Server: Status; stale values fail closed.",
+      required: true,
+    },
+  ],
+  resultKind: "json",
+  keywords: ["host", "server", "restart", "generation", "loreserver"],
+};
+
+export default manifest;

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,6 +53,8 @@ if-addrs = "0.13"
 # (SBAI-4087). Generates a cert+key pair on first host and caches it under the
 # app data dir so packaged installs never need the lore dev checkout.
 rcgen = "0.13"
+# Backend-only hosted-server replay credentials are scrubbed on stop/app exit.
+zeroize = "1"
 
 [features]
 # Forward to lore-vm so the whole app can switch backends from one flag.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2963,6 +2963,16 @@ pub fn host_server_stop(state: State<'_, AppState>) -> Result<HostStatus, LoreEr
     Ok(status)
 }
 
+/// Reconcile the externally-visible URL with the backend-owned process state.
+/// The boolean return also controls the LAN announcer: only a live child may
+/// retain either advertisement surface.
+fn reconcile_host_advertised_url(running: bool, advertised: &mut Option<String>) -> bool {
+    if !running {
+        *advertised = None;
+    }
+    running
+}
+
 /// Restart the active hosted server from the backend-owned launch recipe.
 /// `expected_generation` makes stale UI callbacks fail closed and repeated
 /// delivery of an already-successful request idempotent. No launch options or
@@ -2982,11 +2992,15 @@ pub fn host_server_restart(
             // A failed restart may have restored the prior child. Preserve its
             // advertisement only in that case; otherwise remove stale endpoint
             // claims immediately rather than waiting for a later status poll.
-            if !server_host::status(&mut slot).running {
-                *state
+            let running = server_host::status(&mut slot).running;
+            let keep_advertisements = {
+                let mut advertised = state
                     .advertised_url
                     .lock()
-                    .unwrap_or_else(|e| e.into_inner()) = None;
+                    .unwrap_or_else(|e| e.into_inner());
+                reconcile_host_advertised_url(running, &mut advertised)
+            };
+            if !keep_advertisements {
                 *state
                     .lan_announcer
                     .lock()
@@ -3019,10 +3033,17 @@ pub fn host_server_status(state: State<'_, AppState>) -> Result<HostStatus, Lore
         .lock()
         .unwrap_or_else(|e| e.into_inner());
     let status = server_host::status(&mut slot);
-    if !status.running {
+    let keep_advertisements = {
+        let mut advertised = state
+            .advertised_url
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reconcile_host_advertised_url(status.running, &mut advertised)
+    };
+    if !keep_advertisements {
         // Server is down — a stale advertised URL is meaningless; drop it.
         *state
-            .advertised_url
+            .lan_announcer
             .lock()
             .unwrap_or_else(|e| e.into_inner()) = None;
         return Ok(status);
@@ -3835,6 +3856,25 @@ pub fn lan_discover_refresh(
 pub fn lan_discover_stop(state: State<'_, AppState>) -> Result<(), LoreError> {
     *state.lan_browser.lock().unwrap_or_else(|e| e.into_inner()) = None;
     Ok(())
+}
+
+#[cfg(test)]
+mod host_restart_advertisement_tests {
+    use super::reconcile_host_advertised_url;
+
+    #[test]
+    fn rollback_success_preserves_advertised_url() {
+        let mut advertised = Some("lore://relay.example/repo".to_owned());
+        assert!(reconcile_host_advertised_url(true, &mut advertised));
+        assert_eq!(advertised.as_deref(), Some("lore://relay.example/repo"));
+    }
+
+    #[test]
+    fn rollback_failure_clears_advertised_url() {
+        let mut advertised = Some("lore://relay.example/repo".to_owned());
+        assert!(!reconcile_host_advertised_url(false, &mut advertised));
+        assert!(advertised.is_none());
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2963,6 +2963,49 @@ pub fn host_server_stop(state: State<'_, AppState>) -> Result<HostStatus, LoreEr
     Ok(status)
 }
 
+/// Restart the active hosted server from the backend-owned launch recipe.
+/// `expected_generation` makes stale UI callbacks fail closed and repeated
+/// delivery of an already-successful request idempotent. No launch options or
+/// credentials are accepted over IPC.
+#[tauri::command]
+pub fn host_server_restart(
+    state: State<'_, AppState>,
+    expected_generation: u64,
+) -> Result<HostStatus, LoreError> {
+    let mut slot = state
+        .hosted_server
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let status = match server_host::restart(&mut slot, expected_generation) {
+        Ok(status) => status,
+        Err(error) => {
+            // A failed restart may have restored the prior child. Preserve its
+            // advertisement only in that case; otherwise remove stale endpoint
+            // claims immediately rather than waiting for a later status poll.
+            if !server_host::status(&mut slot).running {
+                *state
+                    .advertised_url
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()) = None;
+                *state
+                    .lan_announcer
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()) = None;
+            }
+            return Err(error);
+        }
+    };
+    // Restart preserves the same endpoint, so the existing advertised URL and
+    // LAN announcement remain valid. Their backend-owned values are not
+    // reconstructed from frontend input.
+    let advertised = state
+        .advertised_url
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone();
+    Ok(status.with_advertised_url(advertised.as_deref()))
+}
+
 /// Current hosted-server status (running? + URL/port/pid). Reaps if it died.
 ///
 /// Overlays any externally-registered advertised URL (SBAI-4072) onto the

--- a/src-tauri/src/ipc_harness_tests.rs
+++ b/src-tauri/src/ipc_harness_tests.rs
@@ -113,6 +113,7 @@ fn build_app_with_config(config_dir: &std::path::Path) -> App<tauri::test::MockR
             commands::shared_store_create,
             commands::service_start,
             commands::service_stop,
+            commands::host_server_restart,
             commands::lock_inbox_list,
         ])
         .build(mock_context(noop_assets()))
@@ -455,6 +456,25 @@ fn auth_clear_without_repository_uses_local_auth_lifecycle() {
 
     invoke(&webview, "auth_clear", json!({}))
         .expect("auth_clear must use local auth lifecycle without a repository");
+}
+
+#[test]
+fn host_restart_rejects_without_backend_session_through_real_ipc() {
+    let app = build_app();
+    let webview = WebviewWindowBuilder::new(&app, "main", Default::default())
+        .build()
+        .expect("build webview");
+    let error = invoke(
+        &webview,
+        "host_server_restart",
+        json!({ "expectedGeneration": 41 }),
+    )
+    .expect_err("restart without a backend-owned session must fail closed");
+    assert_eq!(error["kind"], "CommandFailed");
+    assert!(error["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("no backend-owned hosted server session"));
 }
 
 #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -204,6 +204,7 @@ pub fn run() {
             commands::host_server_start,
             commands::host_server_render_config,
             commands::host_server_stop,
+            commands::host_server_restart,
             commands::host_server_status,
             commands::host_server_set_advertised_url,
             commands::host_server_clear_advertised_url,

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -2111,6 +2111,23 @@ pub fn restart(
     slot: &mut Option<HostedServer>,
     expected_generation: u64,
 ) -> Result<HostStatus, LoreError> {
+    restart_with_spawn(slot, expected_generation, spawn_verified_restart)
+}
+
+fn restart_with_spawn<F>(
+    slot: &mut Option<HostedServer>,
+    expected_generation: u64,
+    mut spawn: F,
+) -> Result<HostStatus, LoreError>
+where
+    F: FnMut(&HostedServer, u32) -> Result<Child, LoreError>,
+{
+    // A successful-generation marker is only an idempotency hint, never proof
+    // that its child is still alive. Reap before *any* generation return so a
+    // dead child cannot retain a stale PID, endpoint, or restart capability.
+    if !status(slot).running {
+        return Err(LoreError::CommandFailed(RESTART_DISABLED_STOPPED.into()));
+    }
     let Some(current) = slot.as_ref() else {
         return Err(LoreError::CommandFailed(RESTART_DISABLED_STOPPED.into()));
     };
@@ -2131,7 +2148,7 @@ pub fn restart(
         let _ = child.wait();
     }
 
-    match spawn_verified_restart(&server, previous_pid) {
+    match spawn(&server, previous_pid) {
         Ok(child) => {
             server.pid = child.id();
             server.child = Some(child);
@@ -2142,7 +2159,7 @@ pub fn restart(
             Ok(status)
         }
         Err(restart_error) => {
-            if let Ok(rollback) = spawn_verified_restart(&server, previous_pid) {
+            if let Ok(rollback) = spawn(&server, previous_pid) {
                 server.pid = rollback.id();
                 server.child = Some(rollback);
                 *slot = Some(server);
@@ -3470,5 +3487,83 @@ mod tests {
         assert!(!json.contains("PRIVATE_ID"));
         assert!(!json.contains("PRIVATE_SECRET"));
         let _ = stop(&mut slot);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn successful_restart_marker_never_advertises_a_dead_child() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut server = fake_managed_server(tmp.path(), 10, Some(9));
+        let mut child = server.child.take().expect("managed child");
+        child.kill().unwrap();
+        child.wait().unwrap();
+        server.child = Some(child);
+        let mut slot = Some(server);
+
+        let error = restart(&mut slot, 9).expect_err("dead retry must fail closed");
+
+        assert!(error
+            .to_string()
+            .contains("no backend-owned hosted server session"));
+        assert!(slot.is_none(), "dead child must be reaped from owned state");
+        let stopped = status(&mut slot);
+        assert!(!stopped.running);
+        assert!(!stopped.restart_supported);
+        assert!(stopped.pid.is_none());
+        assert!(stopped.url.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_restart_with_successful_rollback_preserves_live_owned_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let server = fake_managed_server(tmp.path(), 10, None);
+        let mut slot = Some(server);
+        let mut attempt = 0;
+
+        let error = restart_with_spawn(&mut slot, 10, |_server, _previous_pid| {
+            attempt += 1;
+            if attempt == 1 {
+                Err(LoreError::CommandFailed("seeded restart failure".into()))
+            } else {
+                Command::new("sh")
+                    .args(["-c", "sleep 30"])
+                    .spawn()
+                    .map_err(|e| LoreError::CommandFailed(e.to_string()))
+            }
+        })
+        .expect_err("restart failure must remain visible after rollback");
+
+        assert!(error.to_string().contains("prior server was restored"));
+        let rolled_back = status(&mut slot);
+        assert!(
+            rolled_back.running,
+            "live rollback keeps advertisements valid"
+        );
+        assert!(rolled_back.restart_supported);
+        assert!(rolled_back.pid.is_some());
+        assert!(rolled_back.url.is_some());
+        let _ = stop(&mut slot);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_restart_and_failed_rollback_clear_owned_advertisement_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let server = fake_managed_server(tmp.path(), 10, None);
+        let mut slot = Some(server);
+
+        let error = restart_with_spawn(&mut slot, 10, |_server, _previous_pid| {
+            Err(LoreError::CommandFailed("seeded spawn failure".into()))
+        })
+        .expect_err("double failure must fail closed");
+
+        assert!(error.to_string().contains("rollback could not restore"));
+        assert!(slot.is_none(), "no dead session may retain advertisements");
+        let stopped = status(&mut slot);
+        assert!(!stopped.running);
+        assert!(!stopped.restart_supported);
+        assert!(stopped.pid.is_none());
+        assert!(stopped.url.is_none());
     }
 }

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -32,12 +32,17 @@
 //!    `cargo tauri dev` runs where neither cache nor resource dir may be
 //!    present.  In a release build this branch is compiled out.
 
+use std::io::{Read, Write};
+use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
 use lore_vm::LoreError;
 use rcgen::{CertificateParams, DistinguishedName, DnType, KeyPair, SanType};
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
 
 /// Default QUIC/gRPC port for a hosted server. The HTTP service is `port + 2`,
 /// matching the spike. 41337 is the spike default and is unprivileged.
@@ -47,6 +52,10 @@ pub const DEFAULT_PORT: u16 = 41337;
 /// is a deliberate, separate concern (firewalling, real certs, auth) and is not
 /// what the first-run "Host a server" flow does.
 const BIND_HOST: &str = "127.0.0.1";
+const RESTART_HEALTH_TIMEOUT: Duration = Duration::from_secs(15);
+const RESTART_DISABLED_STOPPED: &str =
+    "Restart is unavailable because no backend-owned hosted server session is running.";
+static HOST_GENERATION: AtomicU64 = AtomicU64::new(0);
 
 /// Inputs from the frontend "Host a server" flow.
 ///
@@ -477,6 +486,22 @@ pub struct HostedServer {
     pub server_name: Option<String>,
     /// Whether the owned launch config enabled authentication.
     pub auth_required: bool,
+    generation: u64,
+    restarted_from: Option<u64>,
+    /// Private replay recipe. Never serialized/debugged; secret strings zeroize
+    /// when Stop or app teardown drops the hosted session.
+    restart: RestartRecipe,
+}
+
+struct RestartRecipe {
+    binary: PathBuf,
+    config_dir: PathBuf,
+    config_path: PathBuf,
+    config_toml: String,
+    expected_store_dir: PathBuf,
+    access_key_id: Option<Zeroizing<String>>,
+    secret_access_key: Option<Zeroizing<String>>,
+    region: Option<String>,
 }
 
 impl Drop for HostedServer {
@@ -521,6 +546,9 @@ pub struct HostStatus {
     /// Authentication mode from the actual backend-owned launch configuration.
     /// `None` means there is no running server configuration to report.
     pub auth_required: Option<bool>,
+    pub generation: Option<u64>,
+    pub restart_supported: bool,
+    pub restart_disabled_reason: Option<String>,
     /// An externally-registered, publicly-reachable URL that supersedes [`url`]
     /// for display (SBAI-4072). The open core never sets this; an external module
     /// (the proprietary cross-network relay overlay) registers it via
@@ -543,6 +571,9 @@ impl HostStatus {
             store_dir: None,
             server_name: None,
             auth_required: None,
+            generation: None,
+            restart_supported: false,
+            restart_disabled_reason: Some(RESTART_DISABLED_STOPPED.to_owned()),
             advertised_url: None,
         }
     }
@@ -558,6 +589,9 @@ impl HostStatus {
             store_dir: Some(server.store_dir.to_string_lossy().into_owned()),
             server_name: server.server_name.clone(),
             auth_required: Some(server.auth_required),
+            generation: Some(server.generation),
+            restart_supported: true,
+            restart_disabled_reason: None,
             advertised_url: None,
         }
     }
@@ -1333,12 +1367,20 @@ fn resolve_s3(opts: &S3StoreOptions) -> Result<ResolvedS3, LoreError> {
         ));
     }
 
+    let access_key_id = norm_str(&opts.access_key_id);
+    let secret_access_key = norm_str(&opts.secret_access_key);
+    if access_key_id.is_some() != secret_access_key.is_some() {
+        return Err(LoreError::CommandFailed(
+            "S3 access key id and secret access key must be supplied together".into(),
+        ));
+    }
+
     Ok(ResolvedS3 {
         endpoint: norm_str(&opts.endpoint),
         bucket: bucket.to_owned(),
         region: norm_str(&opts.region),
-        access_key_id: norm_str(&opts.access_key_id),
-        secret_access_key: norm_str(&opts.secret_access_key),
+        access_key_id,
+        secret_access_key,
         force_path_style: opts.force_path_style,
         dynamodb_endpoint: norm_str(&opts.dynamodb_endpoint),
     })
@@ -1823,6 +1865,12 @@ pub fn start(
         .parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(|| PathBuf::from("."));
+    let config_toml = std::fs::read_to_string(&config_path).map_err(|e| {
+        LoreError::CommandFailed(format!(
+            "could not retain restart config {}: {e}",
+            config_path.display()
+        ))
+    })?;
 
     // Boot exactly like the spike: LORE_CONFIG_PATH points at the dir holding
     // local.toml, LORE_ENV=local selects it. cwd = config dir.
@@ -1857,6 +1905,24 @@ pub fn start(
         ))
     })?;
 
+    let restart = RestartRecipe {
+        binary,
+        config_dir,
+        config_path: config_path.clone(),
+        config_toml,
+        expected_store_dir: cfg.store_dir.clone(),
+        access_key_id: cfg
+            .s3
+            .as_ref()
+            .and_then(|s| s.access_key_id.clone())
+            .map(Zeroizing::new),
+        secret_access_key: cfg
+            .s3
+            .as_ref()
+            .and_then(|s| s.secret_access_key.clone())
+            .map(Zeroizing::new),
+        region: cfg.s3.as_ref().and_then(|s| s.region.clone()),
+    };
     let server = HostedServer {
         pid: child.id(),
         child: Some(child),
@@ -1872,10 +1938,223 @@ pub fn start(
             .filter(|name| !name.is_empty())
             .map(str::to_owned),
         auth_required: cfg.auth,
+        generation: HOST_GENERATION.fetch_add(1, Ordering::SeqCst) + 1,
+        restarted_from: None,
+        restart,
     };
     let status = HostStatus::from(&server);
     *slot = Some(server);
     Ok(status)
+}
+
+fn validate_restart_recipe(recipe: &RestartRecipe) -> Result<(), LoreError> {
+    if recipe.access_key_id.is_some() != recipe.secret_access_key.is_some() {
+        return Err(LoreError::CommandFailed(
+            "restart refused: required S3 credential material is unavailable".into(),
+        ));
+    }
+    let current = std::fs::read_to_string(&recipe.config_path).map_err(|e| {
+        LoreError::CommandFailed(format!(
+            "restart refused: backend-owned config {} is unavailable: {e}",
+            recipe.config_path.display()
+        ))
+    })?;
+    if current != recipe.config_toml {
+        return Err(LoreError::CommandFailed(
+            "restart refused: backend-owned launch config changed since start".into(),
+        ));
+    }
+    let expected_config = recipe.expected_store_dir.join(".loregui-host/local.toml");
+    if recipe.config_path != expected_config {
+        return Err(LoreError::CommandFailed(format!(
+            "restart refused: launch config no longer identifies selected store {}",
+            recipe.expected_store_dir.display()
+        )));
+    }
+    Ok(())
+}
+
+fn spawn_recipe(recipe: &RestartRecipe) -> Result<Child, LoreError> {
+    validate_restart_recipe(recipe)?;
+    let mut command = Command::new(&recipe.binary);
+    command
+        .env("LORE_CONFIG_PATH", &recipe.config_dir)
+        .env("LORE_ENV", "local")
+        .current_dir(&recipe.config_dir);
+    if let Some(id) = &recipe.access_key_id {
+        command.env("AWS_ACCESS_KEY_ID", id.as_str());
+    }
+    if let Some(secret) = &recipe.secret_access_key {
+        command.env("AWS_SECRET_ACCESS_KEY", secret.as_str());
+    }
+    if let Some(region) = &recipe.region {
+        command
+            .env("AWS_REGION", region)
+            .env("AWS_DEFAULT_REGION", region);
+    }
+    command.spawn().map_err(|e| {
+        LoreError::CommandFailed(format!(
+            "failed to relaunch loreserver ({}): {e}",
+            recipe.binary.display()
+        ))
+    })
+}
+
+fn health_probe_host(url: &str) -> &str {
+    url.strip_prefix("lore://")
+        .and_then(|rest| rest.split(':').next())
+        .filter(|host| *host != "0.0.0.0" && *host != "::")
+        .unwrap_or("127.0.0.1")
+}
+
+fn wait_for_health(child: &mut Child, host: &str, http_port: u16) -> Result<(), LoreError> {
+    let deadline = Instant::now() + RESTART_HEALTH_TIMEOUT;
+    let address = format!("{host}:{http_port}");
+    let mut last = "health endpoint did not answer".to_owned();
+    while Instant::now() < deadline {
+        if let Some(exit) = child.try_wait().map_err(|e| {
+            LoreError::CommandFailed(format!("could not inspect restarted loreserver: {e}"))
+        })? {
+            return Err(LoreError::CommandFailed(format!(
+                "restarted loreserver exited before health verification: {exit}"
+            )));
+        }
+        if let Ok(mut stream) = TcpStream::connect_timeout(
+            &address
+                .parse()
+                .map_err(|e| LoreError::CommandFailed(format!("invalid health address: {e}")))?,
+            Duration::from_millis(500),
+        ) {
+            let _ = stream.set_read_timeout(Some(Duration::from_millis(750)));
+            let _ = stream.write_all(
+                b"GET /health_check HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+            );
+            let mut response = String::new();
+            match stream.read_to_string(&mut response) {
+                Ok(_)
+                    if response.starts_with("HTTP/1.1 200")
+                        || response.starts_with("HTTP/1.0 200") =>
+                {
+                    return Ok(())
+                }
+                Ok(_) => {
+                    last = response
+                        .lines()
+                        .next()
+                        .unwrap_or("empty health response")
+                        .to_owned()
+                }
+                Err(e) => last = e.to_string(),
+            }
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    Err(LoreError::CommandFailed(format!(
+        "restarted loreserver failed /health_check verification on {address}: {last}"
+    )))
+}
+
+fn verify_safe_store_operation(url: &str, generation: u64) -> Result<(), LoreError> {
+    use lore_vm::ops::repository::list::{list, ListArgs};
+    use lore_vm::LoreApi;
+
+    let probe_root = std::env::temp_dir().join(format!(
+        "loregui-host-restart-probe-{}-{generation}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&probe_root).map_err(|e| {
+        LoreError::CommandFailed(format!("could not create restart probe root: {e}"))
+    })?;
+    let api = LoreApi::new(probe_root.clone());
+    let result = tauri::async_runtime::block_on(list(
+        &api,
+        ListArgs {
+            url: url.to_owned(),
+        },
+    ));
+    let _ = std::fs::remove_dir_all(probe_root);
+    result.map(|_| ()).map_err(|e| {
+        LoreError::CommandFailed(format!(
+            "restarted loreserver failed safe repository-list verification: {e}"
+        ))
+    })
+}
+
+fn verify_restarted_child(
+    child: &mut Child,
+    previous_pid: u32,
+    server: &HostedServer,
+) -> Result<(), LoreError> {
+    if child.id() == previous_pid {
+        return Err(LoreError::CommandFailed(
+            "restart verification failed: process id did not change".into(),
+        ));
+    }
+    validate_restart_recipe(&server.restart)?;
+    wait_for_health(child, health_probe_host(&server.url), server.http_port)?;
+    verify_safe_store_operation(&server.url, server.generation)
+}
+
+fn spawn_verified_restart(server: &HostedServer, previous_pid: u32) -> Result<Child, LoreError> {
+    let mut child = spawn_recipe(&server.restart)?;
+    if let Err(error) = verify_restarted_child(&mut child, previous_pid, server) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
+    Ok(child)
+}
+
+/// Restart from the private backend launch recipe. The frontend supplies only
+/// the generation it observed, never configuration or credential material.
+pub fn restart(
+    slot: &mut Option<HostedServer>,
+    expected_generation: u64,
+) -> Result<HostStatus, LoreError> {
+    let Some(current) = slot.as_ref() else {
+        return Err(LoreError::CommandFailed(RESTART_DISABLED_STOPPED.into()));
+    };
+    if current.restarted_from == Some(expected_generation) {
+        return Ok(HostStatus::from(current));
+    }
+    if current.generation != expected_generation {
+        let actual = current.generation;
+        return Err(LoreError::CommandFailed(format!(
+            "restart refused: stale hosted-server generation {expected_generation}; current generation is {actual}"
+        )));
+    }
+    validate_restart_recipe(&current.restart)?;
+    let mut server = slot.take().expect("hosted server checked above");
+    let previous_pid = server.pid;
+    if let Some(mut child) = server.child.take() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    match spawn_verified_restart(&server, previous_pid) {
+        Ok(child) => {
+            server.pid = child.id();
+            server.child = Some(child);
+            server.restarted_from = Some(expected_generation);
+            server.generation = HOST_GENERATION.fetch_add(1, Ordering::SeqCst) + 1;
+            let status = HostStatus::from(&server);
+            *slot = Some(server);
+            Ok(status)
+        }
+        Err(restart_error) => {
+            if let Ok(rollback) = spawn_verified_restart(&server, previous_pid) {
+                server.pid = rollback.id();
+                server.child = Some(rollback);
+                *slot = Some(server);
+                return Err(LoreError::CommandFailed(format!(
+                    "restart failed and the prior server was restored: {restart_error}"
+                )));
+            }
+            Err(LoreError::CommandFailed(format!(
+                "restart failed and rollback could not restore the server: {restart_error}"
+            )))
+        }
+    }
 }
 
 /// Stop the hosted server (kill + reap). Idempotent: a no-op if none running.
@@ -2280,7 +2559,7 @@ mod tests {
             bucket: "  my-bucket  ".into(),
             region: Some("".into()),
             access_key_id: Some("  key  ".into()),
-            secret_access_key: None,
+            secret_access_key: Some("  secret  ".into()),
             force_path_style: true,
             dynamodb_endpoint: None,
         };
@@ -2289,6 +2568,7 @@ mod tests {
         assert_eq!(resolved.endpoint.as_deref(), Some("https://s3.example.com"));
         assert_eq!(resolved.region, None);
         assert_eq!(resolved.access_key_id.as_deref(), Some("key"));
+        assert_eq!(resolved.secret_access_key.as_deref(), Some("secret"));
         assert!(resolved.force_path_style);
         assert_eq!(resolved.fragments_table(), "my-bucket-fragments");
         assert_eq!(resolved.metadata_table(), "my-bucket-fragment-metadata");
@@ -2308,6 +2588,9 @@ mod tests {
             store_dir: None,
             server_name: Some("repo".into()),
             auth_required: Some(false),
+            generation: Some(1),
+            restart_supported: true,
+            restart_disabled_reason: None,
             advertised_url: None,
         };
 
@@ -2355,6 +2638,18 @@ mod tests {
             store_dir: PathBuf::from(r"E:\lore"),
             server_name: Some("world-bible".into()),
             auth_required: resolved.auth,
+            generation: 1,
+            restarted_from: None,
+            restart: RestartRecipe {
+                binary: PathBuf::from("loreserver"),
+                config_dir: PathBuf::from(r"E:\lore\.loregui-host"),
+                config_path: PathBuf::from(r"E:\lore\.loregui-host\local.toml"),
+                config_toml: String::new(),
+                expected_store_dir: PathBuf::from(r"E:\lore"),
+                access_key_id: None,
+                secret_access_key: None,
+                region: None,
+            },
         };
 
         let status = HostStatus::from(&server);
@@ -2852,6 +3147,15 @@ mod tests {
         }
         assert!(st.running, "status should still be running once bound");
 
+        let original_pid = started.pid.expect("pid");
+        let generation = started.generation.expect("generation");
+        let restarted = restart(&mut slot, generation)
+            .expect("restart must prove process, health, and repository-list operation");
+        assert_ne!(restarted.pid, Some(original_pid));
+        assert_eq!(restarted.store_dir, started.store_dir);
+        assert_eq!(restarted.url, started.url);
+        assert!(restarted.generation.expect("new generation") > generation);
+
         let stopped = stop(&mut slot).expect("stop");
         assert!(
             !stopped.running,
@@ -3065,5 +3369,106 @@ mod tests {
         // The actual error vs success depends on whether the dev checkout exists,
         // so we only assert this does not panic.
         let _ = resolve_host_cert(&ctx, false);
+    }
+
+    #[test]
+    fn restart_recipe_rejects_partial_s3_credentials_before_launch() {
+        let opts = S3StoreOptions {
+            endpoint: None,
+            bucket: "assets".into(),
+            region: None,
+            access_key_id: Some("AKIA_TEST".into()),
+            secret_access_key: None,
+            force_path_style: false,
+            dynamodb_endpoint: None,
+        };
+        let error = resolve_s3(&opts).expect_err("partial credentials must fail closed");
+        assert!(error.to_string().contains("must be supplied together"));
+    }
+
+    #[test]
+    fn restart_recipe_rejects_changed_backend_config() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config_dir = tmp.path().join(".loregui-host");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let config_path = config_dir.join("local.toml");
+        std::fs::write(&config_path, "original").unwrap();
+        let recipe = RestartRecipe {
+            binary: PathBuf::from("loreserver"),
+            config_dir,
+            config_path: config_path.clone(),
+            config_toml: "original".into(),
+            expected_store_dir: tmp.path().to_path_buf(),
+            access_key_id: None,
+            secret_access_key: None,
+            region: None,
+        };
+        std::fs::write(config_path, "tampered").unwrap();
+        let error = validate_restart_recipe(&recipe).expect_err("tamper must fail closed");
+        assert!(error.to_string().contains("launch config changed"));
+    }
+
+    #[cfg(unix)]
+    fn fake_managed_server(
+        root: &Path,
+        generation: u64,
+        restarted_from: Option<u64>,
+    ) -> HostedServer {
+        let config_dir = root.join(".loregui-host");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let config_path = config_dir.join("local.toml");
+        std::fs::write(&config_path, "exact-config").unwrap();
+        let child = Command::new("sh").args(["-c", "sleep 30"]).spawn().unwrap();
+        HostedServer {
+            pid: child.id(),
+            child: Some(child),
+            port: 41337,
+            http_port: 41339,
+            url: "lore://127.0.0.1:41337/test".into(),
+            config_path: config_path.clone(),
+            store_dir: root.to_path_buf(),
+            server_name: Some("test".into()),
+            auth_required: false,
+            generation,
+            restarted_from,
+            restart: RestartRecipe {
+                binary: PathBuf::from("sh"),
+                config_dir,
+                config_path,
+                config_toml: "exact-config".into(),
+                expected_store_dir: root.to_path_buf(),
+                access_key_id: Some(Zeroizing::new("PRIVATE_ID".into())),
+                secret_access_key: Some(Zeroizing::new("PRIVATE_SECRET".into())),
+                region: None,
+            },
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restart_rejects_stale_generation_without_touching_live_process() {
+        let tmp = tempfile::tempdir().unwrap();
+        let server = fake_managed_server(tmp.path(), 9, None);
+        let pid = server.pid;
+        let mut slot = Some(server);
+        let error = restart(&mut slot, 8).expect_err("stale generation must fail");
+        assert!(error.to_string().contains("stale hosted-server generation"));
+        assert_eq!(status(&mut slot).pid, Some(pid));
+        let _ = stop(&mut slot);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn successful_restart_retry_is_idempotent_and_status_never_serializes_secrets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let server = fake_managed_server(tmp.path(), 10, Some(9));
+        let pid = server.pid;
+        let mut slot = Some(server);
+        let retried = restart(&mut slot, 9).expect("same request retry");
+        assert_eq!(retried.pid, Some(pid), "retry must not spawn again");
+        let json = serde_json::to_string(&retried).unwrap();
+        assert!(!json.contains("PRIVATE_ID"));
+        assert!(!json.contains("PRIVATE_SECRET"));
+        let _ = stop(&mut slot);
     }
 }


### PR DESCRIPTION
## Summary
- add a real `host_server_restart` IPC path owned by the existing app-level `loreserver` controller (not upstream service stubs)
- retain the exact binary/config/store plus zeroizing process-local credential material in a private, non-serialized replay recipe
- make restart generation-safe and retry-idempotent, with stale-generation rejection and explicit backend capability/reason fields
- verify a new PID, exact selected-store config identity, `/health_check`, and a real read-only repository-list operation before reporting success
- attempt exact-recipe rollback on failure; otherwise return a visible stopped/error state and clear stale endpoint advertisements
- enable Restart in the merged #420 Hosted Server card only when the backend declares it supported

## Security / product boundaries
- frontend sends only `expectedGeneration`; it cannot supply config, paths, digests, or credentials to restart
- explicit S3 key pairs must be complete; retained strings zeroize on Stop/app teardown
- `HostStatus`, UI state, logs, and palette inputs contain no credential material
- after app restart or without a live backend recipe, `restartSupported=false` with an exact reason
- unsupported authenticated local hosting remains fail-closed as established by #420

## Verification
- `cargo test -p loregui --lib` — 74 passed, 2 ignored
- `cargo check --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy -p lore-vm -- -D warnings`
- live ignored canary: actual pinned `loreserver` start → new PID restart → HTTP health → repository-list → stop, PASS
- frontend: 23 files / 261 Vitest tests PASS; TypeScript and production build PASS
- palette parity PASS; upstream parity PASS; open-boundary guard PASS
- license bundles regenerated and diff-clean

## Remaining acceptance gate
Installed Windows/EROS restart evidence is intentionally not claimed by this code PR; it remains the external post-build runtime gate for SBAI-5487.
