### PR TITLE
SBAI-5457: add deterministic LoreGUI surface-map contract

### DIFF
--- a/frontend/e2e/surface/compile.spec.ts
+++ b/frontend/e2e/surface/compile.spec.ts
@@ -13,13 +13,27 @@ const action: SurfaceAction = {
   visible_name: "Clone repository",
   preconditions: ["fixture-owned-server", "repository-listed"],
   risk: "write_reversible",
-  expected_ipc: [{ command: "repository_clone", args_match: {} }],
+  expected_ipc: [
+    {
+      command: "repository_clone",
+      args_match: {
+        url: "lore://127.0.0.1:7177/fixture-repository",
+        dest: "$fixture.clone_root",
+      },
+    },
+  ],
   oracles: ["dom", "ipc", "state", "filesystem"],
   cleanup: "delete fixture-owned clone root",
   platform: ["linux", "windows", "macos"],
 };
 
 const allVariants: SurfaceCaseVariant[] = ["success", "error", "cancel"];
+
+const fixtureOwnership = {
+  token_ref: "run.ownership_token",
+  owned_paths: ["fixture-profile"],
+  loopback_endpoints: ["lore://127.0.0.1:7177/fixture-repository"],
+};
 
 function validFile(): SurfaceMapFile {
   return {
@@ -39,7 +53,7 @@ function validFile(): SurfaceMapFile {
 describe("compileSurfaceMap", () => {
   it("compiles the checked-in P0/P1 core inventory", () => {
     const coreMap = JSON.parse(
-      readFileSync(new URL("./map/core.yaml", import.meta.url), "utf8"),
+      readFileSync("e2e/surface/map/core.yaml", "utf8"),
     ) as Omit<SurfaceMapFile, "file">;
 
     const compiled = compileSurfaceMap([{ file: "map/core.yaml", ...coreMap }]);
@@ -48,8 +62,20 @@ describe("compileSurfaceMap", () => {
       "onboarding.local.open-existing",
       "onboarding.client.connect",
       "server.repository.clone",
-      "settings.server.remove",
+      "repository.delete",
     ]);
+    expect(compiled.actions.map((entry) => entry.expected_ipc[0]?.command)).toEqual([
+      "open_repository",
+      "auth_login_interactive",
+      "repository_clone",
+      "repository_delete",
+    ]);
+    expect(compiled.actions[1]?.expected_ipc[0]?.args_match).toEqual({
+      remoteUrl: "lore://127.0.0.1:7177/fixture-repository",
+    });
+    expect(compiled.actions[3]?.expected_ipc[0]?.args_match).toEqual({
+      repositoryUrl: "lore://127.0.0.1:7177/fixture-repository",
+    });
   });
 
   it("compiles a uniquely resolved inventory into action and case indexes", () => {
@@ -107,6 +133,59 @@ describe("compileSurfaceMap", () => {
       /action server\.repository\.clone requires at least one oracle/i,
     );
   });
+
+  it("rejects screenshot-only evidence because visual classification cannot decide pass or fail", () => {
+    const file = validFile();
+    file.inventory[0] = { ...action, oracles: ["screenshot"] };
+
+    expect(() => compileSurfaceMap([file])).toThrow(
+      /action server\.repository\.clone requires at least one authoritative nonvisual oracle/i,
+    );
+  });
+
+  it("rejects malformed risk values before they can bypass elevated-risk safety checks", () => {
+    const file = validFile();
+    file.inventory[0] = { ...action, risk: "unsafe" } as unknown as SurfaceAction;
+
+    expect(() => compileSurfaceMap([file])).toThrow(
+      /action server\.repository\.clone has invalid risk/i,
+    );
+  });
+
+  it("rejects malformed IPC argument patterns before elevated-risk validation", () => {
+    const file = validFile();
+    file.inventory[0] = {
+      ...action,
+      risk: "external",
+      cleanup: "disconnect fixture-owned loopback client",
+      expected_ipc: [
+        { command: "auth_login_interactive", args_match: null },
+      ] as unknown as SurfaceAction["expected_ipc"],
+    };
+    file.cases[0]!.fixture_ownership = fixtureOwnership;
+
+    expect(() => compileSurfaceMap([file])).toThrow(
+      /action server\.repository\.clone has invalid expected_ipc args_match/i,
+    );
+  });
+
+  it.each(["external", "destructive"] as const)(
+    "rejects %s actions whose IPC pattern has no bound fixture arguments",
+    (risk) => {
+      const file = validFile();
+      file.inventory[0] = {
+        ...action,
+        risk,
+        cleanup: "reset fixture-owned state",
+        expected_ipc: [{ command: "repository_delete", args_match: {} }],
+      };
+      file.cases[0]!.fixture_ownership = fixtureOwnership;
+
+      expect(() => compileSurfaceMap([file])).toThrow(
+        new RegExp(`${risk} action server\\.repository\\.clone requires expected IPC arguments`, "i"),
+      );
+    },
+  );
 
   it("rejects inventory entries that cannot be exercised by a case", () => {
     const file = validFile();

--- a/frontend/e2e/surface/compile.spec.ts
+++ b/frontend/e2e/surface/compile.spec.ts
@@ -139,9 +139,21 @@ describe("compileSurfaceMap", () => {
     file.inventory[0] = { ...action, oracles: ["screenshot"] };
 
     expect(() => compileSurfaceMap([file])).toThrow(
-      /action server\.repository\.clone requires at least one authoritative nonvisual oracle/i,
+      /action server\.repository\.clone requires at least one authoritative oracle/i,
     );
   });
+
+  it.each(["dom", "accessibility"] as const)(
+    "rejects %s-only evidence because it is not an authoritative pass/fail oracle",
+    (oracle) => {
+      const file = validFile();
+      file.inventory[0] = { ...action, oracles: [oracle] };
+
+      expect(() => compileSurfaceMap([file])).toThrow(
+        /action server\.repository\.clone requires at least one authoritative oracle/i,
+      );
+    },
+  );
 
   it("rejects malformed risk values before they can bypass elevated-risk safety checks", () => {
     const file = validFile();
@@ -186,6 +198,44 @@ describe("compileSurfaceMap", () => {
       );
     },
   );
+
+  it("rejects an external action whose URL points outside the declared fixture ownership", () => {
+    const file = validFile();
+    file.inventory[0] = {
+      ...action,
+      risk: "external",
+      cleanup: "disconnect fixture-owned loopback client",
+      expected_ipc: [
+        {
+          command: "auth_login_interactive",
+          args_match: { remoteUrl: "https://production.example" },
+        },
+      ],
+    };
+    file.cases[0]!.fixture_ownership = fixtureOwnership;
+
+    expect(() => compileSurfaceMap([file])).toThrow(
+      /external action server\.repository\.clone has unowned target remoteUrl/i,
+    );
+  });
+
+  it("accepts a token-backed fixture target for an external action", () => {
+    const file = validFile();
+    file.inventory[0] = {
+      ...action,
+      risk: "external",
+      cleanup: "disconnect fixture-owned loopback client",
+      expected_ipc: [
+        {
+          command: "auth_login_interactive",
+          args_match: { remoteUrl: "$fixture.remote_url" },
+        },
+      ],
+    };
+    file.cases[0]!.fixture_ownership = fixtureOwnership;
+
+    expect(() => compileSurfaceMap([file])).not.toThrow();
+  });
 
   it("rejects inventory entries that cannot be exercised by a case", () => {
     const file = validFile();

--- a/frontend/e2e/surface/compile.spec.ts
+++ b/frontend/e2e/surface/compile.spec.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { compileSurfaceMap, type SurfaceMapFile } from "./compile";
+import type { SurfaceAction, SurfaceCaseVariant } from "./types";
+
+const action: SurfaceAction = {
+  schema: 1,
+  app_commit: "test-head",
+  surface_id: "server.repository.clone",
+  state_id: "local-host-no-auth",
+  element_id: "server.repository.clone",
+  selector: { strategy: "qa", value: "server.repository.clone" },
+  visible_name: "Clone repository",
+  preconditions: ["fixture-owned-server", "repository-listed"],
+  risk: "write_reversible",
+  expected_ipc: [{ command: "repository_clone", args_match: {} }],
+  oracles: ["dom", "ipc", "state", "filesystem"],
+  cleanup: "delete fixture-owned clone root",
+  platform: ["linux", "windows", "macos"],
+};
+
+const allVariants: SurfaceCaseVariant[] = ["success", "error", "cancel"];
+
+function validFile(): SurfaceMapFile {
+  return {
+    file: "core.yaml",
+    inventory: [action],
+    cases: [
+      {
+        action_id: "server.repository.clone",
+        state_id: "local-host-no-auth",
+        selector_matches: 1,
+        variants: [...allVariants],
+      },
+    ],
+  };
+}
+
+describe("compileSurfaceMap", () => {
+  it("compiles the checked-in P0/P1 core inventory", () => {
+    const coreMap = JSON.parse(
+      readFileSync(new URL("./map/core.yaml", import.meta.url), "utf8"),
+    ) as Omit<SurfaceMapFile, "file">;
+
+    const compiled = compileSurfaceMap([{ file: "map/core.yaml", ...coreMap }]);
+
+    expect(compiled.actions.map((entry) => entry.surface_id)).toEqual([
+      "onboarding.local.open-existing",
+      "onboarding.client.connect",
+      "server.repository.clone",
+      "settings.server.remove",
+    ]);
+  });
+
+  it("compiles a uniquely resolved inventory into action and case indexes", () => {
+    const compiled = compileSurfaceMap([validFile()]);
+
+    expect(compiled.actions).toHaveLength(1);
+    expect(compiled.actions[0]?.surface_id).toBe("server.repository.clone");
+    expect(compiled.case_by_action_id.get("server.repository.clone")?.selector_matches).toBe(1);
+  });
+
+  it("rejects duplicate action ids before an executor can select the wrong action", () => {
+    const file = validFile();
+    file.inventory.push({ ...action });
+
+    expect(() => compileSurfaceMap([file])).toThrow(/duplicate action id: server\.repository\.clone/i);
+  });
+
+  it.each([0, 2])("rejects selectors that resolve to %i elements", (selector_matches) => {
+    const file = validFile();
+    file.cases[0]!.selector_matches = selector_matches;
+
+    expect(() => compileSurfaceMap([file])).toThrow(
+      new RegExp(`selector for server\\.repository\\.clone resolved to ${selector_matches} elements`, "i"),
+    );
+  });
+
+  it.each(allVariants)(
+    "rejects a case without its %s variant",
+    (missingVariant) => {
+      const file = validFile();
+      file.cases[0]!.variants = allVariants.filter(
+        (variant) => variant !== missingVariant,
+      );
+
+      expect(() => compileSurfaceMap([file])).toThrow(
+        new RegExp(`missing ${missingVariant} variant for server\\.repository\\.clone`, "i"),
+      );
+    },
+  );
+
+  it("rejects destructive actions unless a fixture owner and cleanup are both declared", () => {
+    const file = validFile();
+    file.inventory[0] = { ...action, risk: "destructive", cleanup: null };
+
+    expect(() => compileSurfaceMap([file])).toThrow(
+      /destructive action server\.repository\.clone requires fixture ownership and cleanup/i,
+    );
+  });
+
+  it("rejects actions that leave deterministic oracles unspecified", () => {
+    const file = validFile();
+    file.inventory[0] = { ...action, oracles: [] };
+
+    expect(() => compileSurfaceMap([file])).toThrow(
+      /action server\.repository\.clone requires at least one oracle/i,
+    );
+  });
+
+  it("rejects inventory entries that cannot be exercised by a case", () => {
+    const file = validFile();
+    file.cases = [];
+
+    expect(() => compileSurfaceMap([file])).toThrow(
+      /inventory action server\.repository\.clone has no case/i,
+    );
+  });
+});

--- a/frontend/e2e/surface/compile.ts
+++ b/frontend/e2e/surface/compile.ts
@@ -1,0 +1,108 @@
+import type {
+  CompiledSurfaceMap,
+  SurfaceAction,
+  SurfaceCase,
+  SurfaceCaseVariant,
+  SurfaceMapFile,
+} from "./types";
+
+export type { CompiledSurfaceMap, SurfaceMapFile } from "./types";
+
+const REQUIRED_VARIANTS: readonly SurfaceCaseVariant[] = [
+  "success",
+  "error",
+  "cancel",
+];
+
+/**
+ * Validates already-parsed surface-map files and builds immutable lookup
+ * indexes. File parsing and fixture probing are deliberately outside this
+ * function: the compiler only trusts the deterministic evidence it receives.
+ */
+export function compileSurfaceMap(
+  files: readonly SurfaceMapFile[],
+): CompiledSurfaceMap {
+  const actionById = new Map<string, SurfaceAction>();
+  const caseByActionId = new Map<string, SurfaceCase>();
+
+  for (const file of files) {
+    for (const action of file.inventory) {
+      validateAction(action);
+
+      if (actionById.has(action.surface_id)) {
+        throw new Error(`duplicate action id: ${action.surface_id}`);
+      }
+      actionById.set(action.surface_id, action);
+    }
+
+    for (const surfaceCase of file.cases) {
+      if (caseByActionId.has(surfaceCase.action_id)) {
+        throw new Error(`duplicate case for action: ${surfaceCase.action_id}`);
+      }
+      caseByActionId.set(surfaceCase.action_id, surfaceCase);
+    }
+  }
+
+  for (const [actionId, action] of actionById) {
+    const surfaceCase = caseByActionId.get(actionId);
+    if (!surfaceCase) {
+      throw new Error(`inventory action ${actionId} has no case`);
+    }
+    if (surfaceCase.state_id !== action.state_id) {
+      throw new Error(`case for ${actionId} targets state ${surfaceCase.state_id}, expected ${action.state_id}`);
+    }
+    validateCase(action, surfaceCase);
+  }
+
+  for (const actionId of caseByActionId.keys()) {
+    if (!actionById.has(actionId)) {
+      throw new Error(`case references unknown action: ${actionId}`);
+    }
+  }
+
+  return {
+    actions: [...actionById.values()],
+    cases: [...caseByActionId.values()],
+    action_by_id: actionById,
+    case_by_action_id: caseByActionId,
+  };
+}
+
+function validateAction(action: SurfaceAction): void {
+  if (action.schema !== 1) {
+    throw new Error(`action ${action.surface_id} has unsupported schema: ${action.schema}`);
+  }
+  if (!action.surface_id) {
+    throw new Error("action id must not be empty");
+  }
+  if (!action.oracles.length) {
+    throw new Error(`action ${action.surface_id} requires at least one oracle`);
+  }
+}
+
+function validateCase(action: SurfaceAction, surfaceCase: SurfaceCase): void {
+  if (surfaceCase.selector_matches !== 1) {
+    throw new Error(
+      `selector for ${action.surface_id} resolved to ${surfaceCase.selector_matches} elements`,
+    );
+  }
+
+  for (const variant of REQUIRED_VARIANTS) {
+    if (!surfaceCase.variants.includes(variant)) {
+      throw new Error(`missing ${variant} variant for ${action.surface_id}`);
+    }
+  }
+
+  if (action.risk === "destructive" || action.risk === "external") {
+    const ownership = surfaceCase.fixture_ownership;
+    const hasOwnership = Boolean(
+      ownership?.token_ref &&
+        (ownership.owned_paths.length > 0 || ownership.loopback_endpoints.length > 0),
+    );
+    if (!hasOwnership || !action.cleanup) {
+      throw new Error(
+        `${action.risk} action ${action.surface_id} requires fixture ownership and cleanup`,
+      );
+    }
+  }
+}

--- a/frontend/e2e/surface/compile.ts
+++ b/frontend/e2e/surface/compile.ts
@@ -14,18 +14,47 @@ const REQUIRED_VARIANTS: readonly SurfaceCaseVariant[] = [
   "cancel",
 ];
 
+const RISKS = new Set<SurfaceAction["risk"]>([
+  "read",
+  "write_reversible",
+  "destructive",
+  "external",
+]);
+const ORACLES = new Set<SurfaceAction["oracles"][number]>([
+  "dom",
+  "ipc",
+  "state",
+  "filesystem",
+  "process",
+  "network",
+  "accessibility",
+  "screenshot",
+]);
+const PLATFORMS = new Set<SurfaceAction["platform"][number]>([
+  "linux",
+  "windows",
+  "macos",
+]);
+const SELECTOR_STRATEGIES = new Set<SurfaceAction["selector"]["strategy"]>([
+  "qa",
+  "role",
+  "uia",
+  "manifest",
+]);
+
 /**
  * Validates already-parsed surface-map files and builds immutable lookup
  * indexes. File parsing and fixture probing are deliberately outside this
  * function: the compiler only trusts the deterministic evidence it receives.
  */
 export function compileSurfaceMap(
-  files: readonly SurfaceMapFile[],
+  files: readonly unknown[],
 ): CompiledSurfaceMap {
   const actionById = new Map<string, SurfaceAction>();
   const caseByActionId = new Map<string, SurfaceCase>();
 
-  for (const file of files) {
+  for (const [fileIndex, rawFile] of files.entries()) {
+    const file = parseSurfaceMapFile(rawFile, fileIndex);
     for (const action of file.inventory) {
       validateAction(action);
 
@@ -69,14 +98,13 @@ export function compileSurfaceMap(
 }
 
 function validateAction(action: SurfaceAction): void {
-  if (action.schema !== 1) {
-    throw new Error(`action ${action.surface_id} has unsupported schema: ${action.schema}`);
-  }
-  if (!action.surface_id) {
-    throw new Error("action id must not be empty");
-  }
   if (!action.oracles.length) {
     throw new Error(`action ${action.surface_id} requires at least one oracle`);
+  }
+  if (!action.oracles.some((oracle) => oracle !== "screenshot")) {
+    throw new Error(
+      `action ${action.surface_id} requires at least one authoritative nonvisual oracle`,
+    );
   }
 }
 
@@ -104,5 +132,174 @@ function validateCase(action: SurfaceAction, surfaceCase: SurfaceCase): void {
         `${action.risk} action ${action.surface_id} requires fixture ownership and cleanup`,
       );
     }
+    if (
+      action.expected_ipc.length === 0 ||
+      action.expected_ipc.some((ipc) => Object.keys(ipc.args_match).length === 0)
+    ) {
+      throw new Error(
+        `${action.risk} action ${action.surface_id} requires expected IPC arguments`,
+      );
+    }
+  }
+}
+
+function parseSurfaceMapFile(rawFile: unknown, fileIndex: number): SurfaceMapFile {
+  const file = object(rawFile, `surface map file ${fileIndex}`);
+  const name = string(file.file, `surface map file ${fileIndex} file`);
+  const inventory = array(file.inventory, `surface map file ${name} inventory`).map(
+    parseAction,
+  );
+  const cases = array(file.cases, `surface map file ${name} cases`).map(parseCase);
+
+  return { file: name, inventory, cases };
+}
+
+function parseAction(rawAction: unknown): SurfaceAction {
+  const action = object(rawAction, "action");
+  const surfaceId = string(action.surface_id, "action surface_id");
+  const label = `action ${surfaceId}`;
+
+  if (action.schema !== 1) {
+    throw new Error(`${label} has unsupported schema: ${String(action.schema)}`);
+  }
+  const risk = enumValue(action.risk, RISKS, `${label} has invalid risk`);
+  const selector = object(action.selector, `${label} selector`);
+  const selectorStrategy = enumValue(
+    selector.strategy,
+    SELECTOR_STRATEGIES,
+    `${label} has invalid selector strategy`,
+  );
+  const expectedIpc = array(action.expected_ipc, `${label} has invalid expected_ipc`).map(
+    (rawIpc) => {
+      const ipc = object(rawIpc, `${label} has invalid expected_ipc entry`);
+      return {
+        command: string(ipc.command, `${label} has invalid expected_ipc command`),
+        args_match: object(
+          ipc.args_match,
+          `${label} has invalid expected_ipc args_match`,
+        ),
+      };
+    },
+  );
+  const oracles = array(action.oracles, `${label} has invalid oracles`).map((oracle) =>
+    enumValue(oracle, ORACLES, `${label} has invalid oracle`),
+  );
+  const platform = array(action.platform, `${label} has invalid platform`).map((entry) =>
+    enumValue(entry, PLATFORMS, `${label} has invalid platform`),
+  );
+
+  return {
+    schema: 1,
+    app_commit: string(action.app_commit, `${label} app_commit`),
+    surface_id: surfaceId,
+    state_id: string(action.state_id, `${label} state_id`),
+    element_id: string(action.element_id, `${label} element_id`),
+    selector: {
+      strategy: selectorStrategy,
+      value: string(selector.value, `${label} selector value`),
+    },
+    visible_name: string(action.visible_name, `${label} visible_name`),
+    preconditions: array(action.preconditions, `${label} preconditions`).map((entry) =>
+      string(entry, `${label} precondition`),
+    ),
+    risk,
+    expected_ipc: expectedIpc,
+    oracles,
+    cleanup: nullableString(action.cleanup, `${label} cleanup`),
+    platform,
+  };
+}
+
+function parseCase(rawCase: unknown): SurfaceCase {
+  const surfaceCase = object(rawCase, "surface case");
+  const actionId = string(surfaceCase.action_id, "surface case action_id");
+  const label = `case for ${actionId}`;
+  const variants = array(surfaceCase.variants, `${label} variants`).map((variant) =>
+    enumValue(variant, new Set(REQUIRED_VARIANTS), `${label} has invalid variant`),
+  );
+  const selectorMatches = surfaceCase.selector_matches;
+  if (!Number.isInteger(selectorMatches) || (selectorMatches as number) < 0) {
+    throw new Error(`${label} has invalid selector_matches`);
+  }
+
+  const ownership = surfaceCase.fixture_ownership;
+  return {
+    action_id: actionId,
+    state_id: string(surfaceCase.state_id, `${label} state_id`),
+    selector_matches: selectorMatches as number,
+    variants,
+    fixture_ownership:
+      ownership === undefined
+        ? undefined
+        : parseFixtureOwnership(ownership, label),
+  };
+}
+
+function parseFixtureOwnership(
+  rawOwnership: unknown,
+  label: string,
+): NonNullable<SurfaceCase["fixture_ownership"]> {
+  const ownership = object(rawOwnership, `${label} has invalid fixture ownership`);
+  const endpoints = array(
+    ownership.loopback_endpoints,
+    `${label} has invalid fixture ownership endpoints`,
+  ).map((endpoint) => {
+    const value = string(endpoint, `${label} has invalid fixture ownership endpoint`);
+    if (!isLoopbackEndpoint(value)) {
+      throw new Error(`${label} has non-loopback fixture ownership endpoint`);
+    }
+    return value;
+  });
+
+  return {
+    token_ref: string(ownership.token_ref, `${label} has invalid fixture ownership token`),
+    owned_paths: array(
+      ownership.owned_paths,
+      `${label} has invalid fixture ownership paths`,
+    ).map((path) => string(path, `${label} has invalid fixture ownership path`)),
+    loopback_endpoints: endpoints,
+  };
+}
+
+function object(value: unknown, message: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(message);
+  }
+  return value as Record<string, unknown>;
+}
+
+function array(value: unknown, message: string): unknown[] {
+  if (!Array.isArray(value)) throw new Error(message);
+  return value;
+}
+
+function string(value: unknown, message: string): string {
+  if (typeof value !== "string" || !value.trim()) throw new Error(message);
+  return value;
+}
+
+function nullableString(value: unknown, message: string): string | null {
+  if (value === null) return null;
+  return string(value, message);
+}
+
+function enumValue<T extends string>(
+  value: unknown,
+  values: ReadonlySet<T>,
+  message: string,
+): T {
+  if (typeof value !== "string" || !values.has(value as T)) throw new Error(message);
+  return value as T;
+}
+
+function isLoopbackEndpoint(value: string): boolean {
+  try {
+    const endpoint = new URL(value);
+    return (
+      ["http:", "https:", "lore:"].includes(endpoint.protocol) &&
+      ["127.0.0.1", "localhost", "[::1]"].includes(endpoint.hostname)
+    );
+  } catch {
+    return false;
   }
 }

--- a/frontend/e2e/surface/compile.ts
+++ b/frontend/e2e/surface/compile.ts
@@ -27,8 +27,17 @@ const ORACLES = new Set<SurfaceAction["oracles"][number]>([
   "filesystem",
   "process",
   "network",
+  "remote_client",
   "accessibility",
   "screenshot",
+]);
+const AUTHORITATIVE_ORACLES = new Set<SurfaceAction["oracles"][number]>([
+  "ipc",
+  "state",
+  "filesystem",
+  "process",
+  "network",
+  "remote_client",
 ]);
 const PLATFORMS = new Set<SurfaceAction["platform"][number]>([
   "linux",
@@ -101,9 +110,9 @@ function validateAction(action: SurfaceAction): void {
   if (!action.oracles.length) {
     throw new Error(`action ${action.surface_id} requires at least one oracle`);
   }
-  if (!action.oracles.some((oracle) => oracle !== "screenshot")) {
+  if (!action.oracles.some((oracle) => AUTHORITATIVE_ORACLES.has(oracle))) {
     throw new Error(
-      `action ${action.surface_id} requires at least one authoritative nonvisual oracle`,
+      `action ${action.surface_id} requires at least one authoritative oracle`,
     );
   }
 }
@@ -139,6 +148,16 @@ function validateCase(action: SurfaceAction, surfaceCase: SurfaceCase): void {
       throw new Error(
         `${action.risk} action ${action.surface_id} requires expected IPC arguments`,
       );
+    }
+    for (const ipc of action.expected_ipc) {
+      for (const [argument, value] of Object.entries(ipc.args_match)) {
+        if (!isTargetArgument(argument)) continue;
+        if (!isOwnedTarget(value, ownership)) {
+          throw new Error(
+            `${action.risk} action ${action.surface_id} has unowned target ${argument}`,
+          );
+        }
+      }
     }
   }
 }
@@ -302,4 +321,20 @@ function isLoopbackEndpoint(value: string): boolean {
   } catch {
     return false;
   }
+}
+
+function isTargetArgument(argument: string): boolean {
+  return /(?:url|path|dest|destination|target|resource)$/i.test(argument);
+}
+
+function isOwnedTarget(
+  value: unknown,
+  ownership: NonNullable<SurfaceCase["fixture_ownership"]>,
+): boolean {
+  if (typeof value !== "string") return false;
+  if (value.startsWith("$fixture.")) return Boolean(ownership.token_ref);
+  return (
+    ownership.owned_paths.includes(value) ||
+    ownership.loopback_endpoints.includes(value)
+  );
 }

--- a/frontend/e2e/surface/map/core.yaml
+++ b/frontend/e2e/surface/map/core.yaml
@@ -10,7 +10,7 @@
       "visible_name": "Open Existing",
       "preconditions": ["fixture-owned-project-root", "no-repository-selected"],
       "risk": "write_reversible",
-      "expected_ipc": [{ "command": "open_project", "args_match": {} }],
+      "expected_ipc": [{ "command": "open_repository", "args_match": { "path": "$fixture.project_root" } }],
       "oracles": ["dom", "ipc", "state", "filesystem", "screenshot"],
       "cleanup": "reset fixture profile and project root",
       "platform": ["linux", "windows", "macos"]
@@ -25,7 +25,7 @@
       "visible_name": "Connect",
       "preconditions": ["fixture-owned-loopback-server", "no-auth-required"],
       "risk": "external",
-      "expected_ipc": [{ "command": "client_connect", "args_match": {} }],
+      "expected_ipc": [{ "command": "auth_login_interactive", "args_match": { "remoteUrl": "lore://127.0.0.1:7177/fixture-repository" } }],
       "oracles": ["dom", "ipc", "state", "network", "screenshot"],
       "cleanup": "disconnect fixture-owned loopback client",
       "platform": ["linux", "windows", "macos"]
@@ -40,7 +40,7 @@
       "visible_name": "Clone repository",
       "preconditions": ["fixture-owned-server", "repository-listed"],
       "risk": "write_reversible",
-      "expected_ipc": [{ "command": "repository_clone", "args_match": {} }],
+      "expected_ipc": [{ "command": "repository_clone", "args_match": { "url": "lore://127.0.0.1:7177/fixture-repository", "dest": "$fixture.clone_root" } }],
       "oracles": ["dom", "ipc", "state", "filesystem", "screenshot"],
       "cleanup": "delete fixture-owned clone root",
       "platform": ["linux", "windows", "macos"]
@@ -48,16 +48,16 @@
     {
       "schema": 1,
       "app_commit": "2f1811b538cab616b404db686189f44f284a979f",
-      "surface_id": "settings.server.remove",
-      "state_id": "settings_persisted",
-      "element_id": "settings.server.remove",
-      "selector": { "strategy": "qa", "value": "settings.server.remove" },
-      "visible_name": "Remove saved server",
-      "preconditions": ["fixture-owned-server-record", "settings-persisted"],
+      "surface_id": "repository.delete",
+      "state_id": "local_repo_clean",
+      "element_id": "repository.delete",
+      "selector": { "strategy": "manifest", "value": "repository.delete" },
+      "visible_name": "Repository: Delete",
+      "preconditions": ["fixture-owned-server", "fixture-owned-repository"],
       "risk": "destructive",
-      "expected_ipc": [{ "command": "remove_saved_server", "args_match": {} }],
+      "expected_ipc": [{ "command": "repository_delete", "args_match": { "repositoryUrl": "lore://127.0.0.1:7177/fixture-repository" } }],
       "oracles": ["dom", "ipc", "state", "filesystem", "screenshot"],
-      "cleanup": "restore fixture-owned server record or reset fixture profile",
+      "cleanup": "reset fixture-owned server state",
       "platform": ["linux", "windows", "macos"]
     }
   ],
@@ -68,15 +68,15 @@
       "state_id": "remote_two_user_no_auth",
       "selector_matches": 1,
       "variants": ["success", "error", "cancel"],
-      "fixture_ownership": { "token_ref": "run.ownership_token", "owned_paths": [], "loopback_endpoints": ["http://127.0.0.1:7177"] }
+      "fixture_ownership": { "token_ref": "run.ownership_token", "owned_paths": [], "loopback_endpoints": ["lore://127.0.0.1:7177/fixture-repository"] }
     },
     { "action_id": "server.repository.clone", "state_id": "local_host_no_auth", "selector_matches": 1, "variants": ["success", "error", "cancel"] },
     {
-      "action_id": "settings.server.remove",
-      "state_id": "settings_persisted",
+      "action_id": "repository.delete",
+      "state_id": "local_repo_clean",
       "selector_matches": 1,
       "variants": ["success", "error", "cancel"],
-      "fixture_ownership": { "token_ref": "run.ownership_token", "owned_paths": ["fixture-profile/saved-servers.json"], "loopback_endpoints": [] }
+      "fixture_ownership": { "token_ref": "run.ownership_token", "owned_paths": [], "loopback_endpoints": ["lore://127.0.0.1:7177/fixture-repository"] }
     }
   ]
 }

--- a/frontend/e2e/surface/map/core.yaml
+++ b/frontend/e2e/surface/map/core.yaml
@@ -1,0 +1,82 @@
+{
+  "inventory": [
+    {
+      "schema": 1,
+      "app_commit": "2f1811b538cab616b404db686189f44f284a979f",
+      "surface_id": "onboarding.local.open-existing",
+      "state_id": "fresh_no_repo_no_auth",
+      "element_id": "onboarding.local.open-existing",
+      "selector": { "strategy": "qa", "value": "onboarding.local.open-existing" },
+      "visible_name": "Open Existing",
+      "preconditions": ["fixture-owned-project-root", "no-repository-selected"],
+      "risk": "write_reversible",
+      "expected_ipc": [{ "command": "open_project", "args_match": {} }],
+      "oracles": ["dom", "ipc", "state", "filesystem", "screenshot"],
+      "cleanup": "reset fixture profile and project root",
+      "platform": ["linux", "windows", "macos"]
+    },
+    {
+      "schema": 1,
+      "app_commit": "2f1811b538cab616b404db686189f44f284a979f",
+      "surface_id": "onboarding.client.connect",
+      "state_id": "remote_two_user_no_auth",
+      "element_id": "onboarding.client.connect",
+      "selector": { "strategy": "qa", "value": "onboarding.client.connect" },
+      "visible_name": "Connect",
+      "preconditions": ["fixture-owned-loopback-server", "no-auth-required"],
+      "risk": "external",
+      "expected_ipc": [{ "command": "client_connect", "args_match": {} }],
+      "oracles": ["dom", "ipc", "state", "network", "screenshot"],
+      "cleanup": "disconnect fixture-owned loopback client",
+      "platform": ["linux", "windows", "macos"]
+    },
+    {
+      "schema": 1,
+      "app_commit": "2f1811b538cab616b404db686189f44f284a979f",
+      "surface_id": "server.repository.clone",
+      "state_id": "local_host_no_auth",
+      "element_id": "server.repository.clone",
+      "selector": { "strategy": "qa", "value": "server.repository.clone" },
+      "visible_name": "Clone repository",
+      "preconditions": ["fixture-owned-server", "repository-listed"],
+      "risk": "write_reversible",
+      "expected_ipc": [{ "command": "repository_clone", "args_match": {} }],
+      "oracles": ["dom", "ipc", "state", "filesystem", "screenshot"],
+      "cleanup": "delete fixture-owned clone root",
+      "platform": ["linux", "windows", "macos"]
+    },
+    {
+      "schema": 1,
+      "app_commit": "2f1811b538cab616b404db686189f44f284a979f",
+      "surface_id": "settings.server.remove",
+      "state_id": "settings_persisted",
+      "element_id": "settings.server.remove",
+      "selector": { "strategy": "qa", "value": "settings.server.remove" },
+      "visible_name": "Remove saved server",
+      "preconditions": ["fixture-owned-server-record", "settings-persisted"],
+      "risk": "destructive",
+      "expected_ipc": [{ "command": "remove_saved_server", "args_match": {} }],
+      "oracles": ["dom", "ipc", "state", "filesystem", "screenshot"],
+      "cleanup": "restore fixture-owned server record or reset fixture profile",
+      "platform": ["linux", "windows", "macos"]
+    }
+  ],
+  "cases": [
+    { "action_id": "onboarding.local.open-existing", "state_id": "fresh_no_repo_no_auth", "selector_matches": 1, "variants": ["success", "error", "cancel"] },
+    {
+      "action_id": "onboarding.client.connect",
+      "state_id": "remote_two_user_no_auth",
+      "selector_matches": 1,
+      "variants": ["success", "error", "cancel"],
+      "fixture_ownership": { "token_ref": "run.ownership_token", "owned_paths": [], "loopback_endpoints": ["http://127.0.0.1:7177"] }
+    },
+    { "action_id": "server.repository.clone", "state_id": "local_host_no_auth", "selector_matches": 1, "variants": ["success", "error", "cancel"] },
+    {
+      "action_id": "settings.server.remove",
+      "state_id": "settings_persisted",
+      "selector_matches": 1,
+      "variants": ["success", "error", "cancel"],
+      "fixture_ownership": { "token_ref": "run.ownership_token", "owned_paths": ["fixture-profile/saved-servers.json"], "loopback_endpoints": [] }
+    }
+  ]
+}

--- a/frontend/e2e/surface/schema.json
+++ b/frontend/e2e/surface/schema.json
@@ -20,6 +20,7 @@
     "action": {
       "type": "object",
       "additionalProperties": false,
+      "allOf": [{ "$ref": "#/$defs/elevatedAction" }],
       "required": ["schema", "app_commit", "surface_id", "state_id", "element_id", "selector", "visible_name", "preconditions", "risk", "expected_ipc", "oracles", "cleanup", "platform"],
       "properties": {
         "schema": { "const": 1 },
@@ -54,7 +55,8 @@
         "oracles": {
           "type": "array",
           "minItems": 1,
-          "items": { "enum": ["dom", "ipc", "state", "filesystem", "process", "network", "accessibility", "screenshot"] }
+          "items": { "enum": ["dom", "ipc", "state", "filesystem", "process", "network", "accessibility", "screenshot"] },
+          "contains": { "enum": ["dom", "ipc", "state", "filesystem", "process", "network", "accessibility"] }
         },
         "cleanup": { "type": ["string", "null"] },
         "platform": {
@@ -83,7 +85,22 @@
           "properties": {
             "token_ref": { "type": "string", "minLength": 1 },
             "owned_paths": { "type": "array", "items": { "type": "string", "minLength": 1 } },
-            "loopback_endpoints": { "type": "array", "items": { "type": "string", "pattern": "^https?://(127\\.0\\.0\\.1|localhost)(:|/|$)" } }
+            "loopback_endpoints": { "type": "array", "items": { "type": "string", "pattern": "^(https?|lore)://(127\\.0\\.0\\.1|localhost|\\[::1\\])(:|/|$)" } }
+          }
+        }
+      }
+    },
+    "elevatedAction": {
+      "if": { "properties": { "risk": { "enum": ["destructive", "external"] } } },
+      "then": {
+        "properties": {
+          "expected_ipc": {
+            "minItems": 1,
+            "items": {
+              "properties": {
+                "args_match": { "minProperties": 1 }
+              }
+            }
           }
         }
       }

--- a/frontend/e2e/surface/schema.json
+++ b/frontend/e2e/surface/schema.json
@@ -55,8 +55,8 @@
         "oracles": {
           "type": "array",
           "minItems": 1,
-          "items": { "enum": ["dom", "ipc", "state", "filesystem", "process", "network", "accessibility", "screenshot"] },
-          "contains": { "enum": ["dom", "ipc", "state", "filesystem", "process", "network", "accessibility"] }
+          "items": { "enum": ["dom", "ipc", "state", "filesystem", "process", "network", "remote_client", "accessibility", "screenshot"] },
+          "contains": { "enum": ["ipc", "state", "filesystem", "process", "network", "remote_client"] }
         },
         "cleanup": { "type": ["string", "null"] },
         "platform": {
@@ -98,7 +98,20 @@
             "minItems": 1,
             "items": {
               "properties": {
-                "args_match": { "minProperties": 1 }
+                "args_match": {
+                  "minProperties": 1,
+                  "anyOf": [
+                    { "required": ["url"] },
+                    { "required": ["remoteUrl"] },
+                    { "required": ["repositoryUrl"] },
+                    { "required": ["path"] },
+                    { "required": ["dest"] },
+                    { "required": ["destination"] },
+                    { "required": ["target"] },
+                    { "required": ["resource"] }
+                  ],
+                  "description": "compileSurfaceMap resolves URL/path targets exactly against the case fixture ownership or a token-backed $fixture reference."
+                }
               }
             }
           }

--- a/frontend/e2e/surface/schema.json
+++ b/frontend/e2e/surface/schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://loregui.studiobrain.ai/e2e/surface-map.schema.json",
+  "title": "LoreGUI deterministic surface map",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["inventory", "cases"],
+  "properties": {
+    "inventory": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/action" }
+    },
+    "cases": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/case" }
+    }
+  },
+  "$defs": {
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "app_commit", "surface_id", "state_id", "element_id", "selector", "visible_name", "preconditions", "risk", "expected_ipc", "oracles", "cleanup", "platform"],
+      "properties": {
+        "schema": { "const": 1 },
+        "app_commit": { "type": "string", "minLength": 1 },
+        "surface_id": { "type": "string", "minLength": 1 },
+        "state_id": { "type": "string", "minLength": 1 },
+        "element_id": { "type": "string", "minLength": 1 },
+        "selector": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["strategy", "value"],
+          "properties": {
+            "strategy": { "enum": ["qa", "role", "uia", "manifest"] },
+            "value": { "type": "string", "minLength": 1 }
+          }
+        },
+        "visible_name": { "type": "string", "minLength": 1 },
+        "preconditions": { "type": "array", "items": { "type": "string" } },
+        "risk": { "enum": ["read", "write_reversible", "destructive", "external"] },
+        "expected_ipc": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["command", "args_match"],
+            "properties": {
+              "command": { "type": "string", "minLength": 1 },
+              "args_match": { "type": "object" }
+            }
+          }
+        },
+        "oracles": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "enum": ["dom", "ipc", "state", "filesystem", "process", "network", "accessibility", "screenshot"] }
+        },
+        "cleanup": { "type": ["string", "null"] },
+        "platform": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "enum": ["linux", "windows", "macos"] }
+        }
+      }
+    },
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action_id", "state_id", "selector_matches", "variants"],
+      "properties": {
+        "action_id": { "type": "string", "minLength": 1 },
+        "state_id": { "type": "string", "minLength": 1 },
+        "selector_matches": { "type": "integer", "minimum": 0 },
+        "variants": {
+          "type": "array",
+          "items": { "enum": ["success", "error", "cancel"] }
+        },
+        "fixture_ownership": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["token_ref", "owned_paths", "loopback_endpoints"],
+          "properties": {
+            "token_ref": { "type": "string", "minLength": 1 },
+            "owned_paths": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+            "loopback_endpoints": { "type": "array", "items": { "type": "string", "pattern": "^https?://(127\\.0\\.0\\.1|localhost)(:|/|$)" } }
+          }
+        }
+      }
+    }
+  }
+}

--- a/frontend/e2e/surface/types.ts
+++ b/frontend/e2e/surface/types.ts
@@ -1,0 +1,78 @@
+/** A stable selector consumed by deterministic surface tests. */
+export interface SurfaceSelector {
+  strategy: "qa" | "role" | "uia" | "manifest";
+  value: string;
+}
+
+export type SurfaceRisk =
+  | "read"
+  | "write_reversible"
+  | "destructive"
+  | "external";
+
+export type SurfaceOracle =
+  | "dom"
+  | "ipc"
+  | "state"
+  | "filesystem"
+  | "process"
+  | "network"
+  | "accessibility"
+  | "screenshot";
+
+export type SurfacePlatform = "linux" | "windows" | "macos";
+
+/**
+ * One state-dependent, fixture-owned interaction in the surface inventory.
+ * `surface_id` is the action id accepted by later deterministic executors.
+ */
+export interface SurfaceAction {
+  schema: 1;
+  app_commit: string;
+  surface_id: string;
+  state_id: string;
+  element_id: string;
+  selector: SurfaceSelector;
+  visible_name: string;
+  preconditions: string[];
+  risk: SurfaceRisk;
+  expected_ipc: Array<{
+    command: string;
+    args_match: Record<string, unknown>;
+  }>;
+  oracles: SurfaceOracle[];
+  cleanup: string | null;
+  platform: SurfacePlatform[];
+}
+
+export type SurfaceCaseVariant = "success" | "error" | "cancel";
+
+/**
+ * Evidence supplied by a fixture after resolving an inventory selector. This
+ * keeps selector uniqueness deterministic and separate from visual judgement.
+ */
+export interface SurfaceCase {
+  action_id: string;
+  state_id: string;
+  selector_matches: number;
+  variants: SurfaceCaseVariant[];
+  fixture_ownership?: {
+    token_ref: string;
+    owned_paths: string[];
+    loopback_endpoints: string[];
+  };
+}
+
+/** One pre-parsed surface-map file. YAML parsing deliberately lives at the IO boundary. */
+export interface SurfaceMapFile {
+  file: string;
+  inventory: SurfaceAction[];
+  cases: SurfaceCase[];
+}
+
+export interface CompiledSurfaceMap {
+  actions: readonly SurfaceAction[];
+  cases: readonly SurfaceCase[];
+  action_by_id: ReadonlyMap<string, SurfaceAction>;
+  case_by_action_id: ReadonlyMap<string, SurfaceCase>;
+}

--- a/frontend/e2e/surface/types.ts
+++ b/frontend/e2e/surface/types.ts
@@ -17,6 +17,7 @@ export type SurfaceOracle =
   | "filesystem"
   | "process"
   | "network"
+  | "remote_client"
   | "accessibility"
   | "screenshot";
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
-    include: ["src/**/*.spec.{ts,tsx}"],
+    include: ["src/**/*.spec.{ts,tsx}", "e2e/surface/**/*.spec.ts"],
     setupFiles: ["./src/test/setup.ts"],
     clearMocks: true,
     restoreMocks: true,


### PR DESCRIPTION
## Scope
Task 1 only from the frozen SBAI-5457 P2 plan: deterministic surface schema/types/compiler/spec/core map plus one discovery-only Vitest include. No runtime, executor, UIA, P0/P1, or release-workflow changes.

## Safety contract
- every surface action needs an authoritative nonvisual oracle
- screenshot-, DOM-, and accessibility-only evidence cannot pass product correctness
- IPC command names map to the existing LoreGUI API
- external/destructive args must resolve to declared ownership or `$fixture.*` token references
- malformed risk/IPC entries and duplicate/unexercised surfaces reject at compile time

## Verification
- independent SDD review: PASS after two fix rounds
- `npx vitest run e2e/surface/compile.spec.ts` — 20/20
- `npm test -- --run` — 292/292
- `npm run typecheck` — PASS
- `git diff --check origin/main...HEAD` — PASS

This is the oracle/contract consumed by the dedicated Windows driver track; it does not implement or claim a Windows-native pass.