### PR TITLE
fix(SBAI-5463): normalize Windows release stage paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,13 +359,23 @@ jobs:
           # Fail before exporting STAGE_DIR. A successful empty stage must never
           # turn the later subject glob into an unintended workspace-wide glob.
           node scripts/release-supply-chain.mjs assert-nonempty "$STAGE"
+          # Git Bash's mktemp returns /tmp/..., which Bash/Node can use but
+          # native Windows tools (Syft and the attestation action) cannot.
+          # Export two views of the same directory: POSIX for later Bash steps,
+          # mixed/native for cross-platform JavaScript actions.
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            STAGE_NATIVE="$(cygpath -m "$STAGE")"
+          else
+            STAGE_NATIVE="$STAGE"
+          fi
           echo "STAGE_DIR=$STAGE" >> "$GITHUB_ENV"
+          echo "STAGE_DIR_NATIVE=$STAGE_NATIVE" >> "$GITHUB_ENV"
 
       - name: Generate staged-subject SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          path: "${{ env.STAGE_DIR }}"
-          output-file: "${{ env.STAGE_DIR }}/sbom-${{ matrix.triple }}.spdx.json"
+          path: "${{ env.STAGE_DIR_NATIVE }}"
+          output-file: "${{ env.STAGE_DIR_NATIVE }}/sbom-${{ matrix.triple }}.spdx.json"
           format: spdx-json
           upload-artifact: false
           upload-release-assets: false
@@ -383,4 +393,4 @@ jobs:
       - name: Attest exact released subjects
         uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
         with:
-          subject-path: "${{ env.STAGE_DIR }}/*"
+          subject-path: "${{ env.STAGE_DIR_NATIVE }}/*"

--- a/scripts/release-supply-chain.test.mjs
+++ b/scripts/release-supply-chain.test.mjs
@@ -42,16 +42,64 @@ test("release workflow uses one staged raw-sidecar trust boundary", () => {
   const attest = workflow.indexOf("name: Attest exact released subjects");
   assert.ok(stage >= 0 && stage < sbom && sbom < upload && upload < attest);
 
-  assert.match(workflow, /path: "\$\{\{ env\.STAGE_DIR \}\}"/);
-  assert.match(workflow, /output-file: "\$\{\{ env\.STAGE_DIR \}\}\/sbom-\$\{\{ matrix\.triple \}\}\.spdx\.json"/);
+  assert.match(workflow, /path: "\$\{\{ env\.STAGE_DIR_NATIVE \}\}"/);
+  assert.match(workflow, /output-file: "\$\{\{ env\.STAGE_DIR_NATIVE \}\}\/sbom-\$\{\{ matrix\.triple \}\}\.spdx\.json"/);
   assert.match(workflow, /upload-artifact: false/);
   assert.match(workflow, /upload-release-assets: false/);
   assert.match(workflow, /node scripts\/release-supply-chain\.mjs checksums "\$STAGE_DIR" "\$\{\{ matrix\.triple \}\}"/);
   assert.match(workflow, /gh release upload "\$TAG" "\$STAGE_DIR"\/\*/);
-  assert.match(workflow, /subject-path: "\$\{\{ env\.STAGE_DIR \}\}\/\*"/);
+  assert.match(workflow, /subject-path: "\$\{\{ env\.STAGE_DIR_NATIVE \}\}\/\*"/);
   assert.doesNotMatch(workflow, /\n\s+path: \./);
   assert.doesNotMatch(workflow, /\bsha256sum\b|\bshasum\b/);
 });
+
+test("native actions receive a Windows-native view of the staged directory", () => {
+  const stageBlock = workflow.slice(
+    workflow.indexOf("name: Stage raw sidecar release subjects"),
+    workflow.indexOf("name: Generate staged-subject SBOM"),
+  );
+  const sbomBlock = workflow.slice(
+    workflow.indexOf("name: Generate staged-subject SBOM"),
+    workflow.indexOf("name: Checksum and upload staged supply-chain assets"),
+  );
+  const checksumBlock = workflow.slice(
+    workflow.indexOf("name: Checksum and upload staged supply-chain assets"),
+    workflow.indexOf("name: Attest exact released subjects"),
+  );
+  const attestBlock = workflow.slice(workflow.indexOf("name: Attest exact released subjects"));
+
+  assert.match(stageBlock, /if \[ "\$RUNNER_OS" = "Windows" \]; then/);
+  assert.match(stageBlock, /STAGE_NATIVE="\$\(cygpath -m "\$STAGE"\)"/);
+  assert.match(stageBlock, /echo "STAGE_DIR=\$STAGE" >> "\$GITHUB_ENV"/);
+  assert.match(stageBlock, /echo "STAGE_DIR_NATIVE=\$STAGE_NATIVE" >> "\$GITHUB_ENV"/);
+  assert.match(sbomBlock, /path: "\$\{\{ env\.STAGE_DIR_NATIVE \}\}"/);
+  assert.match(
+    sbomBlock,
+    /output-file: "\$\{\{ env\.STAGE_DIR_NATIVE \}\}[\\/]sbom-\$\{\{ matrix\.triple \}\}\.spdx\.json"/,
+  );
+  assert.match(checksumBlock, /checksums "\$STAGE_DIR"/);
+  assert.match(checksumBlock, /gh release upload "\$TAG" "\$STAGE_DIR"\/\*/);
+  assert.match(attestBlock, /subject-path: "\$\{\{ env\.STAGE_DIR_NATIVE \}\}[\\/]\*"/);
+});
+
+test(
+  "Git Bash stage conversion resolves in a native Windows process",
+  { skip: process.platform !== "win32" },
+  () => {
+    const result = spawnSync(
+      "bash",
+      [
+        "-lc",
+        'set -euo pipefail; stage="$(mktemp -d)"; printf native-path-ok > "$stage/probe"; cygpath -m "$stage"',
+      ],
+      { encoding: "utf8" },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const nativeStage = result.stdout.trim();
+    assert.match(nativeStage, /^[A-Za-z]:\//);
+    assert.equal(readFileSync(join(nativeStage, "probe"), "utf8"), "native-path-ok");
+  },
+);
 
 test("release workflow rejects an empty stage before exporting STAGE_DIR", () => {
   const stageBlock = workflow.slice(


### PR DESCRIPTION
## Summary
- export separate POSIX and Windows-native views of the same staged raw-sidecar directory
- pass the native path to Syft and provenance actions while Bash checksum/upload keeps the POSIX path
- add a contract test plus a Windows-only runtime proof that Git Bash `cygpath -m` output resolves from native Node

## Root cause
Release run `29907645740`, Windows job `88882816669`, built and uploaded the MSI/NSIS successfully, then Syft failed on `dir:/tmp/tmp.eTddZtLQ9Y`: Git Bash `mktemp` emitted a POSIX path that the native Windows Syft process could not resolve.

## RED / GREEN
- RED: new workflow contract failed because no Windows-native stage view existed
- GREEN: `node --test scripts/release-supply-chain.test.mjs` — 7 pass, 1 Windows-only runtime test skipped locally
- GREEN: `bash scripts/check-open-boundary.sh` — 448 files clean
- GREEN: YAML parse + `git diff --check`

## Merge/close gates
- all PR checks green, including the Windows release-supply-chain contract runtime test
- independent exact-head review
- after merge, a fresh real `main` release must prove Windows SBOM + checksum upload + provenance all green before SBAI-5463 can return to Done
