### PR TITLE
SBAI-5505: split release-supply-chain matrix out of boundary-guard (RUNNERS_V1 gate repair)

### DIFF
--- a/.github/scripts/runner-policy-truth-table.mjs
+++ b/.github/scripts/runner-policy-truth-table.mjs
@@ -20,6 +20,11 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const CANON =
   "(github.event_name == 'pull_request' || github.ref != 'refs/heads/main') && 'ubuntu-latest' || fromJSON(vars.LOREGUI_LINUX_RUNNER || '[\"ubuntu-latest\"]')";
 
+// T1-exempt workflows (hosted-only permanently) are deliberately ABSENT from
+// this table — the omission IS the exemption, and it is authoritative only
+// because each one is recorded in docs/RUNNERS_V1.md ("T1-exempt workflows").
+// Keep that doc section and this comment in lockstep. Current exemptions:
+//   - release-supply-chain.yml (SBAI-426/SBAI-5505) — static hosted OS matrix.
 const T1_WORKFLOWS = {
   "auto-release.yml": 1,
   "boundary-guard.yml": 1,

--- a/.github/workflows/boundary-guard.yml
+++ b/.github/workflows/boundary-guard.yml
@@ -20,14 +20,3 @@ jobs:
       - uses: actions/checkout@v4
       - name: Accounts / PII / proprietary boundary guard
         run: bash scripts/check-open-boundary.sh
-
-  release-supply-chain:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Release supply-chain contract
-        shell: bash
-        run: node --test scripts/release-supply-chain.test.mjs

--- a/.github/workflows/release-supply-chain.yml
+++ b/.github/workflows/release-supply-chain.yml
@@ -1,0 +1,25 @@
+name: release-supply-chain
+
+# SBAI-426 supply-chain contract test matrix, split out of boundary-guard.yml
+# (SBAI-5460 RUNNERS_V1): boundary-guard is a T1 canonical-runner workflow with
+# exactly one expression runs-on site. This matrix is static GitHub-hosted OS
+# labels only — it never consults LOREGUI_LINUX_RUNNER and cannot reach
+# self-hosted — so it is not a RUNNERS_V1 T1 subject.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  release-supply-chain:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Release supply-chain contract
+        shell: bash
+        run: node --test scripts/release-supply-chain.test.mjs

--- a/.github/workflows/release-supply-chain.yml
+++ b/.github/workflows/release-supply-chain.yml
@@ -1,10 +1,12 @@
 name: release-supply-chain
 
 # SBAI-426 supply-chain contract test matrix, split out of boundary-guard.yml
-# (SBAI-5460 RUNNERS_V1): boundary-guard is a T1 canonical-runner workflow with
-# exactly one expression runs-on site. This matrix is static GitHub-hosted OS
-# labels only — it never consults LOREGUI_LINUX_RUNNER and cannot reach
-# self-hosted — so it is not a RUNNERS_V1 T1 subject.
+# (SBAI-5460 RUNNERS_V1 / SBAI-5505): boundary-guard is a T1 canonical-runner
+# workflow with exactly one expression runs-on site. This matrix is static
+# GitHub-hosted OS labels only — it never consults LOREGUI_LINUX_RUNNER and
+# cannot reach self-hosted — so it is T1-EXEMPT: deliberately absent from
+# T1_WORKFLOWS and recorded as hosted-only-permanent in docs/RUNNERS_V1.md
+# ("T1-exempt workflows"). Keep that record in sync with this file.
 
 on:
   push:

--- a/docs/RUNNERS_V1.md
+++ b/docs/RUNNERS_V1.md
@@ -49,6 +49,20 @@ return. Variable changes are audit-logged by GitHub.
 on every PR and push, prints the event-context truth table, and fails the run
 if an untrusted PR context (fork or Dependabot) ever resolves to self-hosted.
 
+## T1-exempt workflows (deliberate, hosted-only)
+
+Some workflows are **permanently hosted-only** and are *not* runner-selection
+subjects, so they are deliberately **absent from `T1_WORKFLOWS`** in the truth
+table. The omission IS the exemption — it is authoritative only because it is
+recorded here. Any workflow in this category must be listed here in the same
+edit that lands it; an unlisted omission is a gate bug, not an exemption.
+
+- `release-supply-chain.yml` (SBAI-426, split out of `boundary-guard.yml` in
+  SBAI-5505) — the supply-chain contract test. Static GitHub-hosted OS matrix
+  (`ubuntu-latest` / `macos-latest` / `windows-latest`); never consults
+  `LOREGUI_LINUX_RUNNER`; must stay hosted-only permanently (the SBOM /
+  checksum / provenance contract is verified against GitHub-hosted runners).
+
 ## Fork-safety: defense in depth (four layers)
 
 1. The `runs-on` expression above (workflow level) — every `pull_request`

--- a/scripts/release-supply-chain.test.mjs
+++ b/scripts/release-supply-chain.test.mjs
@@ -15,7 +15,7 @@ const workflow = normalizeNewlines(
   readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8"),
 );
 const guard = normalizeNewlines(
-  readFileSync(new URL("../.github/workflows/boundary-guard.yml", import.meta.url), "utf8"),
+  readFileSync(new URL("../.github/workflows/release-supply-chain.yml", import.meta.url), "utf8"),
 );
 const helper = fileURLToPath(new URL("./release-supply-chain.mjs", import.meta.url));
 


### PR DESCRIPTION
Resolves SBAI-5505.

`truth-table-static` (RUNNERS_V1, SBAI-5460) failed on PRs because boundary-guard.yml carries a second expression runs-on site — the SBAI-426 release-supply-chain matrix job (`runs-on: ${{ matrix.os }}`) — while T1_WORKFLOWS expects exactly one canonical site. Pre-existing on main @2f1811b (evidence: run 29968163692); not caused by any product PR.

Fix: move the matrix job to its own workflow `.github/workflows/release-supply-chain.yml` (same triggers; static GitHub-hosted OS matrix that never consults LOREGUI_LINUX_RUNNER, so not a T1 runner-selection subject) and point `scripts/release-supply-chain.test.mjs` at it. Check names are unchanged (`release-supply-chain (ubuntu-latest|macos-latest|windows-latest)`), so branch-protection contexts are unaffected.

Verified locally: `node .github/scripts/runner-policy-truth-table.mjs` → all 30 rows match policy; `node --test scripts/release-supply-chain.test.mjs` → 7 pass / 1 win32-only skip; `bash scripts/check-open-boundary.sh` → OK.

Split out of loregui PR #427 per sb-lore: gate repair does not ride the product branch.