### PR TITLE
SBAI-5808: validate release sidecars per target format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,15 +44,12 @@ jobs:
           - platform: windows-latest
             triple: x86_64-pc-windows-msvc
             sidecar_ext: ".exe"
-            machine: x64
           - platform: ubuntu-22.04
             triple: x86_64-unknown-linux-gnu
             sidecar_ext: ""
-            machine: x64
           - platform: macos-latest
             triple: aarch64-apple-darwin
             sidecar_ext: ""
-            machine: arm64
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
@@ -221,10 +218,35 @@ jobs:
             exit 1
           fi
           ls -la "$STAGED"
-          # SBAI-5560: existence alone shipped a corrupt/quarantined sidecar as
-          # Windows' "Unsupported 16 Bit Application" — gate on a real PE
-          # header (MZ magic, PE signature, expected machine field) + size.
-          node scripts/verify-sidecar.mjs "$STAGED" ${{ matrix.machine }}
+          # SBAI-5560 / SBAI-5808: existence alone shipped a corrupt or
+          # quarantined sidecar. Validate the real executable header and
+          # architecture for this release target, plus the common size floor.
+          node scripts/verify-sidecar.mjs "$STAGED" ${{ matrix.triple }}
+
+      - name: Prove corrupt sidecar gate rejects target format
+        shell: bash
+        run: |
+          set -euo pipefail
+          STAGED="src-tauri/binaries/loreserver-${{ matrix.triple }}${{ matrix.sidecar_ext }}"
+          CORRUPT="${RUNNER_TEMP}/loreserver-corrupt-${{ matrix.triple }}${{ matrix.sidecar_ext }}"
+          cp "$STAGED" "$CORRUPT"
+          node -e 'const fs = require("node:fs"); const fd = fs.openSync(process.argv[1], "r+"); try { fs.writeSync(fd, Buffer.alloc(4), 0, 4, 0); } finally { fs.closeSync(fd); }' "$CORRUPT"
+          case "${{ matrix.triple }}" in
+            x86_64-pc-windows-msvc) EXPECTED_FAILURE="PE MZ magic" ;;
+            x86_64-unknown-linux-gnu) EXPECTED_FAILURE="ELF magic" ;;
+            aarch64-apple-darwin) EXPECTED_FAILURE="Mach-O 64-bit magic" ;;
+            *) echo "FATAL: no Rule 40 expectation for ${{ matrix.triple }}" >&2; exit 1 ;;
+          esac
+          if VERIFY_OUTPUT="$(node scripts/verify-sidecar.mjs "$CORRUPT" ${{ matrix.triple }} 2>&1)"; then
+            echo "FATAL: corrupt ${{ matrix.triple }} sidecar passed validation" >&2
+            exit 1
+          fi
+          printf '%s\n' "$VERIFY_OUTPUT"
+          if ! grep -Fq "$EXPECTED_FAILURE" <<<"$VERIFY_OUTPUT"; then
+            echo "FATAL: corrupt ${{ matrix.triple }} sidecar failed for an unexpected reason" >&2
+            exit 1
+          fi
+          echo "Rule 40 enforcement proved: corrupt ${{ matrix.triple }} sidecar was rejected for $EXPECTED_FAILURE."
 
       # Windows Authenticode signing (non-blocking). When the WINDOWS_CERTIFICATE
       # secret (base64-encoded PKCS#12 .pfx) is present we import it into a temp
@@ -314,10 +336,10 @@ jobs:
           done
           if [ -n "$BUNDLED" ]; then
             echo "Verifying bundled sidecar at $BUNDLED"
-            node scripts/verify-sidecar.mjs "$BUNDLED" ${{ matrix.machine }}
+            node scripts/verify-sidecar.mjs "$BUNDLED" ${{ matrix.triple }}
           else
             echo "Packed-installer platform (no unpacked bundle dir) — re-verifying the staged sidecar the bundler embedded."
-            node scripts/verify-sidecar.mjs "src-tauri/binaries/loreserver-${{ matrix.triple }}${{ matrix.sidecar_ext }}" ${{ matrix.machine }}
+            node scripts/verify-sidecar.mjs "src-tauri/binaries/loreserver-${{ matrix.triple }}${{ matrix.sidecar_ext }}" ${{ matrix.triple }}
           fi
 
       # ── Raw sidecar binaries for StudioBrain desktop bundling (SBAI-4683) ──

--- a/scripts/release-supply-chain.test.mjs
+++ b/scripts/release-supply-chain.test.mjs
@@ -112,23 +112,39 @@ test("release workflow rejects an empty stage before exporting STAGE_DIR", () =>
   assert.doesNotMatch(stageBlock, /Nothing to upload.*exit 0/);
 });
 
-test("release workflow PE-verifies the sidecar before and after tauri build (SBAI-5560)", () => {
+test("release workflow validates each target format and proves corrupt sidecars are rejected", () => {
   const staged = workflow.indexOf("name: Verify staged sidecar exists");
+  const corrupt = workflow.indexOf("name: Prove corrupt sidecar gate rejects target format");
   const build = workflow.indexOf("name: Build + publish (Tauri → installers → GitHub Release)");
   const bundled = workflow.indexOf("name: Verify bundled sidecar in produced bundle");
   const stage = workflow.indexOf("name: Stage raw sidecar release subjects");
-  assert.ok(staged >= 0 && staged < build && build < bundled && bundled < stage);
+  assert.ok(
+    staged >= 0 &&
+      staged < corrupt &&
+      corrupt < build &&
+      build < bundled &&
+      bundled < stage,
+  );
 
-  // Pre-build: the staged sidecar for every matrix leg is PE-verified, not
-  // just existence-checked, with the machine field picked per target triple.
-  const stagedBlock = workflow.slice(staged, build);
+  // Pre-build: every matrix leg validates the real staged binary against its
+  // target triple, then corrupts a copy and proves the same validator rejects it.
+  const stagedBlock = workflow.slice(staged, corrupt);
   assert.match(
     stagedBlock,
-    /node scripts\/verify-sidecar\.mjs "\$STAGED" \$\{\{ matrix\.machine \}\}/,
+    /node scripts\/verify-sidecar\.mjs "\$STAGED" \$\{\{ matrix\.triple \}\}/,
   );
-  assert.match(workflow, /triple: x86_64-pc-windows-msvc\n\s+sidecar_ext: "\.exe"\n\s+machine: x64/);
-  assert.match(workflow, /triple: x86_64-unknown-linux-gnu\n\s+sidecar_ext: ""\n\s+machine: x64/);
-  assert.match(workflow, /triple: aarch64-apple-darwin\n\s+sidecar_ext: ""\n\s+machine: arm64/);
+  const corruptBlock = workflow.slice(corrupt, build);
+  assert.match(corruptBlock, /cp "\$STAGED" "\$CORRUPT"/);
+  assert.match(corruptBlock, /Buffer\.alloc\(4\)/);
+  assert.match(corruptBlock, /x86_64-pc-windows-msvc\) EXPECTED_FAILURE="PE MZ magic"/);
+  assert.match(corruptBlock, /x86_64-unknown-linux-gnu\) EXPECTED_FAILURE="ELF magic"/);
+  assert.match(corruptBlock, /aarch64-apple-darwin\) EXPECTED_FAILURE="Mach-O 64-bit magic"/);
+  assert.match(
+    corruptBlock,
+    /if VERIFY_OUTPUT="\$\(node scripts\/verify-sidecar\.mjs "\$CORRUPT" \$\{\{ matrix\.triple \}\} 2>&1\)"; then/,
+  );
+  assert.match(corruptBlock, /grep -Fq "\$EXPECTED_FAILURE"/);
+  assert.match(corruptBlock, /Rule 40 enforcement proved/);
 
   // Post-build: the bundled copy inside an unpacked bundle layout (the macOS
   // .app) is verified; packed-installer platforms fall back to re-verifying
@@ -137,52 +153,188 @@ test("release workflow PE-verifies the sidecar before and after tauri build (SBA
   assert.match(bundledBlock, /bundle\/macos\/LoreGUI\.app\/Contents\/MacOS\/loreserver/);
   assert.match(
     bundledBlock,
-    /node scripts\/verify-sidecar\.mjs "\$BUNDLED" \$\{\{ matrix\.machine \}\}/,
+    /node scripts\/verify-sidecar\.mjs "\$BUNDLED" \$\{\{ matrix\.triple \}\}/,
   );
   assert.match(
     bundledBlock,
-    /node scripts\/verify-sidecar\.mjs "src-tauri\/binaries\/loreserver-\$\{\{ matrix\.triple \}\}\$\{\{ matrix\.sidecar_ext \}\}" \$\{\{ matrix\.machine \}\}/,
+    /node scripts\/verify-sidecar\.mjs "src-tauri\/binaries\/loreserver-\$\{\{ matrix\.triple \}\}\$\{\{ matrix\.sidecar_ext \}\}" \$\{\{ matrix\.triple \}\}/,
   );
 });
 
-// A minimal synthetic PE: MZ magic, e_lfanew at 0x80, PE signature, and the
-// given machine field — padded past the script's 1 MB size floor.
-function syntheticPe(machine) {
-  const buffer = Buffer.alloc(1024 * 1024 + 1024);
+const SYNTHETIC_EXECUTABLE_SIZE = 1024 * 1024 + 1024;
+
+function syntheticPe(machine, { executable = true } = {}) {
+  const buffer = Buffer.alloc(SYNTHETIC_EXECUTABLE_SIZE);
   buffer.write("MZ", 0, "latin1");
   buffer.writeUInt32LE(0x80, 0x3c);
   buffer.write("PE\0\0", 0x80, "latin1");
   buffer.writeUInt16LE(machine, 0x84);
+  buffer.writeUInt16LE(1, 0x86); // NumberOfSections
+  buffer.writeUInt16LE(0xf0, 0x94); // SizeOfOptionalHeader (PE32+)
+  buffer.writeUInt16LE(executable ? 0x0022 : 0x0020, 0x96); // Characteristics
+  buffer.writeUInt16LE(0x020b, 0x98); // PE32+ optional-header magic
   return buffer;
 }
 
-test("verify-sidecar.mjs accepts a valid PE64 sidecar (SBAI-5560)", () => {
+function syntheticElf(machine, { fileType = 3 } = {}) {
+  const buffer = Buffer.alloc(SYNTHETIC_EXECUTABLE_SIZE);
+  buffer.set([0x7f, 0x45, 0x4c, 0x46], 0);
+  buffer[4] = 2; // ELFCLASS64
+  buffer[5] = 1; // ELFDATA2LSB
+  buffer[6] = 1; // EV_CURRENT
+  buffer.writeUInt16LE(fileType, 16); // ET_DYN (PIE) by default
+  buffer.writeUInt16LE(machine, 18);
+  buffer.writeUInt32LE(1, 20); // EV_CURRENT
+  return buffer;
+}
+
+function syntheticMachO(cpuType, { littleEndian = true, fileType = 2 } = {}) {
+  const buffer = Buffer.alloc(SYNTHETIC_EXECUTABLE_SIZE);
+  if (littleEndian) {
+    buffer.writeUInt32LE(0xfeedfacf, 0); // MH_MAGIC_64
+    buffer.writeUInt32LE(cpuType, 4);
+    buffer.writeUInt32LE(fileType, 12);
+  } else {
+    buffer.writeUInt32BE(0xfeedfacf, 0); // MH_CIGAM_64 byte order
+    buffer.writeUInt32BE(cpuType, 4);
+    buffer.writeUInt32BE(fileType, 12);
+  }
+  return buffer;
+}
+
+const targetFixtures = [
+  {
+    name: "Windows PE64 x86_64",
+    filename: "loreserver.exe",
+    triple: "x86_64-pc-windows-msvc",
+    format: /PE/,
+    contents: syntheticPe(0x8664),
+  },
+  {
+    name: "Linux ELF64 x86_64",
+    filename: "loreserver-linux",
+    triple: "x86_64-unknown-linux-gnu",
+    format: /ELF/,
+    contents: syntheticElf(0x3e),
+  },
+  {
+    name: "macOS Mach-O64 arm64",
+    filename: "loreserver-macos",
+    triple: "aarch64-apple-darwin",
+    format: /Mach-O/,
+    contents: syntheticMachO(0x0100000c),
+  },
+];
+
+for (const fixture of targetFixtures) {
+  test(`verify-sidecar.mjs accepts ${fixture.name}`, () => {
+    const dir = mkdtempSync(join(tmpdir(), "loregui-verify-sidecar-"));
+    try {
+      const valid = join(dir, fixture.filename);
+      writeFileSync(valid, fixture.contents);
+      const result = spawnSync(process.execPath, [verifySidecar, valid, fixture.triple], {
+        encoding: "utf8",
+      });
+      assert.equal(result.status, 0, result.stderr);
+      assert.match(result.stdout, fixture.format);
+      assert.match(result.stdout, /OK/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+}
+
+test("verify-sidecar.mjs rejects corrupt magic for every release target", () => {
   const dir = mkdtempSync(join(tmpdir(), "loregui-verify-sidecar-"));
   try {
-    const valid = join(dir, "loreserver.exe");
-    writeFileSync(valid, syntheticPe(0x8664));
-    const result = spawnSync(process.execPath, [verifySidecar, valid, "x64"], {
-      encoding: "utf8",
-    });
-    assert.equal(result.status, 0, result.stderr);
-    assert.match(result.stdout, /OK/);
+    for (const fixture of targetFixtures.slice(0, 3)) {
+      const corrupt = Buffer.from(fixture.contents);
+      corrupt.fill(0, 0, 4);
+      const path = join(dir, `corrupt-${fixture.filename}`);
+      writeFileSync(path, corrupt);
+      const result = spawnSync(process.execPath, [verifySidecar, path, fixture.triple], {
+        encoding: "utf8",
+      });
+      assert.notEqual(result.status, 0, `${fixture.name} corrupt magic must be rejected`);
+      assert.match(result.stderr, fixture.format, fixture.name);
+      assert.match(result.stderr, /magic/, fixture.name);
+    }
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("verify-sidecar.mjs rejects corrupt sidecars (SBAI-5560)", () => {
+test("verify-sidecar.mjs rejects non-executable and byte-swapped native headers", () => {
   const dir = mkdtempSync(join(tmpdir(), "loregui-verify-sidecar-"));
   try {
     const cases = [
-      ["empty.exe", Buffer.alloc(0), /only 0 bytes/],
-      ["text.exe", Buffer.from("this is not an executable\n".repeat(50000)), /MZ magic/],
-      ["wrong-machine.exe", syntheticPe(0xaa64), /machine 0xaa64.*expected 0x8664/],
+      [
+        "pe-without-executable-flag.exe",
+        syntheticPe(0x8664, { executable: false }),
+        "x86_64-pc-windows-msvc",
+        /PE.*executable image/,
+      ],
+      [
+        "elf-et-none",
+        syntheticElf(0x3e, { fileType: 0 }),
+        "x86_64-unknown-linux-gnu",
+        /ELF type 0.*ET_EXEC.*ET_DYN/,
+      ],
+      [
+        "macho-object",
+        syntheticMachO(0x0100000c, { fileType: 1 }),
+        "aarch64-apple-darwin",
+        /Mach-O file type 1.*MH_EXECUTE/,
+      ],
+      [
+        "macho-byte-swapped",
+        syntheticMachO(0x0100000c, { littleEndian: false }),
+        "aarch64-apple-darwin",
+        /byte-swapped Mach-O/,
+      ],
     ];
-    for (const [name, contents, pattern] of cases) {
+    for (const [name, contents, triple, pattern] of cases) {
       const path = join(dir, name);
       writeFileSync(path, contents);
-      const result = spawnSync(process.execPath, [verifySidecar, path, "x64"], {
+      const result = spawnSync(process.execPath, [verifySidecar, path, triple], {
+        encoding: "utf8",
+      });
+      assert.notEqual(result.status, 0, `${name} must be rejected`);
+      assert.match(result.stderr, pattern, name);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("verify-sidecar.mjs rejects wrong architectures, truncated files, and unknown triples", () => {
+  const dir = mkdtempSync(join(tmpdir(), "loregui-verify-sidecar-"));
+  try {
+    const cases = [
+      [
+        "wrong-pe-machine.exe",
+        syntheticPe(0xaa64),
+        "x86_64-pc-windows-msvc",
+        /PE machine 0xaa64.*expected 0x8664/,
+      ],
+      [
+        "wrong-elf-machine",
+        syntheticElf(0xb7),
+        "x86_64-unknown-linux-gnu",
+        /ELF machine 0x00b7.*expected 0x003e/,
+      ],
+      [
+        "wrong-macho-cpu",
+        syntheticMachO(0x01000007),
+        "aarch64-apple-darwin",
+        /Mach-O CPU 0x01000007.*expected 0x0100000c/,
+      ],
+      ["empty.exe", Buffer.alloc(0), "x86_64-pc-windows-msvc", /only 0 bytes/],
+    ];
+    for (const [name, contents, triple, pattern] of cases) {
+      const path = join(dir, name);
+      writeFileSync(path, contents);
+      const result = spawnSync(process.execPath, [verifySidecar, path, triple], {
         encoding: "utf8",
       });
       assert.notEqual(result.status, 0, `${name} must be rejected`);
@@ -191,11 +343,21 @@ test("verify-sidecar.mjs rejects corrupt sidecars (SBAI-5560)", () => {
 
     const missing = spawnSync(
       process.execPath,
-      [verifySidecar, join(dir, "absent.exe"), "x64"],
+      [verifySidecar, join(dir, "absent.exe"), "x86_64-pc-windows-msvc"],
       { encoding: "utf8" },
     );
     assert.notEqual(missing.status, 0);
     assert.match(missing.stderr, /not found/);
+
+    const unknown = join(dir, "unknown-target");
+    writeFileSync(unknown, syntheticElf(0x3e));
+    const unknownResult = spawnSync(
+      process.execPath,
+      [verifySidecar, unknown, "x86_64-unknown-freebsd"],
+      { encoding: "utf8" },
+    );
+    assert.notEqual(unknownResult.status, 0);
+    assert.match(unknownResult.stderr, /unknown target triple/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/scripts/verify-sidecar.mjs
+++ b/scripts/verify-sidecar.mjs
@@ -1,14 +1,13 @@
 #!/usr/bin/env node
 
-// SBAI-5560: release gate for the bundled `loreserver` sidecar. The shipped
-// v0.1.3 installers surfaced Windows' "Unsupported 16 Bit Application" because
-// a corrupt / AV-quarantined `loreserver.exe` reached the user's disk — the old
-// CI step only checked that SOME file was staged. This script verifies the
-// file is a real executable: it must exist, be non-trivially sized, and carry
-// a valid PE header (MZ magic, PE signature at the MZ-header e_lfanew offset,
-// and the expected machine field).
+// SBAI-5560 / SBAI-5808: release gate for the bundled `loreserver` sidecar.
+// The shipped v0.1.3 installers surfaced Windows' "Unsupported 16 Bit
+// Application" because a corrupt / AV-quarantined `loreserver.exe` reached the
+// user's disk. The old CI step only checked that SOME file was staged; the
+// first header gate then assumed every release target was Windows PE. Verify
+// existence, useful size, native executable format, and target architecture.
 //
-// Usage: verify-sidecar.mjs <path-to-loreserver[.exe]> <x64|arm64>
+// Usage: verify-sidecar.mjs <path-to-loreserver[.exe]> <target-triple>
 
 import { closeSync, openSync, readSync, statSync } from "node:fs";
 
@@ -17,26 +16,137 @@ import { closeSync, openSync, readSync, statSync } from "node:fs";
 // quarantine stub, never a runnable server.
 const MIN_SIZE_BYTES = 1024 * 1024;
 
-// IMAGE_FILE_MACHINE values from the PE spec.
-const MACHINES = {
-  x64: 0x8664, // IMAGE_FILE_MACHINE_AMD64
-  arm64: 0xaa64, // IMAGE_FILE_MACHINE_ARM64
-};
-
 function fail(message) {
   console.error(`verify-sidecar: ${message}`);
   process.exit(1);
 }
 
-const [sidecarPath, machineArg] = process.argv.slice(2);
-if (!sidecarPath || !machineArg) {
-  fail("usage: verify-sidecar.mjs <path-to-loreserver[.exe]> <x64|arm64>");
+function hex(value, width) {
+  return `0x${value.toString(16).padStart(width, "0")}`;
 }
 
-const expectedMachine = MACHINES[machineArg.toLowerCase()];
-if (expectedMachine === undefined) {
+function readExactly(fd, length, position, description) {
+  const buffer = Buffer.alloc(length);
+  if (readSync(fd, buffer, 0, length, position) !== length) {
+    fail(`sidecar is truncated before ${description} (offset ${position})`);
+  }
+  return buffer;
+}
+
+function verifyPe(fd, sidecarPath, target) {
+  const dos = readExactly(fd, 64, 0, "the PE DOS header");
+  if (dos[0] !== 0x4d || dos[1] !== 0x5a) {
+    fail(`${sidecarPath} is missing the PE MZ magic — not a PE executable`);
+  }
+  const peOffset = dos.readUInt32LE(0x3c);
+  const pe = readExactly(fd, 26, peOffset, "the PE and COFF headers");
+  if (pe.toString("latin1", 0, 4) !== "PE\0\0") {
+    fail(`${sidecarPath} is missing the PE signature at offset ${peOffset}`);
+  }
+  const machine = pe.readUInt16LE(4);
+  if (machine !== target.machine) {
+    fail(
+      `${sidecarPath} has PE machine ${hex(machine, 4)} — expected ${hex(target.machine, 4)} (${target.arch})`,
+    );
+  }
+  const characteristics = pe.readUInt16LE(22);
+  if ((characteristics & 0x0002) === 0) {
+    fail(
+      `${sidecarPath} PE header is missing the executable image characteristic 0x0002`,
+    );
+  }
+  const optionalMagic = pe.readUInt16LE(24);
+  if (optionalMagic !== 0x020b) {
+    fail(`${sidecarPath} has PE optional-header magic ${hex(optionalMagic, 4)} — expected 0x020b (PE32+)`);
+  }
+  return `PE machine ${target.arch}`;
+}
+
+function verifyElf(fd, sidecarPath, target) {
+  const elf = readExactly(fd, 24, 0, "the ELF header");
+  if (
+    elf[0] !== 0x7f ||
+    elf[1] !== 0x45 ||
+    elf[2] !== 0x4c ||
+    elf[3] !== 0x46
+  ) {
+    fail(`${sidecarPath} is missing the ELF magic — not an ELF executable`);
+  }
+  if (elf[4] !== 2) {
+    fail(`${sidecarPath} is ELF class ${elf[4]} — expected ELF64 class 2`);
+  }
+  if (elf[5] !== 1) {
+    fail(`${sidecarPath} is ELF data encoding ${elf[5]} — expected little-endian encoding 1`);
+  }
+  if (elf[6] !== 1) {
+    fail(`${sidecarPath} is ELF identification version ${elf[6]} — expected version 1`);
+  }
+  const fileType = elf.readUInt16LE(16);
+  if (fileType !== 2 && fileType !== 3) {
+    fail(`${sidecarPath} has ELF type ${fileType} — expected ET_EXEC (2) or ET_DYN (3)`);
+  }
+  const machine = elf.readUInt16LE(18);
+  if (machine !== target.machine) {
+    fail(
+      `${sidecarPath} has ELF machine ${hex(machine, 4)} — expected ${hex(target.machine, 4)} (${target.arch})`,
+    );
+  }
+  const version = elf.readUInt32LE(20);
+  if (version !== 1) {
+    fail(`${sidecarPath} is ELF header version ${version} — expected version 1`);
+  }
+  return `ELF64 machine ${target.arch}`;
+}
+
+function verifyMachO(fd, sidecarPath, target) {
+  const mach = readExactly(fd, 16, 0, "the Mach-O header");
+  const magic = mach.readUInt32LE(0);
+  if (magic === 0xcffaedfe) {
+    fail(`${sidecarPath} has byte-swapped Mach-O magic — not executable on macOS`);
+  }
+  if (magic !== 0xfeedfacf) {
+    fail(`${sidecarPath} is missing the Mach-O 64-bit magic — not a Mach-O executable`);
+  }
+  const cpuType = mach.readUInt32LE(4);
+  if (cpuType !== target.machine) {
+    fail(
+      `${sidecarPath} has Mach-O CPU ${hex(cpuType, 8)} — expected ${hex(target.machine, 8)} (${target.arch})`,
+    );
+  }
+  const fileType = mach.readUInt32LE(12);
+  if (fileType !== 2) {
+    fail(`${sidecarPath} has Mach-O file type ${fileType} — expected MH_EXECUTE (2)`);
+  }
+  return `Mach-O64 CPU ${target.arch}, little-endian`;
+}
+
+const TARGETS = {
+  "x86_64-pc-windows-msvc": {
+    arch: "x86_64",
+    machine: 0x8664, // IMAGE_FILE_MACHINE_AMD64
+    verify: verifyPe,
+  },
+  "x86_64-unknown-linux-gnu": {
+    arch: "x86_64",
+    machine: 0x003e, // EM_X86_64
+    verify: verifyElf,
+  },
+  "aarch64-apple-darwin": {
+    arch: "arm64",
+    machine: 0x0100000c, // CPU_TYPE_ARM64
+    verify: verifyMachO,
+  },
+};
+
+const [sidecarPath, targetTriple] = process.argv.slice(2);
+if (!sidecarPath || !targetTriple) {
+  fail("usage: verify-sidecar.mjs <path-to-loreserver[.exe]> <target-triple>");
+}
+
+const target = TARGETS[targetTriple];
+if (!target) {
   fail(
-    `unknown machine "${machineArg}" — expected one of: ${Object.keys(MACHINES).join(", ")}`,
+    `unknown target triple "${targetTriple}" — expected one of: ${Object.keys(TARGETS).join(", ")}`,
   );
 }
 
@@ -56,33 +166,13 @@ if (stat.size <= MIN_SIZE_BYTES) {
 }
 
 const fd = openSync(sidecarPath, "r");
+let formatDescription;
 try {
-  // DOS header: MZ magic + e_lfanew (PE header offset) at 0x3c.
-  const dos = Buffer.alloc(64);
-  readSync(fd, dos, 0, dos.length, 0);
-  if (dos[0] !== 0x4d || dos[1] !== 0x5a) {
-    fail(`${sidecarPath} is missing the MZ magic — not a PE executable`);
-  }
-  const peOffset = dos.readUInt32LE(0x3c);
-
-  // PE signature + COFF machine field.
-  const pe = Buffer.alloc(6);
-  if (readSync(fd, pe, 0, pe.length, peOffset) !== pe.length) {
-    fail(`${sidecarPath} is truncated before the PE header (offset ${peOffset})`);
-  }
-  if (pe.toString("latin1", 0, 4) !== "PE\0\0") {
-    fail(`${sidecarPath} is missing the PE signature at offset ${peOffset}`);
-  }
-  const machine = pe.readUInt16LE(4);
-  if (machine !== expectedMachine) {
-    fail(
-      `${sidecarPath} has PE machine 0x${machine.toString(16).padStart(4, "0")} — expected 0x${expectedMachine.toString(16).padStart(4, "0")} (${machineArg})`,
-    );
-  }
+  formatDescription = target.verify(fd, sidecarPath, target);
 } finally {
   closeSync(fd);
 }
 
 console.log(
-  `verify-sidecar: ${sidecarPath} OK (${stat.size} bytes, PE machine ${machineArg})`,
+  `verify-sidecar: ${sidecarPath} OK (${stat.size} bytes, ${formatDescription}, target ${targetTriple})`,
 );


### PR DESCRIPTION
## Summary
- validate the staged `loreserver` sidecar against the format required by each target triple: PE32+ x86-64, ELF64 x86-64, or Mach-O64 arm64
- require executable architecture/type metadata, fail closed on unsupported triples, and reject byte-swapped Mach-O
- add a Rule 40 gate that corrupts a copy of the real staged sidecar on every matrix runner and proves the validator fails for the expected platform-magic reason
- replace the old PE-only fixtures with target-specific positive and negative coverage

## Jira
- SBAI-5808

## Verification
- `node --check scripts/verify-sidecar.mjs`
- `node --check scripts/release-supply-chain.test.mjs`
- `yamllint -d relaxed .github/workflows/release.yml`
- `node --test scripts/*.test.mjs` — 24 pass, 0 fail, 1 Windows-only local skip
- `git diff --check`
- downloaded all three v0.1.3 release sidecars and proved the validator accepts the real PE/ELF/Mach-O binaries
- corrupted the first four bytes of each real sidecar copy and proved exact expected-magic rejection on all three target triples

## Release gate
HOLD until required CI is green, sb-fable/trio review is complete, the merge lands, and the tag workflow proves all three runners plus Rule 40. No self-merge.