### PR TITLE
SBAI-5808: prepare v0.1.4 stable release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "lore-vm"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "lore",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "loregui"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64 0.22.1",
  "if-addrs",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "lorevm-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "lore-vm",
  "serde",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "lorevm-ffi"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "lore-vm",
  "lorevm-ffi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/lore-vm", "crates/lorevm-cli", "crates/lorevm-ffi", "src-tauri"]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/BiloxiStudios/loregui"

--- a/THIRD-PARTY-LICENSES-RUST.md
+++ b/THIRD-PARTY-LICENSES-RUST.md
@@ -7812,10 +7812,10 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- lore-vm 0.1.3 — https://github.com/BiloxiStudios/loregui
-- lorevm-cli 0.1.3 — https://github.com/BiloxiStudios/loregui
-- lorevm-ffi 0.1.3 — https://github.com/BiloxiStudios/loregui
-- loregui 0.1.3 — https://github.com/BiloxiStudios/loregui
+- lore-vm 0.1.4 — https://github.com/BiloxiStudios/loregui
+- lorevm-cli 0.1.4 — https://github.com/BiloxiStudios/loregui
+- lorevm-ffi 0.1.4 — https://github.com/BiloxiStudios/loregui
+- loregui 0.1.4 — https://github.com/BiloxiStudios/loregui
 - async-stream-impl 0.3.6 — https://github.com/tokio-rs/async-stream
 - async-stream 0.3.6 — https://github.com/tokio-rs/async-stream
 - bitcode_derive 0.6.9 — https://github.com/SoftbearStudios/bitcode/

--- a/frontend/public/licenses/rust.md
+++ b/frontend/public/licenses/rust.md
@@ -7812,10 +7812,10 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- lore-vm 0.1.3 — https://github.com/BiloxiStudios/loregui
-- lorevm-cli 0.1.3 — https://github.com/BiloxiStudios/loregui
-- lorevm-ffi 0.1.3 — https://github.com/BiloxiStudios/loregui
-- loregui 0.1.3 — https://github.com/BiloxiStudios/loregui
+- lore-vm 0.1.4 — https://github.com/BiloxiStudios/loregui
+- lorevm-cli 0.1.4 — https://github.com/BiloxiStudios/loregui
+- lorevm-ffi 0.1.4 — https://github.com/BiloxiStudios/loregui
+- loregui 0.1.4 — https://github.com/BiloxiStudios/loregui
 - async-stream-impl 0.3.6 — https://github.com/tokio-rs/async-stream
 - async-stream 0.3.6 — https://github.com/tokio-rs/async-stream
 - bitcode_derive 0.6.9 — https://github.com/SoftbearStudios/bitcode/

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoreGUI",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "games.braindead.loregui",
   "build": {
     "frontendDist": "../frontend/dist",


### PR DESCRIPTION
## Summary
- bump the workspace package version from `0.1.3` to `0.1.4`
- refresh exactly the four workspace package version stamps in `Cargo.lock`
- align the Tauri application version at `0.1.4`

## Jira
- SBAI-5808
- Manual stable-cut path reviewed by sb-fable because SBAI-5817 independently blocks the scheduled auto-release on fresh runners.

## Verification
- exact version assertion: `Cargo.toml`, `src-tauri/tauri.conf.json`, and the four target `Cargo.lock` packages all equal `0.1.4`
- `cargo metadata --offline --locked --no-deps`
- `node --test scripts/*.test.mjs` — 24 pass, 0 fail, 1 Windows-only local skip
- `cargo check --locked --offline --workspace`
- `git diff --check`

## Release gate
This PR prepares the version commit only. HOLD merge/tag until post-merge nightly run 30576918511 finishes and its three native logs prove the exact Rule 40 platform-magic rejection reasons. After merge, tag the exact reviewed commit once; publish only after the full three-platform stable artifact contract passes. No self-merge.

## CI follow-up
The license-attribution gate correctly caught the four workspace package version labels. Commit cd5efdbc4206ab4b37a38448397572657b24af93 regenerates the two Rust attribution bundles; generation is locally idempotent and both bundled copies are byte-identical. Dependency pins remain unchanged.