### PR TITLE
SBAI-5594: bump lore pin 826ad5d20 → 9664606f5 (JWT aud apex-match widening)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1416,7 +1416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2226,7 +2226,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2761,7 +2761,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 [[package]]
 name = "lore"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
+source = "git+https://github.com/EpicGames/lore.git?rev=9664606f5a4708606642a6670a57d16bd3d37596#9664606f5a4708606642a6670a57d16bd3d37596"
 dependencies = [
  "anyhow",
  "bitcode",
@@ -2796,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "lore-base"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
+source = "git+https://github.com/EpicGames/lore.git?rev=9664606f5a4708606642a6670a57d16bd3d37596#9664606f5a4708606642a6670a57d16bd3d37596"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -2825,7 +2825,7 @@ dependencies = [
 [[package]]
 name = "lore-credential"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
+source = "git+https://github.com/EpicGames/lore.git?rev=9664606f5a4708606642a6670a57d16bd3d37596#9664606f5a4708606642a6670a57d16bd3d37596"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
@@ -2846,7 +2846,7 @@ dependencies = [
 [[package]]
 name = "lore-error-set"
 version = "0.1.0"
-source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
+source = "git+https://github.com/EpicGames/lore.git?rev=9664606f5a4708606642a6670a57d16bd3d37596#9664606f5a4708606642a6670a57d16bd3d37596"
 dependencies = [
  "lore-error-set-macro",
 ]
@@ -2854,7 +2854,7 @@ dependencies = [
 [[package]]
 name = "lore-error-set-macro"
 version = "0.1.0"
-source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
+source = "git+https://github.com/EpicGames/lore.git?rev=9664606f5a4708606642a6670a57d16bd3d37596#9664606f5a4708606642a6670a57d16bd3d37596"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "lore-macro"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
+source = "git+https://github.com/EpicGames/lore.git?rev=9664606f5a4708606642a6670a57d16bd3d37596#9664606f5a4708606642a6670a57d16bd3d37596"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "lore-notification"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
+source = "git+https://github.com/EpicGames/lore.git?rev=9664606f5a4708606642a6670a57d16bd3d37596#9664606f5a4708606642a6670a57d16bd3d37596"
 dependencies = [
  "async-trait",
  "lore-base",
@@ -2890,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "lore-proto"
 version = "0.1.60"
-source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
+source = "git+https://github.com/EpicGames/lore.git?rev=9664606f5a4708606642a6670a57d16bd3d37596#9664606f5a4708606642a6670a57d16bd3d37596"
 dependencies = [
  "lore-base",
  "prost",
@@ -2903,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "lore-revision"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
+source = "git+https://github.com/EpicGames/lore.git?rev=9664606f5a4708606642a6670a57d16bd3d37596#9664606f5a4708606642a6670a57d16bd3d37596"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2963,7 +2963,7 @@ dependencies = [
 [[package]]
 name = "lore-storage"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
+source = "git+https://github.com/EpicGames/lore.git?rev=9664606f5a4708606642a6670a57d16bd3d37596#9664606f5a4708606642a6670a57d16bd3d37596"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -3000,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "lore-telemetry"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
+source = "git+https://github.com/EpicGames/lore.git?rev=9664606f5a4708606642a6670a57d16bd3d37596#9664606f5a4708606642a6670a57d16bd3d37596"
 dependencies = [
  "axum",
  "http",
@@ -3023,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "lore-transport"
 version = "0.8.6-nightly"
-source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
+source = "git+https://github.com/EpicGames/lore.git?rev=9664606f5a4708606642a6670a57d16bd3d37596#9664606f5a4708606642a6670a57d16bd3d37596"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3361,7 +3361,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4115,7 +4115,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools",
  "log",
  "multimap",
@@ -4224,7 +4224,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.11.13"
-source = "git+https://github.com/EpicGames/lore.git?rev=826ad5d20ff4f5814101c946df127cef8253ada3#826ad5d20ff4f5814101c946df127cef8253ada3"
+source = "git+https://github.com/EpicGames/lore.git?rev=9664606f5a4708606642a6670a57d16bd3d37596#9664606f5a4708606642a6670a57d16bd3d37596"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -4261,9 +4261,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4575,7 +4575,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4633,7 +4633,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5719,7 +5719,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6680,7 +6680,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,10 @@ tracing = "0.1"
 # deliberate, manager-owned PR. SBAI-3685 / SBAI-3700 / SBAI-5434 / SBAI-5473 / SBAI-5488 / SBAI-5490.
 # 826ad5d2 = authless user-info parity: exchange operations return typed
 # NotSupported (code 18), and user-info operations forward that error unchanged.
-lore = { git = "https://github.com/EpicGames/lore.git", rev = "826ad5d20ff4f5814101c946df127cef8253ada3" }
+# 9664606f5 (SBAI-5594) = lore-credential JWT `aud` root-domain check now also
+# accepts the apex domain for leading-dot entries (strict widening, upstream
+# bugfix); the other two commits in the gap are test-only.
+lore = { git = "https://github.com/EpicGames/lore.git", rev = "9664606f5a4708606642a6670a57d16bd3d37596" }
 
 # REQUIRED: upstream `lore` patches quinn-proto to a vendored fork that adds
 # `TransportErrorCode::is_crypto()`. A [patch] does NOT propagate through a git
@@ -28,4 +31,4 @@ lore = { git = "https://github.com/EpicGames/lore.git", rev = "826ad5d20ff4f5814
 # ("no method named `is_crypto`"). Same fork, same exact commit, inside the
 # lore repo. Every consumer of the `lore` crate needs this. SBAI-3685 / SBAI-5434 / SBAI-5473 / SBAI-5488 / SBAI-5490.
 [patch.crates-io]
-quinn-proto = { git = "https://github.com/EpicGames/lore.git", rev = "826ad5d20ff4f5814101c946df127cef8253ada3" }
+quinn-proto = { git = "https://github.com/EpicGames/lore.git", rev = "9664606f5a4708606642a6670a57d16bd3d37596" }

--- a/scripts/exact-pin-authless-contract.mjs
+++ b/scripts/exact-pin-authless-contract.mjs
@@ -10,8 +10,12 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+// Exact-pin contract: must move in lockstep with Cargo.toml's `lore` and
+// [patch.crates-io].quinn-proto revs on every pin bump. SBAI-5594:
+// 826ad5d20 → 9664606f5 (JWT aud apex-match widening; the integration gate
+// caught this constant still pointing at the old pin — working as designed).
 export const EXPECTED_LORE_REV =
-  "826ad5d20ff4f5814101c946df127cef8253ada3";
+  "9664606f5a4708606642a6670a57d16bd3d37596";
 
 function manifestPin(manifest, dependency) {
   const escaped = dependency.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/scripts/exact-pin-authless-contract.test.mjs
+++ b/scripts/exact-pin-authless-contract.test.mjs
@@ -10,7 +10,7 @@ import {
   verifyUpstreamAuthlessSource,
 } from "./exact-pin-authless-contract.mjs";
 
-const EXPECTED = "826ad5d20ff4f5814101c946df127cef8253ada3";
+const EXPECTED = "9664606f5a4708606642a6670a57d16bd3d37596";
 const WRONG = "9179c6dc7cd14931af5b66beb3b2e186907f6360";
 
 function fixture({ lore = EXPECTED, quinn = EXPECTED, lockLore = EXPECTED, lockQuinn = EXPECTED } = {}) {
@@ -68,24 +68,28 @@ test("fails closed when the quinn-proto patch pin is missing", () => {
   );
 });
 
+// Negative-case regexes derive the required-rev prefix from EXPECTED so a pin
+// bump only has to move the constant (SBAI-5594).
+const EXPECTED_SHORT = EXPECTED.slice(0, 7);
+
 test("fails closed when the lore manifest pin is wrong", () => {
   assert.throws(
     () => verifyManifestAndLock(fixture({ lore: WRONG }), EXPECTED),
-    /lore manifest pin.*9179c6d.*826ad5d/i,
+    new RegExp(`lore manifest pin.*9179c6d.*${EXPECTED_SHORT}`, "i"),
   );
 });
 
 test("fails closed when the resolved lore lock source is wrong", () => {
   assert.throws(
     () => verifyManifestAndLock(fixture({ lockLore: WRONG }), EXPECTED),
-    /lore lock source.*9179c6d.*826ad5d/i,
+    new RegExp(`lore lock source.*9179c6d.*${EXPECTED_SHORT}`, "i"),
   );
 });
 
 test("fails closed when the resolved quinn-proto lock source is wrong", () => {
   assert.throws(
     () => verifyManifestAndLock(fixture({ lockQuinn: WRONG }), EXPECTED),
-    /quinn-proto lock source.*9179c6d.*826ad5d/i,
+    new RegExp(`quinn-proto lock source.*9179c6d.*${EXPECTED_SHORT}`, "i"),
   );
 });
 


### PR DESCRIPTION
Resolves SBAI-5594. Manager-owned pin bump per the Cargo.toml comment convention.

## Delta (exact-diff evidence, parity watcher 9c8ca482d → 9664606f5; real pin gap 826ad5d20..9664606f5 = 3 commits)
- `1a0e367` — test-only (`--search-nearest`); previously assessed no-op.
- `9664606` — test-only known-failing bug reproduction (directory↔file sync).
- `9c8ca48` — the one source change: `lore-credential/src/jwt.rs` `domain_in_root_domains` now also accepts the apex domain for leading-dot JWT `aud` entries (strict widening, upstream bugfix, upstream tests included; `attacker…` domains still rejected). Callers are client-side login/exchange/token-store paths loregui exposes via `auth login_interactive` / `login_with_token`.

Untouched: lore-server crate + packaging/sidecar build, urc_status seam, editor-hook seam, all manifests/workflows/vendor.

## Change
`Cargo.toml`: `lore` git dep + `quinn-proto` [patch.crates-io] rev → `9664606f5a4708606642a6670a57d16bd3d37596` (lockstep, with audit comment). `Cargo.lock` regenerated. No license-bundle drift (regenerated bundles are byte-identical — no dep set change).

## Verification
- `cargo check -p loregui` green (1m02s).
- `cargo test -p lore-vm --lib` 755/755.
- `scripts/upstream-lore-parity.mjs` on the new pin: 140/140 ops, no drifted ops, no drifted shared schemas (LoreGlobalArgs fingerprint intact incl. `working_directory`), 2 known intentional orphans.
- `scripts/gen-licenses.sh` regenerated — no diff (all permissive).
- `scripts/check-open-boundary.sh` OK.
- Login smoke against a live test server not run here (no server in this environment) — upstream ships the apex-match tests; our auth suites pass unchanged. Flagged honestly on the ticket.