### PR TITLE
SBAI-5566: add escape route out of onboarding setup mode

### DIFF
--- a/frontend/src/App.spec.tsx
+++ b/frontend/src/App.spec.tsx
@@ -155,6 +155,35 @@ describe("App first-run / no-repo handling (#331)", () => {
     expect(screen.queryByText(/^no repository is open$/)).toBeNull();
   });
 
+  it("escapes a fresh-install onboarding trap via Skip and lands in the recoverable no-repo shell (SBAI-5566, SBAI-5573)", async () => {
+    routeInvoke();
+    render(<App />);
+
+    // Fresh install lands on the mode-select screen with no repo set up.
+    expect(
+      await screen.findByText(/Choose Your Setup Mode/i),
+    ).toBeInTheDocument();
+
+    // Previously there was no way out of this screen at all — closing from
+    // the tray and reopening just re-rendered it. The skip action must be
+    // reachable without picking a mode or completing any step.
+    fireEvent.click(
+      screen.getByRole("button", { name: /skip for now/i }),
+    );
+
+    // Skipping lands in the exact same recoverable shell as a normal
+    // "onboarded, no repo open" session — never a blank or stuck screen.
+    expect(await screen.findByText("no repository open")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Set Up Repository/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Choose Your Setup Mode/i)).toBeNull();
+
+    // The skip is persisted, so a tray close + reopen (re-mount) also lands
+    // in the recoverable shell instead of re-trapping the user.
+    expect(localStorage.getItem("loregui.onboarded")).toBe("true");
+  });
+
   it("surfaces CommandFailed repository-not-found errors instead of classifying them as startup", async () => {
     localStorage.setItem("loregui.onboarded", "true");
     routeInvoke({

--- a/frontend/src/onboarding/ModeSelect.spec.tsx
+++ b/frontend/src/onboarding/ModeSelect.spec.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import ModeSelect from "./ModeSelect";
+
+// SBAI-5566 / SBAI-5573: "Choose Your Setup Mode" is the very first screen a
+// fresh install lands on. Before this fix it had no exit at all — no Back
+// (nothing to go back to) and no way to reach the main app without picking a
+// mode and completing (or abandoning mid-way) the wizard. Closing from the
+// tray and reopening re-rendered this exact screen, so the trap persisted
+// across restarts.
+describe("ModeSelect escape route (SBAI-5566, SBAI-5573)", () => {
+  it("does not render a skip action when the caller doesn't provide one", () => {
+    render(<ModeSelect onModeSelect={vi.fn()} />);
+    expect(
+      screen.queryByRole("button", { name: /skip/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a visible skip action and invokes onSkip without requiring a mode pick", () => {
+    const onSkip = vi.fn();
+    render(<ModeSelect onModeSelect={vi.fn()} onSkip={onSkip} />);
+
+    const skipButton = screen.getByRole("button", {
+      name: /skip for now/i,
+    });
+    expect(skipButton).toBeVisible();
+
+    fireEvent.click(skipButton);
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the skip action available after a mode card is selected", () => {
+    const onSkip = vi.fn();
+    const onModeSelect = vi.fn();
+    render(<ModeSelect onModeSelect={onModeSelect} onSkip={onSkip} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /connect to a lore server/i }),
+    );
+    expect(onModeSelect).toHaveBeenCalledWith("client");
+
+    fireEvent.click(screen.getByRole("button", { name: /skip for now/i }));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/onboarding/ModeSelect.tsx
+++ b/frontend/src/onboarding/ModeSelect.tsx
@@ -5,9 +5,17 @@ export type OnboardingMode = "client" | "host";
 interface ModeSelectProps {
   /** Optional callback when a mode is selected. The onboarding shell can wire this. */
   onModeSelect?: (mode: OnboardingMode) => void;
+  /**
+   * Escape hatch out of onboarding entirely (loregui SBAI-5566/5573). This is
+   * the first screen a fresh install lands on and previously had no way back
+   * to the main app — closing/reopening just re-rendered this same screen.
+   * When provided, the caller should mark onboarding complete/skipped so the
+   * user lands in the usable no-repo shell instead of being trapped here.
+   */
+  onSkip?: () => void;
 }
 
-export default function ModeSelect({ onModeSelect }: ModeSelectProps) {
+export default function ModeSelect({ onModeSelect, onSkip }: ModeSelectProps) {
   const [selectedMode, setSelectedMode] = useState<OnboardingMode | null>(null);
 
   const handleSelect = (mode: OnboardingMode) => {
@@ -113,6 +121,18 @@ export default function ModeSelect({ onModeSelect }: ModeSelectProps) {
             onClick={handleContinue}
           >
             Continue with {selectedMode === "client" ? "Client" : "Host"} Mode
+          </button>
+        </div>
+      )}
+
+      {onSkip && (
+        <div className="onboarding-mode-skip">
+          <button
+            type="button"
+            className="onboarding-link"
+            onClick={onSkip}
+          >
+            Skip for now — open LoreGUI without setup
           </button>
         </div>
       )}

--- a/frontend/src/onboarding/OnboardingFlow.spec.tsx
+++ b/frontend/src/onboarding/OnboardingFlow.spec.tsx
@@ -8,10 +8,17 @@ const pendingReports = vi.hoisted(() => ({
 }));
 
 vi.mock("./ModeSelect", () => ({
-  default: ({ onModeSelect }: { onModeSelect: (mode: "client" | "host") => void }) => (
+  default: ({
+    onModeSelect,
+    onSkip,
+  }: {
+    onModeSelect: (mode: "client" | "host") => void;
+    onSkip?: () => void;
+  }) => (
     <div>
       <button onClick={() => onModeSelect("client")}>Choose client</button>
       <button onClick={() => onModeSelect("host")}>Choose host</button>
+      {onSkip && <button onClick={onSkip}>Mode select skip</button>}
     </div>
   ),
 }));
@@ -326,5 +333,50 @@ describe("explicit onboarding navigation state", () => {
     await act(async () => pendingReports.repository?.());
     forceNavigation("Finish");
     expect(onComplete).not.toHaveBeenCalled();
+  });
+});
+
+// SBAI-5566 / SBAI-5573: the mode-select screen and every wizard step must
+// offer a route out of onboarding that doesn't require finishing (or even
+// validly progressing through) the flow, so a user can never be trapped —
+// including across a tray close + reopen, since the trap previously
+// re-rendered the exact same unescapable screen every time.
+describe("escape routes out of onboarding (SBAI-5566, SBAI-5573)", () => {
+  it("forwards the mode-select skip action straight to onComplete", () => {
+    const onComplete = vi.fn();
+    render(<OnboardingFlow onComplete={onComplete} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Mode select skip" }));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a host-mode wizard step skip out even when idle/invalid", () => {
+    const onComplete = vi.fn();
+    render(<OnboardingFlow initialIntent="host" onComplete={onComplete} />);
+
+    // No Backend step interaction at all — the step is idle/unvalidated,
+    // so "Continue" is disabled, but "Skip setup for now" must still work.
+    expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Skip setup for now" }));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a client-mode wizard step skip out after navigating forward", () => {
+    const onComplete = vi.fn();
+    render(<OnboardingFlow initialIntent="connect" onComplete={onComplete} />);
+    fireEvent.click(screen.getByRole("button", { name: "Connect error" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Skip setup for now" }));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps Skip setup for now reachable after using Back", () => {
+    const onComplete = vi.fn();
+    render(<OnboardingFlow initialIntent="host" onComplete={onComplete} />);
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(
+      screen.getByRole("button", { name: "Mode select skip" }),
+    ).toBeVisible();
   });
 });

--- a/frontend/src/onboarding/OnboardingFlow.tsx
+++ b/frontend/src/onboarding/OnboardingFlow.tsx
@@ -259,6 +259,7 @@ export default function OnboardingFlow({
             setHostNextAction(null);
             setHostRepositoryResult({ status: "idle" });
           }}
+          onSkip={onComplete}
         />
       </div>
     );
@@ -435,6 +436,14 @@ export default function OnboardingFlow({
       <div className="onboarding-nav">
         <button className="onboarding-button" onClick={back}>
           Back
+        </button>
+        <button
+          type="button"
+          className="onboarding-link"
+          onClick={onComplete}
+          title="Leave setup and open LoreGUI. You can resume setup any time from the main app."
+        >
+          Skip setup for now
         </button>
         <button
           className="onboarding-button onboarding-button--primary"

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -414,6 +414,28 @@ h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; color: v
   border-color: var(--surface-error-text, var(--red));
 }
 
+/* Low-emphasis text link for optional exits (skip setup) --------------- */
+.onboarding-link {
+  background: none;
+  border: none;
+  padding: 4px;
+  font: inherit;
+  font-size: 13px;
+  color: var(--surface-base-text-secondary, var(--muted));
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.onboarding-link:hover {
+  color: var(--surface-primary-bg, var(--accent));
+}
+
+.onboarding-mode-skip {
+  display: flex;
+  justify-content: center;
+  margin-top: 12px;
+}
+
 /* URL + copy-button row for the host-server connection URL. */
 .onboarding-url-row {
   display: flex;


### PR DESCRIPTION
## Summary
- `ModeSelect` (the "Choose Your Setup Mode" screen, the very first thing a fresh install renders) had no exit at all — no Back, no cancel, no way to reach the main app. Since onboarding gates the entire app render, closing the app from the tray and reopening just re-rendered the same trapped screen.
- Add a "Skip for now" link on `ModeSelect` and a "Skip setup for now" action in every wizard step's nav (both host and client flows), wired to the same `onComplete` the flow already calls on a normal finish.
- Skipping lands the user in the existing "onboarded, no repo open" shell, which already ships a "Set Up Repository" re-entry button — so the recoverable hub already existed, it just wasn't reachable from inside onboarding.

Duplicates SBAI-5573 (closed Done, but its own comment says "tracking there" pointing back at SBAI-5566 — no actual fix had landed on either ticket before this PR). Two workers (GLM, Qwen) and the manager attempted this ticket without shipping a PR; escalated to Boss per pipeline last-resort protocol.

## Test plan
- [x] `npx vitest run` — full suite green, 300/300 (26 files)
- [x] `npx tsc --noEmit` — clean
- [x] New `ModeSelect.spec.tsx`: skip button hidden when no `onSkip` provided, visible + wired when provided, still reachable after picking a mode card
- [x] `OnboardingFlow.spec.tsx`: mode-select skip forwards to `onComplete`; wizard-step skip works even when the current step is idle/invalid (not gated on `navigationReady`); skip stays reachable after `Back`
- [x] `App.spec.tsx`: end-to-end — fresh install renders "Choose Your Setup Mode" → click Skip → lands in "no repository open" shell with "Set Up Repository" visible and `loregui.onboarded` persisted to localStorage (so a tray close/reopen also lands in the recoverable shell)
- [ ] Real Windows GUI screenshot verification — not available from this session (no interactive Windows GUI access); the acceptance criteria's screenshot requirement should be verified by a human or the Windows build/test lane before final close

🤖 Generated with [Claude Code](https://claude.com/claude-code)