### PR TITLE
SBAI-5505: LoreGUI CI: fix truth-table-static red on drift

### DIFF
--- a/.github/workflows/boundary-guard.yml
+++ b/.github/workflows/boundary-guard.yml
@@ -20,14 +20,3 @@ jobs:
       - uses: actions/checkout@v4
       - name: Accounts / PII / proprietary boundary guard
         run: bash scripts/check-open-boundary.sh
-
-  release-supply-chain:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Release supply-chain contract
-        shell: bash
-        run: node --test scripts/release-supply-chain.test.mjs

--- a/.github/workflows/release-supply-chain.yml
+++ b/.github/workflows/release-supply-chain.yml
@@ -1,0 +1,22 @@
+name: release-supply-chain
+
+# SBAI-426: release-supply-chain matrix job (split from boundary-guard.yml)
+# Static GitHub-hosted OS matrix — never consults LOREGUI_LINUX_RUNNER.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  release-supply-chain:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Release supply-chain contract
+        shell: bash
+        run: node --test scripts/release-supply-chain.test.mjs

--- a/scripts/release-supply-chain.test.mjs
+++ b/scripts/release-supply-chain.test.mjs
@@ -15,7 +15,7 @@ const workflow = normalizeNewlines(
   readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8"),
 );
 const guard = normalizeNewlines(
-  readFileSync(new URL("../.github/workflows/boundary-guard.yml", import.meta.url), "utf8"),
+  readFileSync(new URL("../.github/workflows/release-supply-chain.yml", import.meta.url), "utf8"),
 );
 const helper = fileURLToPath(new URL("./release-supply-chain.mjs", import.meta.url));
 


### PR DESCRIPTION
Resolves SBAI-5505

## Summary
Runner-policy gate repair (split out of SBAI-5499 / loregui PR #427).
Problem: truth-table-static fails because boundary-guard.yml carried a SECOND runs-on expression (the matrix job).
Fix: moved the release-supply-chain matrix job into its own workflow file.

## Files Changed
- .github/workflows/boundary-guard.yml: removed release-supply-chain job, ensured canonical runs-on.
- .github/workflows/release-supply-chain.yml: new workflow for the matrix job.
- scripts/release-supply-chain.test.mjs: updated to point to the new workflow.

## Testing
- node .github/scripts/runner-policy-truth-table.mjs passes all 30 rows.
- node --test scripts/release-supply-chain.test.mjs passes (7 pass / 1 skip).
- bash scripts/check-open-boundary.sh OK.