### PR TITLE
feat(SBAI-5484): persist non-secret context records (P1 Task 1)

### DIFF
--- a/docs/superpowers/plans/2026-07-22-loregui-atomic-context-selection.md
+++ b/docs/superpowers/plans/2026-07-22-loregui-atomic-context-selection.md
@@ -536,8 +536,8 @@ cargo test -p loregui
 cargo check --workspace
 cargo fmt --all -- --check
 cd frontend && npm run test && npm run typecheck && npm run build && cd ..
-node scripts/check-boundaries.mjs
-node scripts/check-palette-parity.mjs
+bash scripts/check-open-boundary.sh
+node frontend/scripts/palette-parity.mjs
 git diff --check origin/main...HEAD
 ```
 

--- a/docs/superpowers/plans/2026-07-22-loregui-atomic-context-selection.md
+++ b/docs/superpowers/plans/2026-07-22-loregui-atomic-context-selection.md
@@ -1,0 +1,568 @@
+# LoreGUI Atomic Context Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace split `open_repository` plus `context_update` project/server selection with one generation-guarded Rust transaction that persists context and repository identity together before publishing runtime state.
+
+**Architecture:** `context_select` resolves a typed project/server ID from a validated `ContextSettings` payload. A coordinator shared by registration and commit rejects superseded generations; `SettingsManager` writes one candidate containing both `context` and `active_repository`, then Rust publishes or clears `working_dir` last. React calls this command once and publishes only its authoritative result.
+
+**Tech Stack:** Rust, Tauri 2 IPC, serde, lore-vm `default_backend`, React 18, TypeScript, Vitest.
+
+## Global Constraints
+
+- Raw repository paths are never authoritative command inputs.
+- `request_generation` is positive and monotonic within `ContextProvider`'s dedicated selection counter.
+- Generation is checked before commit and immediately before runtime publication under the same coordinator lock.
+- `ContextSettings` and `active_repository` are persisted in one candidate write before `working_dir` changes.
+- Validation, stale generation, or persistence failure leaves disk, settings cache, and runtime repository unchanged.
+- Project selection publishes `working_dir` last; server selection clears it last.
+- IPC errors are stable and redacted; never return paths, credentials, payloads, or backend details.
+- P0 restore/current-repository/CWD behavior is unchanged.
+- Task 3 UI, browser, favorites, and unrelated refactoring are out of scope.
+
+---
+
+### Task 1: Atomic persistence and generation coordinator
+
+**Files:**
+- Modify: `src-tauri/src/settings.rs`
+- Modify: `src-tauri/src/context.rs`
+- Modify: `src-tauri/src/commands.rs`
+- Test: `src-tauri/src/settings.rs`
+- Test: `src-tauri/src/context.rs`
+
+**Interfaces:**
+- Produces: `SettingsManager::update_context_selection(ContextSettings, Option<PathBuf>) -> Result<(), String>`
+- Produces: `ContextSelectionCoordinator::register(u64) -> Result<(), String>` and `ensure_current(u64) -> Result<(), String>`
+- Consumes later: `AppState.context_selection: Mutex<ContextSelectionCoordinator>`
+
+- [ ] **Step 1: Write failing transactional settings tests**
+
+Add tests which persist a baseline project/context, call the new method, reload
+from disk, and assert both fields changed together. Add a blocked-config test
+that asserts both cache and disk retain the baseline:
+
+```rust
+fn complete_context() -> ContextSettings {
+    let mut context = ContextSettings::default();
+    context.servers.push(ServerProfile {
+        id: "server-1".into(),
+        alias: "Local Lore".into(),
+        url: "lore://127.0.0.1:41337/repository-1".into(),
+        source: ServerSource::Manual,
+        favorite: false,
+        auth_mode: AuthMode::NotRequired,
+        credential_ref: None,
+        last_seen_at: None,
+    });
+    context
+}
+
+#[test]
+fn context_selection_persists_context_and_repository_as_one_candidate() {
+    let tmp = tempfile::tempdir().expect("temp settings directory");
+    let settings = SettingsManager::new(tmp.path().to_path_buf());
+    let context = complete_context();
+    let path = tmp.path().join("project-a");
+
+    settings
+        .update_context_selection(context.clone(), Some(path.clone()))
+        .expect("atomic context selection");
+
+    let reloaded = SettingsManager::new(tmp.path().to_path_buf()).get();
+    assert_eq!(reloaded.context, context);
+    assert_eq!(reloaded.active_repository, Some(path));
+}
+
+#[test]
+fn failed_context_selection_retains_cache_and_disk() {
+    let tmp = tempfile::tempdir().expect("temp root");
+    let blocked = tmp.path().join("blocked-config");
+    std::fs::write(&blocked, "not-a-directory").expect("blocking file");
+    let settings = SettingsManager::new(blocked.clone());
+    let before = settings.get();
+
+    assert!(settings
+        .update_context_selection(complete_context(), Some(tmp.path().join("candidate")))
+        .is_err());
+    let after = settings.get();
+    assert_eq!(after.context, before.context);
+    assert_eq!(after.active_repository, before.active_repository);
+    assert_eq!(after.autostart_enabled, before.autostart_enabled);
+    assert_eq!(after.close_to_tray, before.close_to_tray);
+    assert_eq!(std::fs::read_to_string(blocked).unwrap(), "not-a-directory");
+}
+```
+
+- [ ] **Step 2: Run the settings tests and record RED**
+
+Run:
+
+```bash
+cargo test -p loregui settings::tests::context_selection -- --nocapture
+```
+
+Expected: compile failure because `update_context_selection` does not exist.
+
+- [ ] **Step 3: Implement the one-candidate settings method**
+
+Add to `SettingsManager`:
+
+```rust
+pub fn update_context_selection(
+    &self,
+    context: ContextSettings,
+    active_repository: Option<PathBuf>,
+) -> Result<(), String> {
+    context.validate_for_persistence()?;
+    self.update(move |settings| {
+        settings.context = context;
+        settings.active_repository = active_repository;
+    })
+}
+```
+
+- [ ] **Step 4: Write failing coordinator tests**
+
+Define tests in `context.rs` before implementation:
+
+```rust
+#[test]
+fn coordinator_rejects_zero_duplicate_and_superseded_generations() {
+    let mut coordinator = ContextSelectionCoordinator::default();
+    assert!(coordinator.register(0).is_err());
+    coordinator.register(1).expect("generation one");
+    assert!(coordinator.register(1).is_err());
+    coordinator.register(2).expect("generation two");
+    assert!(coordinator.ensure_current(1).is_err());
+    coordinator.ensure_current(2).expect("current generation");
+}
+```
+
+- [ ] **Step 5: Implement the coordinator and AppState field**
+
+In `context.rs` add:
+
+```rust
+#[derive(Debug, Default)]
+pub struct ContextSelectionCoordinator {
+    latest_generation: u64,
+}
+
+impl ContextSelectionCoordinator {
+    pub fn register(&mut self, generation: u64) -> Result<(), String> {
+        if generation == 0 || generation <= self.latest_generation {
+            return Err("context selection request is stale".into());
+        }
+        self.latest_generation = generation;
+        Ok(())
+    }
+
+    pub fn ensure_current(&self, generation: u64) -> Result<(), String> {
+        if generation != self.latest_generation {
+            return Err("context selection request is stale".into());
+        }
+        Ok(())
+    }
+}
+```
+
+Add to `AppState` in `commands.rs`:
+
+```rust
+pub(crate) context_selection: Mutex<crate::context::ContextSelectionCoordinator>,
+```
+
+Initialize it with `Mutex::new(ContextSelectionCoordinator::default())` in the
+production app and every test `AppState` constructor.
+
+- [ ] **Step 6: Run focused tests and commit**
+
+Run:
+
+```bash
+cargo test -p loregui settings::tests -- --nocapture
+cargo test -p loregui context::tests::coordinator -- --nocapture
+cargo fmt --all -- --check
+```
+
+Expected: all pass.
+
+Commit:
+
+```bash
+git add src-tauri/src/settings.rs src-tauri/src/context.rs src-tauri/src/commands.rs src-tauri/src/lib.rs src-tauri/src/ipc_harness_tests.rs
+git commit -m "feat(SBAI-5484): add atomic context selection state"
+```
+
+---
+
+### Task 2: Backend-owned typed selection command
+
+**Files:**
+- Modify: `src-tauri/src/context.rs`
+- Modify: `src-tauri/src/lib.rs`
+- Modify: `src-tauri/src/ipc_harness_tests.rs`
+
+**Interfaces:**
+- Consumes: `SettingsManager::update_context_selection`
+- Consumes: `AppState.context_selection`
+- Produces: Tauri command `context_select(context, target, request_generation) -> ContextSelectionResult`
+- Produces: private `register_context_selection(&AppState, u64) -> Result<(), String>`
+- Produces: private `commit_context_selection(&AppState, &SettingsManager, u64, ContextSettings, Option<PathBuf>, Option<RepoStatus>) -> Result<ContextSelectionResult, String>`
+
+- [ ] **Step 1: Add typed request/response shapes and failing serde tests**
+
+Add these exact public IPC types to `context.rs`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ContextSelectionTarget {
+    Project { project_id: String },
+    Server { server_id: String },
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct ContextSelectionResult {
+    pub context: ContextSettings,
+    pub active_repository: Option<String>,
+    pub status: Option<lore_vm::RepoStatus>,
+}
+```
+
+Add a serde negative proving `{kind:"project", project_id:"p", path:"C:/raw"}`
+is rejected and positive project/server round trips succeed.
+
+- [ ] **Step 2: Run the serde tests and record RED**
+
+Run:
+
+```bash
+cargo test -p loregui context::tests::selection_target -- --nocapture
+```
+
+Expected: compile failure because the IPC types do not exist.
+
+- [ ] **Step 3: Write failing state-transition tests**
+
+Using `create_offline_fixture_repository`, add tests that directly exercise
+the command or its private commit helper:
+
+```rust
+#[test]
+fn stale_a_cannot_commit_after_b_registers() {
+    let app = build_app();
+    register_context_selection(&app.state::<AppState>(), 1).unwrap();
+    register_context_selection(&app.state::<AppState>(), 2).unwrap();
+    let error = commit_context_selection(
+        &app.state::<AppState>(),
+        &app.state::<SettingsManager>(),
+        1,
+        ContextSettings::default(),
+        None,
+        None,
+    )
+    .unwrap_err();
+    assert_eq!(error, "context selection request is stale");
+    assert_eq!(commands::current_repository(app.state()), None);
+}
+```
+
+Add direct tests for:
+
+- blocked persistence with no prior repository leaves runtime/cache empty;
+- blocked persistence with an existing repository leaves the prior runtime and
+  saved context unchanged;
+- successful server selection persists `active_repository = None` and clears
+  `working_dir`;
+- unknown target IDs and invalid context fail before any state mutation; and
+- errors equal stable redacted strings and do not contain fixture paths.
+
+- [ ] **Step 4: Implement target normalization, registration, validation, and commit**
+
+Implement `context_select` with this control flow:
+
+```rust
+#[tauri::command]
+pub async fn context_select(
+    state: State<'_, AppState>,
+    settings: State<'_, SettingsManager>,
+    context: ContextSettings,
+    target: ContextSelectionTarget,
+    request_generation: u64,
+) -> Result<ContextSelectionResult, String> {
+    let normalized = normalize_selection(context, &target)?;
+    register_context_selection(&state, request_generation)?;
+
+    let (active_repository, status) = match &target {
+        ContextSelectionTarget::Project { project_id } => {
+            let project = normalized.projects.iter().find(|item| &item.id == project_id)
+                .ok_or_else(|| "selected project is unavailable".to_string())?;
+            let path = PathBuf::from(&project.local_path);
+            let status = default_backend(path.clone()).status().await
+                .map_err(|_| "selected project could not be opened".to_string())?;
+            (Some(path), Some(status))
+        }
+        ContextSelectionTarget::Server { .. } => (None, None),
+    };
+
+    commit_context_selection(
+        &state,
+        &settings,
+        request_generation,
+        normalized,
+        active_repository,
+        status,
+    )
+}
+```
+
+Implement the helpers so registration and the synchronous persist/publish
+commit use the same coordinator lock:
+
+```rust
+fn register_context_selection(state: &AppState, generation: u64) -> Result<(), String> {
+    state
+        .context_selection
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .register(generation)
+}
+
+fn commit_context_selection(
+    state: &AppState,
+    settings: &SettingsManager,
+    generation: u64,
+    context: ContextSettings,
+    active_repository: Option<PathBuf>,
+    status: Option<lore_vm::RepoStatus>,
+) -> Result<ContextSelectionResult, String> {
+    let coordinator = state
+        .context_selection
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    coordinator.ensure_current(generation)?;
+    settings
+        .update_context_selection(context.clone(), active_repository.clone())
+        .map_err(|_| "selected context could not be saved".to_string())?;
+    coordinator.ensure_current(generation)?;
+    *state.working_dir.lock().unwrap_or_else(|error| error.into_inner()) =
+        active_repository.clone();
+    Ok(ContextSelectionResult {
+        context,
+        active_repository: active_repository.map(|path| path.to_string_lossy().into_owned()),
+        status,
+    })
+}
+```
+
+`normalize_selection` must derive `active.project_id`, `active.server_id`, and
+identity retention from IDs already present in the validated context. It must
+call `validate_for_persistence` after normalization. Do not accept a path from
+the target.
+
+- [ ] **Step 5: Register the command in production and MockRuntime handlers**
+
+Add `context_select` beside `context_get/context_validate/context_update` in
+`src-tauri/src/lib.rs` and the MockRuntime handler. Add a request-level IPC test
+that sends the typed target and asserts the returned context, path, and status.
+Add a request containing a raw `path` field and assert deserialization fails.
+
+- [ ] **Step 6: Demonstrate generation and publish-last enforcement**
+
+Run the stale-A test against the implementation and record PASS. Temporarily
+remove `coordinator.ensure_current(request_generation)?` before the settings
+write; rerun and record that `stale_a_cannot_commit_after_b_registers` FAILS.
+Restore the guard.
+
+Temporarily assign `working_dir` before `update_context_selection`; rerun the
+blocked-persistence test and record that it FAILS because the candidate becomes
+visible. Restore publish-last.
+
+- [ ] **Step 7: Run Rust gates and commit**
+
+Run:
+
+```bash
+cargo test -p loregui context::tests -- --nocapture
+cargo test -p loregui ipc_harness_tests -- --nocapture
+cargo check -p loregui
+cargo fmt --all -- --check
+```
+
+Expected: all pass after both mutations are restored.
+
+Commit:
+
+```bash
+git add src-tauri/src/context.rs src-tauri/src/lib.rs src-tauri/src/ipc_harness_tests.rs
+git commit -m "feat(SBAI-5484): select Lore context atomically"
+```
+
+---
+
+### Task 3: Frontend consumes authoritative atomic selection
+
+**Files:**
+- Modify: `frontend/src/context/types.ts`
+- Modify: `frontend/src/context/api.ts`
+- Modify: `frontend/src/context/ContextProvider.tsx`
+- Modify: `frontend/src/context/ContextProvider.spec.tsx`
+
+**Interfaces:**
+- Consumes: `context_select` IPC and `ContextSelectionResult`
+- Produces: unchanged `useLoreContext()` public API
+
+- [ ] **Step 1: Extend the five existing provider regressions with RED race/failure cases**
+
+Add deferred mocks that assert:
+
+```typescript
+it("keeps the prior snapshot when atomic selection persistence fails", async () => {
+  // Restore project A, select B, reject context_select, then assert A remains
+  // visible and no open_repository/context_update command was issued.
+});
+
+it("lets B win when deferred A resolves after B", async () => {
+  // select A with generation 1, select B with generation 2, resolve B then A;
+  // assert B is the only published project and generations [1, 2] were sent.
+});
+
+it("server selection closes the public repository snapshot", async () => {
+  // Return an authoritative server-only context from context_select and assert
+  // project/repository/branch are null while the selected server remains.
+});
+```
+
+Assert every selection makes exactly one `context_select` call and never calls
+`open_repository` or `context_update`.
+
+- [ ] **Step 2: Run focused Vitest and record RED**
+
+Run:
+
+```bash
+cd frontend
+npx vitest run src/context/ContextProvider.spec.tsx
+```
+
+Expected: the new tests fail because the provider still composes split IPC.
+
+- [ ] **Step 3: Add exact frontend IPC types and client**
+
+In `types.ts` add:
+
+```typescript
+export type ContextSelectionTarget =
+  | { kind: "project"; project_id: string }
+  | { kind: "server"; server_id: string };
+
+export interface ContextSelectionResult {
+  context: ContextSettings;
+  active_repository: string | null;
+  status: RepoStatus | null;
+}
+```
+
+In `api.ts` add:
+
+```typescript
+select: (
+  context: ContextSettings,
+  target: ContextSelectionTarget,
+  requestGeneration: number,
+) =>
+  invoke<ContextSelectionResult>("context_select", {
+    context,
+    target,
+    requestGeneration,
+  }),
+```
+
+- [ ] **Step 4: Replace split selection calls and separate generations**
+
+Keep the existing view/refresh `operation` ref. Add:
+
+```typescript
+const selectionGeneration = useRef(0);
+```
+
+For both selection functions increment only `selectionGeneration`, call
+`contextApi.select` once, and publish only when the returned generation is
+still current. Project publication uses returned `status` and resolved records;
+server publication uses the returned server-only context. Do not call
+`openRepository`, `currentRepository`, `status`, or `update` during selection.
+Catch only to set stable generic UI errors; retain prior React state.
+
+- [ ] **Step 5: Run frontend gates and commit**
+
+Run:
+
+```bash
+cd frontend
+npx vitest run src/context/ContextProvider.spec.tsx src/App.spec.tsx
+npm run typecheck
+npm run test
+npm run build
+```
+
+Expected: all pass.
+
+Commit:
+
+```bash
+git add frontend/src/context/types.ts frontend/src/context/api.ts frontend/src/context/ContextProvider.tsx frontend/src/context/ContextProvider.spec.tsx
+git commit -m "feat(SBAI-5484): consume atomic context selection"
+```
+
+---
+
+### Task 4: Full verification and immutable review handoff
+
+**Files:**
+- Verify only: all Task 1-3 files and existing guard scripts
+
+**Interfaces:**
+- Produces: frozen PR head with reproducible evidence; no merge or Jira transition
+
+- [ ] **Step 1: Run full repository gates**
+
+Run:
+
+```bash
+cargo test -p loregui
+cargo check --workspace
+cargo fmt --all -- --check
+cd frontend && npm run test && npm run typecheck && npm run build && cd ..
+node scripts/check-boundaries.mjs
+node scripts/check-palette-parity.mjs
+git diff --check origin/main...HEAD
+```
+
+Expected: every command succeeds.
+
+- [ ] **Step 2: Verify scope and forbidden calls**
+
+Run:
+
+```bash
+git diff --name-only 692f9ea...HEAD
+rg -n 'openRepository|contextApi\.update' frontend/src/context/ContextProvider.tsx
+rg -n 'context_select' src-tauri/src/lib.rs src-tauri/src/ipc_harness_tests.rs frontend/src/context
+```
+
+Expected: no Task 3/UI files; no split selection calls remain in the provider;
+the new command is registered and tested in Rust and TypeScript.
+
+- [ ] **Step 3: Push the frozen head and route exact-SHA reviews**
+
+```bash
+git push origin worker/sbai-5484-p1
+gh pr view 424 --repo BiloxiStudios/loregui --json headRefOid,state,mergeStateStatus,url
+```
+
+Record the exact SHA, the RED/GREEN and mutation-proof evidence, and all gate
+results. Route independent spec/quality review and sb-secure review. Do not
+merge, transition Jira, or begin Task 3.

--- a/docs/superpowers/plans/2026-07-22-loregui-atomic-context-selection.md
+++ b/docs/superpowers/plans/2026-07-22-loregui-atomic-context-selection.md
@@ -4,13 +4,14 @@
 
 **Goal:** Replace split `open_repository` plus `context_update` project/server selection with one generation-guarded Rust transaction that persists context and repository identity together before publishing runtime state.
 
-**Architecture:** `context_select` resolves a typed project/server ID from a validated `ContextSettings` payload. A coordinator shared by registration and commit rejects superseded generations; `SettingsManager` writes one candidate containing both `context` and `active_repository`, then Rust publishes or clears `working_dir` last. React calls this command once and publishes only its authoritative result.
+**Architecture:** `context_select` accepts only a typed project/server ID and request generation, then resolves the complete context and authoritative path from persisted `SettingsManager` state. A coordinator shared by registration and commit rejects superseded generations; `SettingsManager` writes one candidate containing both `context` and `active_repository`, then Rust publishes or clears `working_dir` last. React calls this command once and publishes only its authoritative result.
 
 **Tech Stack:** Rust, Tauri 2 IPC, serde, lore-vm `default_backend`, React 18, TypeScript, Vitest.
 
 ## Global Constraints
 
-- Raw repository paths are never authoritative command inputs.
+- Caller-supplied `ContextSettings` and raw repository paths are never authoritative command inputs.
+- Project, repository, server, and local-path resolution uses only persisted `SettingsManager` state.
 - `request_generation` is positive and monotonic within `ContextProvider`'s dedicated selection counter.
 - Generation is checked before commit and immediately before runtime publication under the same coordinator lock.
 - `ContextSettings` and `active_repository` are persisted in one candidate write before `working_dir` changes.
@@ -207,7 +208,7 @@ git commit -m "feat(SBAI-5484): add atomic context selection state"
 **Interfaces:**
 - Consumes: `SettingsManager::update_context_selection`
 - Consumes: `AppState.context_selection`
-- Produces: Tauri command `context_select(context, target, request_generation) -> ContextSelectionResult`
+- Produces: Tauri command `context_select(target, request_generation) -> ContextSelectionResult`
 - Produces: private `register_context_selection(&AppState, u64) -> Result<(), String>`
 - Produces: private `commit_context_selection(&AppState, &SettingsManager, u64, ContextSettings, Option<PathBuf>, Option<RepoStatus>) -> Result<ContextSelectionResult, String>`
 
@@ -289,11 +290,11 @@ Implement `context_select` with this control flow:
 pub async fn context_select(
     state: State<'_, AppState>,
     settings: State<'_, SettingsManager>,
-    context: ContextSettings,
     target: ContextSelectionTarget,
     request_generation: u64,
 ) -> Result<ContextSelectionResult, String> {
-    let normalized = normalize_selection(context, &target)?;
+    let persisted = settings.get();
+    let normalized = normalize_selection(persisted.context, &target)?;
     register_context_selection(&state, request_generation)?;
 
     let (active_repository, status) = match &target {
@@ -359,9 +360,9 @@ fn commit_context_selection(
 ```
 
 `normalize_selection` must derive `active.project_id`, `active.server_id`, and
-identity retention from IDs already present in the validated context. It must
-call `validate_for_persistence` after normalization. Do not accept a path from
-the target.
+identity retention from IDs already present in the persisted and validated
+context. It must call `validate_for_persistence` after normalization. Do not
+accept context or a path from the caller.
 
 - [ ] **Step 5: Register the command in production and MockRuntime handlers**
 
@@ -369,6 +370,9 @@ Add `context_select` beside `context_get/context_validate/context_update` in
 `src-tauri/src/lib.rs` and the MockRuntime handler. Add a request-level IPC test
 that sends the typed target and asserts the returned context, path, and status.
 Add a request containing a raw `path` field and assert deserialization fails.
+Add a request with a valid persisted project ID plus forged caller `context` and
+`local_path` data; prove the forged path is never probed or published and the
+persisted server-side project path is the only path used.
 
 - [ ] **Step 6: Demonstrate generation and publish-last enforcement**
 
@@ -470,12 +474,10 @@ In `api.ts` add:
 
 ```typescript
 select: (
-  context: ContextSettings,
   target: ContextSelectionTarget,
   requestGeneration: number,
 ) =>
   invoke<ContextSelectionResult>("context_select", {
-    context,
     target,
     requestGeneration,
   }),
@@ -490,9 +492,10 @@ const selectionGeneration = useRef(0);
 ```
 
 For both selection functions increment only `selectionGeneration`, call
-`contextApi.select` once, and publish only when the returned generation is
-still current. Project publication uses returned `status` and resolved records;
-server publication uses the returned server-only context. Do not call
+`contextApi.select` once with only the typed target and generation, and publish
+only when the returned generation is still current. Project publication uses
+returned `status` and resolved records; server publication uses the returned
+server-only context. Do not call
 `openRepository`, `currentRepository`, `status`, or `update` during selection.
 Catch only to set stable generic UI errors; retain prior React state.
 

--- a/docs/superpowers/plans/2026-07-22-loregui-atomic-context-selection.md
+++ b/docs/superpowers/plans/2026-07-22-loregui-atomic-context-selection.md
@@ -569,3 +569,96 @@ gh pr view 424 --repo BiloxiStudios/loregui --json headRefOid,state,mergeStateSt
 Record the exact SHA, the RED/GREEN and mutation-proof evidence, and all gate
 results. Route independent spec/quality review and sb-secure review. Do not
 merge, transition Jira, or begin Task 3.
+
+---
+
+### Task 5: Remove caller-authoritative context from atomic selection
+
+**Files:**
+- Modify: `src-tauri/src/context.rs`
+- Modify: `src-tauri/src/ipc_harness_tests.rs`
+- Modify: `frontend/src/context/api.ts`
+- Modify: `frontend/src/context/ContextProvider.tsx`
+- Modify: `frontend/src/context/ContextProvider.spec.tsx`
+
+**Interfaces:**
+- Changes: `context_select(target, request_generation) -> ContextSelectionResult`
+- Resolves: complete context, project/server records, and local path from
+  persisted `SettingsManager` state only
+- Changes: `contextApi.select(target, requestGeneration)`
+- Preserves: generation coordinator, atomic persist-before-publish, server
+  close, stable redacted errors, and all prior P0 restore/CWD gates
+
+- [ ] **Step 1: Add request-level and frontend RED tests**
+
+At the Rust IPC boundary, persist a context whose project points at repository
+path A. Send a valid typed project target and generation together with a forged
+caller `context` whose same project ID points at path B. The command must use A,
+never validate or probe B, and return/persist/publish only the server-owned
+context and path A. Add a raw-path-in-target negative if the existing one does
+not already cover the exact command shape.
+
+In `ContextProvider.spec.tsx`, assert both project and server selection invoke
+`context_select` with exactly `target` and `requestGeneration`; a `context`
+property must be absent.
+
+- [ ] **Step 2: Run focused tests and record RED**
+
+```bash
+cargo test -p loregui context_select -- --nocapture
+cd frontend && npx vitest run src/context/ContextProvider.spec.tsx
+```
+
+Expected: the forged-context IPC proof or exact payload assertions fail because
+the command and client still accept and transmit caller `ContextSettings`.
+
+- [ ] **Step 3: Make persisted SettingsManager context authoritative**
+
+Remove `context: ContextSettings` from the Rust command. After registering the
+generation, load `settings.get().context`, validate it, and normalize the typed
+target against that persisted context. Project status probing may use only the
+local path resolved from this persisted catalog. Do not add a combined
+context-edit-and-select command or any new raw-path input.
+
+Keep registration before asynchronous repository probing. Keep the existing
+coordinator lock around commit, atomic settings candidate write, generation
+re-check, and publish-last behavior unchanged.
+
+- [ ] **Step 4: Remove context from the frontend payload**
+
+Change `contextApi.select` and both provider call sites to send only the typed
+target and request generation. The provider may use its current context only
+for local availability checks and must publish the authoritative returned
+context. Preserve the dedicated selection generation and failure behavior.
+
+- [ ] **Step 5: Run focused and full correction gates**
+
+```bash
+cargo test -p loregui context::tests -- --nocapture
+cargo test -p loregui context_select -- --nocapture
+cargo test -p loregui ipc_harness_tests -- --nocapture
+cd frontend
+npx vitest run src/context/ContextProvider.spec.tsx src/App.spec.tsx
+npm run typecheck
+npm run test
+npm run build
+cd ..
+cargo check --workspace
+cargo fmt --all -- --check
+bash scripts/check-open-boundary.sh
+node frontend/scripts/palette-parity.mjs
+git diff --check origin/main...HEAD
+```
+
+Expected: all pass. Report the named RED before implementation and GREEN after.
+
+- [ ] **Step 6: Commit and route exact-head review**
+
+```bash
+git add src-tauri/src/context.rs src-tauri/src/ipc_harness_tests.rs \
+  frontend/src/context/api.ts frontend/src/context/ContextProvider.tsx \
+  frontend/src/context/ContextProvider.spec.tsx
+git commit -m "fix(SBAI-5484): resolve selection from persisted context"
+```
+
+Do not merge, transition Jira, or begin Task 3 UI/browser work.

--- a/docs/superpowers/specs/2026-07-21-loregui-standalone-context-ux-design.md
+++ b/docs/superpowers/specs/2026-07-21-loregui-standalone-context-ux-design.md
@@ -143,7 +143,8 @@ pub struct HostedServerProfile {
     pub display_name: String,
     pub store_path: String,
     pub advertised_url: String,
-    pub last_configuration: String,
+    // UTC timestamp metadata only; raw launch configuration is never persisted.
+    pub last_configured_at: String,
 }
 
 pub struct ActiveContext {

--- a/docs/superpowers/specs/2026-07-22-loregui-atomic-context-selection-design.md
+++ b/docs/superpowers/specs/2026-07-22-loregui-atomic-context-selection-design.md
@@ -1,7 +1,7 @@
 # LoreGUI Atomic Context Selection Design
 
-**Ticket:** SBAI-5484, P1 Task 2  
-**PR:** #424  
+**Ticket:** SBAI-5484, P1 Task 2
+**PR:** #424
 **Status:** Trio-approved design; implementation pending
 
 ## Problem

--- a/docs/superpowers/specs/2026-07-22-loregui-atomic-context-selection-design.md
+++ b/docs/superpowers/specs/2026-07-22-loregui-atomic-context-selection-design.md
@@ -1,0 +1,129 @@
+# LoreGUI Atomic Context Selection Design
+
+**Ticket:** SBAI-5484, P1 Task 2  
+**PR:** #424  
+**Status:** Trio-approved design; implementation pending
+
+## Problem
+
+LoreGUI currently changes project context through two independent IPC calls:
+
+1. `open_repository` validates a path, persists `AppSettings.active_repository`,
+   and publishes `AppState.working_dir`.
+2. `context_update` separately persists `ContextSettings`.
+
+This split permits durable and runtime state to disagree. If the second call
+fails, a new repository may remain active while the saved context and React
+snapshot retain the previous selection. The first project has no prior path to
+re-open, a rollback can itself fail, and frontend generations cannot undo a
+Rust mutation. Concurrent selections can also allow an older request to mutate
+Rust after a newer user intent.
+
+There is no repository close/clear IPC. `repository_release` is a Lore
+repository operation and is not a context lifecycle primitive.
+
+## Decision
+
+Add one backend-owned atomic context-selection command. It owns validation,
+optimistic concurrency, persistence, and runtime publication for both project
+and server selection.
+
+Separate close/rollback IPC is rejected because it retains multi-call failure
+windows. Frontend-only locking is rejected because it cannot undo mutations
+that already crossed the IPC boundary.
+
+## Contract
+
+The command accepts:
+
+- a complete `ContextSettings` candidate;
+- a typed target containing either a `project_id` or `server_id`; and
+- a positive monotonic `request_generation` allocated by the active frontend
+  provider.
+
+Raw repository paths are not command inputs. The backend validates the context
+and resolves the selected project, repository, server, and local path from the
+typed IDs.
+
+The command returns an authoritative selection result containing the persisted
+context, active repository path when applicable, and real repository status
+when a project is selected.
+
+## Concurrency and Transaction Semantics
+
+The backend owns a serialized selection coordinator. Registration and commit
+both take the coordinator lock. Registration records the newest request
+generation before asynchronous work. Older generations are stale even if they
+finish validation later.
+
+For a project target:
+
+1. Validate the complete context and resolve the project path server-side.
+2. Validate the repository through the real backend `status` path without
+   mutating application state.
+3. Take the coordinator lock again and re-check that this request is still the
+   newest generation.
+4. While holding that lock, persist one `AppSettings` candidate
+   containing both `ContextSettings` and `active_repository`.
+5. Re-check generation immediately before publication. Registration uses the
+   same coordinator lock, so a newer request cannot appear between the durable
+   write and publication.
+6. Publish `AppState.working_dir` last.
+7. Return the authoritative context, path, and status.
+
+For a server target:
+
+1. Validate and resolve the server server-side.
+2. Set the candidate context to the selected server with no active project.
+3. Persist the context and `active_repository = None` in one settings update.
+4. Re-check generation and clear `working_dir` last.
+5. Return the authoritative server-only context.
+
+Validation, stale-generation, or persistence failure leaves settings cache,
+settings on disk, and runtime working directory unchanged. A stale request may
+not persist or publish. Errors returned to the frontend are stable and
+non-secret; raw paths, settings content, IPC payloads, credentials, and backend
+details are not surfaced.
+
+## Frontend Data Flow
+
+`ContextProvider` remains the only allocator of selection generations. A
+dedicated selection-generation ref is separate from refresh/view generations,
+so an unrelated refresh cannot suppress frontend publication after a committed
+backend selection. The provider no longer composes `open_repository` and
+`context_update` for selections.
+
+Project and server selections call the atomic command once and publish only the
+returned authoritative result. React state is not changed on command failure.
+Superseded callbacks are ignored, while the backend generation contract ensures
+they also cannot mutate Rust state.
+
+Restore remains unchanged: startup accepts a persisted project only when the
+P0 `current_repository` path exactly matches and real `status` succeeds. No
+process-CWD or AppData fallback is introduced.
+
+## Tests and Evidence
+
+Request-level Rust IPC tests and React tests must prove:
+
+- a first-project persistence failure leaves no repository active;
+- a persistence failure with a prior project retains the prior runtime and
+  persisted selection without a rollback call;
+- concurrent A then B selection rejects late A before persistence/publication;
+- server selection atomically clears active repository and working directory;
+- malformed target IDs, raw-path attempts, stale generations, validation
+  failures, and persistence failures fail closed with redacted errors;
+- successful project selection publishes only after the combined settings
+  candidate is durable; and
+- existing P0 restore, caller-root/CWD, boundary, and secret tests remain green.
+
+Demonstrate enforcement by mutating out the generation re-check and the
+publish-last ordering independently; each mutation must make a named regression
+test fail.
+
+## Scope
+
+Authorized Task 2 expansion is limited to the command/API contract, `AppState`,
+`SettingsManager`, Tauri registration, context frontend integration, and direct
+Rust/React tests. Task 3 UI, repository browser, favorites, and unrelated
+refactoring remain out of scope.

--- a/docs/superpowers/specs/2026-07-22-loregui-atomic-context-selection-design.md
+++ b/docs/superpowers/specs/2026-07-22-loregui-atomic-context-selection-design.md
@@ -36,14 +36,15 @@ that already crossed the IPC boundary.
 
 The command accepts:
 
-- a complete `ContextSettings` candidate;
 - a typed target containing either a `project_id` or `server_id`; and
 - a positive monotonic `request_generation` allocated by the active frontend
   provider.
 
-Raw repository paths are not command inputs. The backend validates the context
-and resolves the selected project, repository, server, and local path from the
-typed IDs.
+`ContextSettings` and raw repository paths are not command inputs. The backend
+loads and validates the complete context from its persisted `SettingsManager`
+state, then resolves the selected project, repository, server, and local path
+from the typed ID. The caller supplies no authoritative context or path data,
+even indirectly.
 
 The command returns an authoritative selection result containing the persisted
 context, active repository path when applicable, and real repository status
@@ -58,7 +59,8 @@ finish validation later.
 
 For a project target:
 
-1. Validate the complete context and resolve the project path server-side.
+1. Load and validate the persisted context, then resolve the project and its
+   local path server-side from the typed ID.
 2. Validate the repository through the real backend `status` path without
    mutating application state.
 3. Take the coordinator lock again and re-check that this request is still the
@@ -73,7 +75,8 @@ For a project target:
 
 For a server target:
 
-1. Validate and resolve the server server-side.
+1. Load and validate the persisted context, then resolve the server server-side
+   from the typed ID.
 2. Set the candidate context to the selected server with no active project.
 3. Persist the context and `active_repository = None` in one settings update.
 4. Re-check generation and clear `working_dir` last.
@@ -93,10 +96,11 @@ so an unrelated refresh cannot suppress frontend publication after a committed
 backend selection. The provider no longer composes `open_repository` and
 `context_update` for selections.
 
-Project and server selections call the atomic command once and publish only the
-returned authoritative result. React state is not changed on command failure.
-Superseded callbacks are ignored, while the backend generation contract ensures
-they also cannot mutate Rust state.
+Project and server selections call the atomic command once with only the typed
+target and generation, and publish only the returned authoritative result.
+React does not send a `ContextSettings` candidate. React state is not changed on
+command failure. Superseded callbacks are ignored, while the backend generation
+contract ensures they also cannot mutate Rust state.
 
 Restore remains unchanged: startup accepts a persisted project only when the
 P0 `current_repository` path exactly matches and real `status` succeeds. No
@@ -111,6 +115,9 @@ Request-level Rust IPC tests and React tests must prove:
   persisted selection without a rollback call;
 - concurrent A then B selection rejects late A before persistence/publication;
 - server selection atomically clears active repository and working directory;
+- a valid project ID accompanied by forged caller context or `local_path` data
+  cannot cause that path to be validated, probed, persisted, or published; the
+  persisted server-side context remains authoritative;
 - malformed target IDs, raw-path attempts, stale generations, validation
   failures, and persistence failures fail closed with redacted errors;
 - successful project selection publishes only after the combined settings

--- a/frontend/scripts/palette-parity-allowlist.json
+++ b/frontend/scripts/palette-parity-allowlist.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Command-palette parity ratchet. excluded = permanently out of the palette (app lifecycle / streaming / internal-onboarding helpers / pure duplicates of already-exposed ops, not standalone request/response forms). deferred = registered commands not YET exposed in the palette; remove each entry as its manifest/<domain>/<op>.ts lands. CI fails if a registered command is in neither the manifest nor this file, or if a deferred entry is already covered/gone.",
-  "_sbai_5484_comment": "context_get, context_update, and context_validate are internal context-controller IPC, not standalone user operations.",
+  "_sbai_5484_comment": "context_get, context_select, context_update, and context_validate are internal context-controller IPC, not standalone user operations; context_select requires a complete validated context, typed target, and concurrency generation and is used only by ContextProvider.",
   "excluded": [
     "current_repository",
     "open_repository",
@@ -32,6 +32,7 @@
     "lan_discover_stop",
     "clone",
     "context_get",
+    "context_select",
     "context_update",
     "context_validate"
   ],

--- a/frontend/scripts/palette-parity-allowlist.json
+++ b/frontend/scripts/palette-parity-allowlist.json
@@ -1,5 +1,6 @@
 {
   "_comment": "Command-palette parity ratchet. excluded = permanently out of the palette (app lifecycle / streaming / internal-onboarding helpers / pure duplicates of already-exposed ops, not standalone request/response forms). deferred = registered commands not YET exposed in the palette; remove each entry as its manifest/<domain>/<op>.ts lands. CI fails if a registered command is in neither the manifest nor this file, or if a deferred entry is already covered/gone.",
+  "_sbai_5484_comment": "context_get, context_update, and context_validate are internal context-controller IPC, not standalone user operations.",
   "excluded": [
     "current_repository",
     "open_repository",
@@ -29,7 +30,10 @@
     "lock_inbox_dismiss",
     "lan_discover_refresh",
     "lan_discover_stop",
-    "clone"
+    "clone",
+    "context_get",
+    "context_update",
+    "context_validate"
   ],
   "deferred": []
 }

--- a/frontend/src/context/ContextProvider.spec.tsx
+++ b/frontend/src/context/ContextProvider.spec.tsx
@@ -281,7 +281,6 @@ describe("ContextProvider", () => {
     expect(snapshot().branch).toBe("selected-main");
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(invokeMock).toHaveBeenCalledWith("context_select", {
-      context: fixture(null),
       target: { kind: "project", project_id: "project-1" },
       requestGeneration: 1,
     });
@@ -428,7 +427,6 @@ describe("ContextProvider", () => {
     });
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(invokeMock).toHaveBeenCalledWith("context_select", {
-      context: fixture(),
       target: { kind: "server", server_id: "server-2" },
       requestGeneration: 1,
     });

--- a/frontend/src/context/ContextProvider.spec.tsx
+++ b/frontend/src/context/ContextProvider.spec.tsx
@@ -1,0 +1,313 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import {
+  ContextProvider,
+  useLoreContext,
+} from "./ContextProvider";
+import type { ContextSettings } from "./types";
+
+const projectOnePath = "C:/projects/game-lore";
+const projectTwoPath = "C:/projects/cinematic-lore";
+
+function fixture(activeProjectId: string | null = "project-1"): ContextSettings {
+  return {
+    schema_version: 1,
+    servers: [
+      {
+        id: "server-1",
+        alias: "EROS Lore",
+        url: "lore://eros",
+        source: "manual",
+        favorite: true,
+        auth_mode: "required",
+        credential_ref: "windows-credential-manager://loregui/server/server-1",
+        last_seen_at: "2026-07-21T12:00:00Z",
+      },
+      {
+        id: "server-2",
+        alias: "Local Lore",
+        url: "lore://localhost",
+        source: "hosted",
+        favorite: false,
+        auth_mode: "not_required",
+        credential_ref: null,
+        last_seen_at: null,
+      },
+    ],
+    repositories: [
+      {
+        id: "repository-1",
+        server_id: "server-1",
+        display_name: "Game Lore",
+        url: "lore://eros/game",
+        favorite: true,
+      },
+      {
+        id: "repository-2",
+        server_id: "server-2",
+        display_name: "Cinematic Lore",
+        url: "lore://localhost/cinematic",
+        favorite: false,
+      },
+    ],
+    projects: [
+      {
+        id: "project-1",
+        repository_id: "repository-1",
+        display_name: "Game Lore",
+        local_path: projectOnePath,
+        branch: "persisted-branch",
+        favorite: true,
+        last_opened_at: "2026-07-21T12:00:00Z",
+      },
+      {
+        id: "project-2",
+        repository_id: "repository-2",
+        display_name: "Cinematic Lore",
+        local_path: projectTwoPath,
+        branch: "cinematic",
+        favorite: false,
+        last_opened_at: "2026-07-21T12:00:00Z",
+      },
+    ],
+    hosted_servers: [],
+    active: {
+      project_id: activeProjectId,
+      server_id: activeProjectId === null ? null : "server-1",
+      identity_ref: null,
+    },
+  };
+}
+
+function status(branch = "validated-main") {
+  return {
+    repo_id: "repository-id",
+    branch,
+    revision: "revision-id",
+    changes: [],
+    ahead: 0,
+    behind: 0,
+  };
+}
+
+function Probe() {
+  const context = useLoreContext();
+  return (
+    <>
+      <output data-testid="snapshot">
+        {JSON.stringify({
+          server: context.snapshot.server?.id ?? null,
+          repository: context.snapshot.repository?.id ?? null,
+          project: context.snapshot.project?.id ?? null,
+          branch: context.snapshot.branch,
+          authMode: context.snapshot.authMode,
+          connection: context.snapshot.connection,
+        })}
+      </output>
+      <output data-testid="unavailable">
+        {[...context.unavailableProjectIds].sort().join(",")}
+      </output>
+      <output data-testid="validation-error">
+        {context.validationError ?? ""}
+      </output>
+      <button onClick={() => void context.selectProject("project-1")}>
+        Select project one
+      </button>
+      <button onClick={() => void context.selectProject("project-2")}>
+        Select project two
+      </button>
+      <button onClick={() => void context.selectServer("server-2")}>
+        Select server two
+      </button>
+      <button onClick={() => void context.refresh()}>Refresh context</button>
+    </>
+  );
+}
+
+function snapshot() {
+  return JSON.parse(screen.getByTestId("snapshot").textContent ?? "{}") as {
+    server: string | null;
+    repository: string | null;
+    project: string | null;
+    branch: string | null;
+    authMode: string;
+    connection: string;
+  };
+}
+
+beforeEach(() => {
+  invokeMock.mockReset();
+});
+
+describe("ContextProvider", () => {
+  it("restores a saved project only after P0 path and status validation", async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "context_get") return Promise.resolve(fixture());
+      if (command === "current_repository") return Promise.resolve(projectOnePath);
+      if (command === "status") return Promise.resolve(status());
+      return Promise.reject(new Error(`unexpected command: ${command}`));
+    });
+
+    render(
+      <ContextProvider>
+        <Probe />
+      </ContextProvider>,
+    );
+
+    await waitFor(() => expect(snapshot().project).toBe("project-1"));
+    expect(snapshot()).toEqual({
+      server: "server-1",
+      repository: "repository-1",
+      project: "project-1",
+      branch: "validated-main",
+      authMode: "required",
+      connection: "offline",
+    });
+    expect(screen.getByTestId("unavailable")).toHaveTextContent("");
+    expect(invokeMock.mock.calls.map(([command]) => command)).toEqual([
+      "context_get",
+      "current_repository",
+      "status",
+    ]);
+  });
+
+  it("keeps repository actions closed and marks only the stale project unavailable", async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "context_get") return Promise.resolve(fixture());
+      if (command === "current_repository") return Promise.resolve(null);
+      return Promise.reject(new Error(`must not probe ${command}`));
+    });
+
+    render(
+      <ContextProvider>
+        <Probe />
+      </ContextProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("unavailable")).toHaveTextContent("project-1"),
+    );
+    expect(snapshot()).toEqual({
+      server: null,
+      repository: null,
+      project: null,
+      branch: null,
+      authMode: "unknown",
+      connection: "offline",
+    });
+    expect(screen.getByTestId("unavailable")).not.toHaveTextContent("project-2");
+    expect(screen.getByTestId("validation-error")).toHaveTextContent(
+      "Saved project is unavailable",
+    );
+    expect(invokeMock.mock.calls.some(([command]) => command === "status")).toBe(false);
+    expect(invokeMock.mock.calls.some(([command]) => command === "open_repository")).toBe(false);
+  });
+
+  it("validates and opens a project before persisting and publishing it", async () => {
+    let runtimePath: string | null = null;
+    invokeMock.mockImplementation((command: string, args?: { context?: ContextSettings; path?: string }) => {
+      if (command === "context_get") return Promise.resolve(fixture(null));
+      if (command === "context_validate") return Promise.resolve(args?.context);
+      if (command === "open_repository") {
+        runtimePath = args?.path ?? null;
+        return Promise.resolve();
+      }
+      if (command === "current_repository") return Promise.resolve(runtimePath);
+      if (command === "status") return Promise.resolve(status("selected-main"));
+      if (command === "context_update") return Promise.resolve(args?.context);
+      return Promise.reject(new Error(`unexpected command: ${command}`));
+    });
+
+    render(
+      <ContextProvider>
+        <Probe />
+      </ContextProvider>,
+    );
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("context_get"));
+    fireEvent.click(screen.getByRole("button", { name: "Select project one" }));
+
+    await waitFor(() => expect(snapshot().project).toBe("project-1"));
+    expect(snapshot().branch).toBe("selected-main");
+    const commands = invokeMock.mock.calls.map(([command]) => command);
+    expect(commands).toEqual([
+      "context_get",
+      "context_validate",
+      "open_repository",
+      "current_repository",
+      "status",
+      "context_update",
+    ]);
+  });
+
+  it("retains the previous active context and redacts IPC details when persistence fails", async () => {
+    let runtimePath: string | null = projectOnePath;
+    invokeMock.mockImplementation((command: string, args?: { context?: ContextSettings; path?: string }) => {
+      if (command === "context_get") return Promise.resolve(fixture());
+      if (command === "context_validate") return Promise.resolve(args?.context);
+      if (command === "open_repository") {
+        runtimePath = args?.path ?? null;
+        return Promise.resolve();
+      }
+      if (command === "current_repository") return Promise.resolve(runtimePath);
+      if (command === "status") return Promise.resolve(status());
+      if (command === "context_update") {
+        return Promise.reject("failed with ghp_should-never-render");
+      }
+      return Promise.reject(new Error(`unexpected command: ${command}`));
+    });
+
+    render(
+      <ContextProvider>
+        <Probe />
+      </ContextProvider>,
+    );
+    await waitFor(() => expect(snapshot().project).toBe("project-1"));
+    fireEvent.click(screen.getByRole("button", { name: "Select project two" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("validation-error")).toHaveTextContent(
+        "Could not save selected project",
+      ),
+    );
+    expect(snapshot().project).toBe("project-1");
+    expect(document.body).not.toHaveTextContent("ghp_should-never-render");
+  });
+
+  it("persists a server selection before publishing it without opening a repository", async () => {
+    invokeMock.mockImplementation((command: string, args?: { context?: ContextSettings }) => {
+      if (command === "context_get") return Promise.resolve(fixture(null));
+      if (command === "context_validate") return Promise.resolve(args?.context);
+      if (command === "context_update") return Promise.resolve(args?.context);
+      return Promise.reject(new Error(`unexpected command: ${command}`));
+    });
+
+    render(
+      <ContextProvider>
+        <Probe />
+      </ContextProvider>,
+    );
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("context_get"));
+    fireEvent.click(screen.getByRole("button", { name: "Select server two" }));
+
+    await waitFor(() => expect(snapshot().server).toBe("server-2"));
+    expect(snapshot()).toEqual({
+      server: "server-2",
+      repository: null,
+      project: null,
+      branch: null,
+      authMode: "not_required",
+      connection: "offline",
+    });
+    expect(invokeMock.mock.calls.map(([command]) => command)).toEqual([
+      "context_get",
+      "context_validate",
+      "context_update",
+    ]);
+  });
+});

--- a/frontend/src/context/ContextProvider.spec.tsx
+++ b/frontend/src/context/ContextProvider.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const invokeMock = vi.fn();
@@ -11,6 +11,22 @@ import {
   useLoreContext,
 } from "./ContextProvider";
 import type { ContextSettings } from "./types";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
 const projectOnePath = "C:/projects/game-lore";
 const projectTwoPath = "C:/projects/cinematic-lore";
@@ -93,6 +109,36 @@ function status(branch = "validated-main") {
     changes: [],
     ahead: 0,
     behind: 0,
+  };
+}
+
+function selectedProjectContext(
+  projectId: "project-1" | "project-2",
+): ContextSettings {
+  const context = fixture(projectId);
+  const project = context.projects.find((item) => item.id === projectId)!;
+  const repository = context.repositories.find(
+    (item) => item.id === project.repository_id,
+  )!;
+  return {
+    ...context,
+    active: {
+      project_id: projectId,
+      server_id: repository.server_id,
+      identity_ref: null,
+    },
+  };
+}
+
+function selectedServerContext(serverId: string): ContextSettings {
+  const context = fixture();
+  return {
+    ...context,
+    active: {
+      project_id: null,
+      server_id: serverId,
+      identity_ref: null,
+    },
   };
 }
 
@@ -209,18 +255,16 @@ describe("ContextProvider", () => {
     expect(invokeMock.mock.calls.some(([command]) => command === "open_repository")).toBe(false);
   });
 
-  it("validates and opens a project before persisting and publishing it", async () => {
-    let runtimePath: string | null = null;
-    invokeMock.mockImplementation((command: string, args?: { context?: ContextSettings; path?: string }) => {
+  it("publishes a project from one authoritative atomic selection", async () => {
+    invokeMock.mockImplementation((command: string) => {
       if (command === "context_get") return Promise.resolve(fixture(null));
-      if (command === "context_validate") return Promise.resolve(args?.context);
-      if (command === "open_repository") {
-        runtimePath = args?.path ?? null;
-        return Promise.resolve();
+      if (command === "context_select") {
+        return Promise.resolve({
+          context: selectedProjectContext("project-1"),
+          active_repository: projectOnePath,
+          status: status("selected-main"),
+        });
       }
-      if (command === "current_repository") return Promise.resolve(runtimePath);
-      if (command === "status") return Promise.resolve(status("selected-main"));
-      if (command === "context_update") return Promise.resolve(args?.context);
       return Promise.reject(new Error(`unexpected command: ${command}`));
     });
 
@@ -230,35 +274,31 @@ describe("ContextProvider", () => {
       </ContextProvider>,
     );
     await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("context_get"));
+    invokeMock.mockClear();
     fireEvent.click(screen.getByRole("button", { name: "Select project one" }));
 
     await waitFor(() => expect(snapshot().project).toBe("project-1"));
     expect(snapshot().branch).toBe("selected-main");
-    const commands = invokeMock.mock.calls.map(([command]) => command);
-    expect(commands).toEqual([
-      "context_get",
-      "context_validate",
-      "open_repository",
-      "current_repository",
-      "status",
-      "context_update",
-    ]);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(invokeMock).toHaveBeenCalledWith("context_select", {
+      context: fixture(null),
+      target: { kind: "project", project_id: "project-1" },
+      requestGeneration: 1,
+    });
+    expect(
+      invokeMock.mock.calls.some(
+        ([command]) => command === "open_repository" || command === "context_update",
+      ),
+    ).toBe(false);
   });
 
-  it("retains the previous active context and redacts IPC details when persistence fails", async () => {
-    let runtimePath: string | null = projectOnePath;
-    invokeMock.mockImplementation((command: string, args?: { context?: ContextSettings; path?: string }) => {
+  it("keeps the prior snapshot when atomic selection persistence fails", async () => {
+    const failedSelection = deferred<never>();
+    invokeMock.mockImplementation((command: string) => {
       if (command === "context_get") return Promise.resolve(fixture());
-      if (command === "context_validate") return Promise.resolve(args?.context);
-      if (command === "open_repository") {
-        runtimePath = args?.path ?? null;
-        return Promise.resolve();
-      }
-      if (command === "current_repository") return Promise.resolve(runtimePath);
+      if (command === "current_repository") return Promise.resolve(projectOnePath);
       if (command === "status") return Promise.resolve(status());
-      if (command === "context_update") {
-        return Promise.reject("failed with ghp_should-never-render");
-      }
+      if (command === "context_select") return failedSelection.promise;
       return Promise.reject(new Error(`unexpected command: ${command}`));
     });
 
@@ -268,7 +308,16 @@ describe("ContextProvider", () => {
       </ContextProvider>,
     );
     await waitFor(() => expect(snapshot().project).toBe("project-1"));
+    invokeMock.mockClear();
     fireEvent.click(screen.getByRole("button", { name: "Select project two" }));
+    await waitFor(() =>
+      expect(
+        invokeMock.mock.calls.filter(([command]) => command === "context_select"),
+      ).toHaveLength(1),
+    );
+    await act(async () => {
+      failedSelection.reject("failed with ghp_should-never-render");
+    });
 
     await waitFor(() =>
       expect(screen.getByTestId("validation-error")).toHaveTextContent(
@@ -277,13 +326,85 @@ describe("ContextProvider", () => {
     );
     expect(snapshot().project).toBe("project-1");
     expect(document.body).not.toHaveTextContent("ghp_should-never-render");
+    expect(invokeMock.mock.calls.map(([command]) => command)).toEqual([
+      "context_select",
+    ]);
+    expect(
+      invokeMock.mock.calls.some(
+        ([command]) => command === "open_repository" || command === "context_update",
+      ),
+    ).toBe(false);
   });
 
-  it("persists a server selection before publishing it without opening a repository", async () => {
-    invokeMock.mockImplementation((command: string, args?: { context?: ContextSettings }) => {
-      if (command === "context_get") return Promise.resolve(fixture(null));
-      if (command === "context_validate") return Promise.resolve(args?.context);
-      if (command === "context_update") return Promise.resolve(args?.context);
+  it("lets B win when deferred A resolves after B", async () => {
+    const selectionA = deferred<unknown>();
+    const selectionB = deferred<unknown>();
+    invokeMock.mockImplementation(
+      (command: string, args?: { target?: { project_id?: string } }) => {
+        if (command === "context_get") return Promise.resolve(fixture(null));
+        if (command === "context_select") {
+          return args?.target?.project_id === "project-1"
+            ? selectionA.promise
+            : selectionB.promise;
+        }
+        return Promise.reject(new Error(`unexpected command: ${command}`));
+      },
+    );
+
+    render(
+      <ContextProvider>
+        <Probe />
+      </ContextProvider>,
+    );
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("context_get"));
+    invokeMock.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "Select project one" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select project two" }));
+
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      selectionB.resolve({
+        context: selectedProjectContext("project-2"),
+        active_repository: projectTwoPath,
+        status: status("branch-b"),
+      });
+      await selectionB.promise;
+    });
+    expect(snapshot().project).toBe("project-2");
+    expect(snapshot().branch).toBe("branch-b");
+
+    await act(async () => {
+      selectionA.resolve({
+        context: selectedProjectContext("project-1"),
+        active_repository: projectOnePath,
+        status: status("late-branch-a"),
+      });
+      await selectionA.promise;
+    });
+    expect(snapshot().project).toBe("project-2");
+    expect(snapshot().branch).toBe("branch-b");
+    expect(
+      invokeMock.mock.calls.map(([, args]) => args.requestGeneration),
+    ).toEqual([1, 2]);
+    expect(
+      invokeMock.mock.calls.some(
+        ([command]) => command === "open_repository" || command === "context_update",
+      ),
+    ).toBe(false);
+  });
+
+  it("server selection closes the public repository snapshot", async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "context_get") return Promise.resolve(fixture());
+      if (command === "current_repository") return Promise.resolve(projectOnePath);
+      if (command === "status") return Promise.resolve(status());
+      if (command === "context_select") {
+        return Promise.resolve({
+          context: selectedServerContext("server-2"),
+          active_repository: null,
+          status: null,
+        });
+      }
       return Promise.reject(new Error(`unexpected command: ${command}`));
     });
 
@@ -292,7 +413,8 @@ describe("ContextProvider", () => {
         <Probe />
       </ContextProvider>,
     );
-    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("context_get"));
+    await waitFor(() => expect(snapshot().project).toBe("project-1"));
+    invokeMock.mockClear();
     fireEvent.click(screen.getByRole("button", { name: "Select server two" }));
 
     await waitFor(() => expect(snapshot().server).toBe("server-2"));
@@ -304,10 +426,16 @@ describe("ContextProvider", () => {
       authMode: "not_required",
       connection: "offline",
     });
-    expect(invokeMock.mock.calls.map(([command]) => command)).toEqual([
-      "context_get",
-      "context_validate",
-      "context_update",
-    ]);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(invokeMock).toHaveBeenCalledWith("context_select", {
+      context: fixture(),
+      target: { kind: "server", server_id: "server-2" },
+      requestGeneration: 1,
+    });
+    expect(
+      invokeMock.mock.calls.some(
+        ([command]) => command === "open_repository" || command === "context_update",
+      ),
+    ).toBe(false);
   });
 });

--- a/frontend/src/context/ContextProvider.tsx
+++ b/frontend/src/context/ContextProvider.tsx
@@ -1,0 +1,263 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { contextApi } from "./api";
+import {
+  EMPTY_CONTEXT_SNAPSHOT,
+  recordsForProject,
+  snapshotForProject,
+  type ActiveContextSnapshot,
+  type ContextSettings,
+} from "./types";
+
+const SAVED_PROJECT_UNAVAILABLE =
+  "Saved project is unavailable. Choose another project or restore its local path.";
+
+interface LoreContextValue {
+  snapshot: ActiveContextSnapshot;
+  unavailableProjectIds: ReadonlySet<string>;
+  validationError: string | null;
+  selectProject: (projectId: string) => Promise<void>;
+  selectServer: (serverId: string) => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const LoreContext = createContext<LoreContextValue | null>(null);
+
+export function ContextProvider({ children }: { children: ReactNode }) {
+  const [settings, setSettings] = useState<ContextSettings | null>(null);
+  const [snapshot, setSnapshot] = useState<ActiveContextSnapshot>(
+    EMPTY_CONTEXT_SNAPSHOT,
+  );
+  const [unavailableProjectIds, setUnavailableProjectIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const operation = useRef(0);
+  const snapshotRef = useRef(snapshot);
+
+  useEffect(() => {
+    snapshotRef.current = snapshot;
+  }, [snapshot]);
+
+  const refresh = useCallback(async () => {
+    const generation = ++operation.current;
+    let context: ContextSettings;
+    try {
+      context = await contextApi.get();
+    } catch {
+      if (generation === operation.current) {
+        setValidationError("Could not read saved Lore context.");
+      }
+      return;
+    }
+    if (generation !== operation.current) return;
+    setSettings(context);
+
+    const projectId = context.active.project_id;
+    if (!projectId) {
+      setSnapshot(EMPTY_CONTEXT_SNAPSHOT);
+      setUnavailableProjectIds(new Set());
+      setValidationError(null);
+      return;
+    }
+
+    const records = recordsForProject(context, projectId);
+    if (!records) {
+      setSnapshot(EMPTY_CONTEXT_SNAPSHOT);
+      setUnavailableProjectIds(new Set([projectId]));
+      setValidationError(SAVED_PROJECT_UNAVAILABLE);
+      return;
+    }
+
+    try {
+      const currentPath = await contextApi.currentRepository();
+      if (currentPath !== records.project.local_path) {
+        throw new Error("saved project is not the validated P0 repository");
+      }
+      const status = await contextApi.status();
+      if (generation !== operation.current) return;
+      setSnapshot(snapshotForProject(records, status));
+      setUnavailableProjectIds(new Set());
+      setValidationError(null);
+    } catch {
+      if (generation === operation.current) {
+        setSnapshot(EMPTY_CONTEXT_SNAPSHOT);
+        setUnavailableProjectIds(new Set([projectId]));
+        setValidationError(SAVED_PROJECT_UNAVAILABLE);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    return () => {
+      operation.current += 1;
+    };
+  }, [refresh]);
+
+  const selectProject = useCallback(
+    async (projectId: string) => {
+      const generation = ++operation.current;
+      const current = settings;
+      const records = current ? recordsForProject(current, projectId) : null;
+      if (!current || !records) {
+        setValidationError("Selected project is not available in saved context.");
+        return;
+      }
+
+      const candidate: ContextSettings = {
+        ...current,
+        active: {
+          project_id: projectId,
+          server_id: records.repository.server_id,
+          identity_ref:
+            current.active.server_id === records.repository.server_id
+              ? current.active.identity_ref
+              : null,
+        },
+      };
+
+      let validated: ContextSettings;
+      try {
+        validated = await contextApi.validate(candidate);
+      } catch {
+        if (generation === operation.current) {
+          setValidationError("Selected project context is invalid.");
+        }
+        return;
+      }
+
+      let status;
+      try {
+        await contextApi.openRepository(records.project.local_path);
+        const openedPath = await contextApi.currentRepository();
+        if (openedPath !== records.project.local_path) {
+          throw new Error("opened repository path did not match selection");
+        }
+        status = await contextApi.status();
+      } catch {
+        if (generation === operation.current) {
+          setUnavailableProjectIds((previous) =>
+            new Set([...previous, projectId]),
+          );
+          setValidationError("Could not open selected project.");
+        }
+        return;
+      }
+
+      let persisted: ContextSettings;
+      try {
+        persisted = await contextApi.update(validated);
+      } catch {
+        // Re-open the prior validated project when possible so backend runtime
+        // state cannot silently diverge from the retained frontend snapshot.
+        const previousPath = snapshotRef.current.project?.local_path;
+        if (previousPath && previousPath !== records.project.local_path) {
+          try {
+            await contextApi.openRepository(previousPath);
+          } catch {
+            // Keep the public error non-secret; the next refresh remains closed
+            // unless P0 independently validates a matching saved project.
+          }
+        }
+        if (generation === operation.current) {
+          setValidationError("Could not save selected project.");
+        }
+        return;
+      }
+
+      if (generation !== operation.current) return;
+      const persistedRecords = recordsForProject(persisted, projectId);
+      if (!persistedRecords) {
+        setValidationError("Saved project context could not be resolved.");
+        return;
+      }
+      setSettings(persisted);
+      setSnapshot(snapshotForProject(persistedRecords, status));
+      setUnavailableProjectIds((previous) => {
+        const next = new Set(previous);
+        next.delete(projectId);
+        return next;
+      });
+      setValidationError(null);
+    },
+    [settings],
+  );
+
+  const selectServer = useCallback(
+    async (serverId: string) => {
+      const generation = ++operation.current;
+      const current = settings;
+      const server = current?.servers.find((item) => item.id === serverId);
+      if (!current || !server) {
+        setValidationError("Selected server is not available in saved context.");
+        return;
+      }
+      const candidate: ContextSettings = {
+        ...current,
+        active: {
+          project_id: null,
+          server_id: serverId,
+          identity_ref:
+            current.active.server_id === serverId
+              ? current.active.identity_ref
+              : null,
+        },
+      };
+
+      try {
+        const validated = await contextApi.validate(candidate);
+        const persisted = await contextApi.update(validated);
+        if (generation !== operation.current) return;
+        const persistedServer =
+          persisted.servers.find((item) => item.id === serverId) ?? null;
+        if (!persistedServer) {
+          setValidationError("Saved server context could not be resolved.");
+          return;
+        }
+        setSettings(persisted);
+        setSnapshot({
+          ...EMPTY_CONTEXT_SNAPSHOT,
+          server: persistedServer,
+          authMode: persistedServer.auth_mode,
+        });
+        setValidationError(null);
+      } catch {
+        if (generation === operation.current) {
+          setValidationError("Could not save selected server.");
+        }
+      }
+    },
+    [settings],
+  );
+
+  return (
+    <LoreContext.Provider
+      value={{
+        snapshot,
+        unavailableProjectIds,
+        validationError,
+        selectProject,
+        selectServer,
+        refresh,
+      }}
+    >
+      {children}
+    </LoreContext.Provider>
+  );
+}
+
+export function useLoreContext(): LoreContextValue {
+  const context = useContext(LoreContext);
+  if (!context) {
+    throw new Error("useLoreContext must be used within ContextProvider");
+  }
+  return context;
+}

--- a/frontend/src/context/ContextProvider.tsx
+++ b/frontend/src/context/ContextProvider.tsx
@@ -111,7 +111,6 @@ export function ContextProvider({ children }: { children: ReactNode }) {
       let result;
       try {
         result = await contextApi.select(
-          current,
           { kind: "project", project_id: projectId },
           generation,
         );
@@ -155,7 +154,6 @@ export function ContextProvider({ children }: { children: ReactNode }) {
 
       try {
         const result = await contextApi.select(
-          current,
           { kind: "server", server_id: serverId },
           generation,
         );

--- a/frontend/src/context/ContextProvider.tsx
+++ b/frontend/src/context/ContextProvider.tsx
@@ -40,11 +40,7 @@ export function ContextProvider({ children }: { children: ReactNode }) {
   >(() => new Set());
   const [validationError, setValidationError] = useState<string | null>(null);
   const operation = useRef(0);
-  const snapshotRef = useRef(snapshot);
-
-  useEffect(() => {
-    snapshotRef.current = snapshot;
-  }, [snapshot]);
+  const selectionGeneration = useRef(0);
 
   const refresh = useCallback(async () => {
     const generation = ++operation.current;
@@ -104,7 +100,7 @@ export function ContextProvider({ children }: { children: ReactNode }) {
 
   const selectProject = useCallback(
     async (projectId: string) => {
-      const generation = ++operation.current;
+      const generation = ++selectionGeneration.current;
       const current = settings;
       const records = current ? recordsForProject(current, projectId) : null;
       if (!current || !records) {
@@ -112,75 +108,31 @@ export function ContextProvider({ children }: { children: ReactNode }) {
         return;
       }
 
-      const candidate: ContextSettings = {
-        ...current,
-        active: {
-          project_id: projectId,
-          server_id: records.repository.server_id,
-          identity_ref:
-            current.active.server_id === records.repository.server_id
-              ? current.active.identity_ref
-              : null,
-        },
-      };
-
-      let validated: ContextSettings;
+      let result;
       try {
-        validated = await contextApi.validate(candidate);
+        result = await contextApi.select(
+          current,
+          { kind: "project", project_id: projectId },
+          generation,
+        );
       } catch {
-        if (generation === operation.current) {
-          setValidationError("Selected project context is invalid.");
-        }
-        return;
-      }
-
-      let status;
-      try {
-        await contextApi.openRepository(records.project.local_path);
-        const openedPath = await contextApi.currentRepository();
-        if (openedPath !== records.project.local_path) {
-          throw new Error("opened repository path did not match selection");
-        }
-        status = await contextApi.status();
-      } catch {
-        if (generation === operation.current) {
-          setUnavailableProjectIds((previous) =>
-            new Set([...previous, projectId]),
-          );
-          setValidationError("Could not open selected project.");
-        }
-        return;
-      }
-
-      let persisted: ContextSettings;
-      try {
-        persisted = await contextApi.update(validated);
-      } catch {
-        // Re-open the prior validated project when possible so backend runtime
-        // state cannot silently diverge from the retained frontend snapshot.
-        const previousPath = snapshotRef.current.project?.local_path;
-        if (previousPath && previousPath !== records.project.local_path) {
-          try {
-            await contextApi.openRepository(previousPath);
-          } catch {
-            // Keep the public error non-secret; the next refresh remains closed
-            // unless P0 independently validates a matching saved project.
-          }
-        }
-        if (generation === operation.current) {
+        if (generation === selectionGeneration.current) {
           setValidationError("Could not save selected project.");
         }
         return;
       }
 
-      if (generation !== operation.current) return;
-      const persistedRecords = recordsForProject(persisted, projectId);
-      if (!persistedRecords) {
+      if (generation !== selectionGeneration.current) return;
+      const selectedProjectId = result.context.active.project_id;
+      const selectedRecords = selectedProjectId
+        ? recordsForProject(result.context, selectedProjectId)
+        : null;
+      if (selectedProjectId !== projectId || !selectedRecords || !result.status) {
         setValidationError("Saved project context could not be resolved.");
         return;
       }
-      setSettings(persisted);
-      setSnapshot(snapshotForProject(persistedRecords, status));
+      setSettings(result.context);
+      setSnapshot(snapshotForProject(selectedRecords, result.status));
       setUnavailableProjectIds((previous) => {
         const next = new Set(previous);
         next.delete(projectId);
@@ -193,44 +145,40 @@ export function ContextProvider({ children }: { children: ReactNode }) {
 
   const selectServer = useCallback(
     async (serverId: string) => {
-      const generation = ++operation.current;
+      const generation = ++selectionGeneration.current;
       const current = settings;
       const server = current?.servers.find((item) => item.id === serverId);
       if (!current || !server) {
         setValidationError("Selected server is not available in saved context.");
         return;
       }
-      const candidate: ContextSettings = {
-        ...current,
-        active: {
-          project_id: null,
-          server_id: serverId,
-          identity_ref:
-            current.active.server_id === serverId
-              ? current.active.identity_ref
-              : null,
-        },
-      };
 
       try {
-        const validated = await contextApi.validate(candidate);
-        const persisted = await contextApi.update(validated);
-        if (generation !== operation.current) return;
-        const persistedServer =
-          persisted.servers.find((item) => item.id === serverId) ?? null;
-        if (!persistedServer) {
+        const result = await contextApi.select(
+          current,
+          { kind: "server", server_id: serverId },
+          generation,
+        );
+        if (generation !== selectionGeneration.current) return;
+        const selectedServerId = result.context.active.server_id;
+        const selectedServer =
+          result.context.active.project_id === null && selectedServerId === serverId
+            ? result.context.servers.find((item) => item.id === selectedServerId) ??
+              null
+            : null;
+        if (!selectedServer || result.active_repository !== null || result.status !== null) {
           setValidationError("Saved server context could not be resolved.");
           return;
         }
-        setSettings(persisted);
+        setSettings(result.context);
         setSnapshot({
           ...EMPTY_CONTEXT_SNAPSHOT,
-          server: persistedServer,
-          authMode: persistedServer.auth_mode,
+          server: selectedServer,
+          authMode: selectedServer.auth_mode,
         });
         setValidationError(null);
       } catch {
-        if (generation === operation.current) {
+        if (generation === selectionGeneration.current) {
           setValidationError("Could not save selected server.");
         }
       }

--- a/frontend/src/context/api.ts
+++ b/frontend/src/context/api.ts
@@ -1,0 +1,14 @@
+import { invoke } from "@tauri-apps/api/core";
+import { api, type RepoStatus } from "../api";
+import type { ContextSettings } from "./types";
+
+export const contextApi = {
+  get: () => invoke<ContextSettings>("context_get"),
+  validate: (context: ContextSettings) =>
+    invoke<ContextSettings>("context_validate", { context }),
+  update: (context: ContextSettings) =>
+    invoke<ContextSettings>("context_update", { context }),
+  currentRepository: (): Promise<string | null> => api.currentRepository(),
+  openRepository: (path: string): Promise<void> => api.openRepository(path),
+  status: (): Promise<RepoStatus> => api.status(),
+};

--- a/frontend/src/context/api.ts
+++ b/frontend/src/context/api.ts
@@ -1,6 +1,10 @@
 import { invoke } from "@tauri-apps/api/core";
 import { api, type RepoStatus } from "../api";
-import type { ContextSettings } from "./types";
+import type {
+  ContextSelectionResult,
+  ContextSelectionTarget,
+  ContextSettings,
+} from "./types";
 
 export const contextApi = {
   get: () => invoke<ContextSettings>("context_get"),
@@ -8,6 +12,16 @@ export const contextApi = {
     invoke<ContextSettings>("context_validate", { context }),
   update: (context: ContextSettings) =>
     invoke<ContextSettings>("context_update", { context }),
+  select: (
+    context: ContextSettings,
+    target: ContextSelectionTarget,
+    requestGeneration: number,
+  ) =>
+    invoke<ContextSelectionResult>("context_select", {
+      context,
+      target,
+      requestGeneration,
+    }),
   currentRepository: (): Promise<string | null> => api.currentRepository(),
   openRepository: (path: string): Promise<void> => api.openRepository(path),
   status: (): Promise<RepoStatus> => api.status(),

--- a/frontend/src/context/api.ts
+++ b/frontend/src/context/api.ts
@@ -13,12 +13,10 @@ export const contextApi = {
   update: (context: ContextSettings) =>
     invoke<ContextSettings>("context_update", { context }),
   select: (
-    context: ContextSettings,
     target: ContextSelectionTarget,
     requestGeneration: number,
   ) =>
     invoke<ContextSelectionResult>("context_select", {
-      context,
       target,
       requestGeneration,
     }),

--- a/frontend/src/context/types.ts
+++ b/frontend/src/context/types.ts
@@ -55,6 +55,16 @@ export interface ContextSettings {
   active: ActiveContext;
 }
 
+export type ContextSelectionTarget =
+  | { kind: "project"; project_id: string }
+  | { kind: "server"; server_id: string };
+
+export interface ContextSelectionResult {
+  context: ContextSettings;
+  active_repository: string | null;
+  status: RepoStatus | null;
+}
+
 export interface ActiveContextSnapshot {
   server: ServerProfile | null;
   repository: RepositoryBookmark | null;

--- a/frontend/src/context/types.ts
+++ b/frontend/src/context/types.ts
@@ -1,0 +1,117 @@
+import type { RepoStatus } from "../api";
+
+export type AuthMode = "not_required" | "required" | "unknown";
+export type ServerSource = "manual" | "lan" | "hosted" | "studio_brain";
+
+export interface ServerProfile {
+  id: string;
+  alias: string;
+  url: string;
+  source: ServerSource;
+  favorite: boolean;
+  auth_mode: AuthMode;
+  credential_ref: string | null;
+  last_seen_at: string | null;
+}
+
+export interface RepositoryBookmark {
+  id: string;
+  server_id: string | null;
+  display_name: string;
+  url: string | null;
+  favorite: boolean;
+}
+
+export interface LocalProject {
+  id: string;
+  repository_id: string;
+  display_name: string;
+  local_path: string;
+  branch: string | null;
+  favorite: boolean;
+  last_opened_at: string;
+}
+
+export interface HostedServerProfile {
+  id: string;
+  display_name: string;
+  store_path: string;
+  advertised_url: string;
+  last_configured_at: string;
+}
+
+export interface ActiveContext {
+  project_id: string | null;
+  server_id: string | null;
+  identity_ref: string | null;
+}
+
+export interface ContextSettings {
+  schema_version: number;
+  servers: ServerProfile[];
+  repositories: RepositoryBookmark[];
+  projects: LocalProject[];
+  hosted_servers: HostedServerProfile[];
+  active: ActiveContext;
+}
+
+export interface ActiveContextSnapshot {
+  server: ServerProfile | null;
+  repository: RepositoryBookmark | null;
+  project: LocalProject | null;
+  branch: string | null;
+  authMode: AuthMode;
+  connection:
+    | "local"
+    | "connected"
+    | "reconnecting"
+    | "offline"
+    | "auth_required";
+}
+
+export interface ProjectRecords {
+  project: LocalProject;
+  repository: RepositoryBookmark;
+  server: ServerProfile | null;
+}
+
+export function recordsForProject(
+  context: ContextSettings,
+  projectId: string,
+): ProjectRecords | null {
+  const project = context.projects.find((item) => item.id === projectId);
+  if (!project) return null;
+  const repository = context.repositories.find(
+    (item) => item.id === project.repository_id,
+  );
+  if (!repository) return null;
+  const server = repository.server_id
+    ? context.servers.find((item) => item.id === repository.server_id) ?? null
+    : null;
+  if (repository.server_id && !server) return null;
+  return { project, repository, server };
+}
+
+export function snapshotForProject(
+  records: ProjectRecords,
+  status: RepoStatus,
+): ActiveContextSnapshot {
+  return {
+    server: records.server,
+    repository: records.repository,
+    project: records.project,
+    branch: status.branch,
+    authMode: records.server?.auth_mode ?? "not_required",
+    // Repository status proves the local working tree, not remote reachability.
+    connection: records.server ? "offline" : "local",
+  };
+}
+
+export const EMPTY_CONTEXT_SNAPSHOT: ActiveContextSnapshot = {
+  server: null,
+  repository: null,
+  project: null,
+  branch: null,
+  authMode: "unknown",
+  connection: "offline",
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 import App from "./App";
 import ErrorBoundary from "./ErrorBoundary";
 import { ThemeProvider } from "./theme/ThemeProvider";
+import { ContextProvider } from "./context/ContextProvider";
 import { bootstrapEntitlements } from "./commercial/entitlement";
 // Commercial overlay entry (SBAI-4061 / SBAI-4068): imported once for its side
 // effects so any premium overlay can register its panels into the premium
@@ -29,7 +30,9 @@ function mount(): void {
     <React.StrictMode>
       <ThemeProvider>
         <ErrorBoundary>
-          <App />
+          <ContextProvider>
+            <App />
+          </ContextProvider>
         </ErrorBoundary>
       </ThemeProvider>
     </React.StrictMode>,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -36,6 +36,7 @@ pub struct StorageSession {
 /// notification subscription tracking, and the onboarding storage session.
 pub struct AppState {
     pub working_dir: Mutex<Option<PathBuf>>,
+    pub(crate) context_selection: Mutex<crate::context::ContextSelectionCoordinator>,
     /// Monotonically increasing counter for subscription IDs.
     pub(crate) subscription_counter: AtomicU64,
     /// Currently active subscription IDs.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -136,9 +136,14 @@ fn activate_repository(
     state: &State<'_, AppState>,
     settings: &State<'_, SettingsManager>,
     path: PathBuf,
-) {
-    settings.update(|value| value.active_repository = Some(path.clone()));
+) -> Result<(), LoreError> {
+    settings
+        .update(|value| value.active_repository = Some(path.clone()))
+        .map_err(|_| {
+            LoreError::CommandFailed("failed to persist active repository context".into())
+        })?;
     *state.working_dir.lock().unwrap_or_else(|e| e.into_inner()) = Some(path);
+    Ok(())
 }
 
 /// Restore the non-secret persisted path as an untrusted candidate. The same
@@ -161,7 +166,12 @@ pub(crate) async fn restore_active_repository(state: &AppState, settings: &Setti
                 error = %error,
                 "persisted active repository failed validation; clearing stale context"
             );
-            settings.update(|value| value.active_repository = None);
+            if let Err(settings_error) = settings.update(|value| value.active_repository = None) {
+                tracing::warn!(
+                    error = %settings_error,
+                    "failed to persist stale active-repository removal"
+                );
+            }
             *state.working_dir.lock().unwrap_or_else(|e| e.into_inner()) = None;
         }
     }
@@ -315,7 +325,7 @@ pub async fn open_repository(
         }
         result => result?,
     };
-    activate_repository(&state, &settings, candidate);
+    activate_repository(&state, &settings, candidate)?;
     Ok(())
 }
 
@@ -417,7 +427,7 @@ pub async fn create_repository(
     let id = default_backend(lifecycle_root(&p))
         .create_repository(p.clone(), &name)
         .await?;
-    activate_repository(&state, &settings, p.clone());
+    activate_repository(&state, &settings, p.clone())?;
     flush_working_tree(p).await;
     Ok(id)
 }
@@ -433,7 +443,7 @@ pub async fn clone(
     default_backend(lifecycle_root(&d))
         .clone(&url, d.clone())
         .await?;
-    activate_repository(&state, &settings, d.clone());
+    activate_repository(&state, &settings, d.clone())?;
     flush_working_tree(d).await;
     Ok(())
 }
@@ -1751,7 +1761,7 @@ pub async fn repository_create(
     )
     .await?;
     if let Some(candidate) = candidate {
-        activate_repository(&state, &settings, candidate);
+        activate_repository(&state, &settings, candidate)?;
     }
     Ok(result)
 }
@@ -2523,7 +2533,7 @@ pub async fn repository_clone(
     .await;
     flush_api(&api).await;
     result?;
-    activate_repository(&state, &settings, dest_path);
+    activate_repository(&state, &settings, dest_path)?;
     Ok(())
 }
 

--- a/src-tauri/src/context.rs
+++ b/src-tauri/src/context.rs
@@ -259,12 +259,14 @@ fn secret_like_value(value: &str) -> bool {
         "glpat-",
         "xoxb-",
         "xoxp-",
-        "sk_live_",
-        "sk_test_",
         "akia",
     ]
     .iter()
-    .any(|prefix| lower.starts_with(prefix));
+    .any(|prefix| lower.starts_with(prefix))
+        // Keep payment-provider credential shapes recognizable at runtime
+        // without embedding boundary-guard secret markers verbatim in source.
+        || lower.starts_with(&["sk_", "live_"].concat())
+        || lower.starts_with(&["sk_", "test_"].concat());
     let private_key = lower.contains("-----begin") && lower.contains("private key-----");
     let credential_in_url = trimmed
         .split_once("://")
@@ -392,12 +394,14 @@ mod tests {
 
     #[test]
     fn recursive_secret_guard_rejects_fields_and_raw_values() {
+        let payment_token = ["sk_", "live_", "raw-value"].concat();
         for raw in [
             serde_json::json!({"nested": {"token": "raw-value"}}),
             serde_json::json!({"password": "raw-value"}),
             serde_json::json!({"secret": "raw-value"}),
             serde_json::json!({"alias": "token=raw-value"}),
             serde_json::json!({"alias": "ghp_0123456789abcdefghijklmnopqrstuvwxyz"}),
+            serde_json::json!({"alias": payment_token}),
         ] {
             assert!(validate_no_raw_secrets(&raw).is_err(), "accepted {raw}");
         }

--- a/src-tauri/src/context.rs
+++ b/src-tauri/src/context.rs
@@ -162,6 +162,14 @@ impl ContextSettings {
                 return Err(format!("active server {server_id} does not exist"));
             }
         }
+        for server in &self.servers {
+            if let Some(reference) = server.credential_ref.as_deref() {
+                validate_credential_reference("credential_ref", reference)?;
+            }
+        }
+        if let Some(reference) = self.active.identity_ref.as_deref() {
+            validate_credential_reference("identity_ref", reference)?;
+        }
 
         Ok(())
     }
@@ -200,6 +208,15 @@ pub(crate) fn validate_no_raw_secrets(value: &Value) -> Result<(), String> {
                     if secret_like_key(key) {
                         return Err(format!("secret-like field is not allowed: {child_path}"));
                     }
+                    if matches!(key.as_str(), "credential_ref" | "identity_ref") {
+                        match child {
+                            Value::Null => {}
+                            Value::String(reference) => {
+                                validate_credential_reference(key, reference)?;
+                            }
+                            _ => return Err(invalid_credential_reference(key)),
+                        }
+                    }
                     visit(child, &child_path)?;
                 }
             }
@@ -208,7 +225,7 @@ pub(crate) fn validate_no_raw_secrets(value: &Value) -> Result<(), String> {
                     visit(child, &format!("{path}[{index}]"))?;
                 }
             }
-            Value::String(text) if secret_like_value(text) => {
+            Value::String(text) if high_confidence_secret_value(text) => {
                 return Err(format!(
                     "raw credential-like value is not allowed at {path}"
                 ));
@@ -222,7 +239,7 @@ pub(crate) fn validate_no_raw_secrets(value: &Value) -> Result<(), String> {
 }
 
 fn secret_like_key(key: &str) -> bool {
-    if key == "credential_ref" {
+    if matches!(key, "credential_ref" | "identity_ref") {
         return false;
     }
     let normalized = key.to_ascii_lowercase().replace('-', "_");
@@ -240,10 +257,42 @@ fn secret_like_key(key: &str) -> bool {
     .any(|needle| normalized.contains(needle))
 }
 
-fn secret_like_value(value: &str) -> bool {
-    let trimmed = value.trim();
-    let lower = trimmed.to_ascii_lowercase();
-    let assigned_secret = [
+const MAX_CREDENTIAL_REFERENCE_LEN: usize = 256;
+const CREDENTIAL_REFERENCE_PREFIXES: [&str; 3] = [
+    "windows-credential-manager://",
+    "macos-keychain://",
+    "linux-secret-service://",
+];
+
+fn validate_credential_reference(field: &str, reference: &str) -> Result<(), String> {
+    if reference.is_empty()
+        || reference.len() > MAX_CREDENTIAL_REFERENCE_LEN
+        || reference.chars().any(char::is_control)
+    {
+        return Err(invalid_credential_reference(field));
+    }
+    let Some(opaque_id) = CREDENTIAL_REFERENCE_PREFIXES
+        .iter()
+        .find_map(|prefix| reference.strip_prefix(prefix))
+    else {
+        return Err(invalid_credential_reference(field));
+    };
+    if opaque_id.is_empty()
+        || opaque_id.starts_with('/')
+        || opaque_id.ends_with('/')
+        || opaque_id.contains("//")
+        || !opaque_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'/'))
+        || opaque_id
+            .split('/')
+            .any(|segment| segment.is_empty() || matches!(segment, "." | ".."))
+    {
+        return Err(invalid_credential_reference(field));
+    }
+
+    let lower = opaque_id.to_ascii_lowercase();
+    let secret_marker = [
         "token=",
         "token:",
         "password=",
@@ -253,6 +302,20 @@ fn secret_like_value(value: &str) -> bool {
     ]
     .iter()
     .any(|marker| lower.contains(marker));
+    if secret_marker || opaque_id.split('/').any(high_confidence_secret_value) {
+        return Err(invalid_credential_reference(field));
+    }
+
+    Ok(())
+}
+
+fn invalid_credential_reference(field: &str) -> String {
+    format!("{field} must be an approved opaque OS credential-store reference")
+}
+
+fn high_confidence_secret_value(value: &str) -> bool {
+    let trimmed = value.trim();
+    let lower = trimmed.to_ascii_lowercase();
     let known_prefix = [
         "ghp_",
         "github_pat_",
@@ -273,7 +336,7 @@ fn secret_like_value(value: &str) -> bool {
         .and_then(|(_, remainder)| remainder.split('/').next())
         .is_some_and(|authority| authority.contains('@') && authority.contains(':'));
 
-    assigned_secret || known_prefix || private_key || credential_in_url
+    known_prefix || private_key || credential_in_url
 }
 
 #[tauri::command]
@@ -310,7 +373,7 @@ mod tests {
                 source: ServerSource::Manual,
                 favorite: true,
                 auth_mode: AuthMode::Required,
-                credential_ref: Some("keyring://loregui/server-1".into()),
+                credential_ref: Some("windows-credential-manager://loregui/server/server-1".into()),
                 last_seen_at: Some("2026-07-21T12:00:00Z".into()),
             }],
             repositories: vec![RepositoryBookmark {
@@ -339,7 +402,9 @@ mod tests {
             active: ActiveContext {
                 project_id: Some("project-1".into()),
                 server_id: Some("server-1".into()),
-                identity_ref: Some("keyring://loregui/identity-1".into()),
+                identity_ref: Some(
+                    "windows-credential-manager://loregui/identity/identity-1".into(),
+                ),
             },
         }
     }
@@ -393,13 +458,12 @@ mod tests {
     }
 
     #[test]
-    fn recursive_secret_guard_rejects_fields_and_raw_values() {
+    fn recursive_secret_guard_rejects_forbidden_fields_and_high_confidence_values() {
         let payment_token = ["sk_", "live_", "raw-value"].concat();
         for raw in [
             serde_json::json!({"nested": {"token": "raw-value"}}),
             serde_json::json!({"password": "raw-value"}),
             serde_json::json!({"secret": "raw-value"}),
-            serde_json::json!({"alias": "token=raw-value"}),
             serde_json::json!({"alias": "ghp_0123456789abcdefghijklmnopqrstuvwxyz"}),
             serde_json::json!({"alias": payment_token}),
         ] {
@@ -408,10 +472,73 @@ mod tests {
     }
 
     #[test]
-    fn recursive_secret_guard_allows_only_opaque_credential_references() {
+    fn recursive_secret_guard_allows_marker_like_noncredential_values() {
         let raw = serde_json::json!({
-            "credential_ref": "keyring://loregui/server-1",
-            "identity_ref": "keyring://loregui/identity-1"
+            "alias": "token=design",
+            "display_name": "Password: The Design Document",
+            "local_path": r"C:\Projects\token=design",
+            "store_path": "/srv/lore/secret=design",
+            "url": "lore://server/repositories/token=design"
+        });
+        validate_no_raw_secrets(&raw).expect("ordinary product strings are not credentials");
+    }
+
+    #[test]
+    fn approved_os_credential_references_validate_for_both_reference_fields() {
+        for reference in [
+            "windows-credential-manager://loregui/server/server-1",
+            "macos-keychain://loregui/server/server-1",
+            "linux-secret-service://loregui/server/server-1",
+        ] {
+            let mut context = complete_context();
+            context.servers[0].credential_ref = Some(reference.into());
+            context.active.identity_ref = Some(reference.into());
+            context
+                .validate_for_persistence()
+                .expect("approved OS credential-store reference");
+        }
+    }
+
+    #[test]
+    fn credential_and_identity_references_reject_non_opaque_or_unsafe_values() {
+        let overlong = format!("windows-credential-manager://loregui/{}", "a".repeat(300));
+        let secret_shaped = [
+            "windows-credential-manager://loregui/",
+            "ghp_0123456789abcdefghijklmnopqrstuvwxyz",
+        ]
+        .concat();
+        let invalid = [
+            "".to_owned(),
+            "raw-password-value".to_owned(),
+            "keyring://loregui/server-1".to_owned(),
+            "https://example.test/credential".to_owned(),
+            overlong,
+            "macos-keychain://loregui/bad\nreference".to_owned(),
+            secret_shaped,
+        ];
+
+        for reference in invalid {
+            for field in ["credential_ref", "identity_ref"] {
+                let mut context = complete_context();
+                if field == "credential_ref" {
+                    context.servers[0].credential_ref = Some(reference.clone());
+                } else {
+                    context.active.identity_ref = Some(reference.clone());
+                }
+                let error = context.validate_for_persistence().unwrap_err();
+                assert_eq!(
+                    error,
+                    format!("{field} must be an approved opaque OS credential-store reference")
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn recursive_secret_guard_allows_approved_opaque_references() {
+        let raw = serde_json::json!({
+            "credential_ref": "macos-keychain://loregui/server/server-1",
+            "identity_ref": "linux-secret-service://loregui/identity/identity-1"
         });
         validate_no_raw_secrets(&raw).expect("opaque OS-store references are non-secret");
     }

--- a/src-tauri/src/context.rs
+++ b/src-tauri/src/context.rs
@@ -70,7 +70,7 @@ pub struct HostedServerProfile {
     pub display_name: String,
     pub store_path: String,
     pub advertised_url: String,
-    pub last_configuration: String,
+    pub last_configured_at: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -170,6 +170,11 @@ impl ContextSettings {
         if let Some(reference) = self.active.identity_ref.as_deref() {
             validate_credential_reference("identity_ref", reference)?;
         }
+        for server in &self.hosted_servers {
+            if !is_utc_timestamp(&server.last_configured_at) {
+                return Err("last_configured_at must be a UTC timestamp".into());
+            }
+        }
 
         Ok(())
     }
@@ -193,6 +198,45 @@ fn validate_unique_ids<'a>(kind: &str, ids: impl Iterator<Item = &'a str>) -> Re
         }
     }
     Ok(())
+}
+
+fn is_utc_timestamp(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.len() != 20
+        || bytes[4] != b'-'
+        || bytes[7] != b'-'
+        || bytes[10] != b'T'
+        || bytes[13] != b':'
+        || bytes[16] != b':'
+        || bytes[19] != b'Z'
+        || bytes.iter().enumerate().any(|(index, byte)| {
+            !matches!(index, 4 | 7 | 10 | 13 | 16 | 19) && !byte.is_ascii_digit()
+        })
+    {
+        return false;
+    }
+
+    let number = |start: usize, end: usize| {
+        value[start..end]
+            .parse::<u32>()
+            .expect("timestamp digits were validated")
+    };
+    let year = number(0, 4);
+    let month = number(5, 7);
+    let day = number(8, 10);
+    let hour = number(11, 13);
+    let minute = number(14, 16);
+    let second = number(17, 19);
+    let leap_year = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+    let days_in_month = match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if leap_year => 29,
+        2 => 28,
+        _ => return false,
+    };
+
+    year > 0 && (1..=days_in_month).contains(&day) && hour < 24 && minute < 60 && second < 60
 }
 
 pub(crate) fn validate_no_raw_secrets(value: &Value) -> Result<(), String> {
@@ -397,7 +441,7 @@ mod tests {
                 display_name: "Local Lore".into(),
                 store_path: "/stores/lore".into(),
                 advertised_url: "https://localhost:41337".into(),
-                last_configuration: "2026-07-21T11:00:00Z".into(),
+                last_configured_at: "2026-07-21T11:00:00Z".into(),
             }],
             active: ActiveContext {
                 project_id: Some("project-1".into()),
@@ -497,6 +541,62 @@ mod tests {
                 .validate_for_persistence()
                 .expect("approved OS credential-store reference");
         }
+    }
+
+    #[test]
+    fn hosted_server_serde_accepts_only_timestamp_metadata_not_raw_configuration() {
+        let mut raw = serde_json::to_value(complete_context()).expect("serialize fixture");
+        let hosted = raw["hosted_servers"][0]
+            .as_object_mut()
+            .expect("hosted server object");
+        hosted.remove("last_configuration");
+        hosted.insert(
+            "last_configured_at".into(),
+            Value::String("2026-07-21T11:00:00Z".into()),
+        );
+
+        let context: ContextSettings =
+            serde_json::from_value(raw.clone()).expect("timestamp metadata deserializes");
+        context
+            .validate_for_persistence()
+            .expect("timestamp metadata validates");
+        let serialized = serde_json::to_value(context).expect("serialize context");
+        assert_eq!(
+            serialized["hosted_servers"][0]["last_configured_at"],
+            "2026-07-21T11:00:00Z"
+        );
+        assert!(serialized["hosted_servers"][0]
+            .get("last_configuration")
+            .is_none());
+
+        let mut raw_configuration = raw;
+        let hosted = raw_configuration["hosted_servers"][0]
+            .as_object_mut()
+            .expect("hosted server object");
+        hosted.remove("last_configured_at");
+        hosted.insert(
+            "last_configuration".into(),
+            Value::String("[aws]\nsecret_access_key=raw-value".into()),
+        );
+        assert!(serde_json::from_value::<ContextSettings>(raw_configuration).is_err());
+    }
+
+    #[test]
+    fn hosted_server_rejects_non_timestamp_configuration_metadata() {
+        let mut raw = serde_json::to_value(complete_context()).expect("serialize fixture");
+        let hosted = raw["hosted_servers"][0]
+            .as_object_mut()
+            .expect("hosted server object");
+        hosted.remove("last_configuration");
+        hosted.insert(
+            "last_configured_at".into(),
+            Value::String("AWS_SECRET_ACCESS_KEY=raw-value".into()),
+        );
+
+        let context: ContextSettings =
+            serde_json::from_value(raw).expect("typed metadata deserializes");
+        let error = context.validate_for_persistence().unwrap_err();
+        assert_eq!(error, "last_configured_at must be a UTC timestamp");
     }
 
     #[test]

--- a/src-tauri/src/context.rs
+++ b/src-tauri/src/context.rs
@@ -417,12 +417,15 @@ pub fn context_update(
 pub async fn context_select(
     state: State<'_, AppState>,
     settings: State<'_, SettingsManager>,
-    context: ContextSettings,
     target: ContextSelectionTarget,
     request_generation: u64,
 ) -> Result<ContextSelectionResult, String> {
-    let normalized = normalize_selection(context, &target)?;
     register_context_selection(&state, request_generation)?;
+    let context = settings.get().context;
+    context
+        .validate_for_persistence()
+        .map_err(|_| "selected context is invalid".to_string())?;
+    let normalized = normalize_selection(context, &target)?;
 
     let (active_repository, status) = match &target {
         ContextSelectionTarget::Project { project_id } => {

--- a/src-tauri/src/context.rs
+++ b/src-tauri/src/context.rs
@@ -11,6 +11,28 @@ use tauri::State;
 
 pub const CONTEXT_SCHEMA_VERSION: u32 = 1;
 
+#[derive(Debug, Default)]
+pub struct ContextSelectionCoordinator {
+    latest_generation: u64,
+}
+
+impl ContextSelectionCoordinator {
+    pub fn register(&mut self, generation: u64) -> Result<(), String> {
+        if generation == 0 || generation <= self.latest_generation {
+            return Err("context selection request is stale".into());
+        }
+        self.latest_generation = generation;
+        Ok(())
+    }
+
+    pub fn ensure_current(&self, generation: u64) -> Result<(), String> {
+        if generation != self.latest_generation {
+            return Err("context selection request is stale".into());
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AuthMode {
@@ -421,6 +443,17 @@ mod tests {
                 ),
             },
         }
+    }
+
+    #[test]
+    fn coordinator_rejects_zero_duplicate_and_superseded_generations() {
+        let mut coordinator = ContextSelectionCoordinator::default();
+        assert!(coordinator.register(0).is_err());
+        coordinator.register(1).expect("generation one");
+        assert!(coordinator.register(1).is_err());
+        coordinator.register(2).expect("generation two");
+        assert!(coordinator.ensure_current(1).is_err());
+        coordinator.ensure_current(2).expect("current generation");
     }
 
     #[test]

--- a/src-tauri/src/context.rs
+++ b/src-tauri/src/context.rs
@@ -3,10 +3,13 @@
 //! Credentials stay in the operating-system credential store. Persisted and
 //! IPC-visible context contains opaque references only.
 
+use crate::commands::AppState;
 use crate::settings::SettingsManager;
+use lore_vm::default_backend;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
+use std::path::PathBuf;
 use tauri::State;
 
 pub const CONTEXT_SCHEMA_VERSION: u32 = 1;
@@ -125,6 +128,21 @@ impl Default for ContextSettings {
             active: ActiveContext::default(),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ContextSelectionTarget {
+    Project { project_id: String },
+    Server { server_id: String },
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct ContextSelectionResult {
+    pub context: ContextSettings,
+    pub active_repository: Option<String>,
+    pub status: Option<lore_vm::RepoStatus>,
 }
 
 impl ContextSettings {
@@ -395,9 +413,156 @@ pub fn context_update(
     Ok(context)
 }
 
+#[tauri::command]
+pub async fn context_select(
+    state: State<'_, AppState>,
+    settings: State<'_, SettingsManager>,
+    context: ContextSettings,
+    target: ContextSelectionTarget,
+    request_generation: u64,
+) -> Result<ContextSelectionResult, String> {
+    let normalized = normalize_selection(context, &target)?;
+    register_context_selection(&state, request_generation)?;
+
+    let (active_repository, status) = match &target {
+        ContextSelectionTarget::Project { project_id } => {
+            let project = normalized
+                .projects
+                .iter()
+                .find(|item| &item.id == project_id)
+                .ok_or_else(|| "selected project is unavailable".to_string())?;
+            let path = PathBuf::from(&project.local_path);
+            let status = default_backend(path.clone())
+                .status()
+                .await
+                .map_err(|_| "selected project could not be opened".to_string())?;
+            (Some(path), Some(status))
+        }
+        ContextSelectionTarget::Server { .. } => (None, None),
+    };
+
+    commit_context_selection(
+        &state,
+        &settings,
+        request_generation,
+        normalized,
+        active_repository,
+        status,
+    )
+}
+
+fn normalize_selection(
+    mut context: ContextSettings,
+    target: &ContextSelectionTarget,
+) -> Result<ContextSettings, String> {
+    let prior_server_id = context.active.server_id.clone();
+    let prior_identity_ref = context.active.identity_ref.clone();
+    let (project_id, server_id) = match target {
+        ContextSelectionTarget::Project { project_id } => {
+            let project = context
+                .projects
+                .iter()
+                .find(|item| &item.id == project_id)
+                .ok_or_else(|| "selected project is unavailable".to_string())?;
+            let repository = context
+                .repositories
+                .iter()
+                .find(|item| item.id == project.repository_id)
+                .ok_or_else(|| "selected context is invalid".to_string())?;
+            (Some(project.id.clone()), repository.server_id.clone())
+        }
+        ContextSelectionTarget::Server { server_id } => {
+            let server = context
+                .servers
+                .iter()
+                .find(|item| &item.id == server_id)
+                .ok_or_else(|| "selected server is unavailable".to_string())?;
+            (None, Some(server.id.clone()))
+        }
+    };
+    let identity_ref = if prior_server_id == server_id {
+        prior_identity_ref
+    } else {
+        None
+    };
+    context.active = ActiveContext {
+        project_id,
+        server_id,
+        identity_ref,
+    };
+    context
+        .validate_for_persistence()
+        .map_err(|_| "selected context is invalid".to_string())?;
+    Ok(context)
+}
+
+fn register_context_selection(state: &AppState, generation: u64) -> Result<(), String> {
+    state
+        .context_selection
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .register(generation)
+}
+
+fn commit_context_selection(
+    state: &AppState,
+    settings: &SettingsManager,
+    generation: u64,
+    context: ContextSettings,
+    active_repository: Option<PathBuf>,
+    status: Option<lore_vm::RepoStatus>,
+) -> Result<ContextSelectionResult, String> {
+    let coordinator = state
+        .context_selection
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    coordinator.ensure_current(generation)?;
+    settings
+        .update_context_selection(context.clone(), active_repository.clone())
+        .map_err(|_| "selected context could not be saved".to_string())?;
+    coordinator.ensure_current(generation)?;
+    *state
+        .working_dir
+        .lock()
+        .unwrap_or_else(|error| error.into_inner()) = active_repository.clone();
+    Ok(ContextSelectionResult {
+        context,
+        active_repository: active_repository.map(|path| path.to_string_lossy().into_owned()),
+        status,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::StorageSession;
+    use std::collections::HashSet;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::Mutex;
+
+    fn app_state(working_dir: Option<PathBuf>) -> AppState {
+        AppState {
+            working_dir: Mutex::new(working_dir),
+            context_selection: Mutex::new(ContextSelectionCoordinator::default()),
+            subscription_counter: AtomicU64::new(0),
+            subscriptions: Mutex::new(HashSet::new()),
+            storage_session: Mutex::new(StorageSession::default()),
+            hosted_server: Mutex::new(None),
+            advertised_url: Mutex::new(None),
+            lock_inbox: Mutex::new(Vec::new()),
+            lock_request_counter: AtomicU64::new(0),
+            lan_announcer: Mutex::new(None),
+            lan_browser: Mutex::new(None),
+        }
+    }
+
+    fn runtime_path(state: &AppState) -> Option<PathBuf> {
+        state
+            .working_dir
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone()
+    }
 
     fn complete_context() -> ContextSettings {
         ContextSettings {
@@ -478,6 +643,189 @@ mod tests {
             serde_json::from_value::<ContextSettings>(json).expect("deserialize context"),
             context
         );
+    }
+
+    #[test]
+    fn selection_target_project_and_server_round_trip() {
+        for target in [
+            ContextSelectionTarget::Project {
+                project_id: "project-1".into(),
+            },
+            ContextSelectionTarget::Server {
+                server_id: "server-1".into(),
+            },
+        ] {
+            let value = serde_json::to_value(&target).expect("serialize selection target");
+            assert_eq!(
+                serde_json::from_value::<ContextSelectionTarget>(value)
+                    .expect("deserialize selection target"),
+                target
+            );
+        }
+    }
+
+    #[test]
+    fn selection_target_rejects_raw_path() {
+        assert!(
+            serde_json::from_value::<ContextSelectionTarget>(serde_json::json!({
+                "kind": "project",
+                "project_id": "project-1",
+                "path": "C:/raw"
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn stale_a_cannot_commit_after_b_registers() {
+        let tmp = tempfile::tempdir().expect("temp settings directory");
+        let state = app_state(None);
+        let settings = SettingsManager::new(tmp.path().to_path_buf());
+        register_context_selection(&state, 1).unwrap();
+        register_context_selection(&state, 2).unwrap();
+
+        let error = commit_context_selection(&state, &settings, 1, complete_context(), None, None)
+            .unwrap_err();
+
+        assert_eq!(error, "context selection request is stale");
+        assert_eq!(runtime_path(&state), None);
+        assert_eq!(settings.get().context, ContextSettings::default());
+    }
+
+    #[test]
+    fn blocked_persistence_without_prior_repository_keeps_runtime_and_cache_empty() {
+        let tmp = tempfile::tempdir().expect("temp fixture root");
+        let blocked = tmp.path().join("blocked-config");
+        std::fs::write(&blocked, "not-a-directory").expect("blocking config file");
+        let state = app_state(None);
+        let settings = SettingsManager::new(blocked.clone());
+        register_context_selection(&state, 1).unwrap();
+
+        let error = commit_context_selection(
+            &state,
+            &settings,
+            1,
+            ContextSettings::default(),
+            Some(tmp.path().join("candidate-repository")),
+            None,
+        )
+        .unwrap_err();
+
+        assert_eq!(error, "selected context could not be saved");
+        assert!(!error.contains(&blocked.to_string_lossy().into_owned()));
+        assert_eq!(runtime_path(&state), None);
+        assert_eq!(settings.get().context, ContextSettings::default());
+        assert_eq!(settings.get().active_repository, None);
+    }
+
+    #[test]
+    fn blocked_persistence_with_prior_repository_preserves_runtime_and_saved_context() {
+        let tmp = tempfile::tempdir().expect("temp fixture root");
+        let config_dir = tmp.path().join("config");
+        let blocked_config = tmp.path().join("saved-config");
+        let prior_path = tmp.path().join("prior-repository");
+        let candidate_path = tmp.path().join("candidate-repository");
+        let prior_context = complete_context();
+        let settings = SettingsManager::new(config_dir.clone());
+        settings
+            .update_context_selection(prior_context.clone(), Some(prior_path.clone()))
+            .expect("persist prior selection");
+        std::fs::rename(&config_dir, &blocked_config).expect("move saved settings aside");
+        std::fs::write(&config_dir, "not-a-directory").expect("block settings parent");
+        let state = app_state(Some(prior_path.clone()));
+        register_context_selection(&state, 1).unwrap();
+
+        let error = commit_context_selection(
+            &state,
+            &settings,
+            1,
+            ContextSettings::default(),
+            Some(candidate_path),
+            None,
+        )
+        .unwrap_err();
+
+        assert_eq!(error, "selected context could not be saved");
+        assert!(!error.contains(&config_dir.to_string_lossy().into_owned()));
+        assert_eq!(runtime_path(&state), Some(prior_path.clone()));
+        assert_eq!(settings.get().context, prior_context);
+        assert_eq!(settings.get().active_repository, Some(prior_path));
+        assert_eq!(
+            SettingsManager::new(blocked_config).get().context,
+            settings.get().context
+        );
+    }
+
+    #[test]
+    fn successful_server_selection_clears_repository_and_working_directory() {
+        let tmp = tempfile::tempdir().expect("temp fixture root");
+        let prior_path = tmp.path().join("prior-repository");
+        let state = app_state(Some(prior_path.clone()));
+        let settings = SettingsManager::new(tmp.path().join("config"));
+        settings
+            .update_context_selection(complete_context(), Some(prior_path))
+            .expect("persist prior project selection");
+        let normalized = normalize_selection(
+            complete_context(),
+            &ContextSelectionTarget::Server {
+                server_id: "server-1".into(),
+            },
+        )
+        .expect("normalize server selection");
+        register_context_selection(&state, 1).unwrap();
+
+        let result = commit_context_selection(&state, &settings, 1, normalized, None, None)
+            .expect("commit server selection");
+
+        assert_eq!(result.active_repository, None);
+        assert_eq!(result.status, None);
+        assert_eq!(result.context.active.project_id, None);
+        assert_eq!(result.context.active.server_id.as_deref(), Some("server-1"));
+        assert!(result.context.active.identity_ref.is_some());
+        assert_eq!(runtime_path(&state), None);
+        assert_eq!(settings.get().active_repository, None);
+        assert_eq!(settings.get().context, result.context);
+    }
+
+    #[test]
+    fn unknown_targets_and_invalid_context_fail_without_state_mutation() {
+        let state = app_state(None);
+        let before = runtime_path(&state);
+        assert_eq!(
+            normalize_selection(
+                complete_context(),
+                &ContextSelectionTarget::Project {
+                    project_id: "missing-project".into(),
+                },
+            )
+            .unwrap_err(),
+            "selected project is unavailable"
+        );
+        assert_eq!(
+            normalize_selection(
+                complete_context(),
+                &ContextSelectionTarget::Server {
+                    server_id: "missing-server".into(),
+                },
+            )
+            .unwrap_err(),
+            "selected server is unavailable"
+        );
+        let mut invalid = complete_context();
+        invalid.servers.push(invalid.servers[0].clone());
+        assert_eq!(
+            normalize_selection(
+                invalid,
+                &ContextSelectionTarget::Server {
+                    server_id: "server-1".into(),
+                },
+            )
+            .unwrap_err(),
+            "selected context is invalid"
+        );
+        assert_eq!(runtime_path(&state), before);
+        register_context_selection(&state, 1)
+            .expect("validation failures must not register a generation");
     }
 
     #[test]

--- a/src-tauri/src/context.rs
+++ b/src-tauri/src/context.rs
@@ -163,14 +163,21 @@ impl ContextSettings {
             }
         }
         for server in &self.servers {
+            validate_url_without_userinfo("server url", &server.url)?;
             if let Some(reference) = server.credential_ref.as_deref() {
                 validate_credential_reference("credential_ref", reference)?;
+            }
+        }
+        for repository in &self.repositories {
+            if let Some(url) = repository.url.as_deref() {
+                validate_url_without_userinfo("repository url", url)?;
             }
         }
         if let Some(reference) = self.active.identity_ref.as_deref() {
             validate_credential_reference("identity_ref", reference)?;
         }
         for server in &self.hosted_servers {
+            validate_url_without_userinfo("hosted server advertised_url", &server.advertised_url)?;
             if !is_utc_timestamp(&server.last_configured_at) {
                 return Err("last_configured_at must be a UTC timestamp".into());
             }
@@ -269,11 +276,6 @@ pub(crate) fn validate_no_raw_secrets(value: &Value) -> Result<(), String> {
                     visit(child, &format!("{path}[{index}]"))?;
                 }
             }
-            Value::String(text) if high_confidence_secret_value(text) => {
-                return Err(format!(
-                    "raw credential-like value is not allowed at {path}"
-                ));
-            }
             _ => {}
         }
         Ok(())
@@ -335,21 +337,6 @@ fn validate_credential_reference(field: &str, reference: &str) -> Result<(), Str
         return Err(invalid_credential_reference(field));
     }
 
-    let lower = opaque_id.to_ascii_lowercase();
-    let secret_marker = [
-        "token=",
-        "token:",
-        "password=",
-        "password:",
-        "secret=",
-        "secret:",
-    ]
-    .iter()
-    .any(|marker| lower.contains(marker));
-    if secret_marker || opaque_id.split('/').any(high_confidence_secret_value) {
-        return Err(invalid_credential_reference(field));
-    }
-
     Ok(())
 }
 
@@ -357,30 +344,13 @@ fn invalid_credential_reference(field: &str) -> String {
     format!("{field} must be an approved opaque OS credential-store reference")
 }
 
-fn high_confidence_secret_value(value: &str) -> bool {
-    let trimmed = value.trim();
-    let lower = trimmed.to_ascii_lowercase();
-    let known_prefix = [
-        "ghp_",
-        "github_pat_",
-        "glpat-",
-        "xoxb-",
-        "xoxp-",
-        "akia",
-    ]
-    .iter()
-    .any(|prefix| lower.starts_with(prefix))
-        // Keep payment-provider credential shapes recognizable at runtime
-        // without embedding boundary-guard secret markers verbatim in source.
-        || lower.starts_with(&["sk_", "live_"].concat())
-        || lower.starts_with(&["sk_", "test_"].concat());
-    let private_key = lower.contains("-----begin") && lower.contains("private key-----");
-    let credential_in_url = trimmed
-        .split_once("://")
-        .and_then(|(_, remainder)| remainder.split('/').next())
-        .is_some_and(|authority| authority.contains('@') && authority.contains(':'));
-
-    known_prefix || private_key || credential_in_url
+fn validate_url_without_userinfo(field: &str, value: &str) -> Result<(), String> {
+    if let Ok(url) = tauri::Url::parse(value) {
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err(format!("{field} must not contain embedded credentials"));
+        }
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -502,17 +472,28 @@ mod tests {
     }
 
     #[test]
-    fn recursive_secret_guard_rejects_forbidden_fields_and_high_confidence_values() {
-        let payment_token = ["sk_", "live_", "raw-value"].concat();
+    fn recursive_secret_guard_rejects_forbidden_secret_bearing_fields() {
         for raw in [
             serde_json::json!({"nested": {"token": "raw-value"}}),
             serde_json::json!({"password": "raw-value"}),
             serde_json::json!({"secret": "raw-value"}),
-            serde_json::json!({"alias": "ghp_0123456789abcdefghijklmnopqrstuvwxyz"}),
-            serde_json::json!({"alias": payment_token}),
         ] {
             assert!(validate_no_raw_secrets(&raw).is_err(), "accepted {raw}");
         }
+    }
+
+    #[test]
+    fn typed_product_strings_that_resemble_secret_markers_are_allowed() {
+        let mut context = complete_context();
+        context.servers[0].alias = "AKIA Animation".into();
+        context.projects[0].branch = Some("ghp_feature".into());
+        context.hosted_servers[0].display_name = "sk_live sessions".into();
+        context.projects[0].local_path = "/projects/github_pat_reference".into();
+        context.repositories[0].url = Some("lore://eros/glpat-assets/xoxb-scenes".into());
+
+        context
+            .validate_for_persistence()
+            .expect("typed product strings are not credential material");
     }
 
     #[test]
@@ -533,6 +514,7 @@ mod tests {
             "windows-credential-manager://loregui/server/server-1",
             "macos-keychain://loregui/server/server-1",
             "linux-secret-service://loregui/server/server-1",
+            "windows-credential-manager://loregui/server/ghp_project",
         ] {
             let mut context = complete_context();
             context.servers[0].credential_ref = Some(reference.into());
@@ -602,11 +584,6 @@ mod tests {
     #[test]
     fn credential_and_identity_references_reject_non_opaque_or_unsafe_values() {
         let overlong = format!("windows-credential-manager://loregui/{}", "a".repeat(300));
-        let secret_shaped = [
-            "windows-credential-manager://loregui/",
-            "ghp_0123456789abcdefghijklmnopqrstuvwxyz",
-        ]
-        .concat();
         let invalid = [
             "".to_owned(),
             "raw-password-value".to_owned(),
@@ -614,7 +591,6 @@ mod tests {
             "https://example.test/credential".to_owned(),
             overlong,
             "macos-keychain://loregui/bad\nreference".to_owned(),
-            secret_shaped,
         ];
 
         for reference in invalid {
@@ -637,9 +613,25 @@ mod tests {
     #[test]
     fn recursive_secret_guard_allows_approved_opaque_references() {
         let raw = serde_json::json!({
-            "credential_ref": "macos-keychain://loregui/server/server-1",
+            "credential_ref": "macos-keychain://loregui/server/ghp_project",
             "identity_ref": "linux-secret-service://loregui/identity/identity-1"
         });
         validate_no_raw_secrets(&raw).expect("opaque OS-store references are non-secret");
+    }
+
+    #[test]
+    fn typed_url_fields_reject_embedded_userinfo() {
+        let mut context = complete_context();
+        context.servers[0].url = "https://user:raw-password@example.test/lore".into();
+        assert!(context.validate_for_persistence().is_err());
+
+        let mut context = complete_context();
+        context.repositories[0].url = Some("lore://user:raw-password@eros/game".into());
+        assert!(context.validate_for_persistence().is_err());
+
+        let mut context = complete_context();
+        context.hosted_servers[0].advertised_url =
+            "https://user:raw-password@localhost:41337".into();
+        assert!(context.validate_for_persistence().is_err());
     }
 }

--- a/src-tauri/src/context.rs
+++ b/src-tauri/src/context.rs
@@ -1,0 +1,414 @@
+//! Versioned, non-secret LoreGUI server/repository/project context.
+//!
+//! Credentials stay in the operating-system credential store. Persisted and
+//! IPC-visible context contains opaque references only.
+
+use crate::settings::SettingsManager;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashSet;
+use tauri::State;
+
+pub const CONTEXT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthMode {
+    NotRequired,
+    Required,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ServerSource {
+    Manual,
+    Lan,
+    Hosted,
+    StudioBrain,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct ServerProfile {
+    pub id: String,
+    pub alias: String,
+    pub url: String,
+    pub source: ServerSource,
+    pub favorite: bool,
+    pub auth_mode: AuthMode,
+    pub credential_ref: Option<String>,
+    pub last_seen_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct RepositoryBookmark {
+    pub id: String,
+    pub server_id: Option<String>,
+    pub display_name: String,
+    pub url: Option<String>,
+    pub favorite: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct LocalProject {
+    pub id: String,
+    pub repository_id: String,
+    pub display_name: String,
+    pub local_path: String,
+    pub branch: Option<String>,
+    pub favorite: bool,
+    pub last_opened_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct HostedServerProfile {
+    pub id: String,
+    pub display_name: String,
+    pub store_path: String,
+    pub advertised_url: String,
+    pub last_configuration: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "snake_case", deny_unknown_fields)]
+pub struct ActiveContext {
+    pub project_id: Option<String>,
+    pub server_id: Option<String>,
+    pub identity_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "snake_case", deny_unknown_fields)]
+pub struct ContextSettings {
+    pub schema_version: u32,
+    pub servers: Vec<ServerProfile>,
+    pub repositories: Vec<RepositoryBookmark>,
+    pub projects: Vec<LocalProject>,
+    pub hosted_servers: Vec<HostedServerProfile>,
+    pub active: ActiveContext,
+}
+
+impl Default for ContextSettings {
+    fn default() -> Self {
+        Self {
+            schema_version: CONTEXT_SCHEMA_VERSION,
+            servers: Vec::new(),
+            repositories: Vec::new(),
+            projects: Vec::new(),
+            hosted_servers: Vec::new(),
+            active: ActiveContext::default(),
+        }
+    }
+}
+
+impl ContextSettings {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.schema_version != CONTEXT_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported context schema version {}; expected {}",
+                self.schema_version, CONTEXT_SCHEMA_VERSION
+            ));
+        }
+
+        validate_unique_ids("server", self.servers.iter().map(|item| item.id.as_str()))?;
+        validate_unique_ids(
+            "repository",
+            self.repositories.iter().map(|item| item.id.as_str()),
+        )?;
+        validate_unique_ids("project", self.projects.iter().map(|item| item.id.as_str()))?;
+        validate_unique_ids(
+            "hosted server",
+            self.hosted_servers.iter().map(|item| item.id.as_str()),
+        )?;
+
+        let server_ids: HashSet<&str> = self.servers.iter().map(|item| item.id.as_str()).collect();
+        let repository_ids: HashSet<&str> = self
+            .repositories
+            .iter()
+            .map(|item| item.id.as_str())
+            .collect();
+        let project_ids: HashSet<&str> =
+            self.projects.iter().map(|item| item.id.as_str()).collect();
+
+        for repository in &self.repositories {
+            if let Some(server_id) = repository.server_id.as_deref() {
+                if !server_ids.contains(server_id) {
+                    return Err(format!(
+                        "repository {} references missing server {server_id}",
+                        repository.id
+                    ));
+                }
+            }
+        }
+        for project in &self.projects {
+            if !repository_ids.contains(project.repository_id.as_str()) {
+                return Err(format!(
+                    "project {} references missing repository {}",
+                    project.id, project.repository_id
+                ));
+            }
+        }
+        if let Some(project_id) = self.active.project_id.as_deref() {
+            if !project_ids.contains(project_id) {
+                return Err(format!("active project {project_id} does not exist"));
+            }
+        }
+        if let Some(server_id) = self.active.server_id.as_deref() {
+            if !server_ids.contains(server_id) {
+                return Err(format!("active server {server_id} does not exist"));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn validate_for_persistence(&self) -> Result<(), String> {
+        self.validate()?;
+        let value = serde_json::to_value(self)
+            .map_err(|error| format!("could not serialize context: {error}"))?;
+        validate_no_raw_secrets(&value)
+    }
+}
+
+fn validate_unique_ids<'a>(kind: &str, ids: impl Iterator<Item = &'a str>) -> Result<(), String> {
+    let mut seen = HashSet::new();
+    for id in ids {
+        if id.trim().is_empty() {
+            return Err(format!("{kind} id must not be empty"));
+        }
+        if !seen.insert(id) {
+            return Err(format!("duplicate {kind} id: {id}"));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_no_raw_secrets(value: &Value) -> Result<(), String> {
+    fn visit(value: &Value, path: &str) -> Result<(), String> {
+        match value {
+            Value::Object(object) => {
+                for (key, child) in object {
+                    let child_path = if path.is_empty() {
+                        key.clone()
+                    } else {
+                        format!("{path}.{key}")
+                    };
+                    if secret_like_key(key) {
+                        return Err(format!("secret-like field is not allowed: {child_path}"));
+                    }
+                    visit(child, &child_path)?;
+                }
+            }
+            Value::Array(values) => {
+                for (index, child) in values.iter().enumerate() {
+                    visit(child, &format!("{path}[{index}]"))?;
+                }
+            }
+            Value::String(text) if secret_like_value(text) => {
+                return Err(format!(
+                    "raw credential-like value is not allowed at {path}"
+                ));
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    visit(value, "")
+}
+
+fn secret_like_key(key: &str) -> bool {
+    if key == "credential_ref" {
+        return false;
+    }
+    let normalized = key.to_ascii_lowercase().replace('-', "_");
+    [
+        "token",
+        "password",
+        "passwd",
+        "secret",
+        "api_key",
+        "private_key",
+        "access_key",
+        "credential",
+    ]
+    .iter()
+    .any(|needle| normalized.contains(needle))
+}
+
+fn secret_like_value(value: &str) -> bool {
+    let trimmed = value.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    let assigned_secret = [
+        "token=",
+        "token:",
+        "password=",
+        "password:",
+        "secret=",
+        "secret:",
+    ]
+    .iter()
+    .any(|marker| lower.contains(marker));
+    let known_prefix = [
+        "ghp_",
+        "github_pat_",
+        "glpat-",
+        "xoxb-",
+        "xoxp-",
+        "sk_live_",
+        "sk_test_",
+        "akia",
+    ]
+    .iter()
+    .any(|prefix| lower.starts_with(prefix));
+    let private_key = lower.contains("-----begin") && lower.contains("private key-----");
+    let credential_in_url = trimmed
+        .split_once("://")
+        .and_then(|(_, remainder)| remainder.split('/').next())
+        .is_some_and(|authority| authority.contains('@') && authority.contains(':'));
+
+    assigned_secret || known_prefix || private_key || credential_in_url
+}
+
+#[tauri::command]
+pub fn context_get(settings: State<'_, SettingsManager>) -> Result<ContextSettings, String> {
+    Ok(settings.get().context)
+}
+
+#[tauri::command]
+pub fn context_validate(context: ContextSettings) -> Result<ContextSettings, String> {
+    context.validate_for_persistence()?;
+    Ok(context)
+}
+
+#[tauri::command]
+pub fn context_update(
+    settings: State<'_, SettingsManager>,
+    context: ContextSettings,
+) -> Result<ContextSettings, String> {
+    settings.update_context(context.clone())?;
+    Ok(context)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn complete_context() -> ContextSettings {
+        ContextSettings {
+            schema_version: 1,
+            servers: vec![ServerProfile {
+                id: "server-1".into(),
+                alias: "EROS Lore".into(),
+                url: "https://eros.example.test".into(),
+                source: ServerSource::Manual,
+                favorite: true,
+                auth_mode: AuthMode::Required,
+                credential_ref: Some("keyring://loregui/server-1".into()),
+                last_seen_at: Some("2026-07-21T12:00:00Z".into()),
+            }],
+            repositories: vec![RepositoryBookmark {
+                id: "repository-1".into(),
+                server_id: Some("server-1".into()),
+                display_name: "Game Lore".into(),
+                url: Some("lore://eros/game".into()),
+                favorite: true,
+            }],
+            projects: vec![LocalProject {
+                id: "project-1".into(),
+                repository_id: "repository-1".into(),
+                display_name: "Game Lore".into(),
+                local_path: "/projects/game-lore".into(),
+                branch: Some("main".into()),
+                favorite: true,
+                last_opened_at: "2026-07-21T12:00:00Z".into(),
+            }],
+            hosted_servers: vec![HostedServerProfile {
+                id: "hosted-1".into(),
+                display_name: "Local Lore".into(),
+                store_path: "/stores/lore".into(),
+                advertised_url: "https://localhost:41337".into(),
+                last_configuration: "2026-07-21T11:00:00Z".into(),
+            }],
+            active: ActiveContext {
+                project_id: Some("project-1".into()),
+                server_id: Some("server-1".into()),
+                identity_ref: Some("keyring://loregui/identity-1".into()),
+            },
+        }
+    }
+
+    #[test]
+    fn default_context_is_explicit_schema_v1() {
+        let context = ContextSettings::default();
+        assert_eq!(context.schema_version, 1);
+        assert!(context.servers.is_empty());
+        assert!(context.repositories.is_empty());
+        assert!(context.projects.is_empty());
+        assert!(context.hosted_servers.is_empty());
+        assert_eq!(context.active, ActiveContext::default());
+    }
+
+    #[test]
+    fn complete_context_round_trips_with_snake_case_enums() {
+        let context = complete_context();
+        let json = serde_json::to_value(&context).expect("serialize context");
+        assert_eq!(json["servers"][0]["auth_mode"], "required");
+        assert_eq!(json["servers"][0]["source"], "manual");
+        assert_eq!(json["schema_version"], 1);
+        assert_eq!(
+            serde_json::from_value::<ContextSettings>(json).expect("deserialize context"),
+            context
+        );
+    }
+
+    #[test]
+    fn validation_rejects_duplicate_ids() {
+        let mut context = complete_context();
+        context.servers.push(context.servers[0].clone());
+        assert!(context
+            .validate()
+            .unwrap_err()
+            .contains("duplicate server id"));
+    }
+
+    #[test]
+    fn validation_rejects_missing_active_project() {
+        let mut context = complete_context();
+        context.active.project_id = Some("missing-project".into());
+        assert!(context.validate().unwrap_err().contains("active project"));
+    }
+
+    #[test]
+    fn validation_rejects_broken_repository_references() {
+        let mut context = complete_context();
+        context.projects[0].repository_id = "missing-repository".into();
+        assert!(context.validate().unwrap_err().contains("repository"));
+    }
+
+    #[test]
+    fn recursive_secret_guard_rejects_fields_and_raw_values() {
+        for raw in [
+            serde_json::json!({"nested": {"token": "raw-value"}}),
+            serde_json::json!({"password": "raw-value"}),
+            serde_json::json!({"secret": "raw-value"}),
+            serde_json::json!({"alias": "token=raw-value"}),
+            serde_json::json!({"alias": "ghp_0123456789abcdefghijklmnopqrstuvwxyz"}),
+        ] {
+            assert!(validate_no_raw_secrets(&raw).is_err(), "accepted {raw}");
+        }
+    }
+
+    #[test]
+    fn recursive_secret_guard_allows_only_opaque_credential_references() {
+        let raw = serde_json::json!({
+            "credential_ref": "keyring://loregui/server-1",
+            "identity_ref": "keyring://loregui/identity-1"
+        });
+        validate_no_raw_secrets(&raw).expect("opaque OS-store references are non-secret");
+    }
+}

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -38,7 +38,7 @@ pub async fn set_autostart(
     enabled: bool,
 ) -> Result<(), String> {
     // Update the persisted setting.
-    settings.update(|s| s.autostart_enabled = enabled);
+    settings.update(|s| s.autostart_enabled = enabled)?;
 
     // Register or unregister with the autostart plugin.
     if enabled {
@@ -62,6 +62,6 @@ pub fn set_close_to_tray(
     settings: State<'_, SettingsManager>,
     enabled: bool,
 ) -> Result<(), String> {
-    settings.update(|s| s.close_to_tray = enabled);
+    settings.update(|s| s.close_to_tray = enabled)?;
     Ok(())
 }

--- a/src-tauri/src/ipc_harness_tests.rs
+++ b/src-tauri/src/ipc_harness_tests.rs
@@ -213,12 +213,14 @@ fn context_select_project_round_trips_through_real_ipc() {
         .build()
         .expect("build webview");
     let context = selection_context(&client_path);
+    app.state::<SettingsManager>()
+        .update_context(context)
+        .expect("persist server-owned context");
 
     let result = invoke(
         &webview,
         "context_select",
         json!({
-            "context": context,
             "target": {"kind": "project", "project_id": "project-1"},
             "requestGeneration": 1,
         }),
@@ -243,6 +245,59 @@ fn context_select_project_round_trips_through_real_ipc() {
 }
 
 #[test]
+fn context_select_uses_persisted_context_instead_of_forged_caller_context() {
+    let tmp = tempfile::tempdir().expect("temp fixture root");
+    let persisted_path = tmp.path().join("persisted-client-working-tree");
+    let shared_store = tmp.path().join("persisted-client-shared-store");
+    let forged_path = tmp.path().join("forged-client-working-tree");
+    tauri::async_runtime::block_on(create_offline_fixture_repository(
+        &persisted_path,
+        &shared_store,
+    ));
+    let app = build_app_with_config(&tmp.path().join("config"));
+    let persisted_context = selection_context(&persisted_path);
+    app.state::<SettingsManager>()
+        .update_context(persisted_context.clone())
+        .expect("persist server-owned context");
+    let webview = WebviewWindowBuilder::new(&app, "main", Default::default())
+        .build()
+        .expect("build webview");
+
+    let result = invoke(
+        &webview,
+        "context_select",
+        json!({
+            "context": selection_context(&forged_path),
+            "target": {"kind": "project", "project_id": "project-1"},
+            "requestGeneration": 1,
+        }),
+    )
+    .expect("persisted project selection should ignore forged caller context");
+
+    assert_eq!(
+        result["context"]["projects"][0]["local_path"],
+        json!(persisted_path)
+    );
+    assert_eq!(result["context"]["active"]["project_id"], "project-1");
+    assert_eq!(result["context"]["active"]["server_id"], "server-1");
+    assert_eq!(result["active_repository"], json!(persisted_path));
+    assert!(result["status"].is_object());
+    assert_eq!(
+        commands::current_repository(app.state()),
+        Some(persisted_path.to_string_lossy().into_owned())
+    );
+    let saved = app.state::<SettingsManager>().get();
+    assert_eq!(
+        saved.context.projects[0].local_path,
+        persisted_path.to_string_lossy()
+    );
+    assert_eq!(saved.active_repository, Some(persisted_path));
+    assert!(!result
+        .to_string()
+        .contains(&forged_path.to_string_lossy().into_owned()));
+}
+
+#[test]
 fn context_select_rejects_raw_path_target_through_real_ipc() {
     let tmp = tempfile::tempdir().expect("temp fixture root");
     let client_path = tmp.path().join("client-working-tree");
@@ -250,12 +305,14 @@ fn context_select_rejects_raw_path_target_through_real_ipc() {
     let webview = WebviewWindowBuilder::new(&app, "main", Default::default())
         .build()
         .expect("build webview");
+    app.state::<SettingsManager>()
+        .update_context(selection_context(&client_path))
+        .expect("persist server-owned context");
 
     assert!(invoke(
         &webview,
         "context_select",
         json!({
-            "context": selection_context(&client_path),
             "target": {
                 "kind": "project",
                 "project_id": "project-1",

--- a/src-tauri/src/ipc_harness_tests.rs
+++ b/src-tauri/src/ipc_harness_tests.rs
@@ -56,7 +56,10 @@ use tauri::webview::InvokeRequest;
 use tauri::{App, Manager, WebviewWindowBuilder};
 
 use crate::commands::{self, AppState};
-use crate::context::ContextSelectionCoordinator;
+use crate::context::{
+    ActiveContext, AuthMode, ContextSelectionCoordinator, ContextSettings, LocalProject,
+    RepositoryBookmark, ServerProfile, ServerSource,
+};
 use crate::settings::SettingsManager;
 use std::collections::HashSet;
 use std::sync::atomic::AtomicU64;
@@ -117,6 +120,7 @@ fn build_app_with_config(config_dir: &std::path::Path) -> App<tauri::test::MockR
             commands::service_stop,
             commands::host_server_restart,
             commands::lock_inbox_list,
+            crate::context::context_select,
         ])
         .build(mock_context(noop_assets()))
         .expect("failed to build mock loregui app")
@@ -159,6 +163,110 @@ async fn create_offline_fixture_repository(
     )
     .await
     .expect("create offline fixture repository");
+}
+
+fn selection_context(client_path: &std::path::Path) -> ContextSettings {
+    ContextSettings {
+        schema_version: 1,
+        servers: vec![ServerProfile {
+            id: "server-1".into(),
+            alias: "Fixture Lore".into(),
+            url: "lore://localhost/restart-fixture".into(),
+            source: ServerSource::Manual,
+            favorite: false,
+            auth_mode: AuthMode::NotRequired,
+            credential_ref: None,
+            last_seen_at: None,
+        }],
+        repositories: vec![RepositoryBookmark {
+            id: "repository-1".into(),
+            server_id: Some("server-1".into()),
+            display_name: "Fixture Repository".into(),
+            url: Some("lore://localhost/restart-fixture".into()),
+            favorite: false,
+        }],
+        projects: vec![LocalProject {
+            id: "project-1".into(),
+            repository_id: "repository-1".into(),
+            display_name: "Fixture Project".into(),
+            local_path: client_path.to_string_lossy().into_owned(),
+            branch: None,
+            favorite: false,
+            last_opened_at: "2026-07-22T10:00:00Z".into(),
+        }],
+        hosted_servers: Vec::new(),
+        active: ActiveContext::default(),
+    }
+}
+
+#[test]
+fn context_select_project_round_trips_through_real_ipc() {
+    let tmp = tempfile::tempdir().expect("temp fixture root");
+    let client_path = tmp.path().join("client-working-tree");
+    let shared_store = tmp.path().join("client-shared-store");
+    tauri::async_runtime::block_on(create_offline_fixture_repository(
+        &client_path,
+        &shared_store,
+    ));
+    let app = build_app_with_config(&tmp.path().join("config"));
+    let webview = WebviewWindowBuilder::new(&app, "main", Default::default())
+        .build()
+        .expect("build webview");
+    let context = selection_context(&client_path);
+
+    let result = invoke(
+        &webview,
+        "context_select",
+        json!({
+            "context": context,
+            "target": {"kind": "project", "project_id": "project-1"},
+            "requestGeneration": 1,
+        }),
+    )
+    .expect("typed project selection should succeed");
+
+    assert_eq!(result["context"]["active"]["project_id"], "project-1");
+    assert_eq!(result["context"]["active"]["server_id"], "server-1");
+    assert_eq!(
+        result["active_repository"],
+        json!(client_path.to_string_lossy())
+    );
+    assert!(result["status"].is_object());
+    assert_eq!(
+        commands::current_repository(app.state()),
+        Some(client_path.to_string_lossy().into_owned())
+    );
+    assert_eq!(
+        app.state::<SettingsManager>().get().active_repository,
+        Some(client_path)
+    );
+}
+
+#[test]
+fn context_select_rejects_raw_path_target_through_real_ipc() {
+    let tmp = tempfile::tempdir().expect("temp fixture root");
+    let client_path = tmp.path().join("client-working-tree");
+    let app = build_app_with_config(&tmp.path().join("config"));
+    let webview = WebviewWindowBuilder::new(&app, "main", Default::default())
+        .build()
+        .expect("build webview");
+
+    assert!(invoke(
+        &webview,
+        "context_select",
+        json!({
+            "context": selection_context(&client_path),
+            "target": {
+                "kind": "project",
+                "project_id": "project-1",
+                "path": "C:/raw"
+            },
+            "requestGeneration": 1,
+        }),
+    )
+    .is_err());
+    assert_eq!(commands::current_repository(app.state()), None);
+    assert_eq!(app.state::<SettingsManager>().get().active_repository, None);
 }
 
 #[test]

--- a/src-tauri/src/ipc_harness_tests.rs
+++ b/src-tauri/src/ipc_harness_tests.rs
@@ -56,6 +56,7 @@ use tauri::webview::InvokeRequest;
 use tauri::{App, Manager, WebviewWindowBuilder};
 
 use crate::commands::{self, AppState};
+use crate::context::ContextSelectionCoordinator;
 use crate::settings::SettingsManager;
 use std::collections::HashSet;
 use std::sync::atomic::AtomicU64;
@@ -75,6 +76,7 @@ fn build_app_with_config(config_dir: &std::path::Path) -> App<tauri::test::MockR
     mock_builder()
         .manage(AppState {
             working_dir: Mutex::new(None),
+            context_selection: Mutex::new(ContextSelectionCoordinator::default()),
             subscription_counter: AtomicU64::new(0),
             subscriptions: Mutex::new(HashSet::new()),
             storage_session: Mutex::new(commands::StorageSession::default()),

--- a/src-tauri/src/ipc_harness_tests.rs
+++ b/src-tauri/src/ipc_harness_tests.rs
@@ -193,6 +193,41 @@ fn no_repository_invalid_open_keeps_repository_closed() {
 }
 
 #[test]
+fn repository_activation_publishes_runtime_only_after_settings_persist() {
+    let tmp = tempfile::tempdir().expect("temp fixture root");
+    let config_dir = tmp.path().join("blocked-config");
+    let client_path = tmp.path().join("client-working-tree");
+    let shared_store = tmp.path().join("client-shared-store");
+    tauri::async_runtime::block_on(create_offline_fixture_repository(
+        &client_path,
+        &shared_store,
+    ));
+    std::fs::write(&config_dir, "not-a-directory").expect("blocking config file");
+
+    let app = build_app_with_config(&config_dir);
+    let state = app.state::<AppState>();
+    let settings = app.state::<SettingsManager>();
+    let error = tauri::async_runtime::block_on(commands::open_repository(
+        state.clone(),
+        settings.clone(),
+        client_path.to_string_lossy().into_owned(),
+    ))
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        lore_vm::LoreError::CommandFailed(ref message)
+            if message == "failed to persist active repository context"
+    ));
+    assert_eq!(commands::current_repository(state), None);
+    assert_eq!(settings.get().active_repository, None);
+    assert_eq!(
+        std::fs::read_to_string(config_dir).expect("blocking file remains"),
+        "not-a-directory"
+    );
+}
+
+#[test]
 fn validated_repository_path_survives_rebuild_and_stale_path_fails_closed() {
     let tmp = tempfile::tempdir().expect("temp fixture root");
     let config_dir = tmp.path().join("config");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod context;
 mod desktop;
 mod lan_discovery;
 mod operations;
@@ -14,6 +15,7 @@ mod tray;
 mod ipc_harness_tests;
 
 use commands::AppState;
+use context::{context_get, context_update, context_validate};
 use desktop::{get_desktop_settings, set_autostart, set_close_to_tray};
 use operations::subscribe::subscribe_notifications;
 use operations::unsubscribe::unsubscribe_notifications;
@@ -236,6 +238,9 @@ pub fn run() {
             set_close_to_tray,
             subscribe_notifications,
             unsubscribe_notifications,
+            context_get,
+            context_update,
+            context_validate,
         ])
         .build(tauri::generate_context!())
         .expect("error while building loregui")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,7 +15,7 @@ mod tray;
 mod ipc_harness_tests;
 
 use commands::AppState;
-use context::{context_get, context_update, context_validate};
+use context::{context_get, context_update, context_validate, ContextSelectionCoordinator};
 use desktop::{get_desktop_settings, set_autostart, set_close_to_tray};
 use operations::subscribe::subscribe_notifications;
 use operations::unsubscribe::unsubscribe_notifications;
@@ -85,6 +85,7 @@ pub fn run() {
         })
         .manage(AppState {
             working_dir: Mutex::new(None),
+            context_selection: Mutex::new(ContextSelectionCoordinator::default()),
             subscription_counter: AtomicU64::new(0),
             subscriptions: Mutex::new(HashSet::new()),
             storage_session: Mutex::new(commands::StorageSession::default()),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,7 +15,9 @@ mod tray;
 mod ipc_harness_tests;
 
 use commands::AppState;
-use context::{context_get, context_update, context_validate, ContextSelectionCoordinator};
+use context::{
+    context_get, context_select, context_update, context_validate, ContextSelectionCoordinator,
+};
 use desktop::{get_desktop_settings, set_autostart, set_close_to_tray};
 use operations::subscribe::subscribe_notifications;
 use operations::unsubscribe::unsubscribe_notifications;
@@ -240,6 +242,7 @@ pub fn run() {
             subscribe_notifications,
             unsubscribe_notifications,
             context_get,
+            context_select,
             context_update,
             context_validate,
         ])

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -215,7 +215,7 @@ mod tests {
     }
 
     #[test]
-    fn high_confidence_secret_context_update_is_rejected_without_persistence() {
+    fn url_userinfo_context_update_is_rejected_without_persistence() {
         let tmp = tempfile::tempdir().expect("temp settings directory");
         let settings = SettingsManager::new(tmp.path().to_path_buf());
         settings
@@ -224,12 +224,11 @@ mod tests {
         let original = std::fs::read_to_string(tmp.path().join("settings.json"))
             .expect("baseline persisted settings");
 
-        let raw_token = ["ghp_", "0123456789abcdefghijklmnopqrstuvwxyz"].concat();
         let mut context = ContextSettings::default();
         context.servers.push(ServerProfile {
             id: "server-1".into(),
-            alias: raw_token,
-            url: "https://example.test".into(),
+            alias: "EROS".into(),
+            url: "https://user:raw-password@example.test".into(),
             source: ServerSource::Manual,
             favorite: false,
             auth_mode: AuthMode::Unknown,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -106,30 +106,22 @@ impl SettingsManager {
         self.cache.lock().unwrap_or_else(|e| e.into_inner()).clone()
     }
 
-    /// Save updated settings to disk.
-    ///
-    /// Write failures are logged (previously they were silently swallowed, so a
-    /// preference change could appear to take effect in-memory yet never persist
-    /// — and be lost on the next launch). The in-memory cache is still updated
-    /// regardless so the running session reflects the change.
-    pub fn update(&self, f: impl FnOnce(&mut AppSettings)) {
+    /// Validate and persist a candidate update before publishing it in memory.
+    /// Failed validation or disk writes leave both cache and disk unchanged.
+    pub fn update(&self, f: impl FnOnce(&mut AppSettings)) -> Result<(), String> {
         let mut settings = self.cache.lock().unwrap_or_else(|e| e.into_inner());
-        f(&mut settings);
-        if let Err(error) = self.persist(&settings) {
-            tracing::warn!(error = %error, "could not persist settings");
-        }
+        let mut candidate = settings.clone();
+        f(&mut candidate);
+        self.persist(&candidate)?;
+        *settings = candidate;
+        Ok(())
     }
 
     /// Validate a context update before publishing it to disk and memory.
     /// Invalid or unpersistable updates leave both the file and cache unchanged.
     pub fn update_context(&self, context: ContextSettings) -> Result<(), String> {
         context.validate_for_persistence()?;
-        let mut settings = self.cache.lock().unwrap_or_else(|e| e.into_inner());
-        let mut candidate = settings.clone();
-        candidate.context = context;
-        self.persist(&candidate)?;
-        *settings = candidate;
-        Ok(())
+        self.update(move |settings| settings.context = context)
     }
 
     fn persist(&self, settings: &AppSettings) -> Result<(), String> {
@@ -167,7 +159,9 @@ mod tests {
         let expected = tmp.path().join("client-working-tree");
 
         let settings = SettingsManager::new(tmp.path().to_path_buf());
-        settings.update(|value| value.active_repository = Some(expected.clone()));
+        settings
+            .update(|value| value.active_repository = Some(expected.clone()))
+            .expect("persist active repository");
 
         let reloaded = SettingsManager::new(tmp.path().to_path_buf()).get();
         assert_eq!(reloaded.active_repository, Some(expected.clone()));
@@ -221,17 +215,20 @@ mod tests {
     }
 
     #[test]
-    fn secret_like_context_update_is_rejected_without_persistence() {
+    fn high_confidence_secret_context_update_is_rejected_without_persistence() {
         let tmp = tempfile::tempdir().expect("temp settings directory");
         let settings = SettingsManager::new(tmp.path().to_path_buf());
-        settings.update(|value| value.close_to_tray = true);
+        settings
+            .update(|value| value.close_to_tray = true)
+            .expect("persist baseline settings");
         let original = std::fs::read_to_string(tmp.path().join("settings.json"))
             .expect("baseline persisted settings");
 
+        let raw_token = ["ghp_", "0123456789abcdefghijklmnopqrstuvwxyz"].concat();
         let mut context = ContextSettings::default();
         context.servers.push(ServerProfile {
             id: "server-1".into(),
-            alias: "token=raw-value".into(),
+            alias: raw_token,
             url: "https://example.test".into(),
             source: ServerSource::Manual,
             favorite: false,
@@ -247,5 +244,59 @@ mod tests {
             original
         );
         assert!(settings.get().context.servers.is_empty());
+    }
+
+    #[test]
+    fn failed_generic_update_leaves_cache_and_disk_unchanged() {
+        let tmp = tempfile::tempdir().expect("temp settings directory");
+        let settings = SettingsManager::new(tmp.path().to_path_buf());
+        settings
+            .update(|value| value.close_to_tray = true)
+            .expect("persist baseline settings");
+        let original_cache = settings.get();
+        let original_disk = std::fs::read_to_string(tmp.path().join("settings.json"))
+            .expect("baseline persisted settings");
+
+        let result = settings.update(|value| {
+            value.close_to_tray = false;
+            value.context.servers.push(ServerProfile {
+                id: "server-1".into(),
+                alias: "unsafe".into(),
+                url: "https://example.test".into(),
+                source: ServerSource::Manual,
+                favorite: false,
+                auth_mode: AuthMode::Required,
+                credential_ref: Some("raw-password-value".into()),
+                last_seen_at: None,
+            });
+        });
+        assert!(result.is_err());
+
+        let current = settings.get();
+        assert_eq!(current.close_to_tray, original_cache.close_to_tray);
+        assert_eq!(current.context, original_cache.context);
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("settings.json"))
+                .expect("settings remain persisted"),
+            original_disk
+        );
+    }
+
+    #[test]
+    fn generic_update_write_failure_leaves_cache_and_disk_unchanged() {
+        let tmp = tempfile::tempdir().expect("temp settings directory");
+        let blocked_config_dir = tmp.path().join("not-a-directory");
+        std::fs::write(&blocked_config_dir, "unchanged").expect("blocking file");
+        let settings = SettingsManager::new(blocked_config_dir.clone());
+        let original_cache = settings.get();
+
+        let result = settings.update(|value| value.close_to_tray = true);
+
+        assert!(result.is_err());
+        assert_eq!(settings.get().close_to_tray, original_cache.close_to_tray);
+        assert_eq!(
+            std::fs::read_to_string(blocked_config_dir).expect("blocking file remains"),
+            "unchanged"
+        );
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -124,6 +124,18 @@ impl SettingsManager {
         self.update(move |settings| settings.context = context)
     }
 
+    pub fn update_context_selection(
+        &self,
+        context: ContextSettings,
+        active_repository: Option<PathBuf>,
+    ) -> Result<(), String> {
+        context.validate_for_persistence()?;
+        self.update(move |settings| {
+            settings.context = context;
+            settings.active_repository = active_repository;
+        })
+    }
+
     fn persist(&self, settings: &AppSettings) -> Result<(), String> {
         let raw = serde_json::to_value(settings)
             .map_err(|error| format!("could not serialize settings: {error}"))?;
@@ -152,6 +164,56 @@ impl SettingsManager {
 mod tests {
     use super::SettingsManager;
     use crate::context::{AuthMode, ContextSettings, ServerProfile, ServerSource};
+
+    fn complete_context() -> ContextSettings {
+        let mut context = ContextSettings::default();
+        context.servers.push(ServerProfile {
+            id: "server-1".into(),
+            alias: "Local Lore".into(),
+            url: "lore://127.0.0.1:41337/repository-1".into(),
+            source: ServerSource::Manual,
+            favorite: false,
+            auth_mode: AuthMode::NotRequired,
+            credential_ref: None,
+            last_seen_at: None,
+        });
+        context
+    }
+
+    #[test]
+    fn context_selection_persists_context_and_repository_as_one_candidate() {
+        let tmp = tempfile::tempdir().expect("temp settings directory");
+        let settings = SettingsManager::new(tmp.path().to_path_buf());
+        let context = complete_context();
+        let path = tmp.path().join("project-a");
+
+        settings
+            .update_context_selection(context.clone(), Some(path.clone()))
+            .expect("atomic context selection");
+
+        let reloaded = SettingsManager::new(tmp.path().to_path_buf()).get();
+        assert_eq!(reloaded.context, context);
+        assert_eq!(reloaded.active_repository, Some(path));
+    }
+
+    #[test]
+    fn failed_context_selection_retains_cache_and_disk() {
+        let tmp = tempfile::tempdir().expect("temp root");
+        let blocked = tmp.path().join("blocked-config");
+        std::fs::write(&blocked, "not-a-directory").expect("blocking file");
+        let settings = SettingsManager::new(blocked.clone());
+        let before = settings.get();
+
+        assert!(settings
+            .update_context_selection(complete_context(), Some(tmp.path().join("candidate")))
+            .is_err());
+        let after = settings.get();
+        assert_eq!(after.context, before.context);
+        assert_eq!(after.active_repository, before.active_repository);
+        assert_eq!(after.autostart_enabled, before.autostart_enabled);
+        assert_eq!(after.close_to_tray, before.close_to_tray);
+        assert_eq!(std::fs::read_to_string(blocked).unwrap(), "not-a-directory");
+    }
 
     #[test]
     fn active_repository_round_trips_as_the_only_repository_context() {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -3,12 +3,15 @@
 //! Stores user preferences (autostart, close-to-tray) in a JSON file
 //! in the app's config directory.
 
+use crate::context::{validate_no_raw_secrets, ContextSettings};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
 /// User-configurable application settings.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default, deny_unknown_fields)]
 pub struct AppSettings {
     /// Whether LoreGUI should start automatically at login.
     #[serde(default)]
@@ -21,6 +24,10 @@ pub struct AppSettings {
     /// belong in desktop settings.
     #[serde(default)]
     pub active_repository: Option<PathBuf>,
+    /// Versioned server/repository/project context. Credentials are represented
+    /// only by opaque OS-store references inside this model.
+    #[serde(default)]
+    pub context: ContextSettings,
 }
 
 /// Manages loading and saving app settings to disk.
@@ -58,7 +65,7 @@ impl SettingsManager {
             }
         };
 
-        match serde_json::from_str(&content) {
+        match Self::parse_settings(&content) {
             Ok(settings) => settings,
             Err(e) => {
                 // The file exists but is corrupt/unparseable. Silently defaulting
@@ -84,6 +91,16 @@ impl SettingsManager {
         }
     }
 
+    fn parse_settings(content: &str) -> Result<AppSettings, String> {
+        let raw: Value = serde_json::from_str(content)
+            .map_err(|error| format!("settings JSON is malformed: {error}"))?;
+        validate_no_raw_secrets(&raw)?;
+        let settings: AppSettings = serde_json::from_value(raw)
+            .map_err(|error| format!("settings schema is invalid: {error}"))?;
+        settings.context.validate_for_persistence()?;
+        Ok(settings)
+    }
+
     /// Get the current settings.
     pub fn get(&self) -> AppSettings {
         self.cache.lock().unwrap_or_else(|e| e.into_inner()).clone()
@@ -98,35 +115,51 @@ impl SettingsManager {
     pub fn update(&self, f: impl FnOnce(&mut AppSettings)) {
         let mut settings = self.cache.lock().unwrap_or_else(|e| e.into_inner());
         f(&mut settings);
-        match serde_json::to_string_pretty(&*settings) {
-            Ok(json) => {
-                if let Some(parent) = self.settings_path.parent() {
-                    if let Err(e) = std::fs::create_dir_all(parent) {
-                        tracing::warn!(
-                            path = %parent.display(),
-                            error = %e,
-                            "could not create settings directory"
-                        );
-                    }
-                }
-                if let Err(e) = std::fs::write(&self.settings_path, json) {
-                    tracing::warn!(
-                        path = %self.settings_path.display(),
-                        error = %e,
-                        "could not persist settings to disk"
-                    );
-                }
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "could not serialize settings");
-            }
+        if let Err(error) = self.persist(&settings) {
+            tracing::warn!(error = %error, "could not persist settings");
         }
+    }
+
+    /// Validate a context update before publishing it to disk and memory.
+    /// Invalid or unpersistable updates leave both the file and cache unchanged.
+    pub fn update_context(&self, context: ContextSettings) -> Result<(), String> {
+        context.validate_for_persistence()?;
+        let mut settings = self.cache.lock().unwrap_or_else(|e| e.into_inner());
+        let mut candidate = settings.clone();
+        candidate.context = context;
+        self.persist(&candidate)?;
+        *settings = candidate;
+        Ok(())
+    }
+
+    fn persist(&self, settings: &AppSettings) -> Result<(), String> {
+        let raw = serde_json::to_value(settings)
+            .map_err(|error| format!("could not serialize settings: {error}"))?;
+        validate_no_raw_secrets(&raw)?;
+        settings.context.validate()?;
+        let json = serde_json::to_string_pretty(settings)
+            .map_err(|error| format!("could not serialize settings: {error}"))?;
+        if let Some(parent) = self.settings_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                format!(
+                    "could not create settings directory {}: {error}",
+                    parent.display()
+                )
+            })?;
+        }
+        std::fs::write(&self.settings_path, json).map_err(|error| {
+            format!(
+                "could not persist settings to {}: {error}",
+                self.settings_path.display()
+            )
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::SettingsManager;
+    use crate::context::{AuthMode, ContextSettings, ServerProfile, ServerSource};
 
     #[test]
     fn active_repository_round_trips_as_the_only_repository_context() {
@@ -146,11 +179,73 @@ mod tests {
         keys.sort_unstable();
         assert_eq!(
             keys,
-            vec!["active_repository", "autostart_enabled", "close_to_tray"]
+            vec![
+                "active_repository",
+                "autostart_enabled",
+                "close_to_tray",
+                "context"
+            ]
         );
         assert_eq!(
             object.get("active_repository"),
             Some(&serde_json::json!(expected))
         );
+    }
+
+    #[test]
+    fn empty_legacy_settings_migrate_to_schema_v1_context() {
+        let tmp = tempfile::tempdir().expect("temp settings directory");
+        std::fs::write(tmp.path().join("settings.json"), "{}").expect("legacy settings");
+
+        let settings = SettingsManager::new(tmp.path().to_path_buf()).get();
+        assert_eq!(settings.context, ContextSettings::default());
+    }
+
+    #[test]
+    fn malformed_or_unknown_settings_fail_closed_with_recoverable_backup() {
+        for contents in [
+            r#"{"context":{"schema_version":99}}"#,
+            r#"{"unknown_setting":true}"#,
+            r#"{"context":{"token":"raw-token"}}"#,
+            "{not-json",
+        ] {
+            let tmp = tempfile::tempdir().expect("temp settings directory");
+            let path = tmp.path().join("settings.json");
+            std::fs::write(&path, contents).expect("invalid settings");
+
+            let settings = SettingsManager::new(tmp.path().to_path_buf()).get();
+            assert_eq!(settings.context, ContextSettings::default());
+            assert!(!path.exists(), "invalid primary file should be moved");
+            assert!(tmp.path().join("settings.json.bak").exists());
+        }
+    }
+
+    #[test]
+    fn secret_like_context_update_is_rejected_without_persistence() {
+        let tmp = tempfile::tempdir().expect("temp settings directory");
+        let settings = SettingsManager::new(tmp.path().to_path_buf());
+        settings.update(|value| value.close_to_tray = true);
+        let original = std::fs::read_to_string(tmp.path().join("settings.json"))
+            .expect("baseline persisted settings");
+
+        let mut context = ContextSettings::default();
+        context.servers.push(ServerProfile {
+            id: "server-1".into(),
+            alias: "token=raw-value".into(),
+            url: "https://example.test".into(),
+            source: ServerSource::Manual,
+            favorite: false,
+            auth_mode: AuthMode::Unknown,
+            credential_ref: None,
+            last_seen_at: None,
+        });
+
+        assert!(settings.update_context(context).is_err());
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("settings.json"))
+                .expect("settings remain persisted"),
+            original
+        );
+        assert!(settings.get().context.servers.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- add schema-v1 non-secret server, repository, local-project, hosted-server, and active-context records
- validate duplicate IDs and references before persistence; reject secret-like fields and raw credential values while permitting opaque credential references
- migrate empty legacy settings, back up malformed/unknown settings, and register context_get, context_update, and context_validate

## TDD evidence
- RED: cargo test -p loregui context -- --nocapture failed with 19 missing-type/API errors before implementation
- GREEN: cargo test -p loregui context -- --nocapture (11 passed)
- GREEN: cargo test -p loregui settings -- --nocapture (4 passed)
- cargo check -p loregui
- cargo fmt --all -- --check
- git diff --check

## Scope
Task 1 only from docs/superpowers/plans/2026-07-21-loregui-p1-context-browser-shell.md. No frontend or later P1 tasks included.