### PR TITLE
SBAI-5490: advance Epic authless user-info parity to 826ad5d20

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,6 +11,8 @@ name: integration
 #      stand-in).
 #   3. exact-pin service CWD — builds the pinned Epic `lore` CLI and proves a
 #      service in cwd A resolves a relative repository against caller root B.
+#   4. exact-pin authless contract — boots a real authless server and proves the
+#      public C ABI returns 18 (not 12) plus the Rust wrapper preserves the wire.
 # Kept SEPARATE from the fast `ci.yml` so it never blocks normal op PRs — `ci.yml`
 # runs only the fast unit tests (`cargo test -p lore-vm`, no feature).
 on:
@@ -25,6 +27,9 @@ on:
       - "Cargo.lock"
       - "scripts/exact-pin-service-cwd-canary.sh"
       - "scripts/exact-pin-service-cwd-canary.test.sh"
+      - "scripts/exact-pin-authless-contract.mjs"
+      - "scripts/exact-pin-authless-contract.test.mjs"
+      - "scripts/live-server-client.sh"
       - ".github/workflows/integration.yml"
   workflow_dispatch:
 
@@ -50,3 +55,9 @@ jobs:
         run: scripts/exact-pin-service-cwd-canary.test.sh
       - name: Exact-pin service resolves relative repository against caller root
         run: scripts/exact-pin-service-cwd-canary.sh
+      - name: Exact-pin authless negative fixtures fail closed
+        run: node --test scripts/exact-pin-authless-contract.test.mjs
+      # REQUIRED and non-skippable: real authless loreserver + public C ABI +
+      # LoreGUI Rust wrapper. Any missing/wrong pin or status/wire drift fails.
+      - name: Exact-pin authless C-ABI and Rust wire contract
+        run: scripts/live-server-client.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1416,7 +1416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2226,7 +2226,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2761,7 +2761,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 [[package]]
 name = "lore"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
+source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
 dependencies = [
  "anyhow",
  "bitcode",
@@ -2796,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "lore-base"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
+source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -2825,7 +2825,7 @@ dependencies = [
 [[package]]
 name = "lore-credential"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
+source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
@@ -2846,7 +2846,7 @@ dependencies = [
 [[package]]
 name = "lore-error-set"
 version = "0.1.0"
-source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
+source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
 dependencies = [
  "lore-error-set-macro",
 ]
@@ -2854,7 +2854,7 @@ dependencies = [
 [[package]]
 name = "lore-error-set-macro"
 version = "0.1.0"
-source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
+source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "lore-macro"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
+source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "lore-notification"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
+source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
 dependencies = [
  "async-trait",
  "lore-base",
@@ -2890,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "lore-proto"
 version = "0.1.60"
-source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
+source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
 dependencies = [
  "lore-base",
  "prost",
@@ -2903,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "lore-revision"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
+source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2963,7 +2963,7 @@ dependencies = [
 [[package]]
 name = "lore-storage"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
+source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -3000,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "lore-telemetry"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
+source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
 dependencies = [
  "axum",
  "http",
@@ -3023,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "lore-transport"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
+source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3361,7 +3361,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4115,7 +4115,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -4224,7 +4224,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.11.13"
-source = "git+https://github.com/EpicGames/lore.git?rev=9179c6dc7cd14931af5b66beb3b2e186907f6360#9179c6dc7cd14931af5b66beb3b2e186907f6360"
+source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -4261,9 +4261,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4575,7 +4575,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4633,7 +4633,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5719,7 +5719,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6680,7 +6680,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,15 @@ tokio = { version = "1", features = ["process", "rt-multi-thread", "macros", "io
 tracing = "0.1"
 
 # Lore's own API library — pinned by exact rev. Pre-1.0, so any bump is a
-# deliberate, manager-owned PR. SBAI-3685 / SBAI-3700 / SBAI-5434 / SBAI-5473 / SBAI-5488.
-# 9179c6dc = post-v0.8.5 nightly: service calls carry their caller working
-# directory so relative paths never resolve against the service process cwd.
-lore = { git = "https://github.com/EpicGames/lore.git", rev = "9179c6dc7cd14931af5b66beb3b2e186907f6360" }
+# deliberate, manager-owned PR. SBAI-3685 / SBAI-3700 / SBAI-5434 / SBAI-5473 / SBAI-5488 / SBAI-5490.
+# 826ad5d2 = authless user-info parity: exchange operations return typed
+# NotSupported (code 18), and user-info operations forward that error unchanged.
+lore = { git = "https://github.com/EpicGames/lore.git", rev = "826ad5d20ff4f5814101c946df127cef8253ada3" }
 
 # REQUIRED: upstream `lore` patches quinn-proto to a vendored fork that adds
 # `TransportErrorCode::is_crypto()`. A [patch] does NOT propagate through a git
 # dependency, so without replicating it here `lore-transport` fails to compile
 # ("no method named `is_crypto`"). Same fork, same exact commit, inside the
-# lore repo. Every consumer of the `lore` crate needs this. SBAI-3685 / SBAI-5434 / SBAI-5473 / SBAI-5488.
+# lore repo. Every consumer of the `lore` crate needs this. SBAI-3685 / SBAI-5434 / SBAI-5473 / SBAI-5488 / SBAI-5490.
 [patch.crates-io]
-quinn-proto = { git = "https://github.com/EpicGames/lore.git", rev = "9179c6dc7cd14931af5b66beb3b2e186907f6360" }
+quinn-proto = { git = "https://github.com/EpicGames/lore.git", rev = "826ad5d20ff4f5814101c946df127cef8253ada3" }

--- a/crates/lore-vm/examples/live_server_client.rs
+++ b/crates/lore-vm/examples/live_server_client.rs
@@ -33,8 +33,14 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use lore_vm::api::LoreApi;
+use lore_vm::error::LoreError;
 use lore_vm::global::LoreGlobal;
 use lore_vm::ops;
+
+const NOT_AUTHENTICATED_FFI_CODE: i32 = 12;
+const NOT_SUPPORTED_FFI_CODE: i32 = 18;
+const AUTHLESS_NOT_SUPPORTED_WIRE: &str =
+    "Operation not supported: No authentication configured on server";
 
 /// An ONLINE api (offline=false) so push/clone actually hit the server. The
 /// identity flows through as the revision author and the connection identity;
@@ -76,9 +82,9 @@ async fn run(repo_url: &str, dir_a: &Path, dir_b: &Path) -> Result<(), String> {
         Err(lore_vm::error::LoreError::CommandFailed(message))
             if message == "Operation not supported: No authentication configured on server" =>
         {
-            // SBAI-5465 / SBAI-5473 regression canary: nightly NotSupported (code 18)
-            // exact wording preserved across the 437e727d pin.
-            println!("[auth] verified exact no-auth server response (nightly f20ef0d7d+/437e727d, NotSupported code 18)");
+            // SBAI-5465 / SBAI-5473 / SBAI-5490 regression canary: nightly
+            // NotSupported (code 18), exact wording preserved through 826ad5d2.
+            println!("[auth] verified exact no-auth server response (nightly f20ef0d7d+/826ad5d2, NotSupported code 18)");
         }
         other => {
             return Err(format!(
@@ -102,6 +108,59 @@ async fn run(repo_url: &str, dir_a: &Path, dir_b: &Path) -> Result<(), String> {
     .await
     .map_err(|e| format!("A repository::create failed: {e}"))?;
     println!("[A] created repo id={} name={}", created.id, created.name);
+
+    // ---- exact-pin authless contract: public C ABI + LoreGUI Rust wrapper --
+    // The public C entry point is what generated SDK bindings call. Drive it
+    // on a blocking thread because its synchronous ABI blocks on Lore's runtime.
+    let ffi_globals = alice.globals().build();
+    let ffi_args = lore::auth::LoreAuthUserInfoArgs {
+        user_ids: lore::interface::LoreArray::from_vec(vec![
+            lore::interface::LoreString::from_str("some-other-user"),
+        ]),
+    };
+    let ffi_status = tokio::task::spawn_blocking(move || {
+        lore::interface::lore_auth_user_info(
+            &ffi_globals,
+            &ffi_args,
+            lore::interface::LoreEventCallbackConfig {
+                user_context: 0,
+                func: None,
+            },
+        )
+    })
+    .await
+    .map_err(|e| format!("C-ABI authUserInfo task failed: {e}"))?;
+    if ffi_status == NOT_AUTHENTICATED_FFI_CODE {
+        return Err(format!(
+            "C-ABI authUserInfo returned NotAuthenticated ({NOT_AUTHENTICATED_FFI_CODE}); expected NotSupported ({NOT_SUPPORTED_FFI_CODE})"
+        ));
+    }
+    if ffi_status != NOT_SUPPORTED_FFI_CODE {
+        return Err(format!(
+            "C-ABI authUserInfo returned {ffi_status}; expected NotSupported ({NOT_SUPPORTED_FFI_CODE}) and not NotAuthenticated ({NOT_AUTHENTICATED_FFI_CODE})"
+        ));
+    }
+    println!(
+        "[auth] C-ABI authUserInfo verified code {NOT_SUPPORTED_FFI_CODE} != {NOT_AUTHENTICATED_FFI_CODE}"
+    );
+
+    let user_info = ops::auth::resolve_user_info::resolve_user_info(
+        &alice,
+        ops::auth::resolve_user_info::ResolveUserInfoArgs {
+            user_ids: vec!["some-other-user".to_string()],
+        },
+    )
+    .await;
+    match user_info {
+        Err(LoreError::CommandFailed(message)) if message == AUTHLESS_NOT_SUPPORTED_WIRE => {
+            println!("[auth] Rust authUserInfo wire verified: {message}");
+        }
+        other => {
+            return Err(format!(
+                "Rust authUserInfo returned {other:?}; expected exact {AUTHLESS_NOT_SUPPORTED_WIRE:?}"
+            ));
+        }
+    }
 
     // ---- client A: write + stage + commit (one process keeps staged state) --
     let file_path = dir_a.join("hello.txt");

--- a/crates/lore-vm/src/ops/lock/file_message_send.rs
+++ b/crates/lore-vm/src/ops/lock/file_message_send.rs
@@ -6,7 +6,7 @@
 //!
 //! # Blocking Dependency
 //!
-//! The upstream `lore` crate (pinned commit `437e727d` and earlier, including
+//! The upstream `lore` crate (through the current `826ad5d2` pin, including
 //! the v0.8.5 tag target `2d86d1dd`) does NOT provide
 //! `lore::lock::file_message_send`, nor does `LoreEvent` include a
 //! `LockFileMessageSend` variant. The `lore::notification` module has no

--- a/crates/lore-vm/tests/service_unix_smoke.rs
+++ b/crates/lore-vm/tests/service_unix_smoke.rs
@@ -354,7 +354,8 @@ fn unix_service_run_start_stop_smoke() {
     eprintln!("[service] clean shutdown verified");
 }
 
-/// Behavioral exact-pin canary for Epic 9179c6d.
+/// Behavioral exact-pin canary for caller-CWD support introduced at Epic
+/// 9179c6d and retained by the current 826ad5d2 pin.
 ///
 /// A background service is started from A while the client performs a relative
 /// repository operation from B. The repository must be created only under B;

--- a/docs/superpowers/plans/2026-07-22-sbai-5490-epic-authless-parity.md
+++ b/docs/superpowers/plans/2026-07-22-sbai-5490-epic-authless-parity.md
@@ -1,0 +1,162 @@
+# SBAI-5490 Epic Authless Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Advance LoreGUI to Epic Lore `826ad5d20ff4f5814101c946df127cef8253ada3` and prove that remote user-info resolution against an authless server returns typed `NotSupported` code 18, never `NotAuthenticated` code 12.
+
+**Architecture:** Keep LoreGUI as a thin exact-pin consumer. The root manifest and lockfile select the upstream implementation; a small exact-pin contract checker validates both dependency pins, lock sources, and the upstream source semantics. The existing live `loreserver` harness exercises both the public C-ABI `lore_auth_user_info` status and LoreGUI's Rust wrapper/wire rendering while frontend compatibility tests preserve the legacy and prior-nightly contracts.
+
+**Tech Stack:** Rust workspace, Epic Lore git dependencies, Bash live harness, Node contract tests, Vitest/React frontend tests, cargo-about license generation.
+
+## Global Constraints
+
+- Both `lore` and `[patch.crates-io].quinn-proto` must use exact revision `826ad5d20ff4f5814101c946df127cef8253ada3`.
+- The live C-ABI call must return `18` and explicitly prove it is not `12`; the gate may not skip when its artifacts are absent.
+- The Rust wrapper must render exactly `Operation not supported: No authentication configured on server`.
+- Preserve the exact legacy `No authentication configured on server`, prior-nightly rendered NotSupported, and `No auth endpoint available` classifiers.
+- Unrelated and near-miss authentication errors remain visible and fail closed.
+- Regenerate `Cargo.lock`, root/public Rust attribution bundles, and audit every pin consumer/comment.
+- Do not modify or rebase `worker/sbai-5484-p1`; do not merge or transition Jira.
+
+---
+
+### Task 1: Exact dual-pin contract and negative fixtures
+
+**Files:**
+- Create: `scripts/exact-pin-authless-contract.mjs`
+- Create: `scripts/exact-pin-authless-contract.test.mjs`
+- Modify: `scripts/live-server-client.sh`
+- Modify: `.github/workflows/integration.yml`
+
+**Interfaces:**
+- Produces: `verifyExactPin(repoRoot, expectedRev)` which throws on a missing/mismatched manifest pin, lock source, checkout provenance, or upstream auth semantic.
+- Consumes: root `Cargo.toml`, `Cargo.lock`, and Cargo's exact git checkout for Epic Lore.
+
+- [ ] **Step 1: Write failing contract fixtures**
+
+  Add executable tests with temporary manifests/locks for the exact dual pin, a missing quinn pin, a wrong lore pin, a wrong lock source, and a target checkout whose exchange source does not contain the canonical typed NotSupported operation.
+
+- [ ] **Step 2: Verify RED**
+
+  Run `node --test scripts/exact-pin-authless-contract.test.mjs`.
+  Expected: failure because `scripts/exact-pin-authless-contract.mjs` does not exist.
+
+- [ ] **Step 3: Implement the minimal contract checker**
+
+  Parse both manifest entries independently, require exact full-SHA equality, require `lore` and `quinn-proto` lock sources at that revision, resolve the Cargo checkout by full `git rev-parse HEAD`, and require both auth exchange branches plus all three user-info forwarders from the target source.
+
+- [ ] **Step 4: Make the live harness consume the checker**
+
+  Run the checker before building any artifact. Keep the live harness non-skippable and add it as a required integration workflow step with all checker/harness/example paths in the workflow trigger.
+
+- [ ] **Step 5: Verify GREEN**
+
+  Run `node --test scripts/exact-pin-authless-contract.test.mjs scripts/upstream-lore-parity.test.mjs`.
+  Expected: all fixtures pass, including asserted non-zero exits for missing/wrong pins.
+
+### Task 2: Public C-ABI and Rust wire canaries
+
+**Files:**
+- Modify: `crates/lore-vm/examples/live_server_client.rs`
+- Test: `scripts/live-server-client.sh`
+
+**Interfaces:**
+- Consumes: `lore::interface::lore_auth_user_info` and `lore_vm::ops::auth::resolve_user_info::resolve_user_info`.
+- Produces: live assertions for status `18 != 12` and canonical wire text.
+
+- [ ] **Step 1: Write the failing live assertions**
+
+  After creating the remote-backed repository, call the public C-ABI entry point with a non-current user and assert `status == 18` and `status != 12`. Call the LoreGUI Rust wrapper with the same identity and assert the exact `CommandFailed` message.
+
+- [ ] **Step 2: Verify RED at the old pin**
+
+  Run `scripts/live-server-client.sh` on `9179c6dc7cd14931af5b66beb3b2e186907f6360`.
+  Expected: the C-ABI assertion reports code 12 instead of 18, proving the regression canary distinguishes the upstream change.
+
+- [ ] **Step 3: Verify GREEN at the target pin**
+
+  Run `scripts/live-server-client.sh` after the dual pin update.
+  Expected: C-ABI `authUserInfo` prints code 18 and not 12; Rust wrapper prints the canonical wire string; the full network create/push/clone round trip remains green.
+
+### Task 3: Compatibility classifier preservation
+
+**Files:**
+- Modify: `frontend/src/api.ts`
+- Modify: `frontend/src/api.spec.ts`
+- Modify: `frontend/src/AccountPanel.spec.tsx`
+- Modify: `frontend/src/onboarding/ClientConnect.spec.tsx`
+- Modify: `crates/lore-vm/examples/live_server_client.rs`
+
+**Interfaces:**
+- Consumes: three exact compatibility strings from #404, #414, and SBAI-5478.
+- Produces: narrow predicates that accept only those exact strings.
+
+- [ ] **Step 1: Add target-pin regression cases before comment updates**
+
+  Assert the target-pin user-info error is neutral in identity loaders, while suffixed/prefixed NotSupported messages, bare NotSupported, connection failures, and I/O errors stay visible.
+
+- [ ] **Step 2: Verify focused tests**
+
+  Run `npm --prefix frontend run test:vitest -- src/api.spec.ts src/AccountPanel.spec.tsx src/onboarding/ClientConnect.spec.tsx`.
+  Expected: exact legacy/nightly/target strings pass and unrelated cases remain rejected.
+
+- [ ] **Step 3: Update only stale provenance comments**
+
+  Record `826ad5d20` as the pin establishing forwarded user-info/exchange semantics; do not broaden predicate matching.
+
+### Task 4: Pin, lock, and attribution regeneration
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `Cargo.lock`
+- Modify: `THIRD-PARTY-LICENSES-RUST.md`
+- Modify: `frontend/public/licenses/rust.md`
+- Modify: pin-specific comments found by repository-wide search
+
+**Interfaces:**
+- Produces: one dependency graph whose lore-family and quinn-proto sources resolve to the target full SHA.
+
+- [ ] **Step 1: Update both exact pins**
+
+  Change only the two Epic Lore revisions and their provenance comments.
+
+- [ ] **Step 2: Regenerate the lockfile**
+
+  Run `cargo update -p lore --precise 826ad5d20ff4f5814101c946df127cef8253ada3` and verify every Epic Lore/quinn source ends in `#826ad5d20ff4f5814101c946df127cef8253ada3`.
+
+- [ ] **Step 3: Regenerate licenses**
+
+  Run `bash scripts/gen-licenses.sh`; verify only dependency-derived Rust attribution changes are produced.
+
+- [ ] **Step 4: Sweep all consumers**
+
+  Search for `9179c6d`, stale pin labels, dual-pin extractors, and authless operation strings. Classify every remaining old SHA reference as intentional history or update it.
+
+### Task 5: Scoped and full verification
+
+**Files:**
+- Verify all files changed above.
+
+- [ ] **Step 1: Focused schema/boundary/parity/license gates**
+
+  Run exact-pin contract tests, `scripts/upstream-lore-parity.mjs --json`, `scripts/check-open-boundary.sh`, license regeneration followed by `git diff --exit-code` on generated bundles, and `cargo metadata --locked`.
+
+- [ ] **Step 2: Rust surface gates**
+
+  Run `cargo test -p lore-vm`, `cargo test -p lorevm-cli`, `cargo test -p lorevm-ffi`, and the feature-scoped lore-vm integration tests required by `.github/workflows/integration.yml`.
+
+- [ ] **Step 3: Frontend compatibility gates**
+
+  Run focused auth tests, frontend typecheck, and the full frontend test suite.
+
+- [ ] **Step 4: Live authless proof**
+
+  Run `scripts/live-server-client.sh` with no skip flags and retain output proving public C-ABI code 18, inequality to 12, canonical Rust wire text, and network round trip.
+
+- [ ] **Step 5: Adversarial audit and freeze**
+
+  Run `cargo fmt --all --check`, `git diff --check`, inspect the complete base-to-head diff, verify `Cargo.lock --locked` behavior, and re-run the exact canary after deliberately exercising its wrong-pin fixture.
+
+- [ ] **Step 6: Publish without merge**
+
+  Commit with SBAI-5490, push `worker/sbai-5490`, create a non-draft PR titled `SBAI-5490: advance Epic authless user-info parity to 826ad5d20`, and report the immutable head plus exact evidence. Do not merge or transition Jira.

--- a/frontend/src/AccountPanel.spec.tsx
+++ b/frontend/src/AccountPanel.spec.tsx
@@ -69,7 +69,7 @@ describe("auth-disabled connection from the account panel (#404)", () => {
     expect(screen.queryByText(/No authentication configured/)).toBeNull();
   });
 
-  it("shows a successful no-auth connection for nightly (f20ef0d7d+) NotSupported code 18", async () => {
+  it("shows a successful no-auth connection for 826ad5d2 NotSupported code 18", async () => {
     routeCommands({
       loginError: {
         kind: "CommandFailed",

--- a/frontend/src/api.spec.ts
+++ b/frontend/src/api.spec.ts
@@ -145,7 +145,7 @@ describe("auth + onboarding wrappers", () => {
     expect(isNoAuthConfigured({ kind: "CommandFailed" })).toBe(false);
   });
 
-  it("recognizes nightly (f20ef0d7d+) NotSupported code 18 authless signal", () => {
+  it("recognizes 826ad5d2 NotSupported code 18 authless signal", () => {
     const message =
       "Operation not supported: No authentication configured on server";
     expect(isNoAuthConfigured(message)).toBe(true);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -133,15 +133,15 @@ export interface UserInfo {
  * every connection surface makes the same narrow decision.
  *
  * - v0.8.5 (2d86d1dd): "No authentication configured on server"
- * - f20ef0d7d+ / 437e727d pin (nightly, NotSupported code 18):
+ * - f20ef0d7d+ through 826ad5d2 (nightly, NotSupported code 18):
  *   "Operation not supported: No authentication configured on server"
  *
- * Regression canary for SBAI-5465 / SBAI-5473 pin bumps.
+ * Regression canary for SBAI-5465 / SBAI-5473 / SBAI-5490 pin bumps.
  */
 export const NO_AUTH_CONFIGURED = "No authentication configured on server";
 
 /**
- * Nightly (f20ef0d7d+) authless signal — typed NotSupported code 18 rendered
+ * Nightly (f20ef0d7d+ through 826ad5d2) authless signal — typed NotSupported code 18 rendered
  * as this exact error text. Must NOT broadly swallow other NotSupported failures
  * (e.g. "Operation not supported: disk full"); only the exact auth operation
  * message indicates authless-server compatibility.

--- a/frontend/src/onboarding/ClientConnect.spec.tsx
+++ b/frontend/src/onboarding/ClientConnect.spec.tsx
@@ -53,7 +53,7 @@ describe("auth-disabled server connection (#404)", () => {
     expect(screen.queryByText(/CommandFailed/)).toBeNull();
   });
 
-  it("accepts the nightly (f20ef0d7d+) NotSupported code 18 authless signal", async () => {
+  it("accepts the 826ad5d2 NotSupported code 18 authless signal", async () => {
     routeAuthFailure({
       kind: "CommandFailed",
       message:

--- a/scripts/exact-pin-authless-contract.mjs
+++ b/scripts/exact-pin-authless-contract.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const EXPECTED_LORE_REV =
+  "826ad5d20ff4f5814101c946df127cef8253ada3";
+
+function manifestPin(manifest, dependency) {
+  const escaped = dependency.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const line = manifest.match(new RegExp(`^${escaped}\\s*=\\s*\\{[^\\n]+$`, "m"));
+  if (!line) throw new Error(`${dependency} manifest pin is missing`);
+  const rev = line[0].match(/\brev\s*=\s*"([0-9a-f]{40})"/);
+  if (!rev) throw new Error(`${dependency} manifest pin is missing a full 40-character rev`);
+  return rev[1];
+}
+
+function lockSource(lock, dependency) {
+  const block = lock
+    .split(/\n\[\[package\]\]\n/)
+    .find((candidate) => new RegExp(`^name = "${dependency}"$`, "m").test(candidate));
+  if (!block) throw new Error(`${dependency} lock package is missing`);
+  const source = block.match(/^source = "([^"]+)"$/m);
+  if (!source) throw new Error(`${dependency} lock source is missing`);
+  return source[1];
+}
+
+function resolvedSha(source) {
+  return source.match(/#([0-9a-f]{40})$/)?.[1] ?? source;
+}
+
+export function verifyManifestAndLock(repoRoot, expectedRev = EXPECTED_LORE_REV) {
+  const manifest = readFileSync(join(repoRoot, "Cargo.toml"), "utf8");
+  const lock = readFileSync(join(repoRoot, "Cargo.lock"), "utf8");
+
+  for (const dependency of ["lore", "quinn-proto"]) {
+    const pin = manifestPin(manifest, dependency);
+    if (pin !== expectedRev) {
+      throw new Error(
+        `${dependency} manifest pin ${pin} does not equal required ${expectedRev}`,
+      );
+    }
+    const source = lockSource(lock, dependency);
+    const sha = resolvedSha(source);
+    if (
+      !source.includes("git+https://github.com/EpicGames/lore.git") ||
+      !source.includes(`?rev=${expectedRev}#`) ||
+      sha !== expectedRev
+    ) {
+      throw new Error(
+        `${dependency} lock source ${sha} does not equal required ${expectedRev}`,
+      );
+    }
+  }
+}
+
+function occurrences(source, needle) {
+  return source.split(needle).length - 1;
+}
+
+export function verifyUpstreamAuthlessSource(checkoutRoot) {
+  const exchangePath = join(
+    checkoutRoot,
+    "lore-transport",
+    "src",
+    "auth",
+    "exchange.rs",
+  );
+  const userInfoPath = join(
+    checkoutRoot,
+    "lore-revision",
+    "src",
+    "auth",
+    "userinfo.rs",
+  );
+  const exchange = readFileSync(exchangePath, "utf8");
+  const userInfo = readFileSync(userInfoPath, "utf8");
+  const operation = 'operation: "No authentication configured on server".to_string()';
+  if (occurrences(exchange, operation) !== 2) {
+    throw new Error(
+      "upstream checkout must contain two typed NotSupported authless exchange branches",
+    );
+  }
+  const forwarder =
+    '.forward::<UserInfoError>("Failed authorization token exchange")?;';
+  if (occurrences(userInfo, forwarder) !== 3) {
+    throw new Error(
+      "upstream checkout must contain three forwarded user-info exchange errors",
+    );
+  }
+  if (userInfo.includes("debug_map_err(UserInfoError::from(NotAuthenticated))")) {
+    throw new Error("upstream checkout retains a legacy NotAuthenticated remap");
+  }
+}
+
+export function locateExactCheckout(
+  expectedRev = EXPECTED_LORE_REV,
+  cargoHome = process.env.CARGO_HOME || join(homedir(), ".cargo"),
+) {
+  const checkouts = join(cargoHome, "git", "checkouts");
+  if (!existsSync(checkouts)) {
+    throw new Error(`Cargo git checkout directory is missing: ${checkouts}`);
+  }
+  for (const repository of readdirSync(checkouts)) {
+    if (!repository.startsWith("lore-")) continue;
+    const repositoryPath = join(checkouts, repository);
+    for (const candidate of readdirSync(repositoryPath)) {
+      const checkout = join(repositoryPath, candidate);
+      if (!statSync(checkout).isDirectory()) continue;
+      try {
+        const head = execFileSync("git", ["-C", checkout, "rev-parse", "HEAD"], {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+        }).trim();
+        if (head === expectedRev) return checkout;
+      } catch {
+        // Ignore unrelated or incomplete Cargo checkout directories.
+      }
+    }
+  }
+  throw new Error(
+    `exact Epic Lore checkout ${expectedRev} is missing; run cargo fetch first`,
+  );
+}
+
+export function verifyExactPin(repoRoot, expectedRev = EXPECTED_LORE_REV) {
+  verifyManifestAndLock(repoRoot, expectedRev);
+  const checkout = locateExactCheckout(expectedRev);
+  verifyUpstreamAuthlessSource(checkout);
+  return checkout;
+}
+
+function argValue(name) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? null : process.argv[index + 1];
+}
+
+const invokedAsScript =
+  process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (invokedAsScript) {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = resolve(argValue("--repo-root") ?? join(here, ".."));
+  const expectedRev = argValue("--expected") ?? EXPECTED_LORE_REV;
+  try {
+    const checkout = verifyExactPin(repoRoot, expectedRev);
+    console.log(`exact Epic Lore authless contract verified at ${expectedRev}`);
+    console.log(`checkout: ${checkout}`);
+  } catch (error) {
+    console.error(`FATAL: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/exact-pin-authless-contract.test.mjs
+++ b/scripts/exact-pin-authless-contract.test.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  verifyManifestAndLock,
+  verifyUpstreamAuthlessSource,
+} from "./exact-pin-authless-contract.mjs";
+
+const EXPECTED = "826ad5d20ff4f5814101c946df127cef8253ada3";
+const WRONG = "9179c6dc7cd14931af5b66beb3b2e186907f6360";
+
+function fixture({ lore = EXPECTED, quinn = EXPECTED, lockLore = EXPECTED, lockQuinn = EXPECTED } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "loregui-authless-pin-"));
+  writeFileSync(
+    join(root, "Cargo.toml"),
+    `[workspace.dependencies]\n` +
+      `lore = { git = "https://github.com/EpicGames/lore.git", rev = "${lore}" }\n\n` +
+      `[patch.crates-io]\n` +
+      (quinn === null
+        ? ""
+        : `quinn-proto = { git = "https://github.com/EpicGames/lore.git", rev = "${quinn}" }\n`),
+  );
+  writeFileSync(
+    join(root, "Cargo.lock"),
+    `version = 4\n\n[[package]]\nname = "lore"\nversion = "0.8.6-nightly"\n` +
+      `source = "git+https://github.com/EpicGames/lore.git?rev=${lore}#${lockLore}"\n\n` +
+      `[[package]]\nname = "quinn-proto"\nversion = "0.11.13"\n` +
+      `source = "git+https://github.com/EpicGames/lore.git?rev=${quinn ?? EXPECTED}#${lockQuinn}"\n`,
+  );
+  return root;
+}
+
+function upstreamFixture({ exchangeCount = 2, forwardCount = 3, legacyRemap = false } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "loregui-authless-source-"));
+  const exchangeDir = join(root, "lore-transport", "src", "auth");
+  const userInfoDir = join(root, "lore-revision", "src", "auth");
+  mkdirSync(exchangeDir, { recursive: true });
+  mkdirSync(userInfoDir, { recursive: true });
+  const exchange = Array.from(
+    { length: exchangeCount },
+    () =>
+      `return Err(NotSupported { operation: "No authentication configured on server".to_string() }.into());`,
+  ).join("\n");
+  const forward = Array.from(
+    { length: forwardCount },
+    () => `.forward::<UserInfoError>("Failed authorization token exchange")?;`,
+  ).join("\n");
+  writeFileSync(join(exchangeDir, "exchange.rs"), exchange);
+  writeFileSync(
+    join(userInfoDir, "userinfo.rs"),
+    `${forward}\n${legacyRemap ? ".debug_map_err(UserInfoError::from(NotAuthenticated))?;" : ""}`,
+  );
+  return root;
+}
+
+test("accepts only the exact dual manifest and lock pin", () => {
+  assert.doesNotThrow(() => verifyManifestAndLock(fixture(), EXPECTED));
+});
+
+test("fails closed when the quinn-proto patch pin is missing", () => {
+  assert.throws(
+    () => verifyManifestAndLock(fixture({ quinn: null }), EXPECTED),
+    /quinn-proto.*missing/i,
+  );
+});
+
+test("fails closed when the lore manifest pin is wrong", () => {
+  assert.throws(
+    () => verifyManifestAndLock(fixture({ lore: WRONG }), EXPECTED),
+    /lore manifest pin.*9179c6d.*826ad5d/i,
+  );
+});
+
+test("fails closed when the resolved lore lock source is wrong", () => {
+  assert.throws(
+    () => verifyManifestAndLock(fixture({ lockLore: WRONG }), EXPECTED),
+    /lore lock source.*9179c6d.*826ad5d/i,
+  );
+});
+
+test("fails closed when the resolved quinn-proto lock source is wrong", () => {
+  assert.throws(
+    () => verifyManifestAndLock(fixture({ lockQuinn: WRONG }), EXPECTED),
+    /quinn-proto lock source.*9179c6d.*826ad5d/i,
+  );
+});
+
+test("accepts the exact exchange wire operation and three user-info forwarders", () => {
+  assert.doesNotThrow(() => verifyUpstreamAuthlessSource(upstreamFixture()));
+});
+
+test("rejects a checkout missing either authless exchange branch", () => {
+  assert.throws(
+    () => verifyUpstreamAuthlessSource(upstreamFixture({ exchangeCount: 1 })),
+    /two typed NotSupported authless exchange branches/i,
+  );
+});
+
+test("rejects a checkout that still remaps user-info to NotAuthenticated", () => {
+  assert.throws(
+    () => verifyUpstreamAuthlessSource(upstreamFixture({ legacyRemap: true })),
+    /legacy NotAuthenticated remap/i,
+  );
+});
+
+test("rejects a checkout missing any user-info exchange forwarder", () => {
+  assert.throws(
+    () => verifyUpstreamAuthlessSource(upstreamFixture({ forwardCount: 2 })),
+    /three forwarded user-info exchange errors/i,
+  );
+});

--- a/scripts/live-server-client.sh
+++ b/scripts/live-server-client.sh
@@ -11,8 +11,8 @@
 # Client B clones from the SERVER into its own separate store, so a successful
 # verify proves a genuine network round trip (not a shared-local-store shortcut).
 #
-# LOCAL-ONLY. Binds 127.0.0.1 exclusively. Not wired into CI — the lore server
-# is built from the pinned upstream `lore` git checkout, which CI does not have.
+# Binds 127.0.0.1 exclusively. The required integration job runs this harness
+# from the exact pinned upstream checkout after Cargo fetches the dependency.
 #
 # Usage:   scripts/live-server-client.sh
 # Env:     LORE_PORT (default 41337)   KEEP_TMP=1 to leave temp dirs for inspection
@@ -27,22 +27,17 @@ SPIKE_DIR="$(mktemp -d /tmp/lore-spike.XXXXXX)"
 SERVER_LOG="${SPIKE_DIR}/server.log"
 SERVER_PID=""
 
-# ---- locate the pinned upstream lore checkout (for the loreserver binary) ---
-# loregui pins `lore` by rev in Cargo.toml; cargo unpacks it under the git cache.
+# ---- validate and locate the exact pinned upstream lore checkout ------------
+# This fails closed unless both manifest and lock pins are exact and the target
+# upstream source contains the typed authless exchange + user-info forwarding.
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-LORE_REV="$(grep -oE 'rev = "[0-9a-f]{40}"' "${REPO_ROOT}/Cargo.toml" | head -1 | grep -oE '[0-9a-f]{40}')"
-if [[ -z "${LORE_REV}" ]]; then
-  echo "FATAL: could not read pinned lore rev from Cargo.toml" >&2
-  exit 1
-fi
-SHORT_REV="${LORE_REV:0:7}"
-LORE_CHECKOUT="$(find "${CARGO_HOME:-$HOME/.cargo}/git/checkouts" -maxdepth 2 -type d -name "${SHORT_REV}" 2>/dev/null | head -1)"
+CONTRACT_OUTPUT="$(node "${REPO_ROOT}/scripts/exact-pin-authless-contract.mjs" --repo-root "${REPO_ROOT}")"
+echo "${CONTRACT_OUTPUT}"
+LORE_CHECKOUT="$(printf '%s\n' "${CONTRACT_OUTPUT}" | sed -n 's/^checkout: //p')"
 if [[ -z "${LORE_CHECKOUT}" ]]; then
-  echo "FATAL: lore checkout for rev ${SHORT_REV} not found under cargo git cache." >&2
-  echo "       Run a build that fetches the dep first (e.g. cargo fetch)." >&2
+  echo "FATAL: exact-pin contract did not return a lore checkout" >&2
   exit 1
 fi
-echo "lore checkout: ${LORE_CHECKOUT}"
 
 cleanup() {
   if [[ -n "${SERVER_PID}" ]] && kill -0 "${SERVER_PID}" 2>/dev/null; then


### PR DESCRIPTION
## Summary

- advance both `lore` and patched `quinn-proto` to exact Epic revision `826ad5d20ff4f5814101c946df127cef8253ada3`
- fail closed on missing/wrong manifest, lock, checkout, exchange, or user-info forwarding provenance
- require the live authless server contract in CI: public C ABI returns NotSupported code 18, never NotAuthenticated code 12, and LoreGUI preserves the exact Rust wire string
- retain the narrow #404/#414 legacy and prior-nightly compatibility classifiers; unrelated and near-miss errors remain visible
- regenerate Cargo.lock and verify license bundles are stable

## RED to GREEN evidence

- old exact pin `9179c6dc7cd14931af5b66beb3b2e186907f6360`: live public `authUserInfo` returned code 12 and the harness failed
- target exact pin `826ad5d20ff4f5814101c946df127cef8253ada3`: live public `authUserInfo` returned code 18, explicitly `18 != 12`
- target Rust wrapper preserved exactly: `Operation not supported: No authentication configured on server`
- real authless loreserver push and independent clone round trip passed

## Verification

- `node --test scripts/exact-pin-authless-contract.test.mjs` — 9 passed, including missing/wrong pins and legacy remap rejection
- `node scripts/upstream-lore-parity.mjs --json` — 140 pinned/head ops, no new/drifted/orphaned bindings or shared-schema drift
- `scripts/check-open-boundary.sh` — 448 files clean
- frontend focused auth compatibility — 47 passed
- frontend full suite — 266 passed; `npm run typecheck` passed
- `cargo test -p lore-vm -p lorevm-cli -p lorevm-ffi` — passed, including 755 lore-vm unit tests, CLI lifecycle/plumbing, and 6 FFI smoke tests
- integration roundtrip + e2e lifecycle — 6 passed
- exact-pin service CWD positive canary — passed; missing/wrong binary fixtures — passed
- `scripts/gen-licenses.sh` — regenerated twice with stable hashes; no license bundle diff
- `cargo fmt --all -- --check`, `cargo metadata --locked`, and `git diff --check` — passed

## Scope

No merge and no Jira transition in this PR handoff.
