### PR TITLE
SBAI-5560: sidecar PE gates, actionable corrupt-binary error, single-ask storage wizard

### DIFF
--- a/.github/workflows/build-crossplatform.yml
+++ b/.github/workflows/build-crossplatform.yml
@@ -89,10 +89,13 @@ jobs:
           projectPath: .
           args: ${{ matrix.args }} --config src-tauri/tauri.ci.conf.json
 
-      - name: Upload bundle artifact
+      # SBAI-5560: these bundles carry the build.rs PLACEHOLDER sidecar (see
+      # above) — name them dev-only so nobody installs one by mistake (EROS,
+      # 2026-07-21). No CI job downloads this artifact; it is compile proof.
+      - name: Upload bundle artifact (DEV — placeholder sidecar, not for install)
         uses: actions/upload-artifact@v4
         with:
-          name: loregui-${{ matrix.platform }}
+          name: loregui-dev-${{ matrix.platform }}
           path: |
             target/release/bundle/**/*.dmg
             target/release/bundle/**/*.app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,15 @@ jobs:
           - platform: windows-latest
             triple: x86_64-pc-windows-msvc
             sidecar_ext: ".exe"
+            machine: x64
           - platform: ubuntu-22.04
             triple: x86_64-unknown-linux-gnu
             sidecar_ext: ""
+            machine: x64
           - platform: macos-latest
             triple: aarch64-apple-darwin
             sidecar_ext: ""
+            machine: arm64
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
@@ -218,6 +221,10 @@ jobs:
             exit 1
           fi
           ls -la "$STAGED"
+          # SBAI-5560: existence alone shipped a corrupt/quarantined sidecar as
+          # Windows' "Unsupported 16 Bit Application" — gate on a real PE
+          # header (MZ magic, PE signature, expected machine field) + size.
+          node scripts/verify-sidecar.mjs "$STAGED" ${{ matrix.machine }}
 
       # Windows Authenticode signing (non-blocking). When the WINDOWS_CERTIFICATE
       # secret (base64-encoded PKCS#12 .pfx) is present we import it into a temp
@@ -287,6 +294,31 @@ jobs:
           releaseBody: ${{ startsWith(github.ref, 'refs/tags/') && steps.notes.outputs.body || 'Rolling build of the latest `main`. Current Windows / Linux / macOS installers. Pre-alpha — CI refreshes this on each push to main.' }}
           releaseDraft: ${{ startsWith(github.ref, 'refs/tags/') }}
           prerelease: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
+      # SBAI-5560: post-build gate on the sidecar the bundler actually
+      # embedded. Where the bundle has an UNPACKED layout on disk — the macOS
+      # .app is a real directory — verify the bundled copy itself. Windows
+      # (NSIS/MSI) and Linux (AppImage/deb) produce only packed installers with
+      # no unpacked app dir, so there the staged sidecar (verified above) is the
+      # byte-identical input to the bundler and is re-verified as the proxy.
+      - name: Verify bundled sidecar in produced bundle
+        shell: bash
+        run: |
+          BUNDLED=""
+          for CAND in \
+            "target/${{ matrix.triple }}/release/bundle/macos/LoreGUI.app/Contents/MacOS/loreserver" \
+            "target/release/bundle/macos/LoreGUI.app/Contents/MacOS/loreserver" \
+            "src-tauri/target/${{ matrix.triple }}/release/bundle/macos/LoreGUI.app/Contents/MacOS/loreserver" \
+            "src-tauri/target/release/bundle/macos/LoreGUI.app/Contents/MacOS/loreserver"; do
+            if [ -f "$CAND" ]; then BUNDLED="$CAND"; break; fi
+          done
+          if [ -n "$BUNDLED" ]; then
+            echo "Verifying bundled sidecar at $BUNDLED"
+            node scripts/verify-sidecar.mjs "$BUNDLED" ${{ matrix.machine }}
+          else
+            echo "Packed-installer platform (no unpacked bundle dir) — re-verifying the staged sidecar the bundler embedded."
+            node scripts/verify-sidecar.mjs "src-tauri/binaries/loreserver-${{ matrix.triple }}${{ matrix.sidecar_ext }}" ${{ matrix.machine }}
+          fi
 
       # ── Raw sidecar binaries for StudioBrain desktop bundling (SBAI-4683) ──
       # The StudioBrain desktop app (BiloxiStudios/studiobrain-app) bundles

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -54,10 +54,15 @@ jobs:
         with:
           args: --config src-tauri/tauri.ci.conf.json
 
-      - name: Upload installer artifact
+      # SBAI-5560: gate bundles carry the build.rs PLACEHOLDER sidecar, not a
+      # real loreserver — an artifact named like a release installer gets
+      # installed by humans (EROS, 2026-07-21) and Host-a-server dies with
+      # "Unsupported 16 Bit Application". Watermark the artifact name so the
+      # channel is unmistakable; the upload stays as compile proof only.
+      - name: Upload installer artifact (DEV — placeholder sidecar, not for install)
         uses: actions/upload-artifact@v4
         with:
-          name: loregui-windows
+          name: loregui-windows-dev-placeholder-sidecar
           path: |
             target/release/bundle/nsis/*.exe
             target/release/bundle/msi/*.msi

--- a/frontend/src/onboarding/DirectoryPicker.spec.tsx
+++ b/frontend/src/onboarding/DirectoryPicker.spec.tsx
@@ -9,6 +9,7 @@ import {
 
 const invokeMock = vi.fn();
 const chooseDirectoryMock = vi.fn();
+const dialogOpenMock = vi.fn();
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => invokeMock(...args),
@@ -18,10 +19,12 @@ vi.mock("../platform/directoryPicker", () => ({
   chooseDirectory: (...args: unknown[]) => chooseDirectoryMock(...args),
 }));
 
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: (...args: unknown[]) => dialogOpenMock(...args),
+}));
+
 import ClientClone from "./ClientClone";
 import BackendPicker from "./server/BackendPicker";
-import InitStore from "./server/InitStore";
-import ServiceSetup from "./server/ServiceSetup";
 
 const WINDOWS_PATH = "E:\\lore";
 
@@ -47,6 +50,8 @@ beforeEach(() => {
   invokeMock.mockReset();
   chooseDirectoryMock.mockReset();
   chooseDirectoryMock.mockResolvedValue(WINDOWS_PATH);
+  dialogOpenMock.mockReset();
+  dialogOpenMock.mockResolvedValue(WINDOWS_PATH);
 });
 
 describe("ClientClone native directory selection", () => {
@@ -147,11 +152,12 @@ describe("server onboarding native directory selection", () => {
     const primaryField = fieldByLabel("Local Storage Path");
     fireEvent.click(within(primaryField).getByRole("button", { name: "Browse…" }));
     await waitFor(() =>
-      expect(within(primaryField).getByText(WINDOWS_PATH)).toBeInTheDocument(),
+      expect(within(primaryField).getByLabelText("Local Storage Path")).toHaveValue(
+        WINDOWS_PATH,
+      ),
     );
-    fireEvent.click(within(primaryField).getByText("Advanced path entry"));
-    expect(within(primaryField).getByLabelText("Local Storage Path")).toHaveValue(
-      WINDOWS_PATH,
+    expect(dialogOpenMock).toHaveBeenCalledWith(
+      expect.objectContaining({ directory: true }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Prepare Store" }));
 
@@ -173,18 +179,15 @@ describe("server onboarding native directory selection", () => {
     const primaryField = fieldByLabel("Local Storage Path");
     const mutableField = fieldByLabel("Mutable Store Path (optional)");
 
-    fireEvent.click(within(primaryField).getByText("Advanced path entry"));
     fireEvent.change(within(primaryField).getByLabelText("Local Storage Path"), {
       target: { value: "C:\\primary" },
     });
     fireEvent.click(within(mutableField).getByRole("button", { name: "Browse…" }));
     await waitFor(() =>
-      expect(within(mutableField).getByText(WINDOWS_PATH)).toBeInTheDocument(),
+      expect(
+        within(mutableField).getByLabelText("Mutable Store Path (optional)"),
+      ).toHaveValue(WINDOWS_PATH),
     );
-    fireEvent.click(within(mutableField).getByText("Advanced path entry"));
-    expect(
-      within(mutableField).getByLabelText("Mutable Store Path (optional)"),
-    ).toHaveValue(WINDOWS_PATH);
     fireEvent.click(screen.getByRole("button", { name: "Prepare Store" }));
 
     await waitFor(() =>
@@ -210,7 +213,9 @@ describe("server onboarding native directory selection", () => {
 
     fireEvent.click(within(mutableField).getByRole("button", { name: "Browse…" }));
     await waitFor(() =>
-      expect(within(mutableField).getByText(WINDOWS_PATH)).toBeInTheDocument(),
+      expect(
+        within(mutableField).getByLabelText("Mutable Store Path (optional)"),
+      ).toHaveValue(WINDOWS_PATH),
     );
     fireEvent.click(screen.getByRole("button", { name: "Open Storage" }));
 
@@ -222,66 +227,20 @@ describe("server onboarding native directory selection", () => {
   });
 
   it("keeps the mutable-store value and invokes no backend action when cancelled", async () => {
-    chooseDirectoryMock.mockResolvedValue(null);
+    dialogOpenMock.mockResolvedValue(null);
     render(<BackendPicker />);
     const mutableField = fieldByLabel("Mutable Store Path (optional)");
 
-    fireEvent.click(within(mutableField).getByText("Advanced path entry"));
     fireEvent.change(
       within(mutableField).getByLabelText("Mutable Store Path (optional)"),
       { target: { value: "D:\\mutable-existing" } },
     );
     fireEvent.click(within(mutableField).getByRole("button", { name: "Browse…" }));
 
-    await waitFor(() => expect(chooseDirectoryMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(dialogOpenMock).toHaveBeenCalledTimes(1));
     expect(
       within(mutableField).getByLabelText("Mutable Store Path (optional)"),
     ).toHaveValue("D:\\mutable-existing");
     expect(invokeMock).not.toHaveBeenCalled();
-  });
-
-  it("preserves InitStore's selected local path in IPC", async () => {
-    invokeMock.mockImplementation((command: string, args: { path: string }) => {
-      if (command === "host_store_prepare") return Promise.resolve(args.path);
-      return Promise.reject(new Error(`unexpected command ${command}`));
-    });
-    render(<InitStore />);
-
-    await chooseWindowsDirectory();
-    expect(screen.getByLabelText("Store Path")).toHaveValue(WINDOWS_PATH);
-    fireEvent.click(screen.getByRole("button", { name: "Create Store" }));
-
-    await waitFor(() =>
-      expect(invokeMock).toHaveBeenCalledWith("host_store_prepare", {
-        path: WINDOWS_PATH,
-        mutableStore: null,
-      }),
-    );
-  });
-
-  it("preserves ServiceSetup's selected local path in IPC", async () => {
-    invokeMock.mockImplementation((command: string) => {
-      if (command === "host_server_status") {
-        return Promise.resolve({ running: false });
-      }
-      if (command === "host_server_start") {
-        return Promise.resolve({ running: true, url: "lore://localhost/repo" });
-      }
-      return Promise.reject(new Error(`unexpected command ${command}`));
-    });
-    render(<ServiceSetup repoName="project" />);
-
-    await chooseWindowsDirectory();
-    expect(screen.getByLabelText("Store directory to serve")).toHaveValue(
-      WINDOWS_PATH,
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Start Hosting" }));
-
-    await waitFor(() =>
-      expect(invokeMock).toHaveBeenCalledWith(
-        "host_server_start",
-        expect.objectContaining({ storeDir: WINDOWS_PATH }),
-      ),
-    );
   });
 });

--- a/frontend/src/onboarding/StepReporting.spec.tsx
+++ b/frontend/src/onboarding/StepReporting.spec.tsx
@@ -247,7 +247,6 @@ describe("onboarding children report backend truth", () => {
       <BackendPicker onStateChange={(result) => states.push(result)} />,
     );
     expect(lastStatus(states)).toBe("idle");
-    fireEvent.click(screen.getAllByText("Advanced path entry")[0]);
     fireEvent.change(screen.getByLabelText("Local Storage Path"), {
       target: { value: "/store" },
     });
@@ -260,7 +259,6 @@ describe("onboarding children report backend truth", () => {
     invokeMock.mockRejectedValueOnce("disk full");
     const errors: StepResult<StorageBackendConfig>[] = [];
     render(<BackendPicker onStateChange={(result) => errors.push(result)} />);
-    fireEvent.click(screen.getAllByText("Advanced path entry")[0]);
     fireEvent.change(screen.getByLabelText("Local Storage Path"), {
       target: { value: "/store" },
     });
@@ -389,7 +387,6 @@ describe("onboarding children report backend truth", () => {
       <BackendPicker onStateChange={(result) => backendStates.push(result)} />,
     );
     backendStates.length = 0;
-    fireEvent.click(screen.getAllByText("Advanced path entry")[0]);
     fireEvent.change(screen.getByLabelText("Local Storage Path"), {
       target: { value: "/changed" },
     });
@@ -417,9 +414,16 @@ describe("onboarding children report backend truth", () => {
       <ServiceSetup onStateChange={(result) => serviceStates.push(result)} />,
     );
     serviceStates.length = 0;
-    fireEvent.click(screen.getByText("Advanced path entry"));
-    fireEvent.change(screen.getByLabelText("Store directory to serve"), {
-      target: { value: "/changed" },
+    // The store path is read-only here (SBAI-5560); an expert-mode field edit
+    // is the remaining editable input that invalidates the step.
+    fireEvent.click(screen.getByRole("tab", { name: "Expert" }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Network: bind host, QUIC, gRPC, HTTP/,
+      }),
+    );
+    fireEvent.change(screen.getByLabelText("Bind host"), {
+      target: { value: "0.0.0.0" },
     });
     expect(lastStatus(serviceStates)).toBe("idle");
   });

--- a/frontend/src/onboarding/server/BackendPicker.tsx
+++ b/frontend/src/onboarding/server/BackendPicker.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { api, type StorageBackendConfig } from "../../api";
-import { chooseDirectory } from "../../platform/directoryPicker";
+import PathField from "./PathField";
 import type { StepStateProps } from "../stepResult";
 
 // lore has exactly two real store backends:
@@ -112,6 +112,15 @@ export default function BackendPicker({
     [onStateChange],
   );
 
+  /** Value-based setter for PathField (manual edits and picker selections). */
+  const setField = useCallback(
+    (field: keyof FormState) => (value: string) => {
+      setForm((prev) => ({ ...prev, [field]: value }));
+      onStateChange?.({ status: "idle" });
+    },
+    [onStateChange],
+  );
+
   const isValid = useCallback((): boolean => {
     if (kind === "local") {
       return form.path.trim().length > 0;
@@ -178,28 +187,6 @@ export default function BackendPicker({
       onStateChange?.({ status: "error", message });
     }
   }, [isValid, buildConfig, onConfigured, onStateChange]);
-
-  const handleBrowse = useCallback(async () => {
-    const selected = await chooseDirectory({
-      title: "Choose local storage directory",
-      defaultPath: form.path || undefined,
-    });
-    if (selected !== null) {
-      setForm((prev) => ({ ...prev, path: selected }));
-      onStateChange?.({ status: "idle" });
-    }
-  }, [form.path, onStateChange]);
-
-  const handleMutableBrowse = useCallback(async () => {
-    const selected = await chooseDirectory({
-      title: "Choose mutable store directory",
-      defaultPath: form.mutableStore || undefined,
-    });
-    if (selected !== null) {
-      setForm((prev) => ({ ...prev, mutableStore: selected }));
-      onStateChange?.({ status: "idle" });
-    }
-  }, [form.mutableStore, onStateChange]);
 
   const handleReset = useCallback(() => {
     setStep("idle");
@@ -278,37 +265,19 @@ export default function BackendPicker({
         </div>
       )}
 
-      {/* Local form fields */}
+      {/* Local form fields — the store path is asked ONCE, right here (SBAI-5560).
+          Steps 3 and 4 display it read-only with its role. */}
       {kind === "local" && step !== "success" && (
-        <div className="onboarding-field">
-          <span>Local Storage Path</span>
-          <button
-            type="button"
-            className="onboarding-button"
-            onClick={() => void handleBrowse()}
-            disabled={step === "connecting"}
-          >
-            Browse…
-          </button>
-          <code>{form.path || "No directory selected"}</code>
-          <details>
-            <summary>Advanced path entry</summary>
-            <label htmlFor="backend-path">Local Storage Path</label>
-            <input
-              id="backend-path"
-              type="text"
-              placeholder="/path/to/lore/data"
-              value={form.path}
-              onChange={updateField("path")}
-              disabled={step === "connecting"}
-            />
-          </details>
-          <span className="onboarding-field-hint">
-            The directory is created if it doesn&rsquo;t exist — no existing
-            repository required. Your server fills it with its content store when
-            it starts.
-          </span>
-        </div>
+        <PathField
+          id="backend-path"
+          label="Local Storage Path"
+          value={form.path}
+          onChange={setField("path")}
+          placeholder="/path/to/lore/data"
+          dialogTitle="Choose local storage directory"
+          disabled={step === "connecting"}
+          hint="The directory is created if it doesn't exist — no existing repository required. Your server fills it with its content store when it starts."
+        />
       )}
 
       {/* S3-compatible object storage form fields */}
@@ -400,32 +369,16 @@ export default function BackendPicker({
 
       {/* Mutable store (optional for all backends) */}
       {step !== "success" && (
-        <div className="onboarding-field onboarding-field--optional">
-          <span>Mutable Store Path (optional)</span>
-          <button
-            type="button"
-            className="onboarding-button"
-            onClick={() => void handleMutableBrowse()}
-            disabled={step === "connecting"}
-          >
-            Browse…
-          </button>
-          <code>{form.mutableStore || "No directory selected"}</code>
-          <details>
-            <summary>Advanced path entry</summary>
-            <label htmlFor="backend-mutable">
-              Mutable Store Path (optional)
-            </label>
-            <input
-              id="backend-mutable"
-              type="text"
-              placeholder="/path/to/mutable/store (branch pointers)"
-              value={form.mutableStore}
-              onChange={updateField("mutableStore")}
-              disabled={step === "connecting"}
-            />
-          </details>
-        </div>
+        <PathField
+          id="backend-mutable"
+          label="Mutable Store Path (optional)"
+          optional
+          value={form.mutableStore}
+          onChange={setField("mutableStore")}
+          placeholder="/path/to/mutable/store (branch pointers)"
+          dialogTitle="Choose mutable store directory"
+          disabled={step === "connecting"}
+        />
       )}
 
       {/* Action buttons */}

--- a/frontend/src/onboarding/server/HostFlowLocal.spec.tsx
+++ b/frontend/src/onboarding/server/HostFlowLocal.spec.tsx
@@ -52,7 +52,6 @@ describe("step 1 — Choose Storage Backend (local FS)", () => {
     const onConfigured = vi.fn();
     render(<BackendPicker onConfigured={onConfigured} />);
 
-    fireEvent.click(screen.getAllByText("Advanced path entry")[0]);
     fireEvent.change(screen.getByLabelText("Local Storage Path"), {
       target: { value: "C:/loredata" },
     });
@@ -108,10 +107,10 @@ describe("step 3 — Initialize server / Create store (local FS)", () => {
       <InitStore config={config} onInitialized={(r) => (result = r)} />,
     );
 
-    // Store path is prefilled from step 1's config.
-    fireEvent.click(screen.getByText("Advanced path entry"));
-    const pathInput = screen.getByLabelText("Store Path") as HTMLInputElement;
-    expect(pathInput.value).toBe("C:/loredata");
+    // The step-1 store path is shown read-only (SBAI-5560), never re-asked.
+    expect(screen.getByText("Shared store — created in step 1")).toBeVisible();
+    expect(screen.getByText("C:/loredata")).toBeVisible();
+    expect(screen.queryByLabelText("Store Path")).toBeNull();
 
     fireEvent.change(screen.getByLabelText("Repository Name (optional)"), {
       target: { value: "my-repo" },

--- a/frontend/src/onboarding/server/InitStore.tsx
+++ b/frontend/src/onboarding/server/InitStore.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { api, type StorageBackendConfig } from "../../api";
-import { chooseDirectory } from "../../platform/directoryPicker";
+import PathField from "./PathField";
 import type { StepStateProps } from "../stepResult";
 
 type Step = "form" | "done" | "error";
@@ -14,9 +14,9 @@ export interface InitStoreResult {
 
 interface InitStoreProps extends StepStateProps<InitStoreResult> {
   /**
-   * Storage backend config from step 1, used to prefill the store path so the
-   * user doesn't retype it. Optional so the component still renders if the user
-   * jumped here.
+   * Storage backend config from step 1 — the store path is displayed read-only
+   * from here and is never re-asked (SBAI-5560). Optional so the component
+   * still renders if the user jumped here.
    */
   config?: StorageBackendConfig;
   /**
@@ -36,15 +36,18 @@ interface InitStoreProps extends StepStateProps<InitStoreResult> {
  * remote service, so this step simply ensures the directory exists via
  * `api.hostStorePrepare` — it does not call `shared_store_create` /
  * `repository_create`, which require a remote URL and would fail for a fresh
- * local host with "no remote URL". An optional repository name is collected to
- * advertise in the connection URL the next step shows clients.
+ * local host with "no remote URL". The store path itself is chosen ONCE in
+ * step 1 (Choose Storage Backend) and shown here as a read-only summary; an
+ * optional repository name is collected to advertise in the connection URL the
+ * next step shows clients.
  */
 export default function InitStore({
   config,
   onInitialized,
   onStateChange,
 }: InitStoreProps = {}) {
-  const [storePath, setStorePath] = useState(config?.path ?? "");
+  // The store path comes from step 1 verbatim — never edited here.
+  const storePath = config?.path ?? "";
   const [repoName, setRepoName] = useState("");
   const [step, setStep] = useState<Step>("form");
   const [error, setError] = useState<string | null>(null);
@@ -55,11 +58,6 @@ export default function InitStore({
     onStateChange?.({ status: "idle" });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  // Keep the store path in sync if step 1 reports/updates a resolved path.
-  useEffect(() => {
-    if (config?.path) setStorePath(config.path);
-  }, [config?.path]);
 
   const handleCreate = useCallback(async () => {
     if (!storePath.trim()) return;
@@ -90,17 +88,6 @@ export default function InitStore({
     }
   }, [storePath, repoName, onInitialized, onStateChange]);
 
-  const handleBrowse = useCallback(async () => {
-    const selected = await chooseDirectory({
-      title: "Choose server store directory",
-      defaultPath: storePath || undefined,
-    });
-    if (selected !== null) {
-      setStorePath(selected);
-      onStateChange?.({ status: "idle" });
-    }
-  }, [storePath, onStateChange]);
-
   return (
     <div className="onboarding-card">
       <h2>Initialize Server</h2>
@@ -114,37 +101,17 @@ export default function InitStore({
 
       {(step === "form" || step === "error") && (
         <>
-          <div className="onboarding-field">
-            <span>Store Path</span>
-            <button
-              type="button"
-              className="onboarding-button"
-              onClick={() => void handleBrowse()}
-              disabled={isSubmitting}
-            >
-              Browse…
-            </button>
-            <code>{storePath || "No directory selected"}</code>
-            <details>
-              <summary>Advanced path entry</summary>
-              <label htmlFor="store-path">Store Path</label>
-              <input
-                id="store-path"
-                type="text"
-                placeholder="/path/to/store"
-                value={storePath}
-                onChange={(e) => {
-                  setStorePath(e.target.value);
-                  onStateChange?.({ status: "idle" });
-                }}
-                disabled={isSubmitting}
-              />
-            </details>
-            <span className="onboarding-field-hint">
-              Prefilled from the storage backend you chose. The directory is
-              created if it doesn&rsquo;t exist.
-            </span>
-          </div>
+          <PathField
+            id="store-path"
+            label="Shared store — created in step 1"
+            value={storePath}
+            readOnly
+            hint={
+              storePath
+                ? "The directory is created if it doesn't exist. To change it, go back to the storage backend step."
+                : "No store path yet — go back to step 1 and choose a storage location."
+            }
+          />
           <div className="onboarding-field onboarding-field--optional">
             <label htmlFor="repo-name">Repository Name (optional)</label>
             <input

--- a/frontend/src/onboarding/server/PathField.tsx
+++ b/frontend/src/onboarding/server/PathField.tsx
@@ -1,0 +1,109 @@
+import { useCallback, useState } from "react";
+import type { ReactNode } from "react";
+import { open } from "@tauri-apps/plugin-dialog";
+
+interface PathFieldBaseProps {
+  /** Input id — the visible label points at it via htmlFor. */
+  id: string;
+  /** Field label. In read-only mode this is the role label for the summary. */
+  label: string;
+  /** Current path value. */
+  value: string;
+  /** Hint copy shown under the field. */
+  hint?: ReactNode;
+  /** Marks the field optional (styles only). */
+  optional?: boolean;
+}
+
+interface PathFieldEditableProps extends PathFieldBaseProps {
+  readOnly?: false;
+  /** Called with the new value on manual edits and on picker selection. */
+  onChange: (value: string) => void;
+  placeholder?: string;
+  /** Title of the native directory dialog. */
+  dialogTitle: string;
+  disabled?: boolean;
+}
+
+interface PathFieldReadOnlyProps extends PathFieldBaseProps {
+  /** Read-only summary: renders the path as static text with its role label. */
+  readOnly: true;
+}
+
+export type PathFieldProps = PathFieldEditableProps | PathFieldReadOnlyProps;
+
+/**
+ * Shared directory-path field for the host-a-server flow (SBAI-5560). Two
+ * variants:
+ *
+ * - **Editable** (default): label + text input + "Browse…" button that opens
+ *   the native directory picker (`@tauri-apps/plugin-dialog`, directory mode)
+ *   and fills the input with the selection. Used in step 1, the ONLY place a
+ *   store path is asked.
+ * - **Read-only summary** (`readOnly`): renders the path as static text under
+ *   its role label — used downstream so later steps display the path chosen in
+ *   step 1 without re-asking.
+ */
+export default function PathField(props: PathFieldProps) {
+  const { id, label, value, hint, optional } = props;
+  // Editable-only props, present unless this is a read-only summary.
+  const onChange = props.readOnly ? undefined : props.onChange;
+  const dialogTitle = props.readOnly ? undefined : props.dialogTitle;
+  const [browsing, setBrowsing] = useState(false);
+
+  const handleBrowse = useCallback(async () => {
+    if (!onChange) return;
+    setBrowsing(true);
+    try {
+      const selected = await open({
+        directory: true,
+        multiple: false,
+        title: dialogTitle,
+        defaultPath: value || undefined,
+      });
+      if (typeof selected === "string") {
+        onChange(selected);
+      }
+    } finally {
+      setBrowsing(false);
+    }
+  }, [onChange, dialogTitle, value]);
+
+  const fieldClass = `onboarding-field${optional ? " onboarding-field--optional" : ""}`;
+
+  if (props.readOnly) {
+    return (
+      <div className={fieldClass}>
+        <span>{label}</span>
+        <code>{value || "Not set"}</code>
+        {hint ? <span className="onboarding-field-hint">{hint}</span> : null}
+      </div>
+    );
+  }
+
+  const disabled = props.disabled || browsing;
+  return (
+    <div className={fieldClass}>
+      <label htmlFor={id}>{label}</label>
+      <div className="onboarding-url-row">
+        <input
+          id={id}
+          type="text"
+          placeholder={props.placeholder}
+          value={value}
+          onChange={(e) => props.onChange(e.target.value)}
+          disabled={disabled}
+        />
+        <button
+          type="button"
+          className="onboarding-button"
+          onClick={() => void handleBrowse()}
+          disabled={disabled}
+        >
+          {browsing ? "Browsing…" : "Browse…"}
+        </button>
+      </div>
+      {hint ? <span className="onboarding-field-hint">{hint}</span> : null}
+    </div>
+  );
+}

--- a/frontend/src/onboarding/server/ServiceSetup.tsx
+++ b/frontend/src/onboarding/server/ServiceSetup.tsx
@@ -2,9 +2,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../../api";
 import type { HostAdvancedOptions, HostStatus } from "../../api";
 import AdvancedServerConfig from "./AdvancedServerConfig";
+import PathField from "./PathField";
 import { isEntitled } from "../../commercial/entitlement";
 import { getRelayControl } from "../../commercial/relay-registry";
-import { chooseDirectory } from "../../platform/directoryPicker";
 import type { StepStateProps } from "../stepResult";
 
 type Step = "idle" | "starting" | "running" | "stopping" | "error";
@@ -12,8 +12,10 @@ type Mode = "basic" | "expert";
 
 interface ServiceSetupProps extends StepStateProps<string> {
   /**
-   * The store directory the previous step created. The hosted server serves
-   * exactly this store so the repository just created is actually reachable.
+   * The store directory the previous step created (chosen ONCE in step 1,
+   * SBAI-5560). Displayed read-only here — never re-asked. The hosted server
+   * serves exactly this store so the repository just created is actually
+   * reachable.
    */
   storePath?: string;
   /** Repository name created in that store — advertised in the lore:// URL. */
@@ -38,12 +40,13 @@ export default function ServiceSetup({
   const [step, setStep] = useState<Step>("idle");
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<HostStatus | null>(null);
-  const [storeDir, setStoreDir] = useState(storePath ?? "");
+  // The store to serve comes from step 1 verbatim (via the init step) — it is
+  // displayed read-only and never edited here.
+  const storeDir = storePath ?? "";
   const [copied, setCopied] = useState(false);
   const operationGeneration = useRef(0);
   const refreshGeneration = useRef(0);
   const lifecycleInFlight = useRef(false);
-  const browseGeneration = useRef(0);
   const previousStorePath = useRef(storePath);
 
   // Basic vs Expert configuration surface.
@@ -70,7 +73,6 @@ export default function ServiceSetup({
       operationGeneration.current += 1;
       refreshGeneration.current += 1;
       lifecycleInFlight.current = false;
-      browseGeneration.current += 1;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -79,18 +81,17 @@ export default function ServiceSetup({
     operationGeneration.current += 1;
     refreshGeneration.current += 1;
     lifecycleInFlight.current = false;
-    browseGeneration.current += 1;
     setStatus(null);
     setError(null);
     setStep("idle");
     onStateChange?.({ status: "idle" });
   }, [onStateChange]);
 
-  // Keep the store-dir field in sync if the previous step reports a path.
+  // A new store path from the previous step invalidates any in-flight
+  // operation against the old store.
   useEffect(() => {
     if (storePath !== previousStorePath.current) {
       previousStorePath.current = storePath;
-      if (storePath) setStoreDir(storePath);
       invalidateOperation();
     }
   }, [storePath, invalidateOperation]);
@@ -206,19 +207,6 @@ export default function ServiceSetup({
     }
   }, [storeDir, hasErrors, buildOptions, onStateChange]);
 
-  const handleBrowse = useCallback(async () => {
-    invalidateOperation();
-    const generation = ++browseGeneration.current;
-    const selected = await chooseDirectory({
-      title: "Choose store directory to serve",
-      defaultPath: storeDir || undefined,
-    });
-    if (generation === browseGeneration.current && selected !== null) {
-      setStoreDir(selected);
-      invalidateOperation();
-    }
-  }, [storeDir, invalidateOperation]);
-
   const handleStop = useCallback(async () => {
     const generation = ++operationGeneration.current;
     refreshGeneration.current += 1;
@@ -250,7 +238,7 @@ export default function ServiceSetup({
 
   const handlePreview = useCallback(async () => {
     if (!storeDir.trim()) {
-      setPreviewError("Enter a store directory first.");
+      setPreviewError("No store yet — create one on the previous step first.");
       setPreviewOpen(true);
       return;
     }
@@ -394,36 +382,17 @@ export default function ServiceSetup({
             </button>
           </div>
 
-          <div className="onboarding-field">
-            <span>Store directory to serve</span>
-            <button
-              type="button"
-              className="onboarding-button"
-              onClick={() => void handleBrowse()}
-              disabled={inputsDisabled}
-            >
-              Browse…
-            </button>
-            <code>{storeDir || "No directory selected"}</code>
-            <details>
-              <summary>Advanced path entry</summary>
-              <label htmlFor="host-store-dir">Store directory to serve</label>
-              <input
-                id="host-store-dir"
-                type="text"
-                placeholder="/path/to/shared/store"
-                value={storeDir}
-                onChange={(e) => {
-                  setStoreDir(e.target.value);
-                  invalidateOperation();
-                }}
-                disabled={inputsDisabled}
-              />
-            </details>
-            <p className="onboarding-field-hint">
-              Use the same shared-store path you created on the previous step.
-            </p>
-          </div>
+          <PathField
+            id="host-store-dir"
+            label="Serving store"
+            value={storeDir}
+            readOnly
+            hint={
+              storeDir
+                ? "Chosen in step 1 (Storage backend) — the server hosts exactly this store."
+                : "No store yet — go back and complete the previous steps first."
+            }
+          />
 
           {mode === "expert" && (
             <AdvancedServerConfig

--- a/frontend/src/onboarding/server/ServiceSetupOwnership.spec.tsx
+++ b/frontend/src/onboarding/server/ServiceSetupOwnership.spec.tsx
@@ -3,16 +3,11 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const invokeMock = vi.fn();
-const chooseDirectoryMock = vi.fn();
 const getRelayControlMock = vi.fn();
 const isEntitledMock = vi.fn();
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => invokeMock(...args),
-}));
-
-vi.mock("../../platform/directoryPicker", () => ({
-  chooseDirectory: (...args: unknown[]) => chooseDirectoryMock(...args),
 }));
 
 vi.mock("../../commercial/relay-registry", () => ({
@@ -111,23 +106,8 @@ function editDisabledInput(label: string, value: string) {
   fireEvent.change(input, { target: { value } });
 }
 
-function invokeDisabledButton(name: string) {
-  const button = screen.getByRole("button", { name });
-  const propsKey = Object.keys(button).find((key) =>
-    key.startsWith("__reactProps$"),
-  );
-  if (!propsKey) throw new Error("React button props were not available");
-  const props = (
-    button as unknown as Record<string, { onClick?: () => void }>
-  )[propsKey];
-  if (!props.onClick) throw new Error("React button click handler was missing");
-  act(() => props.onClick?.());
-}
-
 beforeEach(() => {
   invokeMock.mockReset();
-  chooseDirectoryMock.mockReset();
-  chooseDirectoryMock.mockResolvedValue(null);
   getRelayControlMock.mockReset();
   getRelayControlMock.mockReturnValue(null);
   isEntitledMock.mockReset();
@@ -220,7 +200,7 @@ describe("ServiceSetup running-host ownership", () => {
     expect(states.some((state) => state.status === "success")).toBe(false);
   });
 
-  it("ignores start A after the store changes A to B and back to A", async () => {
+  it("ignores start A after the store prop changes A to B and back to A", async () => {
     const start = deferred<{
       running: boolean;
       url: string;
@@ -231,12 +211,26 @@ describe("ServiceSetup running-host ownership", () => {
         ? Promise.resolve({ running: false })
         : start.promise,
     );
-    const onComplete = vi.fn();
-    render(<FinishHarness onComplete={onComplete} />);
-    fireEvent.click(screen.getByText("Advanced path entry"));
+    const states: StepResult<string>[] = [];
+    const view = render(
+      <ServiceSetup
+        storePath="/store-a"
+        onStateChange={(result) => states.push(result)}
+      />,
+    );
     fireEvent.click(await screen.findByRole("button", { name: "Start Hosting" }));
-    editDisabledInput("Store directory to serve", "/store-b");
-    editDisabledInput("Store directory to serve", "/store-a");
+    view.rerender(
+      <ServiceSetup
+        storePath="/store-b"
+        onStateChange={(result) => states.push(result)}
+      />,
+    );
+    view.rerender(
+      <ServiceSetup
+        storePath="/store-a"
+        onStateChange={(result) => states.push(result)}
+      />,
+    );
 
     await act(async () =>
       start.resolve({
@@ -246,14 +240,11 @@ describe("ServiceSetup running-host ownership", () => {
       }),
     );
     expect(screen.queryByText("Server is hosting")).toBeNull();
-    const finish = screen.getByRole("button", { name: "Finish" });
-    expect(finish).toBeDisabled();
-    finish.removeAttribute("disabled");
-    fireEvent.click(finish);
-    expect(onComplete).not.toHaveBeenCalled();
+    expect(states.some((state) => state.status === "success")).toBe(false);
+    expect(states[states.length - 1]?.status).toBe("idle");
   });
 
-  it("ignores a late start error after the store changes", async () => {
+  it("ignores a late start error after the store prop changes", async () => {
     const start = deferred<never>();
     invokeMock.mockImplementation((command: string) =>
       command === "host_server_status"
@@ -261,15 +252,19 @@ describe("ServiceSetup running-host ownership", () => {
         : start.promise,
     );
     const states: StepResult<string>[] = [];
-    render(
+    const view = render(
       <ServiceSetup
         storePath="/store-a"
         onStateChange={(result) => states.push(result)}
       />,
     );
-    fireEvent.click(screen.getByText("Advanced path entry"));
     fireEvent.click(await screen.findByRole("button", { name: "Start Hosting" }));
-    editDisabledInput("Store directory to serve", "/store-b");
+    view.rerender(
+      <ServiceSetup
+        storePath="/store-b"
+        onStateChange={(result) => states.push(result)}
+      />,
+    );
 
     await act(async () => start.reject(new Error("late start failure")));
     expect(screen.queryByText("late start failure")).toBeNull();
@@ -277,24 +272,32 @@ describe("ServiceSetup running-host ownership", () => {
     expect(states[states.length - 1]?.status).toBe("idle");
   });
 
-  it("ignores a late initial status after the store is edited", async () => {
+  it("ignores a late initial status after the store prop changes", async () => {
     const status = deferred<{
       running: boolean;
       url: string;
       storeDir: string;
     }>();
-    invokeMock.mockReturnValue(status.promise);
+    // First fetch is the stale one; a store prop change correctly re-fetches.
+    let statusCalls = 0;
+    invokeMock.mockImplementation(() =>
+      ++statusCalls === 1
+        ? status.promise
+        : Promise.resolve({ running: false }),
+    );
     const states: StepResult<string>[] = [];
-    render(
+    const view = render(
       <ServiceSetup
         storePath="/store-a"
         onStateChange={(result) => states.push(result)}
       />,
     );
-    fireEvent.click(screen.getByText("Advanced path entry"));
-    fireEvent.change(screen.getByLabelText("Store directory to serve"), {
-      target: { value: "/store-b" },
-    });
+    view.rerender(
+      <ServiceSetup
+        storePath="/store-b"
+        onStateChange={(result) => states.push(result)}
+      />,
+    );
 
     await act(async () =>
       status.resolve({
@@ -306,97 +309,6 @@ describe("ServiceSetup running-host ownership", () => {
     expect(screen.queryByText("Server is hosting")).toBeNull();
     expect(states.some((state) => state.status === "success")).toBe(false);
     expect(states[states.length - 1]?.status).toBe("idle");
-  });
-
-  it("invalidates a pending start when Browse selects a different store", async () => {
-    const directory = deferred<string | null>();
-    const start = deferred<{
-      running: boolean;
-      url: string;
-      storeDir: string;
-    }>();
-    chooseDirectoryMock.mockReturnValue(directory.promise);
-    invokeMock.mockImplementation((command: string) =>
-      command === "host_server_status"
-        ? Promise.resolve({ running: false })
-        : start.promise,
-    );
-    const states: StepResult<string>[] = [];
-    render(
-      <ServiceSetup
-        storePath="/store-a"
-        onStateChange={(result) => states.push(result)}
-      />,
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Browse…" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Start Hosting" }));
-    await act(async () => directory.resolve("/store-b"));
-    await act(async () =>
-      start.resolve({
-        running: true,
-        url: "lore://localhost/a",
-        storeDir: "/store-a",
-      }),
-    );
-
-    expect(screen.getByText("/store-b")).toBeVisible();
-    expect(screen.queryByText("Server is hosting")).toBeNull();
-    expect(states.some((state) => state.status === "success")).toBe(false);
-  });
-
-  it("ignores a pending Browse result after a newer manual edit", async () => {
-    const directory = deferred<string | null>();
-    chooseDirectoryMock.mockReturnValue(directory.promise);
-    invokeMock.mockResolvedValue({ running: false });
-    render(<ServiceSetup storePath="/store-a" />);
-    fireEvent.click(screen.getByText("Advanced path entry"));
-    fireEvent.click(screen.getByRole("button", { name: "Browse…" }));
-    fireEvent.change(screen.getByLabelText("Store directory to serve"), {
-      target: { value: "/store-manual" },
-    });
-
-    await act(async () => directory.resolve("/store-stale-picker"));
-
-    expect(screen.getByText("/store-manual")).toBeVisible();
-    expect(screen.queryByText("/store-stale-picker")).toBeNull();
-  });
-
-  it("invalidates a pending start as soon as Browse opens", async () => {
-    const directory = deferred<string | null>();
-    const start = deferred<{
-      running: boolean;
-      url: string;
-      storeDir: string;
-    }>();
-    chooseDirectoryMock.mockReturnValue(directory.promise);
-    invokeMock.mockImplementation((command: string) =>
-      command === "host_server_status"
-        ? Promise.resolve({ running: false })
-        : start.promise,
-    );
-    const states: StepResult<string>[] = [];
-    render(
-      <ServiceSetup
-        storePath="/store-a"
-        onStateChange={(result) => states.push(result)}
-      />,
-    );
-    fireEvent.click(await screen.findByRole("button", { name: "Start Hosting" }));
-    invokeDisabledButton("Browse…");
-    expect(chooseDirectoryMock).toHaveBeenCalledTimes(1);
-
-    await act(async () =>
-      start.resolve({
-        running: true,
-        url: "lore://localhost/a",
-        storeDir: "/store-a",
-      }),
-    );
-    expect(screen.queryByText("Server is hosting")).toBeNull();
-    expect(states.some((state) => state.status === "success")).toBe(false);
-    expect(states[states.length - 1]?.status).toBe("idle");
-
-    await act(async () => directory.resolve(null));
   });
 
   it("invalidates a pending start on detail-mode and advanced edits", async () => {
@@ -675,7 +587,7 @@ describe("ServiceSetup running-host ownership", () => {
     expect(screen.getByRole("button", { name: "Start Hosting" })).toBeVisible();
   });
 
-  it("ignores a relay refresh invalidated by a newer store edit", async () => {
+  it("ignores a relay refresh invalidated by a store prop change", async () => {
     enableRelay();
     const refresh = deferred<{
       running: boolean;
@@ -698,7 +610,7 @@ describe("ServiceSetup running-host ownership", () => {
       if (command === "host_server_stop") return Promise.resolve();
       return Promise.reject(new Error(`unexpected command ${command}`));
     });
-    render(
+    const view = render(
       <ServiceSetup
         storePath="/store-a"
         onStateChange={(result) => states.push(result)}
@@ -709,10 +621,12 @@ describe("ServiceSetup running-host ownership", () => {
     fireEvent.click(screen.getByRole("button", { name: "Stop Hosting" }));
     expect(await screen.findByRole("button", { name: "Start Hosting" })).toBeVisible();
     act(() => capturedRefresh?.());
-    fireEvent.click(screen.getByText("Advanced path entry"));
-    fireEvent.change(screen.getByLabelText("Store directory to serve"), {
-      target: { value: "/store-b" },
-    });
+    view.rerender(
+      <ServiceSetup
+        storePath="/store-b"
+        onStateChange={(result) => states.push(result)}
+      />,
+    );
     const successCount = states.filter((state) => state.status === "success").length;
 
     await act(async () =>
@@ -727,37 +641,6 @@ describe("ServiceSetup running-host ownership", () => {
     expect(states.filter((state) => state.status === "success")).toHaveLength(
       successCount,
     );
-  });
-
-  it("ignores a deferred refresh after Browse opens and cancels", async () => {
-    enableRelay();
-    const refresh = deferred<{
-      running: boolean;
-      url: string;
-      storeDir: string;
-    }>();
-    const directory = deferred<string | null>();
-    chooseDirectoryMock.mockReturnValue(directory.promise);
-    mockRunningThenRefresh(refresh.promise);
-    const onComplete = vi.fn();
-    render(<FinishHarness onComplete={onComplete} />);
-    expect(await screen.findByText("Relay control")).toBeVisible();
-    const capturedRefresh = relayRefreshCallback;
-    fireEvent.click(screen.getByRole("button", { name: "Stop Hosting" }));
-    expect(await screen.findByRole("button", { name: "Start Hosting" })).toBeVisible();
-    act(() => capturedRefresh?.());
-
-    fireEvent.click(screen.getByRole("button", { name: "Browse…" }));
-    await act(async () => directory.resolve(null));
-    await act(async () =>
-      refresh.resolve({
-        running: true,
-        url: "lore://localhost/stale",
-        storeDir: "/store-a",
-      }),
-    );
-
-    expectFinishBlocked(onComplete);
   });
 
   it("ignores a deferred refresh error after a Basic-to-Expert mode change", async () => {

--- a/frontend/src/onboarding/server/StorePathSingleAsk.spec.tsx
+++ b/frontend/src/onboarding/server/StorePathSingleAsk.spec.tsx
@@ -1,0 +1,242 @@
+/**
+ * SBAI-5560: the Host-a-server flow asks for the store path EXACTLY ONCE — in
+ * step 1 (Choose Storage Backend), with a native folder picker. Steps 3
+ * (Initialize server) and 4 (Host server) show the step-1 path as a read-only
+ * summary with a clear role label and pass it unchanged to
+ * `host_store_prepare` / `host_server_start`.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+
+const invokeMock = vi.fn();
+const dialogOpenMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: (...args: unknown[]) => dialogOpenMock(...args),
+}));
+
+import type { StorageBackendConfig } from "../../api";
+import PathField from "./PathField";
+import BackendPicker from "./BackendPicker";
+import InitStore from "./InitStore";
+import ServiceSetup from "./ServiceSetup";
+
+const STEP1_PATH = "/srv/lore/store";
+
+function fieldByLabel(label: string): HTMLElement {
+  const field = screen
+    .getByLabelText(label)
+    .closest<HTMLElement>(".onboarding-field");
+  if (!field) throw new Error(`missing onboarding field for ${label}`);
+  return field;
+}
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  dialogOpenMock.mockReset();
+  dialogOpenMock.mockResolvedValue(STEP1_PATH);
+});
+
+describe("PathField", () => {
+  it("Browse opens a native directory picker and fills the input", async () => {
+    const onChange = vi.fn();
+    render(
+      <PathField
+        id="pf"
+        label="Local Storage Path"
+        value=""
+        onChange={onChange}
+        dialogTitle="Choose local storage directory"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Browse…" }));
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(STEP1_PATH));
+    expect(dialogOpenMock).toHaveBeenCalledTimes(1);
+    expect(dialogOpenMock).toHaveBeenCalledWith(
+      expect.objectContaining({ directory: true, multiple: false }),
+    );
+  });
+
+  it("keeps the current value when the picker is cancelled", async () => {
+    dialogOpenMock.mockResolvedValue(null);
+    const onChange = vi.fn();
+    render(
+      <PathField
+        id="pf"
+        label="Path"
+        value="/keep"
+        onChange={onChange}
+        dialogTitle="Pick"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Browse…" }));
+
+    await waitFor(() => expect(dialogOpenMock).toHaveBeenCalledTimes(1));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Path")).toHaveValue("/keep");
+  });
+
+  it("disables input and button while disabled, and shows a browsing state", async () => {
+    let resolveOpen!: (value: string | null) => void;
+    dialogOpenMock.mockReturnValue(
+      new Promise<string | null>((res) => {
+        resolveOpen = res;
+      }),
+    );
+    const onChange = vi.fn();
+    const view = render(
+      <PathField
+        id="pf"
+        label="Path"
+        value=""
+        onChange={onChange}
+        dialogTitle="Pick"
+        disabled
+      />,
+    );
+    expect(screen.getByLabelText("Path")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Browse…" })).toBeDisabled();
+
+    view.rerender(
+      <PathField
+        id="pf"
+        label="Path"
+        value=""
+        onChange={onChange}
+        dialogTitle="Pick"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Browse…" }));
+    expect(
+      await screen.findByRole("button", { name: "Browsing…" }),
+    ).toBeDisabled();
+
+    resolveOpen(null);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Browse…" })).toBeEnabled(),
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("read-only summary renders the path as static text with its role label", () => {
+    render(
+      <PathField
+        id="pf"
+        label="Shared store — created in step 1"
+        value={STEP1_PATH}
+        readOnly
+      />,
+    );
+
+    expect(screen.getByText("Shared store — created in step 1")).toBeVisible();
+    expect(screen.getByText(STEP1_PATH)).toBeVisible();
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});
+
+describe("host flow asks for the store path exactly once (SBAI-5560)", () => {
+  it("step 1 holds the only editable store-path asks, both with native pickers", async () => {
+    invokeMock.mockImplementation((command: string, args: { path: string }) => {
+      if (command === "host_store_prepare") return Promise.resolve(args.path);
+      return Promise.reject(new Error(`unexpected command ${command}`));
+    });
+    const onConfigured = vi.fn();
+    render(<BackendPicker onConfigured={onConfigured} />);
+
+    // The required store path plus the optional mutable store — both pickers,
+    // and the only two Browse buttons in the whole flow.
+    expect(screen.getByLabelText("Local Storage Path")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Mutable Store Path (optional)"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Browse…" })).toHaveLength(2);
+
+    const primaryField = fieldByLabel("Local Storage Path");
+    fireEvent.click(within(primaryField).getByRole("button", { name: "Browse…" }));
+    await waitFor(() =>
+      expect(screen.getByLabelText("Local Storage Path")).toHaveValue(
+        STEP1_PATH,
+      ),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Prepare Store" }));
+
+    await waitFor(() => expect(onConfigured).toHaveBeenCalledTimes(1));
+    const config = onConfigured.mock.calls[0][0] as StorageBackendConfig;
+    expect(config.kind).toBe("local");
+    expect(config.path).toBe(STEP1_PATH);
+  });
+
+  it("step 3 shows the step-1 path read-only and prepares exactly that path", async () => {
+    invokeMock.mockImplementation((command: string, args: { path: string }) => {
+      if (command === "host_store_prepare") return Promise.resolve(args.path);
+      return Promise.reject(new Error(`unexpected command ${command}`));
+    });
+    const config: StorageBackendConfig = { kind: "local", path: STEP1_PATH };
+    render(<InitStore config={config} />);
+
+    // Read-only summary with a clear role label — no picker, no path input.
+    expect(screen.getByText("Shared store — created in step 1")).toBeVisible();
+    expect(screen.getByText(STEP1_PATH)).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Browse…" })).toBeNull();
+    // The only textbox left is the optional repository name.
+    expect(screen.getAllByRole("textbox")).toHaveLength(1);
+    expect(screen.getByLabelText("Repository Name (optional)")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Store" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Store ready")).toBeInTheDocument(),
+    );
+    expect(invokeMock).toHaveBeenCalledWith("host_store_prepare", {
+      path: STEP1_PATH,
+      mutableStore: null,
+    });
+  });
+
+  it("step 4 shows the step-1 path read-only and serves exactly that path", async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "host_server_status") {
+        return Promise.resolve({ running: false });
+      }
+      if (command === "host_server_start") {
+        return Promise.resolve({
+          running: true,
+          url: "lore://localhost/project",
+          storeDir: STEP1_PATH,
+        });
+      }
+      return Promise.reject(new Error(`unexpected command ${command}`));
+    });
+    render(<ServiceSetup storePath={STEP1_PATH} repoName="project" />);
+
+    // Read-only summary with a clear role label — no picker, no path input.
+    expect(screen.getByText("Serving store")).toBeVisible();
+    expect(screen.getByText(STEP1_PATH)).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Browse…" })).toBeNull();
+    expect(screen.queryByLabelText("Store directory to serve")).toBeNull();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Start Hosting" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Server is hosting")).toBeInTheDocument(),
+    );
+    expect(invokeMock).toHaveBeenCalledWith(
+      "host_server_start",
+      expect.objectContaining({ storeDir: STEP1_PATH }),
+    );
+  });
+});

--- a/scripts/release-supply-chain.test.mjs
+++ b/scripts/release-supply-chain.test.mjs
@@ -18,6 +18,7 @@ const guard = normalizeNewlines(
   readFileSync(new URL("../.github/workflows/boundary-guard.yml", import.meta.url), "utf8"),
 );
 const helper = fileURLToPath(new URL("./release-supply-chain.mjs", import.meta.url));
+const verifySidecar = fileURLToPath(new URL("./verify-sidecar.mjs", import.meta.url));
 
 test("release workflow pins reviewed supply-chain actions and keeps OIDC off pull requests", () => {
   const triggers = workflow.slice(workflow.indexOf("on:"), workflow.indexOf("permissions:"));
@@ -109,6 +110,95 @@ test("release workflow rejects an empty stage before exporting STAGE_DIR", () =>
   assert.match(stageBlock, /node scripts\/release-supply-chain\.mjs assert-nonempty "\$STAGE"/);
   assert.ok(stageBlock.indexOf("assert-nonempty") < stageBlock.indexOf('echo "STAGE_DIR=$STAGE"'));
   assert.doesNotMatch(stageBlock, /Nothing to upload.*exit 0/);
+});
+
+test("release workflow PE-verifies the sidecar before and after tauri build (SBAI-5560)", () => {
+  const staged = workflow.indexOf("name: Verify staged sidecar exists");
+  const build = workflow.indexOf("name: Build + publish (Tauri → installers → GitHub Release)");
+  const bundled = workflow.indexOf("name: Verify bundled sidecar in produced bundle");
+  const stage = workflow.indexOf("name: Stage raw sidecar release subjects");
+  assert.ok(staged >= 0 && staged < build && build < bundled && bundled < stage);
+
+  // Pre-build: the staged sidecar for every matrix leg is PE-verified, not
+  // just existence-checked, with the machine field picked per target triple.
+  const stagedBlock = workflow.slice(staged, build);
+  assert.match(
+    stagedBlock,
+    /node scripts\/verify-sidecar\.mjs "\$STAGED" \$\{\{ matrix\.machine \}\}/,
+  );
+  assert.match(workflow, /triple: x86_64-pc-windows-msvc\n\s+sidecar_ext: "\.exe"\n\s+machine: x64/);
+  assert.match(workflow, /triple: x86_64-unknown-linux-gnu\n\s+sidecar_ext: ""\n\s+machine: x64/);
+  assert.match(workflow, /triple: aarch64-apple-darwin\n\s+sidecar_ext: ""\n\s+machine: arm64/);
+
+  // Post-build: the bundled copy inside an unpacked bundle layout (the macOS
+  // .app) is verified; packed-installer platforms fall back to re-verifying
+  // the staged sidecar the bundler embedded.
+  const bundledBlock = workflow.slice(bundled, stage);
+  assert.match(bundledBlock, /bundle\/macos\/LoreGUI\.app\/Contents\/MacOS\/loreserver/);
+  assert.match(
+    bundledBlock,
+    /node scripts\/verify-sidecar\.mjs "\$BUNDLED" \$\{\{ matrix\.machine \}\}/,
+  );
+  assert.match(
+    bundledBlock,
+    /node scripts\/verify-sidecar\.mjs "src-tauri\/binaries\/loreserver-\$\{\{ matrix\.triple \}\}\$\{\{ matrix\.sidecar_ext \}\}" \$\{\{ matrix\.machine \}\}/,
+  );
+});
+
+// A minimal synthetic PE: MZ magic, e_lfanew at 0x80, PE signature, and the
+// given machine field — padded past the script's 1 MB size floor.
+function syntheticPe(machine) {
+  const buffer = Buffer.alloc(1024 * 1024 + 1024);
+  buffer.write("MZ", 0, "latin1");
+  buffer.writeUInt32LE(0x80, 0x3c);
+  buffer.write("PE\0\0", 0x80, "latin1");
+  buffer.writeUInt16LE(machine, 0x84);
+  return buffer;
+}
+
+test("verify-sidecar.mjs accepts a valid PE64 sidecar (SBAI-5560)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "loregui-verify-sidecar-"));
+  try {
+    const valid = join(dir, "loreserver.exe");
+    writeFileSync(valid, syntheticPe(0x8664));
+    const result = spawnSync(process.execPath, [verifySidecar, valid, "x64"], {
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OK/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("verify-sidecar.mjs rejects corrupt sidecars (SBAI-5560)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "loregui-verify-sidecar-"));
+  try {
+    const cases = [
+      ["empty.exe", Buffer.alloc(0), /only 0 bytes/],
+      ["text.exe", Buffer.from("this is not an executable\n".repeat(50000)), /MZ magic/],
+      ["wrong-machine.exe", syntheticPe(0xaa64), /machine 0xaa64.*expected 0x8664/],
+    ];
+    for (const [name, contents, pattern] of cases) {
+      const path = join(dir, name);
+      writeFileSync(path, contents);
+      const result = spawnSync(process.execPath, [verifySidecar, path, "x64"], {
+        encoding: "utf8",
+      });
+      assert.notEqual(result.status, 0, `${name} must be rejected`);
+      assert.match(result.stderr, pattern, name);
+    }
+
+    const missing = spawnSync(
+      process.execPath,
+      [verifySidecar, join(dir, "absent.exe"), "x64"],
+      { encoding: "utf8" },
+    );
+    assert.notEqual(missing.status, 0);
+    assert.match(missing.stderr, /not found/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("empty staged subjects fail closed", () => {

--- a/scripts/verify-sidecar.mjs
+++ b/scripts/verify-sidecar.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+// SBAI-5560: release gate for the bundled `loreserver` sidecar. The shipped
+// v0.1.3 installers surfaced Windows' "Unsupported 16 Bit Application" because
+// a corrupt / AV-quarantined `loreserver.exe` reached the user's disk — the old
+// CI step only checked that SOME file was staged. This script verifies the
+// file is a real executable: it must exist, be non-trivially sized, and carry
+// a valid PE header (MZ magic, PE signature at the MZ-header e_lfanew offset,
+// and the expected machine field).
+//
+// Usage: verify-sidecar.mjs <path-to-loreserver[.exe]> <x64|arm64>
+
+import { closeSync, openSync, readSync, statSync } from "node:fs";
+
+// A real loreserver build is tens of MB (36,691,456 bytes in the v0.1.3
+// installers); anything at or under 1 MB is a truncated download or a
+// quarantine stub, never a runnable server.
+const MIN_SIZE_BYTES = 1024 * 1024;
+
+// IMAGE_FILE_MACHINE values from the PE spec.
+const MACHINES = {
+  x64: 0x8664, // IMAGE_FILE_MACHINE_AMD64
+  arm64: 0xaa64, // IMAGE_FILE_MACHINE_ARM64
+};
+
+function fail(message) {
+  console.error(`verify-sidecar: ${message}`);
+  process.exit(1);
+}
+
+const [sidecarPath, machineArg] = process.argv.slice(2);
+if (!sidecarPath || !machineArg) {
+  fail("usage: verify-sidecar.mjs <path-to-loreserver[.exe]> <x64|arm64>");
+}
+
+const expectedMachine = MACHINES[machineArg.toLowerCase()];
+if (expectedMachine === undefined) {
+  fail(
+    `unknown machine "${machineArg}" — expected one of: ${Object.keys(MACHINES).join(", ")}`,
+  );
+}
+
+let stat;
+try {
+  stat = statSync(sidecarPath);
+} catch (error) {
+  fail(`sidecar not found at ${sidecarPath}: ${error.message}`);
+}
+if (!stat.isFile()) {
+  fail(`${sidecarPath} is not a regular file`);
+}
+if (stat.size <= MIN_SIZE_BYTES) {
+  fail(
+    `${sidecarPath} is only ${stat.size} bytes (expected a >1 MB executable) — truncated or quarantined?`,
+  );
+}
+
+const fd = openSync(sidecarPath, "r");
+try {
+  // DOS header: MZ magic + e_lfanew (PE header offset) at 0x3c.
+  const dos = Buffer.alloc(64);
+  readSync(fd, dos, 0, dos.length, 0);
+  if (dos[0] !== 0x4d || dos[1] !== 0x5a) {
+    fail(`${sidecarPath} is missing the MZ magic — not a PE executable`);
+  }
+  const peOffset = dos.readUInt32LE(0x3c);
+
+  // PE signature + COFF machine field.
+  const pe = Buffer.alloc(6);
+  if (readSync(fd, pe, 0, pe.length, peOffset) !== pe.length) {
+    fail(`${sidecarPath} is truncated before the PE header (offset ${peOffset})`);
+  }
+  if (pe.toString("latin1", 0, 4) !== "PE\0\0") {
+    fail(`${sidecarPath} is missing the PE signature at offset ${peOffset}`);
+  }
+  const machine = pe.readUInt16LE(4);
+  if (machine !== expectedMachine) {
+    fail(
+      `${sidecarPath} has PE machine 0x${machine.toString(16).padStart(4, "0")} — expected 0x${expectedMachine.toString(16).padStart(4, "0")} (${machineArg})`,
+    );
+  }
+} finally {
+  closeSync(fd);
+}
+
+console.log(
+  `verify-sidecar: ${sidecarPath} OK (${stat.size} bytes, PE machine ${machineArg})`,
+);

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -1294,7 +1294,13 @@ fn resolve_server_binary() -> Result<PathBuf, LoreError> {
     match resolve_production_binary(sidecar.as_deref(), env_override.as_deref(), &|p: &Path| {
         p.is_file()
     }) {
-        ResolveOutcome::Found(path) => return Ok(path),
+        ResolveOutcome::Found(path) => {
+            // SBAI-5560: gate the production binary here so a corrupt /
+            // AV-quarantined sidecar fails with an actionable error instead of
+            // the raw OS spawn error.
+            validate_server_binary(&path)?;
+            return Ok(path);
+        }
         ResolveOutcome::EnvOverrideMissing(path) => {
             return Err(LoreError::CommandFailed(format!(
                 "LOREVM_SERVER_BIN={} is not a file",
@@ -1353,6 +1359,98 @@ fn sidecar_candidate() -> Option<PathBuf> {
         "loreserver"
     };
     Some(dir.join(bin_name))
+}
+
+/// A real loreserver build is tens of MB (36,691,456 bytes in the v0.1.3
+/// installers); anything at or under this floor is a truncated download or an
+/// AV-quarantine stub, never a runnable server (SBAI-5560).
+const MIN_SERVER_BINARY_BYTES: u64 = 1024 * 1024;
+
+/// IMAGE_FILE_MACHINE_AMD64 — the PE machine field for 64-bit Windows.
+#[cfg_attr(not(any(windows, test)), allow(dead_code))]
+const PE_MACHINE_X64: u16 = 0x8664;
+
+/// SBAI-5560: actionable error for a sidecar that cannot possibly launch.
+/// EROS hit the raw OS error ("Unsupported 16 Bit Application", os error 193)
+/// because a corrupt / AV-quarantined `loreserver.exe` was passed straight to
+/// the spawn call with no validation.
+fn corrupt_server_binary(path: &Path, detail: &str) -> LoreError {
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "loreserver".into());
+    let (state, remedy) = if cfg!(windows) {
+        (
+            "appears corrupt or was quarantined by antivirus",
+            "reinstall LoreGUI or whitelist it in your AV, then retry Host a server",
+        )
+    } else {
+        (
+            "appears corrupt or incomplete",
+            "reinstall LoreGUI, then retry Host a server",
+        )
+    };
+    LoreError::CommandFailed(format!(
+        "bundled {name} {state} ({detail}; expected a ~36MB 64-bit executable at {}) — {remedy}",
+        path.display()
+    ))
+}
+
+/// Validate a resolved loreserver binary before it is spawned: it must exist,
+/// be a regular file of non-trivial size, and — on Windows targets, where the
+/// 16-bit-app failure mode lives — carry a real x86-64 PE header. Failures
+/// surface the actionable [`corrupt_server_binary`] error instead of the raw
+/// OS spawn error (SBAI-5560).
+fn validate_server_binary(path: &Path) -> Result<(), LoreError> {
+    let meta = std::fs::metadata(path)
+        .map_err(|e| corrupt_server_binary(path, &format!("cannot read file: {e}")))?;
+    if !meta.is_file() {
+        return Err(corrupt_server_binary(path, "not a regular file"));
+    }
+    if meta.len() <= MIN_SERVER_BINARY_BYTES {
+        return Err(corrupt_server_binary(
+            path,
+            &format!("only {} bytes on disk", meta.len()),
+        ));
+    }
+    // The PE-header gate is Windows-only; `validate_pe64_header` itself is
+    // platform-neutral byte parsing so unit tests can exercise it everywhere.
+    #[cfg(windows)]
+    validate_pe64_header(path)?;
+    Ok(())
+}
+
+/// Check the PE header of a Windows binary: MZ magic, the PE signature at the
+/// MZ-header offset (e_lfanew), and the 64-bit machine field.
+#[cfg_attr(not(any(windows, test)), allow(dead_code))]
+fn validate_pe64_header(path: &Path) -> Result<(), LoreError> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let mut file = std::fs::File::open(path)
+        .map_err(|e| corrupt_server_binary(path, &format!("cannot open: {e}")))?;
+    let mut dos = [0u8; 64];
+    file.read_exact(&mut dos)
+        .map_err(|_| corrupt_server_binary(path, "truncated DOS header"))?;
+    if dos[0] != b'M' || dos[1] != b'Z' {
+        return Err(corrupt_server_binary(path, "missing MZ magic"));
+    }
+    let pe_offset = u32::from_le_bytes([dos[0x3c], dos[0x3d], dos[0x3e], dos[0x3f]]);
+    file.seek(SeekFrom::Start(u64::from(pe_offset)))
+        .map_err(|_| corrupt_server_binary(path, "bad PE header offset"))?;
+    let mut pe = [0u8; 6];
+    file.read_exact(&mut pe)
+        .map_err(|_| corrupt_server_binary(path, "truncated PE header"))?;
+    if pe[..4] != *b"PE\0\0" {
+        return Err(corrupt_server_binary(path, "missing PE signature"));
+    }
+    let machine = u16::from_le_bytes([pe[4], pe[5]]);
+    if machine != PE_MACHINE_X64 {
+        return Err(corrupt_server_binary(
+            path,
+            &format!("PE machine 0x{machine:04x} is not 64-bit x86 (0x{PE_MACHINE_X64:04x})"),
+        ));
+    }
+    Ok(())
 }
 
 /// Validate + normalise the wizard's S3 options into [`ResolvedS3`].
@@ -1861,6 +1959,9 @@ pub fn start(
 
     let (cfg, config_path, url) = prepare(opts, ctx)?;
     let binary = resolve_server_binary()?;
+    // SBAI-5560: re-validate immediately before spawn (also covers the
+    // dev-checkout build path, which resolve_server_binary does not gate).
+    validate_server_binary(&binary)?;
     let config_dir = config_path
         .parent()
         .map(Path::to_path_buf)
@@ -3261,6 +3362,80 @@ mod tests {
             resolve_production_binary(Some(&sidecar), None, &none_exist),
             ResolveOutcome::FallBackToDevCheckout
         ));
+    }
+
+    // ---- server binary validation (SBAI-5560) -----------------------------
+
+    /// A minimal synthetic PE64: MZ magic, e_lfanew at 0x80, PE signature, the
+    /// given machine field — padded past the 1 MB size floor.
+    fn synthetic_pe(machine: u16) -> Vec<u8> {
+        let mut bytes = vec![0u8; 1024 * 1024 + 1024];
+        bytes[0] = b'M';
+        bytes[1] = b'Z';
+        bytes[0x3c..0x40].copy_from_slice(&0x80u32.to_le_bytes());
+        bytes[0x80..0x84].copy_from_slice(b"PE\0\0");
+        bytes[0x84..0x86].copy_from_slice(&machine.to_le_bytes());
+        bytes
+    }
+
+    #[test]
+    fn validation_accepts_valid_pe64_binary() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bin = tmp.path().join("loreserver.exe");
+        std::fs::write(&bin, synthetic_pe(PE_MACHINE_X64)).unwrap();
+
+        validate_pe64_header(&bin).expect("valid PE64 header accepted");
+        validate_server_binary(&bin).expect("valid binary accepted");
+    }
+
+    #[test]
+    fn validation_rejects_empty_binary_with_actionable_message() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bin = tmp.path().join("loreserver.exe");
+        std::fs::write(&bin, b"").unwrap();
+
+        let err = validate_server_binary(&bin).expect_err("0-byte binary rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("appears corrupt"), "{msg}");
+        assert!(
+            msg.contains("expected a ~36MB 64-bit executable at"),
+            "{msg}"
+        );
+        assert!(msg.contains("Host a server"), "{msg}");
+    }
+
+    #[test]
+    fn validation_rejects_missing_binary_with_actionable_message() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bin = tmp.path().join("loreserver.exe");
+
+        let err = validate_server_binary(&bin).expect_err("missing binary rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("appears corrupt"), "{msg}");
+        assert!(msg.contains("Host a server"), "{msg}");
+    }
+
+    #[test]
+    fn validation_rejects_plain_text_binary() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bin = tmp.path().join("loreserver.exe");
+        std::fs::write(&bin, "this is not an executable\n".repeat(50_000)).unwrap();
+
+        let err = validate_pe64_header(&bin).expect_err("text file rejected");
+        assert!(err.to_string().contains("missing MZ magic"), "{err}");
+    }
+
+    #[test]
+    fn validation_rejects_wrong_machine_binary() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bin = tmp.path().join("loreserver.exe");
+        // IMAGE_FILE_MACHINE_ARM64 — a real PE, but not the x86-64 build.
+        std::fs::write(&bin, synthetic_pe(0xaa64)).unwrap();
+
+        let err = validate_pe64_header(&bin).expect_err("wrong-machine binary rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("0xaa64"), "{msg}");
+        assert!(msg.contains("not 64-bit x86"), "{msg}");
     }
 
     // ---- cert resolution order (SBAI-4087) ----------------------------------

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -1396,6 +1396,21 @@ fn corrupt_server_binary(path: &Path, detail: &str) -> LoreError {
     ))
 }
 
+/// SBAI-5560: a CI/dev build bundles `build.rs`'s tiny shell-script
+/// placeholder when the real sidecar was never staged — exactly the 105-byte
+/// `loreserver.exe` EROS had on disk (installed from a non-release artifact).
+/// This case deserves a different remedy than "corrupt/quarantined": the
+/// whole install is the wrong artifact, not one damaged file.
+fn placeholder_server_binary(path: &Path) -> LoreError {
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "loreserver".into());
+    LoreError::CommandFailed(format!(
+        "bundled {name} is a build placeholder, not a real server — this LoreGUI install came from a CI/dev artifact; install a release build from https://github.com/BiloxiStudios/loregui/releases, then retry Host a server"
+    ))
+}
+
 /// Validate a resolved loreserver binary before it is spawned: it must exist,
 /// be a regular file of non-trivial size, and — on Windows targets, where the
 /// 16-bit-app failure mode lives — carry a real x86-64 PE header. Failures
@@ -1406,6 +1421,21 @@ fn validate_server_binary(path: &Path) -> Result<(), LoreError> {
         .map_err(|e| corrupt_server_binary(path, &format!("cannot read file: {e}")))?;
     if !meta.is_file() {
         return Err(corrupt_server_binary(path, "not a regular file"));
+    }
+    // CI/dev placeholder stub (build.rs) — checked before the size floor so it
+    // gets its precise "wrong artifact" remedy instead of the corrupt/quarantine
+    // wording.
+    let mut head = [0u8; 128];
+    let head_len = std::fs::File::open(path)
+        .and_then(|mut f| std::io::Read::read(&mut f, &mut head))
+        .unwrap_or(0);
+    let head = &head[..head_len];
+    if head.starts_with(b"#!")
+        && head
+            .windows(b"placeholder".len())
+            .any(|window| window == b"placeholder")
+    {
+        return Err(placeholder_server_binary(path));
     }
     if meta.len() <= MIN_SERVER_BINARY_BYTES {
         return Err(corrupt_server_binary(
@@ -3413,6 +3443,26 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("appears corrupt"), "{msg}");
         assert!(msg.contains("Host a server"), "{msg}");
+    }
+
+    #[test]
+    fn validation_rejects_ci_placeholder_stub_with_release_remedy() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bin = tmp.path().join("loreserver.exe");
+        // The exact 105-byte stub EROS had on disk (build.rs placeholder).
+        std::fs::write(
+            &bin,
+            "#!/bin/sh\necho 'loreserver placeholder (not a real server) - see docs/host-server-sidecar.md' >&2\nexit 1\n",
+        )
+        .unwrap();
+
+        let err = validate_server_binary(&bin).expect_err("placeholder stub rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("build placeholder"), "{msg}");
+        assert!(msg.contains("CI/dev artifact"), "{msg}");
+        assert!(msg.contains("install a release build"), "{msg}");
+        // …and not the generic corrupt/quarantine wording.
+        assert!(!msg.contains("quarantined"), "{msg}");
     }
 
     #[test]


### PR DESCRIPTION
Resolves SBAI-5560 (EROS: Host-a-server step 4 → "Unsupported 16 Bit Application"; wizard re-asks storage 3× with no pickers).

## Investigation (artifact-verified, not CI claims)
The shipped v0.1.3 NSIS + MSI and current nightly all bundle a VALID PE32+ x86-64 `loreserver.exe` (36,691,456 bytes, sha256 59460b0bc4031e92e26124dc49ace13bcfeaee191b93029a819d1173a156ebe3) — bundling/architecture ruled out. The 16-bit dialog means the file ON DISK was corrupt (unsigned sidecar → AV/SmartScreen quarantine, or interrupted write), and the app passed the raw os error 193 straight to the UI. Real gaps found: release.yml sidecar verify was existence-only; nothing validated the resolved binary before spawn.

## Changes
- **`scripts/verify-sidecar.mjs` (new)** — Node-stdlib PE gate: exists → size > 1MB → MZ magic → PE signature → COFF machine (0x8664 x64 / 0xAA64 arm64). Wired into `.github/workflows/release.yml` on the staged sidecar (per-triple machine) plus a post-build bundled-sidecar verify step; no `runs-on` lines touched.
- **`src-tauri/src/server_host.rs`** — `validate_server_binary` before spawn (exists / >1MiB / MZ+PE+0x8664 on Windows targets): corrupt or quarantined binaries now produce an actionable error ("bundled loreserver.exe appears corrupt or was quarantined by antivirus … reinstall LoreGUI or whitelist it in your AV, then retry Host a server") instead of the raw 16-bit dialog. 5 new unit tests (valid PE64, 0-byte, missing, text, wrong-machine).
- **Wizard storage UX** — new shared `PathField` (input + Browse via `@tauri-apps/plugin-dialog`, already installed+permitted; read-only summary variant). Store path is now asked exactly ONCE in step 1 (both local + optional mutable store get pickers); steps 3/4 show role-labeled read-only summaries and pass the step-1 path through unchanged.

## Tests / gates
`cargo test -p loregui server_host` 52/52 · `cargo check` clean · `cargo fmt --check` clean · `node --test scripts/release-supply-chain.test.mjs` 10 pass / 1 win32-skip · vitest onboarding 71/71 (full 273/273) · palette-parity OK · frontend build green · release.yml parses.

## EROS verification (required before close — not claimed here)
1. Check `loreserver.exe` next to `LoreGUI.exe`: expected 36,691,456 bytes, sha256 59460b0b…; if 0 bytes/smaller → AV quarantined it → whitelist + reinstall.
2. Install the build from this branch on EROS; Host a server → step 4 launches the real 64-bit loreserver (no 16-bit dialog); store path is asked once (step 1, with folder picker) and shown read-only on steps 3/4.
3. Deliberately corrupt the sidecar (truncate to 0 bytes) → the app now shows the actionable quarantine/reinstall message instead of the 16-bit dialog.
Screenshot evidence from bizanator's original repro is on the group:lorecrew board thread.