### PR TITLE
SBAI-5841: fail-closed absolute-path policy for all lifecycle paths

### DIFF
--- a/.github/workflows/tauri-e2e.yml
+++ b/.github/workflows/tauri-e2e.yml
@@ -47,6 +47,24 @@ jobs:
             libayatana-appindicator3-dev
       - name: IPC harness (MockRuntime, in-process)
         run: cargo test -p loregui
+      # SBAI-5841 (sb-secure): release-flavor cfg consistency + the RELEASE
+      # fallback regression. Debug-only `cargo test` never compiles the
+      # `#[cfg(not(debug_assertions))]` twins, so a release build could stop
+      # compiling (or silently regain the dev-checkout fallback) while this
+      # job stayed green. The check proves every target compiles in release;
+      # the scoped release test executes the actual compiled release fallback
+      # and proves a missing bundled sidecar hard-fails.
+      - name: Release cfg consistency (all targets)
+        run: cargo check -p loregui --release --all-targets
+      - name: Release fallback regression (compiled release twin)
+        # Fail closed: a cargo test name filter matching nothing exits 0, so
+        # the step asserts the twin ran exactly once.
+        run: |
+          set -euo pipefail
+          OUT=$(cargo test -p loregui --release release_fallback_twin_hard_fails_without_bundled_sidecar 2>&1)
+          echo "$OUT" | tail -5
+          echo "$OUT" | grep -q "test result: ok. 1 passed" \
+            || { echo "::error::release fallback twin did not run exactly once"; exit 1; }
 
   # ---------------------------------------------------------------------------
   # Layer 2 — WebDriver smoke suite against the BUILT app, headless under xvfb.

--- a/.github/workflows/tauri-e2e.yml
+++ b/.github/workflows/tauri-e2e.yml
@@ -56,15 +56,30 @@ jobs:
       # and proves a missing bundled sidecar hard-fails.
       - name: Release cfg consistency (all targets)
         run: cargo check -p loregui --release --all-targets
-      - name: Release fallback regression (compiled release twin)
-        # Fail closed: a cargo test name filter matching nothing exits 0, so
-        # the step asserts the twin ran exactly once.
+      - name: Debug fallback regression (hermetic compiled debug path)
+        # Unique named assertion for the DEBUG cfg proof, same fail-closed
+        # form as the release twin below: exact name, pass-line count == 1.
         run: |
           set -euo pipefail
-          OUT=$(cargo test -p loregui --release release_fallback_twin_hard_fails_without_bundled_sidecar 2>&1)
+          TWIN=server_host::tests::debug_fallback_resolves_hermetic_prebuilt_checkout_binary
+          OUT=$(cargo test -p loregui --lib "$TWIN" -- --exact 2>&1)
           echo "$OUT" | tail -5
-          echo "$OUT" | grep -q "test result: ok. 1 passed" \
-            || { echo "::error::release fallback twin did not run exactly once"; exit 1; }
+          COUNT=$(echo "$OUT" | grep -Fxc "test ${TWIN} ... ok" || true)
+          [ "$COUNT" = "1" ] \
+            || { echo "::error::named debug hermetic test pass-line count=${COUNT}, expected exactly 1"; exit 1; }
+      - name: Release fallback regression (compiled release twin)
+        # Fail closed: --lib + fully-qualified name + --exact, then count the
+        # EXACT named pass line == 1. (A bare name filter matching nothing
+        # exits 0, and any binary's "1 passed" summary could satisfy a
+        # summary grep.)
+        run: |
+          set -euo pipefail
+          TWIN=server_host::tests::release_fallback_twin_hard_fails_without_bundled_sidecar
+          OUT=$(cargo test -p loregui --lib --release "$TWIN" -- --exact 2>&1)
+          echo "$OUT" | tail -5
+          COUNT=$(echo "$OUT" | grep -Fxc "test ${TWIN} ... ok" || true)
+          [ "$COUNT" = "1" ] \
+            || { echo "::error::named release twin pass-line count=${COUNT}, expected exactly 1"; exit 1; }
 
   # ---------------------------------------------------------------------------
   # Layer 2 — WebDriver smoke suite against the BUILT app, headless under xvfb.

--- a/frontend/e2e/specs/smoke.e2e.ts
+++ b/frontend/e2e/specs/smoke.e2e.ts
@@ -17,6 +17,8 @@
 
 /// <reference types="@wdio/globals/types" />
 
+import { resolve } from "node:path";
+
 // ---- helpers --------------------------------------------------------------
 
 /** Invoke a Tauri IPC command from inside the WebView and return its result.
@@ -352,8 +354,12 @@ describe("LoreGUI desktop smoke", () => {
     // null. The deterministic successful host→open→restart journey runs in the
     // MockRuntime IPC harness with fixture-owned server/client directories.
     const tag = `e2e-${Date.now()}`;
-    const work = `loregui-e2e/${tag}/work`;
-    const store = `loregui-e2e/${tag}/store`;
+    // SBAI-5841: the backend now fail-closed rejects relative lifecycle
+    // paths before they reach the server, so this fixture must supply
+    // absolute deterministic paths (resolved against the wdio runner's CWD)
+    // to exercise its intended unreachable-server error, not the path policy.
+    const work = resolve("loregui-e2e", tag, "work");
+    const store = resolve("loregui-e2e", tag, "store");
 
     try {
       await invoke("repository_create", {

--- a/frontend/src/onboarding/ClientClone.tsx
+++ b/frontend/src/onboarding/ClientClone.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "../api";
 import { chooseDirectory } from "../platform/directoryPicker";
+import { explainPathProblem } from "../platform/pathPolicy";
 import type { StepStateProps } from "./stepResult";
 
 export type ClientRepositoryMode = "choice" | "clone" | "open" | "create";
@@ -87,6 +88,14 @@ export default function ClientClone({
     if (!cloneUrl.trim() || !cloneDest.trim()) return;
     const url = initialCloneUrl ?? cloneUrl.trim();
     const destination = cloneDest.trim();
+    // SBAI-5841: a relative destination would resolve against the app's
+    // startup folder. Say so at the field instead of round-tripping to the
+    // backend (which fails closed on the same rule).
+    const problem = explainPathProblem(destination);
+    if (problem) {
+      setError(problem);
+      return;
+    }
     await run(destination, async (isCurrent) => {
       await api.repositoryClone(url, destination);
       if (!isCurrent()) return;
@@ -115,6 +124,11 @@ export default function ClientClone({
   const handleOpen = async () => {
     if (!openPath.trim()) return;
     const path = openPath.trim();
+    const problem = explainPathProblem(path);
+    if (problem) {
+      setError(problem);
+      return;
+    }
     await run(path, async () => {
       await api.openRepository(path);
     });
@@ -122,6 +136,11 @@ export default function ClientClone({
 
   const handleCreate = async () => {
     if (!createName.trim() || !createPath.trim()) return;
+    const problem = explainPathProblem(createPath);
+    if (problem) {
+      setError(problem);
+      return;
+    }
     await run(createPath.trim(), async (isCurrent) => {
       const path = createPath.trim();
       await api.repositoryCreate(path, createName.trim());

--- a/frontend/src/onboarding/ClientClone.tsx
+++ b/frontend/src/onboarding/ClientClone.tsx
@@ -110,10 +110,26 @@ export default function ClientClone({
     setPath: (path: string) => void,
   ) => {
     const browseGeneration = attemptGeneration.current;
-    const selected = await chooseDirectory({
-      title,
-      defaultPath: currentPath || undefined,
-    });
+    let selected: string | null;
+    try {
+      selected = await chooseDirectory({
+        title,
+        defaultPath: currentPath || undefined,
+      });
+    } catch (e) {
+      // SBAI-5841: the picker fails closed when it has no trusted starting
+      // folder rather than opening at the process CWD. Surface why, and leave
+      // every other piece of state exactly as it was.
+      if (browseGeneration !== attemptGeneration.current) return;
+      setError(
+        typeof e === "string"
+          ? e
+          : e instanceof Error
+            ? e.message
+            : JSON.stringify(e),
+      );
+      return;
+    }
     if (browseGeneration !== attemptGeneration.current) return;
     if (selected !== null) {
       setPath(selected);

--- a/frontend/src/onboarding/DirectoryPicker.spec.tsx
+++ b/frontend/src/onboarding/DirectoryPicker.spec.tsx
@@ -202,6 +202,31 @@ describe("ClientClone rejects relative paths before any backend call", () => {
     expect(invokeMock).not.toHaveBeenCalled();
   });
 
+  it("surfaces a fail-closed picker refusal and changes nothing else", async () => {
+    // chooseDirectory throws rather than opening the dialog at the process CWD
+    // when it has no trusted starting folder (SBAI-5841 gap 5).
+    chooseDirectoryMock.mockRejectedValue(
+      new Error(
+        "Cannot open the folder picker: no trusted starting folder is " +
+          "available (Documents and home lookup failed) — enter an absolute " +
+          "path manually.",
+      ),
+    );
+    render(<ClientClone initialMode="open" />);
+    revealAdvancedPathEntry();
+    fireEvent.change(screen.getByLabelText("Repository Path"), {
+      target: { value: "C:\\existing" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Browse…" }));
+
+    expect(
+      await screen.findByText(/no trusted starting folder/),
+    ).toBeVisible();
+    expect(screen.getByLabelText("Repository Path")).toHaveValue("C:\\existing");
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
   it("still runs the backend for an absolute destination", async () => {
     invokeMock.mockResolvedValue(undefined);
     render(<ClientClone initialMode="open" />);

--- a/frontend/src/onboarding/DirectoryPicker.spec.tsx
+++ b/frontend/src/onboarding/DirectoryPicker.spec.tsx
@@ -9,6 +9,7 @@ import {
 
 const invokeMock = vi.fn();
 const chooseDirectoryMock = vi.fn();
+const defaultDialogPathMock = vi.fn();
 const dialogOpenMock = vi.fn();
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -17,6 +18,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 vi.mock("../platform/directoryPicker", () => ({
   chooseDirectory: (...args: unknown[]) => chooseDirectoryMock(...args),
+  defaultDialogPath: (...args: unknown[]) => defaultDialogPathMock(...args),
 }));
 
 vi.mock("@tauri-apps/plugin-dialog", () => ({
@@ -27,6 +29,7 @@ import ClientClone from "./ClientClone";
 import BackendPicker from "./server/BackendPicker";
 
 const WINDOWS_PATH = "E:\\lore";
+const DOCUMENTS = "C:\\Users\\you\\Documents";
 
 function revealAdvancedPathEntry() {
   fireEvent.click(screen.getByText("Advanced path entry"));
@@ -50,6 +53,8 @@ beforeEach(() => {
   invokeMock.mockReset();
   chooseDirectoryMock.mockReset();
   chooseDirectoryMock.mockResolvedValue(WINDOWS_PATH);
+  defaultDialogPathMock.mockReset();
+  defaultDialogPathMock.mockResolvedValue(DOCUMENTS);
   dialogOpenMock.mockReset();
   dialogOpenMock.mockResolvedValue(WINDOWS_PATH);
 });
@@ -138,6 +143,80 @@ describe("ClientClone native directory selection", () => {
     await waitFor(() => expect(chooseDirectoryMock).toHaveBeenCalledTimes(1));
     expect(screen.getByLabelText("Repository Path")).toHaveValue("C:\\existing");
     expect(invokeMock).not.toHaveBeenCalled();
+  });
+});
+
+/* SBAI-5841: manual (advanced) path entry is the one way a relative lifecycle
+   path can still reach the backend. The field explains the problem and no IPC
+   is attempted; the backend fails closed on the same rule regardless. */
+describe("ClientClone rejects relative paths before any backend call", () => {
+  it("shows an actionable error for a relative clone destination", async () => {
+    invokeMock.mockResolvedValue(undefined);
+    render(<ClientClone initialMode="clone" />);
+
+    fireEvent.change(screen.getByLabelText("Repository URL"), {
+      target: { value: "lore://example/project" },
+    });
+    revealAdvancedPathEntry();
+    fireEvent.change(screen.getByLabelText("Destination Path"), {
+      target: { value: "lore" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Clone" }));
+
+    const error = await screen.findByText(/is a relative path/);
+    expect(error.textContent).toContain('"lore"');
+    expect(error.textContent).toContain("absolute path");
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("shows an actionable error for a relative open path", async () => {
+    invokeMock.mockResolvedValue(undefined);
+    render(<ClientClone initialMode="open" />);
+
+    revealAdvancedPathEntry();
+    fireEvent.change(screen.getByLabelText("Repository Path"), {
+      target: { value: "./repo" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+
+    expect(await screen.findByText(/is a relative path/)).toBeVisible();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("shows the drive-relative fix for a Windows C:foo create path", async () => {
+    invokeMock.mockResolvedValue(undefined);
+    render(<ClientClone initialMode="create" />);
+
+    fireEvent.change(screen.getByLabelText("Project name"), {
+      target: { value: "world-bible" },
+    });
+    revealAdvancedPathEntry();
+    fireEvent.change(screen.getByLabelText("Local project path"), {
+      target: { value: "C:lore" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create project" }));
+
+    expect(
+      await screen.findByText(/backslash after the drive letter/),
+    ).toBeVisible();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("still runs the backend for an absolute destination", async () => {
+    invokeMock.mockResolvedValue(undefined);
+    render(<ClientClone initialMode="open" />);
+
+    revealAdvancedPathEntry();
+    fireEvent.change(screen.getByLabelText("Repository Path"), {
+      target: { value: WINDOWS_PATH },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("open_repository", {
+        path: WINDOWS_PATH,
+      }),
+    );
   });
 });
 

--- a/frontend/src/onboarding/StepReporting.spec.tsx
+++ b/frontend/src/onboarding/StepReporting.spec.tsx
@@ -13,6 +13,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 vi.mock("../platform/directoryPicker", () => ({
   chooseDirectory: () => Promise.resolve(null),
+  defaultDialogPath: () => Promise.resolve("/home/you/Documents"),
 }));
 
 import type { StorageBackendConfig } from "../api";

--- a/frontend/src/onboarding/server/BackendPicker.tsx
+++ b/frontend/src/onboarding/server/BackendPicker.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { api, type StorageBackendConfig } from "../../api";
+import { explainPathProblem } from "../../platform/pathPolicy";
 import PathField from "./PathField";
 import type { StepStateProps } from "../stepResult";
 
@@ -122,8 +123,17 @@ export default function BackendPicker({
   );
 
   const isValid = useCallback((): boolean => {
+    // SBAI-5841: the optional mutable store is a lifecycle path for both
+    // backends — if it is filled in at all it must be absolute, or the
+    // backend will reject the whole prepare/open.
+    const mutableStore = form.mutableStore.trim();
+    if (mutableStore.length > 0 && explainPathProblem(mutableStore) !== null) {
+      return false;
+    }
     if (kind === "local") {
-      return form.path.trim().length > 0;
+      return (
+        form.path.trim().length > 0 && explainPathProblem(form.path) === null
+      );
     }
     // S3-compatible object storage: endpoint + bucket required.
     return (

--- a/frontend/src/onboarding/server/PathField.tsx
+++ b/frontend/src/onboarding/server/PathField.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useState } from "react";
 import type { ReactNode } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
+import { defaultDialogPath } from "../../platform/directoryPicker";
+import {
+  explainPathProblem,
+  isAcceptableAbsolutePath,
+} from "../../platform/pathPolicy";
 
 interface PathFieldBaseProps {
   /** Input id — the visible label points at it via htmlFor. */
@@ -55,11 +60,17 @@ export default function PathField(props: PathFieldProps) {
     if (!onChange) return;
     setBrowsing(true);
     try {
+      // SBAI-5841: never hand the OS an empty or relative starting point — it
+      // resolves that against the process CWD (System32 for a Start Menu
+      // launch). Reuse the current value only when it is already absolute.
+      const defaultPath = isAcceptableAbsolutePath(value)
+        ? value.trim()
+        : await defaultDialogPath();
       const selected = await open({
         directory: true,
         multiple: false,
         title: dialogTitle,
-        defaultPath: value || undefined,
+        defaultPath,
       });
       if (typeof selected === "string") {
         onChange(selected);
@@ -69,7 +80,19 @@ export default function PathField(props: PathFieldProps) {
     }
   }, [onChange, dialogTitle, value]);
 
-  const fieldClass = `onboarding-field${optional ? " onboarding-field--optional" : ""}`;
+  // SBAI-5841: supplemental inline validation. The backend is the authority
+  // and re-checks every lifecycle path; this just tells the user what to fix
+  // before they submit. Stays quiet on an untouched (empty) field — "required"
+  // is the submit button's job, not a red error on first paint.
+  const pathProblem =
+    props.readOnly || value.trim().length === 0
+      ? null
+      : explainPathProblem(value);
+  const errorId = `${id}-path-error`;
+
+  const fieldClass = `onboarding-field${optional ? " onboarding-field--optional" : ""}${
+    pathProblem ? " server-config-field--invalid" : ""
+  }`;
 
   if (props.readOnly) {
     return (
@@ -93,6 +116,8 @@ export default function PathField(props: PathFieldProps) {
           value={value}
           onChange={(e) => props.onChange(e.target.value)}
           disabled={disabled}
+          aria-invalid={pathProblem ? true : undefined}
+          aria-describedby={pathProblem ? errorId : undefined}
         />
         <button
           type="button"
@@ -103,6 +128,11 @@ export default function PathField(props: PathFieldProps) {
           {browsing ? "Browsing…" : "Browse…"}
         </button>
       </div>
+      {pathProblem ? (
+        <p className="server-config-field-error" id={errorId}>
+          {pathProblem}
+        </p>
+      ) : null}
       {hint ? <span className="onboarding-field-hint">{hint}</span> : null}
     </div>
   );

--- a/frontend/src/onboarding/server/PathField.tsx
+++ b/frontend/src/onboarding/server/PathField.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useState } from "react";
 import type { ReactNode } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
-import { defaultDialogPath } from "../../platform/directoryPicker";
+import {
+  defaultDialogPath,
+  NO_TRUSTED_START_MESSAGE,
+} from "../../platform/directoryPicker";
 import {
   explainPathProblem,
-  isAcceptableAbsolutePath,
+  isNativeAbsolutePath,
 } from "../../platform/pathPolicy";
 
 interface PathFieldBaseProps {
@@ -55,17 +58,24 @@ export default function PathField(props: PathFieldProps) {
   const onChange = props.readOnly ? undefined : props.onChange;
   const dialogTitle = props.readOnly ? undefined : props.dialogTitle;
   const [browsing, setBrowsing] = useState(false);
+  const [browseError, setBrowseError] = useState<string | null>(null);
 
   const handleBrowse = useCallback(async () => {
     if (!onChange) return;
     setBrowsing(true);
     try {
-      // SBAI-5841: never hand the OS an empty or relative starting point — it
-      // resolves that against the process CWD (System32 for a Start Menu
-      // launch). Reuse the current value only when it is already absolute.
-      const defaultPath = isAcceptableAbsolutePath(value)
+      // SBAI-5841: never hand the OS an empty, relative, or foreign-platform
+      // starting point — it resolves that against the process CWD (System32
+      // for a Start Menu launch). Reuse the current value only when it is
+      // absolute *on this platform*, and resolve the whole starting folder
+      // BEFORE opening, so "no trusted start" never becomes "open at the CWD".
+      const defaultPath = isNativeAbsolutePath(value)
         ? value.trim()
         : await defaultDialogPath();
+      if (defaultPath === undefined) {
+        setBrowseError(NO_TRUSTED_START_MESSAGE);
+        return;
+      }
       const selected = await open({
         directory: true,
         multiple: false,
@@ -73,6 +83,7 @@ export default function PathField(props: PathFieldProps) {
         defaultPath,
       });
       if (typeof selected === "string") {
+        setBrowseError(null);
         onChange(selected);
       }
     } finally {
@@ -89,9 +100,14 @@ export default function PathField(props: PathFieldProps) {
       ? null
       : explainPathProblem(value);
   const errorId = `${id}-path-error`;
+  const browseErrorId = `${id}-browse-error`;
+  const describedBy =
+    [pathProblem ? errorId : null, browseError ? browseErrorId : null]
+      .filter((part): part is string => part !== null)
+      .join(" ") || undefined;
 
   const fieldClass = `onboarding-field${optional ? " onboarding-field--optional" : ""}${
-    pathProblem ? " server-config-field--invalid" : ""
+    pathProblem || browseError ? " server-config-field--invalid" : ""
   }`;
 
   if (props.readOnly) {
@@ -114,10 +130,14 @@ export default function PathField(props: PathFieldProps) {
           type="text"
           placeholder={props.placeholder}
           value={value}
-          onChange={(e) => props.onChange(e.target.value)}
+          onChange={(e) => {
+            // A manual edit is the user answering the browse failure — drop it.
+            setBrowseError(null);
+            props.onChange(e.target.value);
+          }}
           disabled={disabled}
           aria-invalid={pathProblem ? true : undefined}
-          aria-describedby={pathProblem ? errorId : undefined}
+          aria-describedby={describedBy}
         />
         <button
           type="button"
@@ -131,6 +151,11 @@ export default function PathField(props: PathFieldProps) {
       {pathProblem ? (
         <p className="server-config-field-error" id={errorId}>
           {pathProblem}
+        </p>
+      ) : null}
+      {browseError ? (
+        <p className="server-config-field-error" id={browseErrorId}>
+          {browseError}
         </p>
       ) : null}
       {hint ? <span className="onboarding-field-hint">{hint}</span> : null}

--- a/frontend/src/onboarding/server/StorePathSingleAsk.spec.tsx
+++ b/frontend/src/onboarding/server/StorePathSingleAsk.spec.tsx
@@ -16,6 +16,8 @@ import {
 
 const invokeMock = vi.fn();
 const dialogOpenMock = vi.fn();
+const documentDirMock = vi.fn();
+const homeDirMock = vi.fn();
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => invokeMock(...args),
@@ -25,6 +27,11 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: (...args: unknown[]) => dialogOpenMock(...args),
 }));
 
+vi.mock("@tauri-apps/api/path", () => ({
+  documentDir: (...args: unknown[]) => documentDirMock(...args),
+  homeDir: (...args: unknown[]) => homeDirMock(...args),
+}));
+
 import type { StorageBackendConfig } from "../../api";
 import PathField from "./PathField";
 import BackendPicker from "./BackendPicker";
@@ -32,6 +39,7 @@ import InitStore from "./InitStore";
 import ServiceSetup from "./ServiceSetup";
 
 const STEP1_PATH = "/srv/lore/store";
+const DOCUMENTS = "/home/you/Documents";
 
 function fieldByLabel(label: string): HTMLElement {
   const field = screen
@@ -45,6 +53,10 @@ beforeEach(() => {
   invokeMock.mockReset();
   dialogOpenMock.mockReset();
   dialogOpenMock.mockResolvedValue(STEP1_PATH);
+  documentDirMock.mockReset();
+  documentDirMock.mockResolvedValue(DOCUMENTS);
+  homeDirMock.mockReset();
+  homeDirMock.mockResolvedValue("/home/you");
 });
 
 describe("PathField", () => {
@@ -131,6 +143,140 @@ describe("PathField", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  /* SBAI-5841 --------------------------------------------------------- */
+
+  it("Browse from an empty field starts at Documents, never the process CWD", async () => {
+    render(
+      <PathField
+        id="pf"
+        label="Local Storage Path"
+        value=""
+        onChange={vi.fn()}
+        dialogTitle="Choose local storage directory"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Browse…" }));
+
+    await waitFor(() => expect(dialogOpenMock).toHaveBeenCalledTimes(1));
+    expect(dialogOpenMock).toHaveBeenCalledWith(
+      expect.objectContaining({ directory: true, defaultPath: DOCUMENTS }),
+    );
+  });
+
+  it("Browse from a relative field starts at Documents, not that value", async () => {
+    render(
+      <PathField
+        id="pf"
+        label="Path"
+        value="lore"
+        onChange={vi.fn()}
+        dialogTitle="Pick"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Browse…" }));
+
+    await waitFor(() => expect(dialogOpenMock).toHaveBeenCalledTimes(1));
+    expect(dialogOpenMock).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultPath: DOCUMENTS }),
+    );
+  });
+
+  it("Browse reuses the current value when it is already absolute", async () => {
+    render(
+      <PathField
+        id="pf"
+        label="Path"
+        value={`  ${STEP1_PATH}  `}
+        onChange={vi.fn()}
+        dialogTitle="Pick"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Browse…" }));
+
+    await waitFor(() => expect(dialogOpenMock).toHaveBeenCalledTimes(1));
+    expect(dialogOpenMock).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultPath: STEP1_PATH }),
+    );
+    expect(documentDirMock).not.toHaveBeenCalled();
+  });
+
+  it("manual relative entry shows an actionable error and marks the input invalid", () => {
+    render(
+      <PathField
+        id="pf"
+        label="Local Storage Path"
+        value="lore"
+        onChange={vi.fn()}
+        dialogTitle="Pick"
+      />,
+    );
+
+    const input = screen.getByLabelText("Local Storage Path");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAttribute("aria-describedby", "pf-path-error");
+
+    const error = document.getElementById("pf-path-error");
+    expect(error).not.toBeNull();
+    expect(error).toHaveClass("server-config-field-error");
+    expect(error?.textContent ?? "").toContain('"lore"');
+    expect(error?.textContent ?? "").toContain("absolute path");
+  });
+
+  it("explains the Windows drive-relative case at the field", () => {
+    render(
+      <PathField
+        id="pf"
+        label="Path"
+        value="C:lore"
+        onChange={vi.fn()}
+        dialogTitle="Pick"
+      />,
+    );
+
+    expect(
+      screen.getByText(/backslash after the drive letter/),
+    ).toHaveClass("server-config-field-error");
+  });
+
+  it("shows no error for an absolute value or an untouched empty field", () => {
+    const view = render(
+      <PathField
+        id="pf"
+        label="Path"
+        value={STEP1_PATH}
+        onChange={vi.fn()}
+        dialogTitle="Pick"
+      />,
+    );
+    expect(document.querySelector(".server-config-field-error")).toBeNull();
+    expect(screen.getByLabelText("Path")).not.toHaveAttribute("aria-invalid");
+
+    view.rerender(
+      <PathField
+        id="pf"
+        label="Path"
+        value=""
+        onChange={vi.fn()}
+        dialogTitle="Pick"
+      />,
+    );
+    expect(document.querySelector(".server-config-field-error")).toBeNull();
+
+    view.rerender(
+      <PathField
+        id="pf"
+        label="Path"
+        value={"C:\\LoreData"}
+        onChange={vi.fn()}
+        dialogTitle="Pick"
+      />,
+    );
+    expect(document.querySelector(".server-config-field-error")).toBeNull();
+  });
+
   it("read-only summary renders the path as static text with its role label", () => {
     render(
       <PathField
@@ -145,6 +291,70 @@ describe("PathField", () => {
     expect(screen.getByText(STEP1_PATH)).toBeVisible();
     expect(screen.queryByRole("textbox")).toBeNull();
     expect(screen.queryByRole("button")).toBeNull();
+  });
+});
+
+describe("BackendPicker gates on absolute lifecycle paths (SBAI-5841)", () => {
+  it("keeps Prepare Store disabled for a relative local store path", () => {
+    render(<BackendPicker />);
+    const prepare = () => screen.getByRole("button", { name: "Prepare Store" });
+    expect(prepare()).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Local Storage Path"), {
+      target: { value: "lore" },
+    });
+    expect(prepare()).toBeDisabled();
+    expect(screen.getByText(/is a relative path/)).toHaveClass(
+      "server-config-field-error",
+    );
+
+    fireEvent.change(screen.getByLabelText("Local Storage Path"), {
+      target: { value: STEP1_PATH },
+    });
+    expect(prepare()).toBeEnabled();
+    expect(document.querySelector(".server-config-field-error")).toBeNull();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps Prepare Store disabled for a relative mutable store path", () => {
+    render(<BackendPicker />);
+    fireEvent.change(screen.getByLabelText("Local Storage Path"), {
+      target: { value: STEP1_PATH },
+    });
+    expect(screen.getByRole("button", { name: "Prepare Store" })).toBeEnabled();
+
+    fireEvent.change(screen.getByLabelText("Mutable Store Path (optional)"), {
+      target: { value: "C:mutable" },
+    });
+    expect(screen.getByRole("button", { name: "Prepare Store" })).toBeDisabled();
+    expect(
+      screen.getByText(/backslash after the drive letter/),
+    ).toBeVisible();
+
+    // Optional means optional: clearing it re-enables the step.
+    fireEvent.change(screen.getByLabelText("Mutable Store Path (optional)"), {
+      target: { value: "" },
+    });
+    expect(screen.getByRole("button", { name: "Prepare Store" })).toBeEnabled();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps Open Storage disabled for a relative S3 mutable store path", () => {
+    render(<BackendPicker />);
+    fireEvent.click(screen.getByRole("radio", { name: /S3-compatible/ }));
+    fireEvent.change(screen.getByLabelText("Endpoint URL"), {
+      target: { value: "https://s3.example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Bucket Name"), {
+      target: { value: "lore" },
+    });
+    expect(screen.getByRole("button", { name: "Open Storage" })).toBeEnabled();
+
+    fireEvent.change(screen.getByLabelText("Mutable Store Path (optional)"), {
+      target: { value: "./mutable" },
+    });
+    expect(screen.getByRole("button", { name: "Open Storage" })).toBeDisabled();
+    expect(invokeMock).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/onboarding/server/StorePathSingleAsk.spec.tsx
+++ b/frontend/src/onboarding/server/StorePathSingleAsk.spec.tsx
@@ -203,6 +203,85 @@ describe("PathField", () => {
     expect(documentDirMock).not.toHaveBeenCalled();
   });
 
+  it("refuses to open the picker when no trusted starting folder exists", async () => {
+    // Both path lookups fail → defaultDialogPath() is undefined. Opening the
+    // dialog anyway would let the OS start at the process CWD, so PathField
+    // explains itself instead of opening (SBAI-5841 gap 5).
+    documentDirMock.mockRejectedValue(new Error("unavailable"));
+    homeDirMock.mockRejectedValue(new Error("unavailable"));
+    const onChange = vi.fn();
+    render(
+      <PathField
+        id="pf"
+        label="Path"
+        value=""
+        onChange={onChange}
+        dialogTitle="Pick"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Browse…" }));
+
+    const error = await screen.findByText(/no trusted starting folder/);
+    expect(error).toHaveClass("server-config-field-error");
+    expect(error.id).toBe("pf-browse-error");
+    expect(screen.getByLabelText("Path").getAttribute("aria-describedby")).toContain(
+      "pf-browse-error",
+    );
+    expect(dialogOpenMock).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+    // The button recovers — this is a refusal, not a stuck state.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Browse…" })).toBeEnabled(),
+    );
+  });
+
+  it("clears the browse failure once the user types a path instead", async () => {
+    documentDirMock.mockRejectedValue(new Error("unavailable"));
+    homeDirMock.mockRejectedValue(new Error("unavailable"));
+    render(
+      <PathField
+        id="pf"
+        label="Path"
+        value=""
+        onChange={vi.fn()}
+        dialogTitle="Pick"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Browse…" }));
+    await screen.findByText(/no trusted starting folder/);
+
+    fireEvent.change(screen.getByLabelText("Path"), {
+      target: { value: "/srv/lore" },
+    });
+
+    expect(screen.queryByText(/no trusted starting folder/)).toBeNull();
+    expect(screen.getByLabelText("Path")).not.toHaveAttribute(
+      "aria-describedby",
+    );
+  });
+
+  it("does not start at a value that is absolute only on the other platform", async () => {
+    // Union-acceptable, but not absolute on the host running the test.
+    render(
+      <PathField
+        id="pf"
+        label="Path"
+        value={"C:\\LoreData"}
+        onChange={vi.fn()}
+        dialogTitle="Pick"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Browse…" }));
+
+    await waitFor(() => expect(dialogOpenMock).toHaveBeenCalledTimes(1));
+    expect(dialogOpenMock).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultPath: DOCUMENTS }),
+    );
+  });
+
   it("manual relative entry shows an actionable error and marks the input invalid", () => {
     render(
       <PathField

--- a/frontend/src/platform/directoryPicker.spec.ts
+++ b/frontend/src/platform/directoryPicker.spec.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { open } from "@tauri-apps/plugin-dialog";
 import { documentDir, homeDir } from "@tauri-apps/api/path";
-import { chooseDirectory, defaultDialogPath } from "./directoryPicker";
+import {
+  chooseDirectory,
+  defaultDialogPath,
+  NO_TRUSTED_START_MESSAGE,
+} from "./directoryPicker";
+import { isWindowsPlatform } from "./pathPolicy";
 
 vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn(),
@@ -24,23 +29,37 @@ beforeEach(() => {
 });
 
 describe("chooseDirectory", () => {
-  it("returns one Windows directory and forwards the exact dialog options", async () => {
+  it("returns the chosen directory and forwards the exact dialog options", async () => {
     vi.mocked(open).mockResolvedValue("E:\\lore");
 
     await expect(
       chooseDirectory({
         title: "Choose server storage",
-        defaultPath: "D:\\existing",
+        defaultPath: "/srv/existing",
       }),
     ).resolves.toBe("E:\\lore");
     expect(open).toHaveBeenCalledWith({
       directory: true,
       multiple: false,
       title: "Choose server storage",
-      defaultPath: "D:\\existing",
+      defaultPath: "/srv/existing",
     });
-    // An absolute current value is used as-is — no path API call needed.
+    // A natively-absolute current value is used as-is — no path API call.
     expect(documentDir).not.toHaveBeenCalled();
+  });
+
+  it("does not trust a foreign-platform absolute path as a starting folder", async () => {
+    // SBAI-5841 / gap 6: `D:\…` is union-acceptable (so the inline field error
+    // stays quiet) but it is not absolute on THIS platform, so it must never
+    // be handed to this platform's dialog.
+    expect(isWindowsPlatform()).toBe(false);
+    vi.mocked(open).mockResolvedValue(null);
+
+    await chooseDirectory({ title: "Choose", defaultPath: "D:\\existing" });
+
+    expect(open).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultPath: DOCUMENTS }),
+    );
   });
 
   it("returns null when cancelled", async () => {
@@ -88,15 +107,36 @@ describe("chooseDirectory", () => {
     );
   });
 
-  it("passes undefined only when the path API itself is unavailable", async () => {
+  it("fails closed — never opens the dialog with no trusted start", async () => {
+    // Opening with defaultPath undefined is precisely the CWD inheritance this
+    // whole change exists to prevent, so refuse instead of guessing.
     vi.mocked(documentDir).mockRejectedValue(new Error("unavailable"));
     vi.mocked(homeDir).mockRejectedValue(new Error("unavailable"));
-    vi.mocked(open).mockResolvedValue(null);
 
-    await chooseDirectory({ title: "Choose" });
+    await expect(chooseDirectory({ title: "Choose" })).rejects.toThrow(
+      NO_TRUSTED_START_MESSAGE,
+    );
+    expect(open).not.toHaveBeenCalled();
+  });
 
+  it("fails closed for a relative defaultPath when no fallback resolves", async () => {
+    vi.mocked(documentDir).mockRejectedValue(new Error("unavailable"));
+    vi.mocked(homeDir).mockResolvedValue("Documents");
+
+    await expect(
+      chooseDirectory({ title: "Choose", defaultPath: "lore" }),
+    ).rejects.toThrow(/enter an absolute path manually/);
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("uses the resolved Documents value when the field holds a relative path", async () => {
+    vi.mocked(open).mockResolvedValue("/picked");
+
+    await expect(
+      chooseDirectory({ title: "Choose", defaultPath: "./relative" }),
+    ).resolves.toBe("/picked");
     expect(open).toHaveBeenCalledWith(
-      expect.objectContaining({ defaultPath: undefined }),
+      expect.objectContaining({ defaultPath: DOCUMENTS }),
     );
   });
 
@@ -130,6 +170,14 @@ describe("defaultDialogPath", () => {
     // A path API that somehow answers with a relative value is no better than
     // the CWD — skip it rather than start the dialog there.
     vi.mocked(documentDir).mockResolvedValue("Documents");
+    await expect(defaultDialogPath()).resolves.toBe(HOME);
+  });
+
+  it("vets candidates natively, not by the lenient union", async () => {
+    // A `C:\…` answer on a POSIX host is absolute for the *other* family only;
+    // it is no more usable here than a relative one.
+    expect(isWindowsPlatform()).toBe(false);
+    vi.mocked(documentDir).mockResolvedValue("C:\\Users\\you\\Documents");
     await expect(defaultDialogPath()).resolves.toBe(HOME);
   });
 });

--- a/frontend/src/platform/directoryPicker.spec.ts
+++ b/frontend/src/platform/directoryPicker.spec.ts
@@ -1,16 +1,29 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { open } from "@tauri-apps/plugin-dialog";
-import { chooseDirectory } from "./directoryPicker";
+import { documentDir, homeDir } from "@tauri-apps/api/path";
+import { chooseDirectory, defaultDialogPath } from "./directoryPicker";
 
 vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn(),
 }));
 
-describe("chooseDirectory", () => {
-  beforeEach(() => {
-    vi.mocked(open).mockReset();
-  });
+vi.mock("@tauri-apps/api/path", () => ({
+  documentDir: vi.fn(),
+  homeDir: vi.fn(),
+}));
 
+const DOCUMENTS = "/home/you/Documents";
+const HOME = "/home/you";
+
+beforeEach(() => {
+  vi.mocked(open).mockReset();
+  vi.mocked(documentDir).mockReset();
+  vi.mocked(homeDir).mockReset();
+  vi.mocked(documentDir).mockResolvedValue(DOCUMENTS);
+  vi.mocked(homeDir).mockResolvedValue(HOME);
+});
+
+describe("chooseDirectory", () => {
   it("returns one Windows directory and forwards the exact dialog options", async () => {
     vi.mocked(open).mockResolvedValue("E:\\lore");
 
@@ -26,11 +39,97 @@ describe("chooseDirectory", () => {
       title: "Choose server storage",
       defaultPath: "D:\\existing",
     });
+    // An absolute current value is used as-is — no path API call needed.
+    expect(documentDir).not.toHaveBeenCalled();
   });
 
   it("returns null when cancelled", async () => {
     vi.mocked(open).mockResolvedValue(null);
 
     await expect(chooseDirectory({ title: "Choose" })).resolves.toBeNull();
+  });
+
+  /* SBAI-5841: the dialog must never be opened with no starting directory,
+     because the OS then falls back to the process CWD (System32 for a Start
+     Menu launch on Windows). */
+
+  it("starts at Documents when no defaultPath is supplied", async () => {
+    vi.mocked(open).mockResolvedValue(DOCUMENTS);
+
+    await chooseDirectory({ title: "Choose" });
+
+    expect(open).toHaveBeenCalledWith(
+      expect.objectContaining({ directory: true, defaultPath: DOCUMENTS }),
+    );
+  });
+
+  it.each(["", "   ", "lore", "./x", "C:foo", "\\\\server"])(
+    "starts at Documents instead of inheriting the CWD for defaultPath %j",
+    async (relative) => {
+      vi.mocked(open).mockResolvedValue(null);
+
+      await chooseDirectory({ title: "Choose", defaultPath: relative });
+
+      expect(open).toHaveBeenCalledWith(
+        expect.objectContaining({ defaultPath: DOCUMENTS }),
+      );
+    },
+  );
+
+  it("falls back to the home directory when documentDir throws", async () => {
+    vi.mocked(documentDir).mockRejectedValue(new Error("no Documents"));
+    vi.mocked(open).mockResolvedValue(null);
+
+    await chooseDirectory({ title: "Choose", defaultPath: "lore" });
+
+    expect(homeDir).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultPath: HOME }),
+    );
+  });
+
+  it("passes undefined only when the path API itself is unavailable", async () => {
+    vi.mocked(documentDir).mockRejectedValue(new Error("unavailable"));
+    vi.mocked(homeDir).mockRejectedValue(new Error("unavailable"));
+    vi.mocked(open).mockResolvedValue(null);
+
+    await chooseDirectory({ title: "Choose" });
+
+    expect(open).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultPath: undefined }),
+    );
+  });
+
+  it("keeps state unchanged on cancel even with a fallback default", async () => {
+    vi.mocked(open).mockResolvedValue(null);
+
+    await expect(
+      chooseDirectory({ title: "Choose", defaultPath: "lore" }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("defaultDialogPath", () => {
+  it("prefers Documents", async () => {
+    await expect(defaultDialogPath()).resolves.toBe(DOCUMENTS);
+    expect(homeDir).not.toHaveBeenCalled();
+  });
+
+  it("falls back to home when Documents is unavailable", async () => {
+    vi.mocked(documentDir).mockRejectedValue(new Error("nope"));
+    await expect(defaultDialogPath()).resolves.toBe(HOME);
+  });
+
+  it("returns undefined when both are unavailable", async () => {
+    vi.mocked(documentDir).mockRejectedValue(new Error("nope"));
+    vi.mocked(homeDir).mockRejectedValue(new Error("nope"));
+    await expect(defaultDialogPath()).resolves.toBeUndefined();
+  });
+
+  it("never offers a non-absolute directory it was handed", async () => {
+    // A path API that somehow answers with a relative value is no better than
+    // the CWD — skip it rather than start the dialog there.
+    vi.mocked(documentDir).mockResolvedValue("Documents");
+    await expect(defaultDialogPath()).resolves.toBe(HOME);
   });
 });

--- a/frontend/src/platform/directoryPicker.ts
+++ b/frontend/src/platform/directoryPicker.ts
@@ -1,11 +1,20 @@
 import { open } from "@tauri-apps/plugin-dialog";
 import { documentDir, homeDir } from "@tauri-apps/api/path";
-import { isAcceptableAbsolutePath } from "./pathPolicy";
+import { isNativeAbsolutePath } from "./pathPolicy";
 
 export interface DirectoryPickerOptions {
   title: string;
   defaultPath?: string;
 }
+
+/**
+ * Thrown (and shown) when there is no trusted folder to start the dialog from.
+ * Opening anyway would let the OS fall back to the process working directory,
+ * so the picker refuses instead — fail closed, and tell the user the way out.
+ */
+export const NO_TRUSTED_START_MESSAGE =
+  "Cannot open the folder picker: no trusted starting folder is available " +
+  "(Documents and home lookup failed) — enter an absolute path manually.";
 
 /**
  * SBAI-5841: where a folder picker starts when we have nothing better.
@@ -18,14 +27,19 @@ export interface DirectoryPickerOptions {
  * user-writable place instead: Documents, then the home directory.
  *
  * Returns `undefined` only when the path API itself is unavailable (both calls
- * throw) — i.e. we genuinely have nothing to offer, not merely because the
- * field was empty or held a relative value.
+ * throw or answer with something we cannot trust) — i.e. we genuinely have
+ * nothing to offer, not merely because the field was empty or held a relative
+ * value. Callers must treat `undefined` as "do not open the dialog".
+ *
+ * Candidates are vetted with the **native** check, not the union: a starting
+ * folder is an action, and a path that is absolute only on the *other* OS
+ * family is no more usable here than a relative one.
  */
 export async function defaultDialogPath(): Promise<string | undefined> {
   for (const resolve of [documentDir, homeDir]) {
     try {
       const candidate = await resolve();
-      if (candidate && isAcceptableAbsolutePath(candidate)) return candidate;
+      if (candidate && isNativeAbsolutePath(candidate)) return candidate;
     } catch {
       // Fall through to the next candidate.
     }
@@ -37,20 +51,28 @@ export async function defaultDialogPath(): Promise<string | undefined> {
  * Open the native directory picker and return the chosen absolute path, or
  * `null` when the user cancels (cancel leaves caller state untouched).
  *
- * The dialog starts at `options.defaultPath` only when that value is an
- * acceptable absolute path (see `pathPolicy`); an empty, whitespace, or
- * relative value would otherwise be handed to the OS, which resolves it
- * against the process CWD. In that case we start from
+ * The dialog starts at `options.defaultPath` only when that value is absolute
+ * *on this platform* (see `isNativeAbsolutePath`); an empty, whitespace,
+ * relative, or foreign-family value would otherwise be handed to the OS, which
+ * resolves it against the process CWD. In that case we start from
  * {@link defaultDialogPath} instead.
+ *
+ * If neither yields a trusted folder the picker **fails closed**: it throws
+ * {@link NO_TRUSTED_START_MESSAGE} without ever calling the dialog, because
+ * opening with no `defaultPath` is exactly the CWD inheritance this guards
+ * against. Callers surface the message and let the user type a path instead.
  */
 export async function chooseDirectory(
   options: DirectoryPickerOptions,
 ): Promise<string | null> {
   const { defaultPath, ...rest } = options;
   const start =
-    defaultPath !== undefined && isAcceptableAbsolutePath(defaultPath)
+    defaultPath !== undefined && isNativeAbsolutePath(defaultPath)
       ? defaultPath.trim()
       : await defaultDialogPath();
+  if (start === undefined) {
+    throw new Error(NO_TRUSTED_START_MESSAGE);
+  }
   const selected = await open({
     directory: true,
     multiple: false,

--- a/frontend/src/platform/directoryPicker.ts
+++ b/frontend/src/platform/directoryPicker.ts
@@ -1,17 +1,61 @@
 import { open } from "@tauri-apps/plugin-dialog";
+import { documentDir, homeDir } from "@tauri-apps/api/path";
+import { isAcceptableAbsolutePath } from "./pathPolicy";
 
 export interface DirectoryPickerOptions {
   title: string;
   defaultPath?: string;
 }
 
+/**
+ * SBAI-5841: where a folder picker starts when we have nothing better.
+ *
+ * Opening the native dialog with no `defaultPath` lets the OS fall back to the
+ * process working directory, which for a packaged build can be anything (on
+ * Windows, `C:\Windows\System32` when launched from the Start Menu). That is
+ * how a user ends up "browsing" straight into a system folder and picking a
+ * store location nobody intended. So we always aim at a deliberate,
+ * user-writable place instead: Documents, then the home directory.
+ *
+ * Returns `undefined` only when the path API itself is unavailable (both calls
+ * throw) — i.e. we genuinely have nothing to offer, not merely because the
+ * field was empty or held a relative value.
+ */
+export async function defaultDialogPath(): Promise<string | undefined> {
+  for (const resolve of [documentDir, homeDir]) {
+    try {
+      const candidate = await resolve();
+      if (candidate && isAcceptableAbsolutePath(candidate)) return candidate;
+    } catch {
+      // Fall through to the next candidate.
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Open the native directory picker and return the chosen absolute path, or
+ * `null` when the user cancels (cancel leaves caller state untouched).
+ *
+ * The dialog starts at `options.defaultPath` only when that value is an
+ * acceptable absolute path (see `pathPolicy`); an empty, whitespace, or
+ * relative value would otherwise be handed to the OS, which resolves it
+ * against the process CWD. In that case we start from
+ * {@link defaultDialogPath} instead.
+ */
 export async function chooseDirectory(
   options: DirectoryPickerOptions,
 ): Promise<string | null> {
+  const { defaultPath, ...rest } = options;
+  const start =
+    defaultPath !== undefined && isAcceptableAbsolutePath(defaultPath)
+      ? defaultPath.trim()
+      : await defaultDialogPath();
   const selected = await open({
     directory: true,
     multiple: false,
-    ...options,
+    ...rest,
+    defaultPath: start,
   });
   return typeof selected === "string" ? selected : null;
 }

--- a/frontend/src/platform/pathPolicy.spec.ts
+++ b/frontend/src/platform/pathPolicy.spec.ts
@@ -9,6 +9,8 @@ import {
   classify,
   explainPathProblem,
   isAcceptableAbsolutePath,
+  isNativeAbsolutePath,
+  isWindowsPlatform,
 } from "./pathPolicy";
 
 const ACCEPTED = [
@@ -135,6 +137,99 @@ describe("rejection messages are actionable and name the value", () => {
     expect(message).toContain("A folder is required");
     expect(message).toContain("absolute path");
     expect(message).not.toContain('""');
+  });
+});
+
+/**
+ * The authorizing half. The union above may accept a path the *running*
+ * platform cannot use; anything handed to the OS must clear this instead.
+ */
+describe("isNativeAbsolutePath judges the current platform only", () => {
+  const WINDOWS_ACCEPTS = [
+    "C:\\x",
+    "C:/x",
+    "C:\\LoreData",
+    "C:\\",
+    "\\\\server\\share",
+    "\\\\server\\share\\lore",
+    "\\\\?\\C:\\x",
+    "\\\\?\\UNC\\server\\share",
+  ];
+  const WINDOWS_REJECTS = [
+    "/foo",
+    "/srv/lore",
+    "\\foo",
+    "C:foo",
+    "C:",
+    "lore",
+    "./x",
+    "",
+    "   ",
+    "\\\\server",
+    "\\\\.\\COM1",
+    "\\\\?\\lore",
+  ];
+
+  it.each(WINDOWS_ACCEPTS)("windows accepts %j", (value) => {
+    expect(isNativeAbsolutePath(value, true)).toBe(true);
+  });
+
+  it.each(WINDOWS_REJECTS)("windows rejects %j", (value) => {
+    expect(isNativeAbsolutePath(value, true)).toBe(false);
+  });
+
+  it.each(["/srv/x", "/with spaces/x", "/srv/lore/../store", "//host/share"])(
+    "non-windows accepts %j",
+    (value) => {
+      expect(isNativeAbsolutePath(value, false)).toBe(true);
+    },
+  );
+
+  it.each(["C:\\x", "C:/x", "C:\\LoreData", "\\\\server\\share", "lore", ""])(
+    "non-windows rejects %j",
+    (value) => {
+      expect(isNativeAbsolutePath(value, false)).toBe(false);
+    },
+  );
+
+  it("trims like the union check does", () => {
+    expect(isNativeAbsolutePath("  /srv/lore  ", false)).toBe(true);
+    expect(isNativeAbsolutePath("  C:\\LoreData  ", true)).toBe(true);
+  });
+
+  it("is strictly stricter than the union — the point of having both", () => {
+    // Union-acceptable but NOT usable on Windows: `/foo` and `\foo` resolve
+    // against the current drive there, so they must never start a picker.
+    for (const value of ["/foo", "/srv/lore"]) {
+      expect(isAcceptableAbsolutePath(value)).toBe(true);
+      expect(isNativeAbsolutePath(value, true)).toBe(false);
+    }
+    // …and the mirror image on POSIX.
+    expect(isAcceptableAbsolutePath("C:\\LoreData")).toBe(true);
+    expect(isNativeAbsolutePath("C:\\LoreData", false)).toBe(false);
+  });
+
+  it("defaults to the detected platform", () => {
+    const windows = isWindowsPlatform();
+    expect(isNativeAbsolutePath("/srv/lore")).toBe(
+      isNativeAbsolutePath("/srv/lore", windows),
+    );
+    expect(isNativeAbsolutePath("C:\\LoreData")).toBe(
+      isNativeAbsolutePath("C:\\LoreData", windows),
+    );
+  });
+});
+
+describe("isWindowsPlatform", () => {
+  it("reads the running platform from the user agent", () => {
+    expect(isWindowsPlatform()).toBe(/\bWindows\b/.test(navigator.userAgent));
+  });
+
+  it("is false under jsdom, so the specs above pin both tables explicitly", () => {
+    // jsdom's UA is built from process.platform ("win32", "linux", "darwin"),
+    // none of which contain the word "Windows" — so this holds on every host
+    // and the platform-specific expectations stay deterministic.
+    expect(isWindowsPlatform()).toBe(false);
   });
 });
 

--- a/frontend/src/platform/pathPolicy.spec.ts
+++ b/frontend/src/platform/pathPolicy.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * SBAI-5841: the frontend mirror of `src-tauri/src/path_policy.rs`. The table
+ * below is the same table the Rust unit tests assert, plus the deliberate
+ * union rule: because the UI cannot know the target OS, a value passes when it
+ * is absolute on *either* family, and the backend stays the authority.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  classify,
+  explainPathProblem,
+  isAcceptableAbsolutePath,
+} from "./pathPolicy";
+
+const ACCEPTED = [
+  // Windows drive-absolute, both separators, spaces, and the bare drive root.
+  "C:\\LoreData",
+  "c:\\loredata",
+  "C:/x",
+  "C:\\Lore Data\\with spaces",
+  "C:\\",
+  "D:\\",
+  // UNC with both server and share.
+  "\\\\server\\share",
+  "\\\\server\\share\\lore",
+  // Verbatim disk / verbatim UNC.
+  "\\\\?\\C:\\x",
+  "\\\\?\\UNC\\server\\share",
+  "\\\\?\\UNC\\server\\share\\lore",
+  // Unix-rooted.
+  "/srv/lore",
+  "/with spaces/x",
+  "/srv/lore/../store",
+  "//host/share",
+];
+
+const REJECTED = [
+  "",
+  "   ",
+  ".",
+  "..",
+  "lore",
+  "./x",
+  ".\\lore",
+  "..\\lore",
+  "C:foo",
+  "C:",
+  "\\\\server",
+  "\\\\server\\",
+  "\\\\",
+  "\\\\.\\COM1",
+  "\\\\?\\lore",
+  "\\foo",
+  "~/lore",
+];
+
+describe("explainPathProblem / isAcceptableAbsolutePath", () => {
+  it.each(ACCEPTED)("accepts %j", (value) => {
+    expect(explainPathProblem(value)).toBeNull();
+    expect(isAcceptableAbsolutePath(value)).toBe(true);
+  });
+
+  it.each(REJECTED)("rejects %j", (value) => {
+    const message = explainPathProblem(value);
+    expect(message).not.toBeNull();
+    expect(isAcceptableAbsolutePath(value)).toBe(false);
+    // Every rejection must say what to do, not just that it failed.
+    expect(message).toMatch(
+      /absolute path|drive letter|drive path|server and share|folder/,
+    );
+  });
+
+  it("trims before judging, so padded absolute paths pass", () => {
+    expect(explainPathProblem("  /srv/lore  ")).toBeNull();
+    expect(explainPathProblem("  C:\\LoreData  ")).toBeNull();
+    expect(isAcceptableAbsolutePath("\t/srv/lore\n")).toBe(true);
+  });
+
+  it("accepts /foo — the union edge: unix-absolute wins, backend decides", () => {
+    // The Rust Windows classifier calls this driveless-rootful and rejects it;
+    // the union accepts it because it is a perfectly good POSIX path and the
+    // UI cannot know the target OS. Documented, intended.
+    expect(classify("/foo", true)).toBe("rootRelative");
+    expect(classify("/foo", false)).toBeNull();
+    expect(explainPathProblem("/foo")).toBeNull();
+  });
+});
+
+describe("rejection messages are actionable and name the value", () => {
+  it("relative paths name the startup-folder hazard and a concrete example", () => {
+    const message = explainPathProblem("lore") ?? "";
+    expect(message).toContain('"lore"');
+    expect(message).toContain("relative path");
+    expect(message).toContain("startup folder");
+    expect(message).toContain("C:\\LoreData");
+    expect(message).toContain("/home/you/lore");
+  });
+
+  it("drive-relative paths say to add the backslash after the drive letter", () => {
+    const message = explainPathProblem("C:foo") ?? "";
+    expect(message).toContain('"C:foo"');
+    expect(message).toContain("backslash after the drive letter");
+    expect(message).toContain("C:\\LoreData");
+    expect(explainPathProblem("C:") ?? "").toContain(
+      "backslash after the drive letter",
+    );
+  });
+
+  it("driveless rootful paths ask for the drive letter", () => {
+    const message = explainPathProblem("\\foo") ?? "";
+    expect(message).toContain("does not name a drive");
+    expect(message).toContain("C:\\LoreData");
+  });
+
+  it("incomplete UNC paths ask for both server and share", () => {
+    const message = explainPathProblem("\\\\server") ?? "";
+    expect(message).toContain("incomplete network path");
+    expect(message).toContain("server and share");
+    expect(message).toContain("\\\\server\\share\\lore");
+  });
+
+  it("device paths say it is not a folder", () => {
+    expect(explainPathProblem("\\\\.\\COM1") ?? "").toContain(
+      "Windows device path, not a folder",
+    );
+  });
+
+  it("unsupported verbatim forms name the supported shape", () => {
+    const message = explainPathProblem("\\\\?\\lore") ?? "";
+    expect(message).toContain("unsupported \\\\?\\ form");
+    expect(message).toContain("\\\\?\\C:\\LoreData");
+  });
+
+  it("empty input asks for a folder without quoting an empty string", () => {
+    const message = explainPathProblem("   ") ?? "";
+    expect(message).toContain("A folder is required");
+    expect(message).toContain("absolute path");
+    expect(message).not.toContain('""');
+  });
+});
+
+describe("classify mirrors the backend's per-family table", () => {
+  it("windows accepts exactly the documented absolute forms", () => {
+    expect(classify("C:\\LoreData", true)).toBeNull();
+    expect(classify("C:/x", true)).toBeNull();
+    expect(classify("C:\\", true)).toBeNull();
+    expect(classify("\\\\server\\share", true)).toBeNull();
+    expect(classify("\\\\?\\C:\\x", true)).toBeNull();
+    expect(classify("\\\\?\\UNC\\server\\share", true)).toBeNull();
+  });
+
+  it("windows names the specific defect for every rejected form", () => {
+    expect(classify("", true)).toBe("empty");
+    expect(classify(".", true)).toBe("relative");
+    expect(classify("..", true)).toBe("relative");
+    expect(classify("lore", true)).toBe("relative");
+    expect(classify(".\\lore", true)).toBe("relative");
+    expect(classify("C:foo", true)).toBe("driveRelative");
+    expect(classify("C:", true)).toBe("driveRelative");
+    expect(classify("\\foo", true)).toBe("rootRelative");
+    expect(classify("\\\\", true)).toBe("incompleteUnc");
+    expect(classify("\\\\server", true)).toBe("incompleteUnc");
+    expect(classify("\\\\server\\", true)).toBe("incompleteUnc");
+    expect(classify("\\\\.\\COM1", true)).toBe("deviceNamespace");
+    expect(classify("\\\\?\\lore", true)).toBe("unsupportedVerbatim");
+    expect(classify("\\\\?\\UNC\\server", true)).toBe("incompleteUnc");
+  });
+
+  it("unix accepts only rooted paths", () => {
+    expect(classify("/srv/lore", false)).toBeNull();
+    expect(classify("//host/share", false)).toBeNull();
+    expect(classify("", false)).toBe("empty");
+    expect(classify(".", false)).toBe("relative");
+    expect(classify("lore", false)).toBe("relative");
+    expect(classify("C:\\LoreData", false)).toBe("relative");
+    expect(classify("C:foo", false)).toBe("relative");
+  });
+});

--- a/frontend/src/platform/pathPolicy.ts
+++ b/frontend/src/platform/pathPolicy.ts
@@ -36,6 +36,16 @@
  * classifier (driveless rootful) but *accepted* here, because it is a
  * perfectly good POSIX absolute path and the union accepts it. On Windows the
  * backend still gets the last word.
+ *
+ * **Two checks, two jobs — do not mix them up.**
+ *
+ * - {@link explainPathProblem} / {@link isAcceptableAbsolutePath} — the union.
+ *   *Preflight UX only, non-authorizing.* Their leniency exists so the inline
+ *   field error never scolds a user for a path the backend would accept.
+ * - {@link isNativeAbsolutePath} — the current platform only. *Authorizing.*
+ *   Anything handed to the OS (a folder picker's starting directory) must
+ *   clear this one, because a union pass is not evidence the value means
+ *   anything on the machine we are actually running on.
  */
 
 /** Why a candidate failed. Mirrors `PathRejection` in path_policy.rs. */
@@ -200,6 +210,11 @@ export function rejectionMessage(
  * Acceptance is the **union** of the unix and Windows classifiers (see the
  * module doc); the reported reason is the Windows one, which is always the
  * more specific of the two for a value both families reject.
+ *
+ * **Non-authorizing.** This is preflight *UX* only — it exists to tell the
+ * user what to fix before they submit, and it is deliberately lenient because
+ * the UI cannot know the target OS. Never use it to decide what to hand to the
+ * OS or to the backend; use {@link isNativeAbsolutePath} for that.
  */
 export function explainPathProblem(value: string): string | null {
   const trimmed = value.trim();
@@ -210,10 +225,48 @@ export function explainPathProblem(value: string): string | null {
 }
 
 /**
- * Non-erroring check: would this value survive the policy on *some* platform?
- * Use it to decide whether a value is safe to hand to the native folder picker
- * as its starting directory — never as an authorization decision.
+ * Non-erroring form of {@link explainPathProblem}: would this value survive
+ * the policy on *some* platform?
+ *
+ * **Non-authorizing** — same caveat as `explainPathProblem`. It answers "is
+ * this worth complaining about in the field?", not "is this safe to act on".
+ * Anything that reaches the OS (a picker's starting folder) or stands in for a
+ * real location must go through {@link isNativeAbsolutePath}.
  */
 export function isAcceptableAbsolutePath(value: string): boolean {
   return explainPathProblem(value) === null;
+}
+
+/**
+ * Is the process running on Windows? Detected from the user agent, which is
+ * the only signal available without pulling in a Tauri OS plugin. Guarded so a
+ * non-DOM context (SSR, a bare Node test runner) simply reads as "not
+ * Windows" — the stricter of the two answers for a POSIX-shaped check.
+ */
+export function isWindowsPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent;
+  return typeof ua === "string" && /\bWindows\b/.test(ua);
+}
+
+/**
+ * Is `value` absolute **on the platform actually running this app**?
+ *
+ * This is the **authorizing** check — the one to use for anything handed to
+ * the OS, above all a folder picker's starting directory. The union helpers
+ * ({@link explainPathProblem} / {@link isAcceptableAbsolutePath}) deliberately
+ * accept the other family's forms so the inline field error stays quiet for a
+ * value the backend might well accept; that leniency is fine for a message and
+ * wrong for an action. Concretely, on Windows `/foo` and `\foo` are
+ * driveless-rootful and resolve against the *current drive* — union-acceptable,
+ * never a trusted starting folder.
+ *
+ * `windows` defaults to {@link isWindowsPlatform} and is injectable so both
+ * platform tables stay testable on one host.
+ */
+export function isNativeAbsolutePath(
+  value: string,
+  windows: boolean = isWindowsPlatform(),
+): boolean {
+  return classify(value.trim(), windows) === null;
 }

--- a/frontend/src/platform/pathPolicy.ts
+++ b/frontend/src/platform/pathPolicy.ts
@@ -1,0 +1,219 @@
+/**
+ * SBAI-5841 — lexical absolute-path policy for lifecycle paths, in the UI.
+ *
+ * This is the **supplemental** half of the fail-closed absolute-path policy.
+ * It mirrors `src-tauri/src/path_policy.rs` so the user sees an actionable
+ * message *before* the round-trip, but it is deliberately **not** a trust
+ * boundary: the backend re-validates every store directory and every
+ * repository open/create/clone destination and is the only authority. Never
+ * treat a pass here as permission to skip the backend check.
+ *
+ * Why it exists at all: a packaged app can start with an arbitrary CWD (on
+ * Windows, launching from the Start Menu can leave it at
+ * `C:\Windows\System32`), so a relative value like `.` or `lore` would
+ * silently resolve somewhere the user never intended. Telling the user that
+ * inline — at the field — is far better UX than a backend rejection string.
+ *
+ * **Union semantics (the one deliberate divergence from the backend).** The
+ * backend classifies for its own compile target; the frontend cannot reliably
+ * know the target OS, so a value is acceptable here when it is acceptable on
+ * *either* family:
+ *
+ * | input                          | verdict | why                              |
+ * |--------------------------------|---------|----------------------------------|
+ * | `/srv/lore`, `/with spaces/x`  | accept  | unix-rooted                      |
+ * | `C:\LoreData`, `C:/x`, `C:\`   | accept  | windows drive-absolute           |
+ * | `\\server\share[\…]`           | accept  | UNC with both server and share   |
+ * | `\\?\C:\x`, `\\?\UNC\srv\shr`  | accept  | verbatim disk / verbatim UNC     |
+ * | `""`, `"   "`, `.`, `..`, `x`  | reject  | resolves against the startup dir |
+ * | `C:foo`, `C:`                  | reject  | drive-relative                   |
+ * | `\foo`                         | reject  | driveless rootful (Windows form) |
+ * | `\\server`, `\\`               | reject  | incomplete UNC (no share)        |
+ * | `\\.\COM1`                     | reject  | device namespace, not a folder   |
+ * | `\\?\lore`                     | reject  | unsupported verbatim form        |
+ *
+ * Note the intended edge: `/foo` is *rejected* by the backend's Windows
+ * classifier (driveless rootful) but *accepted* here, because it is a
+ * perfectly good POSIX absolute path and the union accepts it. On Windows the
+ * backend still gets the last word.
+ */
+
+/** Why a candidate failed. Mirrors `PathRejection` in path_policy.rs. */
+export type PathRejection =
+  | "empty"
+  | "relative"
+  | "driveRelative"
+  | "rootRelative"
+  | "deviceNamespace"
+  | "incompleteUnc"
+  | "unsupportedVerbatim";
+
+const isSep = (ch: string): boolean => ch === "\\" || ch === "/";
+
+const isDriveLetter = (ch: string): boolean =>
+  (ch >= "a" && ch <= "z") || (ch >= "A" && ch <= "Z");
+
+/** `\\?\`-style verbatim prefix (either separator accepted lexically). */
+function stripVerbatimPrefix(value: string): string | null {
+  if (
+    value.length >= 4 &&
+    isSep(value[0]) &&
+    isSep(value[1]) &&
+    value[2] === "?" &&
+    isSep(value[3])
+  ) {
+    return value.slice(4);
+  }
+  return null;
+}
+
+/**
+ * `X:\…` or `X:/…` (drive letter, colon, separator). Bare `X:` is
+ * drive-relative and must NOT match.
+ */
+function isDriveAbsolute(value: string): boolean {
+  return (
+    value.length >= 3 &&
+    isDriveLetter(value[0]) &&
+    value[1] === ":" &&
+    isSep(value[2])
+  );
+}
+
+/**
+ * After a UNC prefix: require a non-empty server, a separator, and a non-empty
+ * share component.
+ */
+function requireServerAndShare(rest: string): PathRejection | null {
+  const parts = rest.split(/[\\/]/);
+  const server = parts[0] ?? "";
+  const share = parts[1] ?? "";
+  return server.length === 0 || share.length === 0 ? "incompleteUnc" : null;
+}
+
+/**
+ * Lexically classify `candidate` for one target family. `null` = acceptable.
+ * Mirrors `path_policy::classify`; callers pass an already-trimmed value.
+ */
+export function classify(
+  candidate: string,
+  windows: boolean,
+): PathRejection | null {
+  if (candidate.length === 0) return "empty";
+
+  if (!windows) {
+    return candidate.startsWith("/") ? null : "relative";
+  }
+
+  // Verbatim namespace: `\\?\C:\…` or `\\?\UNC\server\share…`.
+  const verbatim = stripVerbatimPrefix(candidate);
+  if (verbatim !== null) {
+    if (isDriveAbsolute(verbatim)) return null;
+    if (verbatim.startsWith("UNC\\") || verbatim.startsWith("UNC/")) {
+      return requireServerAndShare(verbatim.slice(4));
+    }
+    return "unsupportedVerbatim";
+  }
+
+  // Device namespace: `\\.\COM1` and friends. Never a store directory.
+  if (
+    candidate.length >= 4 &&
+    isSep(candidate[0]) &&
+    isSep(candidate[1]) &&
+    candidate[2] === "." &&
+    isSep(candidate[3])
+  ) {
+    return "deviceNamespace";
+  }
+
+  // UNC: `\\server\share[\…]` — both components required.
+  if (candidate.length >= 2 && isSep(candidate[0]) && isSep(candidate[1])) {
+    return requireServerAndShare(candidate.slice(2));
+  }
+
+  // Drive-letter forms.
+  if (candidate.length >= 2 && isDriveLetter(candidate[0]) && candidate[1] === ":") {
+    return isDriveAbsolute(candidate) ? null : "driveRelative";
+  }
+
+  // Rootful but driveless: `\foo` — relative to the current drive.
+  if (isSep(candidate[0])) return "rootRelative";
+
+  return "relative";
+}
+
+/**
+ * Human-actionable explanation for a rejection — says what the value is and
+ * what to type instead. Mirrors `path_policy::rejection_message` minus the
+ * backend's field-role prefix (the field label already supplies that here).
+ */
+export function rejectionMessage(
+  value: string,
+  rejection: PathRejection,
+): string {
+  switch (rejection) {
+    case "empty":
+      return (
+        "A folder is required — enter a full absolute path such as " +
+        "C:\\LoreData or /home/you/lore"
+      );
+    case "relative":
+      return (
+        `"${value}" is a relative path and would resolve against the app's ` +
+        "startup folder (which can be C:\\Windows\\System32) — enter a full " +
+        "absolute path such as C:\\LoreData or /home/you/lore"
+      );
+    case "driveRelative":
+      return (
+        `"${value}" is drive-relative (it depends on that drive's current ` +
+        "folder) — add a backslash after the drive letter, for example " +
+        "C:\\LoreData"
+      );
+    case "rootRelative":
+      return (
+        `"${value}" does not name a drive — include the drive letter, for ` +
+        "example C:\\LoreData"
+      );
+    case "deviceNamespace":
+      return (
+        `"${value}" is a Windows device path, not a folder — choose a normal ` +
+        "folder such as C:\\LoreData"
+      );
+    case "incompleteUnc":
+      return (
+        `"${value}" is an incomplete network path — include both server and ` +
+        "share, for example \\\\server\\share\\lore"
+      );
+    case "unsupportedVerbatim":
+      return (
+        `"${value}" uses an unsupported \\\\?\\ form — use a drive path such ` +
+        "as \\\\?\\C:\\LoreData, or drop the \\\\?\\ prefix"
+      );
+  }
+}
+
+/**
+ * Explain why `value` is not an acceptable absolute lifecycle path, or `null`
+ * when it is acceptable. Operates on `value.trim()`, so whitespace-only input
+ * reads as empty — exactly like `path_policy::require_absolute`.
+ *
+ * Acceptance is the **union** of the unix and Windows classifiers (see the
+ * module doc); the reported reason is the Windows one, which is always the
+ * more specific of the two for a value both families reject.
+ */
+export function explainPathProblem(value: string): string | null {
+  const trimmed = value.trim();
+  if (classify(trimmed, false) === null) return null;
+  const windowsRejection = classify(trimmed, true);
+  if (windowsRejection === null) return null;
+  return rejectionMessage(trimmed, windowsRejection);
+}
+
+/**
+ * Non-erroring check: would this value survive the policy on *some* platform?
+ * Use it to decide whether a value is safe to hand to the native folder picker
+ * as its starting directory — never as an authorization decision.
+ */
+export function isAcceptableAbsolutePath(value: string): boolean {
+  return explainPathProblem(value) === null;
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -195,6 +195,17 @@ pub(crate) async fn restore_active_repository(state: &AppState, settings: &Setti
 
     match default_backend(candidate.clone()).status().await {
         Ok(_) => {
+            // Gap 9 (re-review): the normalized path is persisted too, so a
+            // padded legacy value is rewritten once instead of being
+            // re-normalized on every startup.
+            if let Err(settings_error) =
+                settings.update(|value| value.active_repository = Some(candidate.clone()))
+            {
+                tracing::warn!(
+                    error = %settings_error,
+                    "failed to persist normalized active repository; runtime continues"
+                );
+            }
             *state.working_dir.lock().unwrap_or_else(|e| e.into_inner()) = Some(candidate);
         }
         Err(error) => {
@@ -1888,15 +1899,19 @@ pub async fn storage_open(
     // in-memory case rather than a relative path reaching the storage op. A
     // non-empty local store path must be absolute before it (or its
     // lifecycle root) touches the filesystem.
-    let repository_path = config
-        .path
-        .as_deref()
-        .map(str::trim)
-        .unwrap_or_default()
-        .to_string();
-    if !repository_path.is_empty() {
-        path_policy::require_absolute(&repository_path, "store path")?;
-    }
+    let repository_path = {
+        let trimmed = config.path.as_deref().map(str::trim).unwrap_or_default();
+        if trimmed.is_empty() {
+            String::new()
+        } else {
+            // The policy's RETURNED path is the only value that flows on —
+            // the raw and even the locally-trimmed input are dropped here so
+            // the dataflow cannot drift if normalization evolves.
+            path_policy::require_absolute(trimmed, "store path")?
+                .to_string_lossy()
+                .into_owned()
+        }
+    };
     let remote_url = config.endpoint.clone().unwrap_or_default();
     let in_memory = repository_path.is_empty() && remote_url.is_empty();
 
@@ -2127,16 +2142,22 @@ pub async fn storage_open_handle(
     // policy bypass. Trim-normalize; in-memory must not smuggle a path at
     // all; a non-empty local path must be absolute before the lifecycle root
     // or the storage op sees it.
-    let repository_path = repository_path.trim().to_string();
-    if in_memory {
-        if !repository_path.is_empty() {
+    let trimmed = repository_path.trim();
+    let repository_path = if in_memory {
+        if !trimmed.is_empty() {
             return Err(LoreError::CommandFailed(
                 "storage open: in-memory mode must not carry a repository path".into(),
             ));
         }
-    } else if !repository_path.is_empty() {
-        path_policy::require_absolute(&repository_path, "store path")?;
-    }
+        String::new()
+    } else if trimmed.is_empty() {
+        String::new()
+    } else {
+        // The policy's RETURNED path is the only value that flows on.
+        path_policy::require_absolute(trimmed, "store path")?
+            .to_string_lossy()
+            .into_owned()
+    };
     let session_root = storage_lifecycle_root(&repository_path);
     let api = LoreApi::new(session_root.clone());
     let result = op_storage_open(
@@ -3309,13 +3330,12 @@ fn suffixed_sibling(dir: &std::path::Path, suffix: &str) -> PathBuf {
 }
 
 /// Clone destination for the rename-failure (lock) fallback: an explicit
-/// non-empty `new_dir` wins; empty string (the palette's "blank optional
-/// field" convention) and `None` both mean "sibling `<dir>-recovered-*`".
-fn recovery_fallback_dest(dir: &std::path::Path, new_dir: Option<String>) -> PathBuf {
-    new_dir
-        .filter(|candidate| !candidate.is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| suffixed_sibling(dir, "-recovered"))
+/// destination wins; `None` (which the command derives from both a missing
+/// and a blank/whitespace palette field) means "sibling `<dir>-recovered-*`".
+/// SBAI-5841: takes an ALREADY policy-validated absolute path — the raw
+/// palette string never reaches this helper.
+fn recovery_fallback_dest(dir: &std::path::Path, new_dir: Option<PathBuf>) -> PathBuf {
+    new_dir.unwrap_or_else(|| suffixed_sibling(dir, "-recovered"))
 }
 
 /// After a failed clone on the rename-success path, put the preserved corrupt
@@ -3388,6 +3408,17 @@ pub async fn repository_recover_local(
     settings: State<'_, SettingsManager>,
     new_dir: Option<String>,
 ) -> Result<RecoverLocalResult, LoreError> {
+    // SBAI-5841 (re-review): the palette-supplied recovery destination is
+    // validated and normalized BEFORE any release/rename/clone or other
+    // filesystem/state mutation — on the rename-failure path it becomes the
+    // clone destination, which previously accepted a raw relative value.
+    // Blank/whitespace keeps the "default sibling" convention.
+    let new_dir = new_dir
+        .as_deref()
+        .map(str::trim)
+        .filter(|candidate| !candidate.is_empty())
+        .map(|candidate| path_policy::require_absolute(candidate, "recovery destination"))
+        .transpose()?;
     let dir = state.dir()?;
 
     // 1. Remote URL + default branch from the active (corrupt) directory.
@@ -3470,16 +3501,16 @@ mod recover_local_tests {
     #[test]
     fn recovery_fallback_dest_honours_explicit_new_dir() {
         let dir = PathBuf::from("/srv/example/repo");
-        let dest = recovery_fallback_dest(&dir, Some("/srv/example/repo-copy".to_string()));
+        let dest = recovery_fallback_dest(&dir, Some(PathBuf::from("/srv/example/repo-copy")));
         assert_eq!(dest, PathBuf::from("/srv/example/repo-copy"));
     }
 
-    /// Empty string (the palette's blank-optional-field convention) falls back
-    /// to a `<dir>-recovered-*` sibling rather than cloning into "".
+    /// `None` (the command maps both a missing and a blank/whitespace palette
+    /// field here) falls back to a `<dir>-recovered-*` sibling.
     #[test]
-    fn recovery_fallback_dest_treats_empty_new_dir_as_default() {
+    fn recovery_fallback_dest_treats_omitted_new_dir_as_default() {
         let dir = PathBuf::from("/srv/example/repo");
-        let dest = recovery_fallback_dest(&dir, Some(String::new()));
+        let dest = recovery_fallback_dest(&dir, None);
         assert!(dest
             .to_string_lossy()
             .starts_with("/srv/example/repo-recovered-"));

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -169,21 +169,29 @@ pub(crate) async fn restore_active_repository(state: &AppState, settings: &Setti
     // SBAI-5841: a legacy persisted *relative* value must be rejected and
     // cleared WITHOUT probing the backend — a status probe would resolve it
     // against the process CWD (System32 under a packaged Windows launch),
-    // which is exactly the seam this policy closes.
-    if !path_policy::is_acceptable(candidate.to_string_lossy().as_ref()) {
-        tracing::warn!(
-            path = %candidate.display(),
-            "persisted active repository is not an absolute path; clearing without probing CWD"
-        );
-        *state.working_dir.lock().unwrap_or_else(|e| e.into_inner()) = None;
-        if let Err(settings_error) = settings.update(|value| value.active_repository = None) {
+    // which is exactly the seam this policy closes. Gap 9: on acceptance the
+    // policy's normalized path is the ONLY value probed and republished.
+    let candidate = match path_policy::require_absolute(
+        candidate.to_string_lossy().as_ref(),
+        "persisted repository location",
+    ) {
+        Ok(normalized) => normalized,
+        Err(error) => {
             tracing::warn!(
-                error = %settings_error,
-                "failed to persist relative active-repository removal"
+                path = %candidate.display(),
+                error = %error,
+                "persisted active repository failed the path policy; clearing without probing CWD"
             );
+            *state.working_dir.lock().unwrap_or_else(|e| e.into_inner()) = None;
+            if let Err(settings_error) = settings.update(|value| value.active_repository = None) {
+                tracing::warn!(
+                    error = %settings_error,
+                    "failed to persist rejected active-repository removal"
+                );
+            }
+            return;
         }
-        return;
-    }
+    };
 
     match default_backend(candidate.clone()).status().await {
         Ok(_) => {
@@ -1771,13 +1779,20 @@ pub async fn repository_create(
     // lower-level `repositoryCreateApi.create` caller omits it.
     path: Option<String>,
 ) -> Result<CreateResult, LoreError> {
+    // SBAI-5841: `None` is the intentional omitted case (fall back to the
+    // active repository). A SUPPLIED empty/whitespace path is caller error
+    // and fails closed instead of silently probing the active state dir.
     let candidate = path
-        .filter(|p| !p.trim().is_empty())
         .map(|p| path_policy::require_absolute(&p, "repository location"))
         .transpose()?;
-    if use_shared_store {
-        path_policy::require_absolute(&shared_store_path, "shared store path")?;
-    }
+    // Gap 9: the normalized (trimmed) value is the ONLY one passed onward.
+    let shared_store_path = if use_shared_store {
+        path_policy::require_absolute(&shared_store_path, "shared store path")?
+            .to_string_lossy()
+            .into_owned()
+    } else {
+        shared_store_path
+    };
     let dir = candidate.clone().map_or_else(|| state.dir(), Ok)?;
     let api = LoreApi::new(dir);
     let result = finalized(
@@ -1869,11 +1884,17 @@ pub async fn storage_open(
     // backends the connection is supplied as a remote URL; "local" backends
     // open the on-disk store at `path`. When no path/endpoint is given we fall
     // back to an in-memory store so the connectivity test can still run.
-    let repository_path = config.path.clone().unwrap_or_default();
-    // A non-empty local store path must be absolute before it reaches the
-    // storage op (SBAI-5841); an empty one falls through to the in-memory
-    // connectivity probe below and touches no filesystem path at all.
-    if !repository_path.trim().is_empty() {
+    // SBAI-5841: trim-normalize so whitespace-only input is the intentional
+    // in-memory case rather than a relative path reaching the storage op. A
+    // non-empty local store path must be absolute before it (or its
+    // lifecycle root) touches the filesystem.
+    let repository_path = config
+        .path
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or_default()
+        .to_string();
+    if !repository_path.is_empty() {
         path_policy::require_absolute(&repository_path, "store path")?;
     }
     let remote_url = config.endpoint.clone().unwrap_or_default();
@@ -2102,6 +2123,20 @@ pub async fn storage_open_handle(
     remote_url: String,
     in_memory: bool,
 ) -> Result<u64, LoreError> {
+    // SBAI-5841: same contract as `storage_open` — the palette path is not a
+    // policy bypass. Trim-normalize; in-memory must not smuggle a path at
+    // all; a non-empty local path must be absolute before the lifecycle root
+    // or the storage op sees it.
+    let repository_path = repository_path.trim().to_string();
+    if in_memory {
+        if !repository_path.is_empty() {
+            return Err(LoreError::CommandFailed(
+                "storage open: in-memory mode must not carry a repository path".into(),
+            ));
+        }
+    } else if !repository_path.is_empty() {
+        path_policy::require_absolute(&repository_path, "store path")?;
+    }
     let session_root = storage_lifecycle_root(&repository_path);
     let api = LoreApi::new(session_root.clone());
     let result = op_storage_open(
@@ -2510,7 +2545,8 @@ pub async fn shared_store_create(path: String) -> Result<String, LoreError> {
         &api,
         SharedStoreCreateArgs {
             remote_url: String::new(),
-            path: Some(path),
+            // Gap 9: pass the normalized target, never the raw input.
+            path: Some(target.to_string_lossy().into_owned()),
             make_default: false,
         },
     )
@@ -3630,9 +3666,14 @@ pub async fn repository_create_with_metadata(
     use_shared_store: bool,
     shared_store_path: String,
 ) -> Result<CreateWithMetadataResult, LoreError> {
-    if use_shared_store {
-        path_policy::require_absolute(&shared_store_path, "shared store path")?;
-    }
+    // Gap 9: the normalized (trimmed) value is the ONLY one passed onward.
+    let shared_store_path = if use_shared_store {
+        path_policy::require_absolute(&shared_store_path, "shared store path")?
+            .to_string_lossy()
+            .into_owned()
+    } else {
+        shared_store_path
+    };
     let api = LoreApi::new(state.dir()?);
     finalized(
         &api,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,6 +13,7 @@ use tauri::{AppHandle, State};
 use tauri::Manager;
 
 use crate::operations::SubscriptionId;
+use crate::path_policy;
 use crate::settings::SettingsManager;
 
 /// Storage session opened by the onboarding "validate connectivity" flow.
@@ -138,6 +139,14 @@ fn activate_repository(
     settings: &State<'_, SettingsManager>,
     path: PathBuf,
 ) -> Result<(), LoreError> {
+    // SBAI-5841 backstop: every caller validates via `path_policy` already;
+    // never persist a CWD-dependent path even if a future caller forgets.
+    if !path.is_absolute() {
+        return Err(LoreError::CommandFailed(format!(
+            "refusing to activate non-absolute repository path \"{}\"",
+            path.display()
+        )));
+    }
     settings
         .update(|value| value.active_repository = Some(path.clone()))
         .map_err(|_| {
@@ -156,6 +165,25 @@ pub(crate) async fn restore_active_repository(state: &AppState, settings: &Setti
         *state.working_dir.lock().unwrap_or_else(|e| e.into_inner()) = None;
         return;
     };
+
+    // SBAI-5841: a legacy persisted *relative* value must be rejected and
+    // cleared WITHOUT probing the backend — a status probe would resolve it
+    // against the process CWD (System32 under a packaged Windows launch),
+    // which is exactly the seam this policy closes.
+    if !path_policy::is_acceptable(candidate.to_string_lossy().as_ref()) {
+        tracing::warn!(
+            path = %candidate.display(),
+            "persisted active repository is not an absolute path; clearing without probing CWD"
+        );
+        *state.working_dir.lock().unwrap_or_else(|e| e.into_inner()) = None;
+        if let Err(settings_error) = settings.update(|value| value.active_repository = None) {
+            tracing::warn!(
+                error = %settings_error,
+                "failed to persist relative active-repository removal"
+            );
+        }
+        return;
+    }
 
     match default_backend(candidate.clone()).status().await {
         Ok(_) => {
@@ -319,7 +347,7 @@ pub async fn open_repository(
     settings: State<'_, SettingsManager>,
     path: String,
 ) -> Result<(), LoreError> {
-    let candidate = PathBuf::from(path);
+    let candidate = path_policy::require_absolute(&path, "repository location")?;
     match default_backend(candidate.clone()).status().await {
         Err(LoreError::CommandFailed(message)) if message.starts_with("Repository not found:") => {
             return Err(LoreError::NoRepository("no repository is open".into()));
@@ -424,7 +452,7 @@ pub async fn create_repository(
     path: String,
     name: String,
 ) -> Result<String, LoreError> {
-    let p = PathBuf::from(&path);
+    let p = path_policy::require_absolute(&path, "repository location")?;
     let id = default_backend(lifecycle_root(&p))
         .create_repository(p.clone(), &name)
         .await?;
@@ -440,7 +468,7 @@ pub async fn clone(
     url: String,
     dest: String,
 ) -> Result<(), LoreError> {
-    let d = PathBuf::from(&dest);
+    let d = path_policy::require_absolute(&dest, "clone destination")?;
     default_backend(lifecycle_root(&d))
         .clone(&url, d.clone())
         .await?;
@@ -1743,7 +1771,13 @@ pub async fn repository_create(
     // lower-level `repositoryCreateApi.create` caller omits it.
     path: Option<String>,
 ) -> Result<CreateResult, LoreError> {
-    let candidate = path.filter(|p| !p.is_empty()).map(PathBuf::from);
+    let candidate = path
+        .filter(|p| !p.trim().is_empty())
+        .map(|p| path_policy::require_absolute(&p, "repository location"))
+        .transpose()?;
+    if use_shared_store {
+        path_policy::require_absolute(&shared_store_path, "shared store path")?;
+    }
     let dir = candidate.clone().map_or_else(|| state.dir(), Ok)?;
     let api = LoreApi::new(dir);
     let result = finalized(
@@ -1836,6 +1870,12 @@ pub async fn storage_open(
     // open the on-disk store at `path`. When no path/endpoint is given we fall
     // back to an in-memory store so the connectivity test can still run.
     let repository_path = config.path.clone().unwrap_or_default();
+    // A non-empty local store path must be absolute before it reaches the
+    // storage op (SBAI-5841); an empty one falls through to the in-memory
+    // connectivity probe below and touches no filesystem path at all.
+    if !repository_path.trim().is_empty() {
+        path_policy::require_absolute(&repository_path, "store path")?;
+    }
     let remote_url = config.endpoint.clone().unwrap_or_default();
     let in_memory = repository_path.is_empty() && remote_url.is_empty();
 
@@ -2461,7 +2501,7 @@ use lore_vm::ops::shared_store::create::{create as op_shared_store_create, Share
 
 #[tauri::command]
 pub async fn shared_store_create(path: String) -> Result<String, LoreError> {
-    let target = PathBuf::from(&path);
+    let target = path_policy::require_absolute(&path, "shared store path")?;
     let api = LoreApi::new(lifecycle_root(&target));
     // The wizard supplies only a filesystem path; the remote URL is left empty
     // so the store defaults to a local backing, and it is not made the global
@@ -2522,7 +2562,7 @@ pub async fn repository_clone(
 ) -> Result<(), LoreError> {
     // Clone into `dest`: point the working dir at it so the local path used by
     // the op (globals.repository_path) is the requested destination.
-    let dest_path = PathBuf::from(&dest);
+    let dest_path = path_policy::require_absolute(&dest, "clone destination")?;
     let api = LoreApi::new(dest_path.clone());
     let result = op_repository_clone(
         &api,
@@ -3590,6 +3630,9 @@ pub async fn repository_create_with_metadata(
     use_shared_store: bool,
     shared_store_path: String,
 ) -> Result<CreateWithMetadataResult, LoreError> {
+    if use_shared_store {
+        path_policy::require_absolute(&shared_store_path, "shared store path")?;
+    }
     let api = LoreApi::new(state.dir()?);
     finalized(
         &api,

--- a/src-tauri/src/context.rs
+++ b/src-tauri/src/context.rs
@@ -434,7 +434,12 @@ pub async fn context_select(
                 .iter()
                 .find(|item| &item.id == project_id)
                 .ok_or_else(|| "selected project is unavailable".to_string())?;
-            let path = PathBuf::from(&project.local_path);
+            // SBAI-5841: a persisted/selected project path must be absolute
+            // before any backend probe — a relative value would resolve
+            // against the process CWD.
+            let path =
+                crate::path_policy::require_absolute(&project.local_path, "project location")
+                    .map_err(|error| error.to_string())?;
             let status = default_backend(path.clone())
                 .status()
                 .await

--- a/src-tauri/src/context.rs
+++ b/src-tauri/src/context.rs
@@ -223,6 +223,18 @@ impl ContextSettings {
             }
         }
 
+        // SBAI-5841 (gap 10): lifecycle paths are checked at the persistence
+        // write boundary — context_update/context_validate must never save a
+        // value that later selection would be the first to reject. The
+        // validator cannot rewrite &self, so a padded value is rejected
+        // rather than silently trimmed.
+        for project in &self.projects {
+            validate_lifecycle_path("project local_path", &project.local_path)?;
+        }
+        for server in &self.hosted_servers {
+            validate_lifecycle_path("hosted server store_path", &server.store_path)?;
+        }
+
         Ok(())
     }
 
@@ -232,6 +244,19 @@ impl ContextSettings {
             .map_err(|error| format!("could not serialize context: {error}"))?;
         validate_no_raw_secrets(&value)
     }
+}
+
+/// SBAI-5841: a persisted lifecycle path must satisfy the shared absolute
+/// path policy and already be normalized (no surrounding whitespace).
+fn validate_lifecycle_path(field: &str, value: &str) -> Result<(), String> {
+    if value != value.trim() {
+        return Err(format!(
+            "{field} must not have surrounding whitespace: \"{value}\""
+        ));
+    }
+    crate::path_policy::require_absolute(value, field)
+        .map(|_| ())
+        .map_err(|error| error.to_string())
 }
 
 fn validate_unique_ids<'a>(kind: &str, ids: impl Iterator<Item = &'a str>) -> Result<(), String> {
@@ -420,33 +445,45 @@ pub async fn context_select(
     target: ContextSelectionTarget,
     request_generation: u64,
 ) -> Result<ContextSelectionResult, String> {
-    register_context_selection(&state, request_generation)?;
+    // SBAI-5841: every PURE check — persisted-context validation, target
+    // normalization, and the lexical path policy — completes BEFORE the
+    // coordinator's latest_generation is consumed, so a rejected request can
+    // never supersede an in-flight valid one. The generation is still
+    // registered before the async backend probe (ordering unchanged there).
     let context = settings.get().context;
     context
         .validate_for_persistence()
         .map_err(|_| "selected context is invalid".to_string())?;
     let normalized = normalize_selection(context, &target)?;
-
-    let (active_repository, status) = match &target {
+    let validated_path = match &target {
         ContextSelectionTarget::Project { project_id } => {
             let project = normalized
                 .projects
                 .iter()
                 .find(|item| &item.id == project_id)
                 .ok_or_else(|| "selected project is unavailable".to_string())?;
-            // SBAI-5841: a persisted/selected project path must be absolute
-            // before any backend probe — a relative value would resolve
-            // against the process CWD.
-            let path =
+            // A persisted/selected project path must be absolute before any
+            // backend probe — a relative value would resolve against the
+            // process CWD.
+            Some(
                 crate::path_policy::require_absolute(&project.local_path, "project location")
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|error| error.to_string())?,
+            )
+        }
+        ContextSelectionTarget::Server { .. } => None,
+    };
+
+    register_context_selection(&state, request_generation)?;
+
+    let (active_repository, status) = match validated_path {
+        Some(path) => {
             let status = default_backend(path.clone())
                 .status()
                 .await
                 .map_err(|_| "selected project could not be opened".to_string())?;
             (Some(path), Some(status))
         }
-        ContextSelectionTarget::Server { .. } => (None, None),
+        None => (None, None),
     };
 
     commit_context_selection(
@@ -869,6 +906,27 @@ mod tests {
         ] {
             assert!(validate_no_raw_secrets(&raw).is_err(), "accepted {raw}");
         }
+    }
+
+    /// SBAI-5841 (gap 10): the persistence write boundary rejects relative
+    /// and padded lifecycle paths — later selection must never be the first
+    /// place a bad persisted value fails.
+    #[test]
+    fn validation_rejects_relative_and_padded_lifecycle_paths() {
+        let mut context = complete_context();
+        context.projects[0].local_path = "lore".into();
+        let error = context.validate_for_persistence().unwrap_err();
+        assert!(error.contains("project local_path"), "{error}");
+
+        let mut context = complete_context();
+        context.projects[0].local_path = " /projects/game-lore ".into();
+        let error = context.validate_for_persistence().unwrap_err();
+        assert!(error.contains("surrounding whitespace"), "{error}");
+
+        let mut context = complete_context();
+        context.hosted_servers[0].store_path = "stores".into();
+        let error = context.validate_for_persistence().unwrap_err();
+        assert!(error.contains("hosted server store_path"), "{error}");
     }
 
     #[test]

--- a/src-tauri/src/ipc_harness_tests.rs
+++ b/src-tauri/src/ipc_harness_tests.rs
@@ -1288,3 +1288,225 @@ fn persisted_relative_repository_is_cleared_without_probing_fake_system32_cwd() 
         "the legacy relative persisted value must be cleared"
     );
 }
+
+/// Gap 3/4 (SBAI-5841 review): whitespace-only local store input is the
+/// intentional in-memory case — it must neither error nor let a relative
+/// value reach the storage op, and nothing may be written under the CWD.
+#[test]
+fn storage_open_whitespace_path_is_the_intentional_in_memory_case() {
+    let fake = FakeSystem32::enter();
+    let app = build_app();
+    let state = app.state::<AppState>();
+
+    tauri::async_runtime::block_on(commands::storage_open(
+        state.clone(),
+        commands::StorageBackendConfig {
+            kind: "local".into(),
+            path: Some("   ".into()),
+            endpoint: None,
+            bucket: None,
+            region: None,
+            access_key_id: None,
+            secret_access_key: None,
+            mutable_store: None,
+        },
+    ))
+    .expect("whitespace-only local path is the in-memory connectivity probe");
+
+    assert_eq!(
+        fake.entries(),
+        Vec::<String>::new(),
+        "in-memory probe must not write under the process CWD"
+    );
+}
+
+/// Gap 4 (SBAI-5841 review): the palette `storage_open_handle` path enforces
+/// the same contract as `storage_open` — it is not a policy bypass.
+#[test]
+fn storage_open_handle_rejects_relative_and_path_carrying_in_memory() {
+    let fake = FakeSystem32::enter();
+    let app = build_app();
+    let state = app.state::<AppState>();
+
+    let error = tauri::async_runtime::block_on(commands::storage_open_handle(
+        state.clone(),
+        "lore".into(),
+        String::new(),
+        false,
+    ))
+    .expect_err("relative local path must fail closed");
+    assert!(error.to_string().contains("store path"), "{error}");
+
+    let error = tauri::async_runtime::block_on(commands::storage_open_handle(
+        state.clone(),
+        "lore".into(),
+        String::new(),
+        true,
+    ))
+    .expect_err("in-memory mode must not smuggle a path");
+    assert!(
+        error
+            .to_string()
+            .contains("must not carry a repository path"),
+        "{error}"
+    );
+
+    tauri::async_runtime::block_on(commands::storage_open_handle(
+        state.clone(),
+        "   ".into(),
+        String::new(),
+        true,
+    ))
+    .expect("whitespace normalizes to the intentional in-memory case");
+
+    assert_eq!(
+        fake.entries(),
+        Vec::<String>::new(),
+        "storage_open_handle must not write under the process CWD"
+    );
+}
+
+/// Gap 7 (SBAI-5841 review): a SUPPLIED empty/whitespace create path is
+/// caller error and fails closed; only an omitted (`None`) path falls back
+/// to the active repository — and that fallback still works.
+#[test]
+fn repository_create_rejects_supplied_empty_path_but_keeps_omitted_fallback() {
+    let fake = FakeSystem32::enter();
+    let app = build_app();
+    let state = app.state::<AppState>();
+    let settings = app.state::<SettingsManager>();
+
+    for supplied in ["", "   "] {
+        let error = tauri::async_runtime::block_on(commands::repository_create(
+            state.clone(),
+            settings.clone(),
+            "lore://127.0.0.1:1/unreachable".into(),
+            "desc".into(),
+            String::new(),
+            false,
+            String::new(),
+            Some(supplied.to_string()),
+        ))
+        .expect_err("supplied empty path must fail closed, not fall back");
+        assert!(error.to_string().contains("repository location"), "{error}");
+    }
+
+    // Omitted path (None) still falls back to the active state dir — with no
+    // repository open that is the structured NoRepository startup error, not
+    // a path-policy rejection.
+    let error = tauri::async_runtime::block_on(commands::repository_create(
+        state.clone(),
+        settings.clone(),
+        "lore://127.0.0.1:1/unreachable".into(),
+        "desc".into(),
+        String::new(),
+        false,
+        String::new(),
+        None,
+    ))
+    .expect_err("no active repository");
+    assert!(
+        matches!(error, lore_vm::LoreError::NoRepository(_)),
+        "omitted path must reach the state-dir fallback, got {error:?}"
+    );
+
+    assert_eq!(fake.entries(), Vec::<String>::new());
+}
+
+/// Gap 9 (SBAI-5841 review): a padded-but-absolute legacy persisted value
+/// validates and then the NORMALIZED path is the only value probed and
+/// republished — the exact trimmed path becomes the active repository.
+#[test]
+fn restore_normalizes_padded_persisted_absolute_path() {
+    let tmp = tempfile::tempdir().expect("temp fixture root");
+    let client_path = tmp.path().join("padded-restore-client");
+    let shared_store = tmp.path().join("padded-restore-store");
+    tauri::async_runtime::block_on(create_offline_fixture_repository(
+        &client_path,
+        &shared_store,
+    ));
+
+    let app = build_app();
+    let state = app.state::<AppState>();
+    let settings = app.state::<SettingsManager>();
+    let padded = format!("  {}  ", client_path.display());
+    settings
+        .update(|value| value.active_repository = Some(std::path::PathBuf::from(&padded)))
+        .expect("seed padded legacy persisted value");
+
+    tauri::async_runtime::block_on(commands::restore_active_repository(&state, &settings));
+
+    assert_eq!(
+        commands::current_repository(state.clone()),
+        Some(client_path.to_string_lossy().into_owned()),
+        "the exact normalized (trimmed) path must flow, not the padded original"
+    );
+}
+
+/// Gap 8 (SBAI-5841 review): a rejected selection must not consume the
+/// coordinator generation — pure validation completes before
+/// `latest_generation` is mutated, so the same generation still succeeds
+/// once the context is valid.
+#[test]
+fn context_select_rejected_request_does_not_consume_the_generation() {
+    let tmp = tempfile::tempdir().expect("temp fixture root");
+    let client_path = tmp.path().join("generation-client");
+    let shared_store = tmp.path().join("generation-store");
+    tauri::async_runtime::block_on(create_offline_fixture_repository(
+        &client_path,
+        &shared_store,
+    ));
+
+    // Legacy seed: a settings.json written by an OLDER build — loaded raw at
+    // startup. (Every runtime settings write now runs the gap-10 boundary
+    // validation, so the on-disk file is the only remaining vector for a
+    // relative persisted project path.)
+    let config_dir = tempfile::tempdir().expect("temp settings dir").keep();
+    let mut legacy = selection_context(&client_path);
+    legacy.projects[0].local_path = "lore".into();
+    std::fs::write(
+        config_dir.join("settings.json"),
+        serde_json::to_string(&json!({ "context": legacy })).expect("serialize legacy settings"),
+    )
+    .expect("write legacy settings.json");
+    let app = build_app_with_config(&config_dir);
+    let state = app.state::<AppState>();
+    let settings = app.state::<SettingsManager>();
+
+    let webview = WebviewWindowBuilder::new(&app, "main", Default::default())
+        .build()
+        .expect("build webview");
+    let error = invoke(
+        &webview,
+        "context_select",
+        json!({
+            "target": { "kind": "project", "project_id": "project-1" },
+            "requestGeneration": 3,
+        }),
+    )
+    .expect_err("relative persisted project path must be rejected");
+    let error_text = error.to_string();
+    assert_eq!(commands::current_repository(state.clone()), None);
+    assert_eq!(settings.get().active_repository, None);
+
+    // Repair the context; the SAME generation must still be accepted —
+    // proving the rejected request never consumed it.
+    settings
+        .update_context(selection_context(&client_path))
+        .expect("repair context");
+    invoke(
+        &webview,
+        "context_select",
+        json!({
+            "target": { "kind": "project", "project_id": "project-1" },
+            "requestGeneration": 3,
+        }),
+    )
+    .unwrap_or_else(|_| {
+        panic!("generation 3 must survive the rejected request (first error was: {error_text})")
+    });
+    assert_eq!(
+        commands::current_repository(state),
+        Some(client_path.to_string_lossy().into_owned())
+    );
+}

--- a/src-tauri/src/ipc_harness_tests.rs
+++ b/src-tauri/src/ipc_harness_tests.rs
@@ -1051,3 +1051,240 @@ fn repo_write_lifecycle_through_ipc() {
         "log should contain the committed revision {rev}, got {log:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// SBAI-5841: fail-closed absolute-path policy at the IPC trust boundary.
+//
+// A packaged process can start with CWD `C:\Windows\System32` (Start Menu /
+// shell launches). These tests run the real commands with the process CWD
+// pointed at a fake System32 directory and prove every relative lifecycle
+// path is rejected BEFORE any filesystem write, backend probe, or state
+// mutation — the fake CWD must stay byte-for-byte untouched.
+// ---------------------------------------------------------------------------
+
+/// Serializes the CWD-mutating tests (Rust tests share one process, and the
+/// process CWD is global). Everything else in this harness uses absolute
+/// tempdir paths and is immune to the temporary change.
+static FAKE_SYSTEM32_LOCK: Mutex<()> = Mutex::new(());
+
+/// RAII fake `System32`: locks, remembers the real CWD, chdirs into a fresh
+/// tempdir, and restores the real CWD on drop.
+struct FakeSystem32 {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    prev: std::path::PathBuf,
+    dir: tempfile::TempDir,
+}
+
+impl FakeSystem32 {
+    fn enter() -> Self {
+        let lock = FAKE_SYSTEM32_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let prev = std::env::current_dir().expect("read real cwd");
+        let dir = tempfile::tempdir().expect("fake System32 tempdir");
+        std::env::set_current_dir(dir.path()).expect("enter fake System32");
+        Self {
+            _lock: lock,
+            prev,
+            dir,
+        }
+    }
+
+    fn path(&self) -> &std::path::Path {
+        self.dir.path()
+    }
+
+    /// Directory entries currently under the fake System32.
+    fn entries(&self) -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(self.path())
+            .expect("read fake System32")
+            .map(|e| {
+                e.expect("dir entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+        names.sort();
+        names
+    }
+}
+
+impl Drop for FakeSystem32 {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.prev).expect("restore real cwd");
+    }
+}
+
+/// Every repository lifecycle command rejects relative input with an
+/// actionable error, mutates no state, and writes nothing under the CWD.
+#[test]
+fn relative_lifecycle_paths_fail_closed_under_fake_system32_cwd() {
+    let fake = FakeSystem32::enter();
+    let app = build_app();
+    let state = app.state::<AppState>();
+    let settings = app.state::<SettingsManager>();
+
+    for input in ["", ".", "..", "lore", "./lore", "C:foo"] {
+        let error = tauri::async_runtime::block_on(commands::open_repository(
+            state.clone(),
+            settings.clone(),
+            input.to_string(),
+        ))
+        .expect_err("open_repository must reject non-absolute input");
+        assert!(
+            error.to_string().contains("repository location"),
+            "actionable error names the field for {input:?}: {error}"
+        );
+    }
+
+    let error = tauri::async_runtime::block_on(commands::create_repository(
+        state.clone(),
+        settings.clone(),
+        "lore".into(),
+        "world-bible".into(),
+    ))
+    .expect_err("legacy create must reject a relative path");
+    assert!(error.to_string().contains("repository location"), "{error}");
+
+    let error = tauri::async_runtime::block_on(commands::clone(
+        state.clone(),
+        settings.clone(),
+        "lore://127.0.0.1:1/unreachable".into(),
+        "lore".into(),
+    ))
+    .expect_err("legacy clone must reject a relative destination");
+    assert!(error.to_string().contains("clone destination"), "{error}");
+
+    let error = tauri::async_runtime::block_on(commands::repository_clone(
+        state.clone(),
+        settings.clone(),
+        "lore://127.0.0.1:1/unreachable".into(),
+        "lore".into(),
+    ))
+    .expect_err("repository_clone must reject a relative destination");
+    assert!(error.to_string().contains("clone destination"), "{error}");
+
+    let error = tauri::async_runtime::block_on(commands::repository_create(
+        state.clone(),
+        settings.clone(),
+        "lore://127.0.0.1:1/unreachable".into(),
+        "desc".into(),
+        String::new(),
+        false,
+        String::new(),
+        Some("lore".into()),
+    ))
+    .expect_err("repository_create must reject a relative target path");
+    assert!(error.to_string().contains("repository location"), "{error}");
+
+    let error = tauri::async_runtime::block_on(commands::shared_store_create("lore".into()))
+        .expect_err("shared_store_create must reject a relative path");
+    assert!(error.to_string().contains("shared store path"), "{error}");
+
+    assert_eq!(commands::current_repository(state.clone()), None);
+    assert_eq!(settings.get().active_repository, None);
+    assert_eq!(
+        fake.entries(),
+        Vec::<String>::new(),
+        "no lifecycle command may write under the process CWD"
+    );
+}
+
+/// The host-store commands are the seam the ticket's System32 evidence names:
+/// `host_store_prepare` used to `create_dir_all` a relative store directly
+/// under the process CWD. Now they reject before touching the filesystem.
+#[test]
+fn relative_host_store_paths_write_nothing_under_fake_system32_cwd() {
+    let fake = FakeSystem32::enter();
+
+    let error = commands::host_store_prepare("lore".into(), None)
+        .expect_err("host_store_prepare must reject a relative store path");
+    assert!(error.to_string().contains("local storage path"), "{error}");
+
+    // A valid absolute store with a relative mutable-store sidecar must fail
+    // closed too, before either directory is created.
+    let store = fake.path().join("valid-store");
+    let error =
+        commands::host_store_prepare(store.to_string_lossy().into_owned(), Some("mutable".into()))
+            .expect_err("relative mutable store must be rejected");
+    assert!(error.to_string().contains("mutable store"), "{error}");
+    assert!(
+        !store.exists(),
+        "store must not be created when the mutable sidecar is rejected"
+    );
+
+    let error = commands::host_store_probe(".".into())
+        .expect_err("host_store_probe must reject a relative store path");
+    assert!(error.to_string().contains("local storage path"), "{error}");
+
+    assert_eq!(
+        fake.entries(),
+        Vec::<String>::new(),
+        "host-store commands must not write under the process CWD"
+    );
+}
+
+/// `storage_open` (the wizard's local connectivity check) rejects a relative
+/// local store path; an empty one still falls through to the in-memory probe.
+#[test]
+fn storage_open_rejects_relative_local_store_path() {
+    let fake = FakeSystem32::enter();
+    let app = build_app();
+    let state = app.state::<AppState>();
+
+    let error = tauri::async_runtime::block_on(commands::storage_open(
+        state.clone(),
+        commands::StorageBackendConfig {
+            kind: "local".into(),
+            path: Some("lore".into()),
+            endpoint: None,
+            bucket: None,
+            region: None,
+            access_key_id: None,
+            secret_access_key: None,
+            mutable_store: None,
+        },
+    ))
+    .expect_err("storage_open must reject a relative local store path");
+    assert!(error.to_string().contains("store path"), "{error}");
+    assert_eq!(
+        fake.entries(),
+        Vec::<String>::new(),
+        "storage_open must not write under the process CWD"
+    );
+}
+
+/// The nastiest legacy trap: settings persisted a *relative* active
+/// repository, and a REAL valid repository sits at exactly that name under
+/// the fake System32 CWD. The old restore probed the backend, which resolved
+/// the candidate against the CWD and activated it. The policy now clears the
+/// persisted value without any probe — the planted repository must stay
+/// inactive.
+#[test]
+fn persisted_relative_repository_is_cleared_without_probing_fake_system32_cwd() {
+    let fake = FakeSystem32::enter();
+    let trap_repo = fake.path().join("lore");
+    let trap_store = fake.path().join("lore-shared-store");
+    tauri::async_runtime::block_on(create_offline_fixture_repository(&trap_repo, &trap_store));
+
+    let app = build_app();
+    let state = app.state::<AppState>();
+    let settings = app.state::<SettingsManager>();
+    settings
+        .update(|value| value.active_repository = Some(std::path::PathBuf::from("lore")))
+        .expect("seed legacy relative persisted value");
+
+    tauri::async_runtime::block_on(commands::restore_active_repository(&state, &settings));
+
+    assert_eq!(
+        commands::current_repository(state.clone()),
+        None,
+        "a relative persisted path must never activate, even when it names a real repository under the CWD"
+    );
+    assert_eq!(
+        settings.get().active_repository,
+        None,
+        "the legacy relative persisted value must be cleared"
+    );
+}

--- a/src-tauri/src/ipc_harness_tests.rs
+++ b/src-tauri/src/ipc_harness_tests.rs
@@ -1441,12 +1441,25 @@ fn restore_normalizes_padded_persisted_absolute_path() {
         Some(client_path.to_string_lossy().into_owned()),
         "the exact normalized (trimmed) path must flow, not the padded original"
     );
+    assert_eq!(
+        settings.get().active_repository,
+        Some(client_path.clone()),
+        "the normalized path must be PERSISTED too, not only published to runtime"
+    );
 }
 
 /// Gap 8 (SBAI-5841 review): a rejected selection must not consume the
 /// coordinator generation — pure validation completes before
 /// `latest_generation` is mutated, so the same generation still succeeds
 /// once the context is valid.
+///
+/// Honest scope (re-review): the seeded relative settings.json is rejected
+/// by `SettingsManager` at STARTUP (renamed to `.bak`, defaults loaded), so
+/// the first select fails on the now-missing project — a pure pre-register
+/// rejection, not the path-policy arm itself. The path-policy rejection is
+/// itself proven pure by `context::validation_rejects_relative_and_padded_
+/// lifecycle_paths`; together they cover the ordering property. The startup
+/// rejection is asserted below so this cannot silently drift.
 #[test]
 fn context_select_rejected_request_does_not_consume_the_generation() {
     let tmp = tempfile::tempdir().expect("temp fixture root");
@@ -1472,6 +1485,10 @@ fn context_select_rejected_request_does_not_consume_the_generation() {
     let app = build_app_with_config(&config_dir);
     let state = app.state::<AppState>();
     let settings = app.state::<SettingsManager>();
+    assert!(
+        config_dir.join("settings.json.bak").exists(),
+        "startup must have rejected the legacy relative context (renamed to .bak)"
+    );
 
     let webview = WebviewWindowBuilder::new(&app, "main", Default::default())
         .build()
@@ -1508,5 +1525,54 @@ fn context_select_rejected_request_does_not_consume_the_generation() {
     assert_eq!(
         commands::current_repository(state),
         Some(client_path.to_string_lossy().into_owned())
+    );
+}
+
+/// Re-review blocker 1: `repository_recover_local` validates a palette-
+/// supplied destination BEFORE any release/rename/clone — rejected inputs
+/// perform no mutation at all. Run with no active repository: the policy
+/// gate fires even before the active-directory read, and the fake System32
+/// CWD stays byte-for-byte untouched.
+#[test]
+fn recover_local_rejects_relative_new_dir_before_any_mutation() {
+    let fake = FakeSystem32::enter();
+    let app = build_app();
+    let state = app.state::<AppState>();
+    let settings = app.state::<SettingsManager>();
+
+    for input in [".", "lore", "C:relative"] {
+        let error = tauri::async_runtime::block_on(commands::repository_recover_local(
+            state.clone(),
+            settings.clone(),
+            Some(input.to_string()),
+        ))
+        .expect_err("relative recovery destination must fail closed");
+        assert!(
+            error.to_string().contains("recovery destination"),
+            "actionable error names the field for {input:?}: {error}"
+        );
+    }
+
+    // Blank/whitespace keeps the default-sibling convention; an absolute
+    // path with spaces is accepted. Both pass the entry gate and proceed to
+    // the active-repository read, which fails NoRepository in this fixture —
+    // proving the gate (not the destination) made the decision.
+    for accepted in ["   ", "/absolute path/with spaces"] {
+        let error = tauri::async_runtime::block_on(commands::repository_recover_local(
+            state.clone(),
+            settings.clone(),
+            Some(accepted.to_string()),
+        ))
+        .expect_err("no active repository in this fixture");
+        assert!(
+            matches!(error, lore_vm::LoreError::NoRepository(_)),
+            "{accepted:?} must pass the entry gate, got {error:?}"
+        );
+    }
+
+    assert_eq!(
+        fake.entries(),
+        Vec::<String>::new(),
+        "rejected recovery input must cause no release/rename/clone/write"
     );
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod context;
 mod desktop;
 mod lan_discovery;
 mod operations;
+mod path_policy;
 mod server_host;
 mod settings;
 mod tray;

--- a/src-tauri/src/path_policy.rs
+++ b/src-tauri/src/path_policy.rs
@@ -1,0 +1,332 @@
+//! SBAI-5841: fail-closed absolute-path policy for lifecycle paths.
+//!
+//! Every user-supplied or persisted *lifecycle* path — host/mutable store
+//! roots, repository open/create/clone targets, and the persisted active
+//! repository context — must be validated here **before** any filesystem
+//! write, config emission, child spawn, or state mutation. A packaged
+//! process can start with an arbitrary CWD (on Windows, launching from the
+//! Start Menu or a shell can leave it at `C:\Windows\System32`), so a
+//! relative value like `.` or `lore` would silently resolve into System32.
+//!
+//! The check is purely **lexical**: create targets do not exist yet, so no
+//! `canonicalize`/filesystem access is allowed here. Working-tree file paths
+//! are the opposite contract (always repo-relative) and are handled by
+//! `resolve_in_working_tree` in `commands.rs`, not by this module.
+//!
+//! Windows semantics (deliberate, tested on all platforms via the
+//! target-parameterized classifier):
+//!
+//! | input                     | verdict | why                                    |
+//! |---------------------------|---------|----------------------------------------|
+//! | `C:\LoreData`, `C:/x`     | accept  | drive-absolute                         |
+//! | `C:\` (drive root)        | accept  | absolute; unusual but explicit         |
+//! | `\\server\share[\...]`    | accept  | UNC with both server and share         |
+//! | `\\?\C:\x`, `\\?\UNC\s\s` | accept  | verbatim disk / verbatim UNC           |
+//! | `C:foo`                   | reject  | drive-relative: depends on per-drive CWD |
+//! | `\foo`, `/foo`            | reject  | rootful but drive-relative on Windows  |
+//! | `\\server`, `\\s\` `\\`   | reject  | incomplete UNC (no share)              |
+//! | `\\.\COM1` (device NS)    | reject  | not a usable folder                    |
+//! | `.`, `..`, `lore`, empty  | reject  | resolves against process CWD           |
+//!
+//! Unix accepts only rooted paths (`/...`). Interior `.`/`..` components in
+//! an otherwise-absolute path are permitted: they resolve deterministically
+//! without consulting the process CWD, which is the trust boundary here.
+
+use std::path::PathBuf;
+
+use lore_vm::LoreError;
+
+/// Why a candidate path failed the policy. Carried so every caller surfaces
+/// the same actionable message for the same defect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathRejection {
+    /// Empty input ([`require_absolute`] trims first, so whitespace-only
+    /// input reaches [`classify`] as empty).
+    Empty,
+    /// Plain relative path: `.`, `..`, `lore`, `./x`, …
+    Relative,
+    /// Windows drive-relative: `C:foo` — resolves against that drive's CWD.
+    DriveRelative,
+    /// Windows rootful-but-driveless: `\foo` or `/foo` — resolves against the
+    /// current drive.
+    RootRelative,
+    /// Windows device namespace (`\\.\…`) — not a usable directory.
+    DeviceNamespace,
+    /// UNC prefix without both a server and a share (`\\server`, `\\`).
+    IncompleteUnc,
+    /// Verbatim prefix in a form we do not support (`\\?\something-else`).
+    UnsupportedVerbatim,
+}
+
+/// Lexically classify `candidate` against the policy for the given target
+/// family. Split out from [`require_absolute`] (which uses the compile
+/// target) so the full Windows table is unit-testable on Linux CI.
+pub fn classify(candidate: &str, windows: bool) -> Result<(), PathRejection> {
+    if candidate.is_empty() {
+        return Err(PathRejection::Empty);
+    }
+    if !windows {
+        return if candidate.starts_with('/') {
+            Ok(())
+        } else {
+            Err(PathRejection::Relative)
+        };
+    }
+
+    let bytes = candidate.as_bytes();
+    let sep = |b: u8| b == b'\\' || b == b'/';
+
+    // Verbatim namespace: `\\?\C:\…` or `\\?\UNC\server\share…`.
+    if let Some(rest) = strip_verbatim_prefix(candidate) {
+        if drive_absolute(rest) {
+            return Ok(());
+        }
+        if let Some(unc) = rest
+            .strip_prefix("UNC\\")
+            .or_else(|| rest.strip_prefix("UNC/"))
+        {
+            return require_server_and_share(unc);
+        }
+        return Err(PathRejection::UnsupportedVerbatim);
+    }
+
+    // Device namespace: `\\.\COM1` and friends. Never a store directory.
+    if candidate.len() >= 4 && sep(bytes[0]) && sep(bytes[1]) && bytes[2] == b'.' && sep(bytes[3]) {
+        return Err(PathRejection::DeviceNamespace);
+    }
+
+    // UNC: `\\server\share[\…]` — both components required.
+    if candidate.len() >= 2 && sep(bytes[0]) && sep(bytes[1]) {
+        return require_server_and_share(&candidate[2..]);
+    }
+
+    // Drive-letter forms.
+    if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+        return if drive_absolute(candidate) {
+            Ok(())
+        } else {
+            Err(PathRejection::DriveRelative)
+        };
+    }
+
+    // Rootful but driveless: `\foo` / `/foo` — relative to the current drive.
+    if sep(bytes[0]) {
+        return Err(PathRejection::RootRelative);
+    }
+
+    Err(PathRejection::Relative)
+}
+
+/// `\\?\`-style verbatim prefix (either separator accepted lexically).
+fn strip_verbatim_prefix(s: &str) -> Option<&str> {
+    let b = s.as_bytes();
+    if s.len() >= 4
+        && (b[0] == b'\\' || b[0] == b'/')
+        && (b[1] == b'\\' || b[1] == b'/')
+        && b[2] == b'?'
+        && (b[3] == b'\\' || b[3] == b'/')
+    {
+        Some(&s[4..])
+    } else {
+        None
+    }
+}
+
+/// `X:\…` or `X:/…` (drive letter, colon, separator). Bare `X:` is drive-
+/// relative and must NOT match.
+fn drive_absolute(s: &str) -> bool {
+    let b = s.as_bytes();
+    b.len() >= 3 && b[0].is_ascii_alphabetic() && b[1] == b':' && (b[2] == b'\\' || b[2] == b'/')
+}
+
+/// After a UNC prefix: require a non-empty server, a separator, and a
+/// non-empty share component.
+fn require_server_and_share(rest: &str) -> Result<(), PathRejection> {
+    let mut parts = rest.split(|c| c == '\\' || c == '/');
+    let server = parts.next().unwrap_or("");
+    let share = parts.next().unwrap_or("");
+    if server.is_empty() || share.is_empty() {
+        return Err(PathRejection::IncompleteUnc);
+    }
+    Ok(())
+}
+
+/// Human-actionable explanation for a rejection. `role` names the field in
+/// the user's terms ("store directory", "repository location", …).
+pub fn rejection_message(role: &str, value: &str, rejection: PathRejection) -> String {
+    match rejection {
+        PathRejection::Empty => format!(
+            "{role}: a directory is required — enter a full absolute path \
+             (for example C:\\LoreData on Windows or /home/you/lore)"
+        ),
+        PathRejection::Relative => format!(
+            "{role}: \"{value}\" is a relative path and would resolve against the \
+             app's startup directory (which can be C:\\Windows\\System32) — enter a \
+             full absolute path such as C:\\LoreData or /home/you/lore"
+        ),
+        PathRejection::DriveRelative => format!(
+            "{role}: \"{value}\" is drive-relative (it depends on that drive's current \
+             directory) — add a backslash after the drive letter, for example C:\\LoreData"
+        ),
+        PathRejection::RootRelative => format!(
+            "{role}: \"{value}\" does not name a drive — include the drive letter, \
+             for example C:\\LoreData"
+        ),
+        PathRejection::DeviceNamespace => format!(
+            "{role}: \"{value}\" is a Windows device path, not a folder — choose a \
+             normal folder such as C:\\LoreData"
+        ),
+        PathRejection::IncompleteUnc => format!(
+            "{role}: \"{value}\" is an incomplete network path — include both server \
+             and share, for example \\\\server\\share\\lore"
+        ),
+        PathRejection::UnsupportedVerbatim => format!(
+            "{role}: \"{value}\" uses an unsupported \\\\?\\ form — use a drive path \
+             such as \\\\?\\C:\\LoreData, or drop the \\\\?\\ prefix"
+        ),
+    }
+}
+
+/// Validate a user-supplied or persisted lifecycle path. Trims surrounding
+/// whitespace, applies [`classify`] for the compile target, and cross-checks
+/// with the platform's own [`std::path::Path::is_absolute`] so the two can
+/// never disagree in the accepting direction. Returns the validated
+/// `PathBuf` on success; fails closed with an actionable [`LoreError`]
+/// otherwise.
+pub fn require_absolute(raw: &str, role: &str) -> Result<PathBuf, LoreError> {
+    let trimmed = raw.trim();
+    classify(trimmed, cfg!(windows))
+        .map_err(|r| LoreError::CommandFailed(rejection_message(role, trimmed, r)))?;
+    let path = PathBuf::from(trimmed);
+    if !path.is_absolute() {
+        // Unreachable when `classify` and std agree; kept as a hard backstop
+        // so a future divergence fails closed rather than open.
+        return Err(LoreError::CommandFailed(rejection_message(
+            role,
+            trimmed,
+            PathRejection::Relative,
+        )));
+    }
+    Ok(path)
+}
+
+/// Non-erroring check for restore paths: is this persisted value acceptable
+/// on the current platform? Used to reject/clear legacy persisted relative
+/// values without ever probing them against the process CWD.
+pub fn is_acceptable(raw: &str) -> bool {
+    let trimmed = raw.trim();
+    classify(trimmed, cfg!(windows)).is_ok() && PathBuf::from(trimmed).is_absolute()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn accepts(input: &str, windows: bool) {
+        assert_eq!(
+            classify(input, windows),
+            Ok(()),
+            "expected accept: {input:?}"
+        );
+    }
+
+    fn rejects(input: &str, windows: bool, why: PathRejection) {
+        assert_eq!(
+            classify(input, windows),
+            Err(why),
+            "expected reject: {input:?}"
+        );
+    }
+
+    #[test]
+    fn windows_accepts_drive_absolute_including_spaces_and_forward_slashes() {
+        accepts(r"C:\LoreData", true);
+        accepts(r"c:\loredata", true);
+        accepts("C:/LoreData", true);
+        accepts(r"C:\Lore Data\with spaces", true);
+        accepts(r"D:\", true); // drive root: explicit and absolute
+    }
+
+    #[test]
+    fn windows_accepts_supported_unc_and_verbatim_forms() {
+        accepts(r"\\server\share", true);
+        accepts(r"\\server\share\lore", true);
+        accepts(r"\\?\C:\LoreData", true);
+        accepts(r"\\?\UNC\server\share", true);
+    }
+
+    #[test]
+    fn windows_rejects_every_cwd_dependent_form() {
+        rejects("", true, PathRejection::Empty);
+        rejects(".", true, PathRejection::Relative);
+        rejects("..", true, PathRejection::Relative);
+        rejects("lore", true, PathRejection::Relative);
+        rejects(r".\lore", true, PathRejection::Relative);
+        rejects(r"..\lore", true, PathRejection::Relative);
+        rejects("C:foo", true, PathRejection::DriveRelative);
+        rejects("C:", true, PathRejection::DriveRelative);
+        rejects(r"\foo", true, PathRejection::RootRelative);
+        rejects("/foo", true, PathRejection::RootRelative);
+    }
+
+    #[test]
+    fn windows_rejects_incomplete_unc_and_device_paths() {
+        rejects(r"\\", true, PathRejection::IncompleteUnc);
+        rejects(r"\\server", true, PathRejection::IncompleteUnc);
+        rejects(r"\\server\", true, PathRejection::IncompleteUnc);
+        rejects(r"\\.\COM1", true, PathRejection::DeviceNamespace);
+        rejects(r"\\?\lore", true, PathRejection::UnsupportedVerbatim);
+    }
+
+    #[test]
+    fn unix_accepts_only_rooted_paths() {
+        accepts("/srv/lore", false);
+        accepts("/srv/lore data/with spaces", false);
+        accepts("//host/share", false); // still rooted on POSIX
+        rejects("", false, PathRejection::Empty);
+        rejects(".", false, PathRejection::Relative);
+        rejects("..", false, PathRejection::Relative);
+        rejects("lore", false, PathRejection::Relative);
+        rejects("./lore", false, PathRejection::Relative);
+        rejects(r"C:\LoreData", false, PathRejection::Relative); // not a unix root
+        rejects("C:foo", false, PathRejection::Relative);
+    }
+
+    #[test]
+    fn require_absolute_trims_and_returns_the_validated_path() {
+        let sample = if cfg!(windows) {
+            r"  C:\LoreData  "
+        } else {
+            "  /srv/lore  "
+        };
+        let expect = if cfg!(windows) {
+            r"C:\LoreData"
+        } else {
+            "/srv/lore"
+        };
+        let path = require_absolute(sample, "store directory").expect("absolute path accepted");
+        assert_eq!(path, PathBuf::from(expect));
+    }
+
+    #[test]
+    fn require_absolute_fails_closed_with_an_actionable_message() {
+        let err = require_absolute("lore", "store directory").unwrap_err();
+        let text = err.to_string();
+        assert!(text.contains("store directory"), "names the field: {text}");
+        assert!(text.contains("\"lore\""), "echoes the value: {text}");
+        assert!(text.contains("absolute path"), "says what to do: {text}");
+    }
+
+    #[test]
+    fn is_acceptable_matches_require_absolute() {
+        assert!(!is_acceptable("lore"));
+        assert!(!is_acceptable(""));
+        assert!(!is_acceptable("."));
+        let good = if cfg!(windows) {
+            r"C:\LoreData"
+        } else {
+            "/srv/lore"
+        };
+        assert!(is_acceptable(good));
+    }
+}

--- a/src-tauri/src/path_policy.rs
+++ b/src-tauri/src/path_policy.rs
@@ -210,14 +210,6 @@ pub fn require_absolute(raw: &str, role: &str) -> Result<PathBuf, LoreError> {
     Ok(path)
 }
 
-/// Non-erroring check for restore paths: is this persisted value acceptable
-/// on the current platform? Used to reject/clear legacy persisted relative
-/// values without ever probing them against the process CWD.
-pub fn is_acceptable(raw: &str) -> bool {
-    let trimmed = raw.trim();
-    classify(trimmed, cfg!(windows)).is_ok() && PathBuf::from(trimmed).is_absolute()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -315,18 +307,5 @@ mod tests {
         assert!(text.contains("store directory"), "names the field: {text}");
         assert!(text.contains("\"lore\""), "echoes the value: {text}");
         assert!(text.contains("absolute path"), "says what to do: {text}");
-    }
-
-    #[test]
-    fn is_acceptable_matches_require_absolute() {
-        assert!(!is_acceptable("lore"));
-        assert!(!is_acceptable(""));
-        assert!(!is_acceptable("."));
-        let good = if cfg!(windows) {
-            r"C:\LoreData"
-        } else {
-            "/srv/lore"
-        };
-        assert!(is_acceptable(good));
     }
 }

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -497,6 +497,12 @@ pub struct HostedServer {
 
 struct RestartRecipe {
     binary: PathBuf,
+    /// Trusted CWD for the child (SBAI-5841 / sb-secure 155611): the
+    /// binary's own directory — never anywhere inside the user-selected
+    /// store, so a file planted in the store can never sit in the child's
+    /// DLL-search CWD. Config/store locations are passed as absolute paths,
+    /// so the CWD carries no path semantics.
+    launch_dir: PathBuf,
     config_dir: PathBuf,
     config_path: PathBuf,
     config_toml: String,
@@ -1289,9 +1295,48 @@ fn resolve_production_binary(
 ///      `target/debug/loreserver`, built via `cargo build -p lore-server
 ///      --bin loreserver` if absent (exactly as the spike script does). Never
 ///      reached in a release build because the sidecar resolves at step 1.
+/// SBAI-5841: the `LOREVM_SERVER_BIN` dev override is honored only in debug
+/// builds (compile-time gate — release builds behave as if it were unset) and
+/// only after [`validate_env_override_path`] hardening.
+fn validated_env_override() -> Result<Option<PathBuf>, LoreError> {
+    if !cfg!(debug_assertions) {
+        return Ok(None);
+    }
+    let Some(raw) = std::env::var_os("LOREVM_SERVER_BIN").map(PathBuf::from) else {
+        return Ok(None);
+    };
+    validate_env_override_path(&raw).map(Some)
+}
+
+/// Pure half of the `LOREVM_SERVER_BIN` policy (unit-testable without env
+/// mutation): the override must be an absolute path that canonicalizes to an
+/// existing regular file. A relative or dangling override must never
+/// influence which binary a host launches.
+fn validate_env_override_path(raw: &Path) -> Result<PathBuf, LoreError> {
+    if !raw.is_absolute() {
+        return Err(LoreError::CommandFailed(format!(
+            "LOREVM_SERVER_BIN must be an absolute path to a loreserver binary; got \"{}\"",
+            raw.display()
+        )));
+    }
+    let canonical = std::fs::canonicalize(raw).map_err(|e| {
+        LoreError::CommandFailed(format!(
+            "LOREVM_SERVER_BIN={} cannot be resolved: {e}",
+            raw.display()
+        ))
+    })?;
+    if !canonical.is_file() {
+        return Err(LoreError::CommandFailed(format!(
+            "LOREVM_SERVER_BIN={} is not a file",
+            canonical.display()
+        )));
+    }
+    Ok(canonical)
+}
+
 fn resolve_server_binary() -> Result<PathBuf, LoreError> {
     let sidecar = sidecar_candidate();
-    let env_override = std::env::var_os("LOREVM_SERVER_BIN").map(PathBuf::from);
+    let env_override = validated_env_override()?;
 
     match resolve_production_binary(sidecar.as_deref(), env_override.as_deref(), &|p: &Path| {
         p.is_file()
@@ -2009,13 +2054,21 @@ pub fn start(
         ))
     })?;
 
-    // Boot exactly like the spike: LORE_CONFIG_PATH points at the dir holding
-    // local.toml, LORE_ENV=local selects it. cwd = config dir.
+    // Boot like the spike: LORE_CONFIG_PATH (absolute) points at the dir
+    // holding local.toml, LORE_ENV=local selects it. The child's CWD is the
+    // trusted binary directory, NOT the store-resident config dir — see the
+    // RestartRecipe::launch_dir doc (SBAI-5841 / sb-secure 155611).
+    let launch_dir = binary.parent().map(Path::to_path_buf).ok_or_else(|| {
+        LoreError::CommandFailed(format!(
+            "loreserver binary {} has no parent directory to launch from",
+            binary.display()
+        ))
+    })?;
     let mut command = Command::new(&binary);
     command
         .env("LORE_CONFIG_PATH", &config_dir)
         .env("LORE_ENV", "local")
-        .current_dir(&config_dir);
+        .current_dir(&launch_dir);
 
     // For an S3-backed (aws-mode) immutable store, lore resolves credentials via
     // the standard AWS credential chain — NOT from the TOML. Export the access
@@ -2044,6 +2097,7 @@ pub fn start(
 
     let restart = RestartRecipe {
         binary,
+        launch_dir,
         config_dir,
         config_path: config_path.clone(),
         config_toml,
@@ -2093,7 +2147,9 @@ fn validate_restart_recipe(recipe: &RestartRecipe) -> Result<(), LoreError> {
     // SBAI-5841: refuse relative recipe paths BEFORE any filesystem access —
     // a relative config_path would otherwise be probed against whatever the
     // process CWD is at restart time.
-    if !recipe.config_path.is_absolute()
+    if !recipe.binary.is_absolute()
+        || !recipe.launch_dir.is_absolute()
+        || !recipe.config_path.is_absolute()
         || !recipe.config_dir.is_absolute()
         || !recipe.expected_store_dir.is_absolute()
     {
@@ -2128,7 +2184,9 @@ fn spawn_recipe(recipe: &RestartRecipe) -> Result<Child, LoreError> {
     command
         .env("LORE_CONFIG_PATH", &recipe.config_dir)
         .env("LORE_ENV", "local")
-        .current_dir(&recipe.config_dir);
+        // Trusted binary-dir CWD, never the store-resident config dir
+        // (SBAI-5841 / sb-secure 155611).
+        .current_dir(&recipe.launch_dir);
     if let Some(id) = &recipe.access_key_id {
         command.env("AWS_ACCESS_KEY_ID", id.as_str());
     }
@@ -2818,7 +2876,8 @@ mod tests {
             generation: 1,
             restarted_from: None,
             restart: RestartRecipe {
-                binary: PathBuf::from("loreserver"),
+                binary: PathBuf::from(r"E:\app\loreserver.exe"),
+                launch_dir: PathBuf::from(r"E:\app"),
                 config_dir: PathBuf::from(r"E:\lore\.loregui-host"),
                 config_path: PathBuf::from(r"E:\lore\.loregui-host\local.toml"),
                 config_toml: String::new(),
@@ -3012,12 +3071,38 @@ mod tests {
         }
     }
 
+    /// SBAI-5841 (gap 2): the LOREVM_SERVER_BIN override is only usable as a
+    /// canonicalized absolute path to an existing file.
+    #[test]
+    fn env_override_requires_a_canonical_absolute_file() {
+        let error = validate_env_override_path(Path::new("loreserver"))
+            .expect_err("relative override must fail closed");
+        assert!(error.to_string().contains("absolute"), "{error}");
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let missing = tmp.path().join("nope");
+        let error =
+            validate_env_override_path(&missing).expect_err("dangling override must fail closed");
+        assert!(error.to_string().contains("cannot be resolved"), "{error}");
+
+        let real = tmp.path().join("loreserver-override");
+        std::fs::write(&real, b"#!/bin/sh\n").expect("write override file");
+        let resolved =
+            validate_env_override_path(&real).expect("absolute existing file is accepted");
+        assert_eq!(
+            resolved,
+            std::fs::canonicalize(&real).expect("canonicalize"),
+            "the canonicalized path is the only value used downstream"
+        );
+    }
+
     /// SBAI-5841: a relative restart recipe must be refused before any
     /// filesystem access, not reinterpreted against the CWD at restart time.
     #[test]
     fn restart_recipe_rejects_relative_paths_before_touching_disk() {
         let recipe = RestartRecipe {
             binary: PathBuf::from("loreserver"),
+            launch_dir: PathBuf::from("lore-bin"),
             config_dir: PathBuf::from("lore/.loregui-host"),
             config_path: PathBuf::from("lore/.loregui-host/local.toml"),
             config_toml: "original".into(),
@@ -3707,7 +3792,8 @@ mod tests {
         let config_path = config_dir.join("local.toml");
         std::fs::write(&config_path, "original").unwrap();
         let recipe = RestartRecipe {
-            binary: PathBuf::from("loreserver"),
+            binary: tmp.path().join("loreserver"),
+            launch_dir: tmp.path().to_path_buf(),
             config_dir,
             config_path: config_path.clone(),
             config_toml: "original".into(),
@@ -3745,7 +3831,8 @@ mod tests {
             generation,
             restarted_from,
             restart: RestartRecipe {
-                binary: PathBuf::from("sh"),
+                binary: PathBuf::from("/bin/sh"),
+                launch_dir: root.to_path_buf(),
                 config_dir,
                 config_path,
                 config_toml: "exact-config".into(),

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -41,6 +41,8 @@ use std::time::{Duration, Instant};
 
 use lore_vm::LoreError;
 use rcgen::{CertificateParams, DistinguishedName, DnType, KeyPair, SanType};
+
+use crate::path_policy;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
 
@@ -1885,12 +1887,10 @@ fn resolve_config(
             "authenticated hosting is not implemented for local loreserver launches".into(),
         ));
     }
-    if opts.store_dir.trim().is_empty() {
-        return Err(LoreError::CommandFailed(
-            "store directory is required to host a server".into(),
-        ));
-    }
-    let store_dir = PathBuf::from(opts.store_dir.trim());
+    // SBAI-5841: the store directory feeds the emitted config, every store
+    // filesystem write, and the child's current_dir — it must be absolute
+    // before any of those happen. Covers the legacy empty-input error too.
+    let store_dir = path_policy::require_absolute(&opts.store_dir, "store directory")?;
 
     let port = match opts.port {
         Some(p) if p != 0 => p,
@@ -1992,10 +1992,16 @@ pub fn start(
     // SBAI-5560: re-validate immediately before spawn (also covers the
     // dev-checkout build path, which resolve_server_binary does not gate).
     validate_server_binary(&binary)?;
-    let config_dir = config_path
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| PathBuf::from("."));
+    // SBAI-5841: config_path derives from the policy-validated absolute
+    // store_dir, so a parent always exists. The old fallback to "." handed
+    // the child a CWD-dependent config dir; now a missing parent is a hard
+    // error and the config/current_dir pair is resolved exactly once here.
+    let config_dir = config_path.parent().map(Path::to_path_buf).ok_or_else(|| {
+        LoreError::CommandFailed(format!(
+            "launch config path {} has no parent directory; refusing to fall back to the process working directory",
+            config_path.display()
+        ))
+    })?;
     let config_toml = std::fs::read_to_string(&config_path).map_err(|e| {
         LoreError::CommandFailed(format!(
             "could not retain restart config {}: {e}",
@@ -2082,6 +2088,17 @@ fn validate_restart_recipe(recipe: &RestartRecipe) -> Result<(), LoreError> {
     if recipe.access_key_id.is_some() != recipe.secret_access_key.is_some() {
         return Err(LoreError::CommandFailed(
             "restart refused: required S3 credential material is unavailable".into(),
+        ));
+    }
+    // SBAI-5841: refuse relative recipe paths BEFORE any filesystem access —
+    // a relative config_path would otherwise be probed against whatever the
+    // process CWD is at restart time.
+    if !recipe.config_path.is_absolute()
+        || !recipe.config_dir.is_absolute()
+        || !recipe.expected_store_dir.is_absolute()
+    {
+        return Err(LoreError::CommandFailed(
+            "restart refused: launch recipe contains a non-absolute path".into(),
         ));
     }
     let current = std::fs::read_to_string(&recipe.config_path).map_err(|e| {
@@ -2379,23 +2396,27 @@ pub fn prepare_local_store(
     store_dir: &str,
     mutable_store: Option<&str>,
 ) -> Result<PathBuf, LoreError> {
-    let trimmed = store_dir.trim();
-    if trimmed.is_empty() {
-        return Err(LoreError::CommandFailed(
-            "a local storage path is required".into(),
-        ));
-    }
-    let path = PathBuf::from(trimmed);
+    // SBAI-5841: validate BOTH directories before creating EITHER — a
+    // relative value here would materialise the store under the process CWD,
+    // and a rejected mutable-store sidecar must not leave a half-created
+    // store behind.
+    let path = path_policy::require_absolute(store_dir, "local storage path")?;
+    let mutable_path = mutable_store
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|dir| path_policy::require_absolute(dir, "mutable store path"))
+        .transpose()?;
     std::fs::create_dir_all(&path).map_err(|e| {
         LoreError::CommandFailed(format!(
             "could not create local store directory {}: {e}",
             path.display()
         ))
     })?;
-    if let Some(mut_dir) = mutable_store.map(str::trim).filter(|s| !s.is_empty()) {
-        std::fs::create_dir_all(mut_dir).map_err(|e| {
+    if let Some(mut_dir) = mutable_path {
+        std::fs::create_dir_all(&mut_dir).map_err(|e| {
             LoreError::CommandFailed(format!(
-                "could not create mutable store directory {mut_dir}: {e}"
+                "could not create mutable store directory {}: {e}",
+                mut_dir.display()
             ))
         })?;
     }
@@ -2769,7 +2790,15 @@ mod tests {
     #[test]
     fn successful_local_status_reports_effective_no_auth_without_secrets() {
         let opts = HostServerOptions {
-            store_dir: r"E:\lore".into(),
+            // SBAI-5841: resolve_config now enforces the absolute-path policy
+            // for the compile target, so the sample store must be absolute on
+            // the platform running the test.
+            store_dir: if cfg!(windows) {
+                r"E:\lore"
+            } else {
+                "/srv/lore"
+            }
+            .into(),
             repository_name: Some("world-bible".into()),
             ..Default::default()
         };
@@ -2960,6 +2989,48 @@ mod tests {
         assert!(!toml.contains("verify_client_certs"));
         assert!(!toml.contains("idle_timeout"));
         assert!(!toml.contains("max_file_size"));
+    }
+
+    /// SBAI-5841: the resolved launch config must never carry a relative
+    /// store — it feeds the emitted TOML, every store write, and the child's
+    /// current_dir.
+    #[test]
+    fn resolve_config_rejects_every_cwd_dependent_store_dir() {
+        for store in ["", "  ", ".", "..", "lore", "C:foo"] {
+            let opts = HostServerOptions {
+                store_dir: store.into(),
+                ..Default::default()
+            };
+            let error = match resolve_config(&opts, &CertContext::none(), true) {
+                Ok(_) => panic!("non-absolute store dir {store:?} must fail closed"),
+                Err(error) => error,
+            };
+            assert!(
+                error.to_string().contains("store directory"),
+                "actionable error for {store:?}: {error}"
+            );
+        }
+    }
+
+    /// SBAI-5841: a relative restart recipe must be refused before any
+    /// filesystem access, not reinterpreted against the CWD at restart time.
+    #[test]
+    fn restart_recipe_rejects_relative_paths_before_touching_disk() {
+        let recipe = RestartRecipe {
+            binary: PathBuf::from("loreserver"),
+            config_dir: PathBuf::from("lore/.loregui-host"),
+            config_path: PathBuf::from("lore/.loregui-host/local.toml"),
+            config_toml: "original".into(),
+            expected_store_dir: PathBuf::from("lore"),
+            access_key_id: None,
+            secret_access_key: None,
+            region: None,
+        };
+        let error = validate_restart_recipe(&recipe).expect_err("relative recipe must fail closed");
+        assert!(
+            error.to_string().contains("non-absolute"),
+            "refusal names the defect: {error}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -2175,6 +2175,23 @@ fn validate_restart_recipe(recipe: &RestartRecipe) -> Result<(), LoreError> {
             recipe.expected_store_dir.display()
         )));
     }
+    // SBAI-5841 (re-review): bind the replay to the same trusted-launch
+    // invariants the initial spawn constructed — identity, not mere
+    // absoluteness — and revalidate the binary before the live child is
+    // killed. A recipe whose launch_dir drifted from the binary's own
+    // directory would reintroduce an untrusted child CWD on restart.
+    if recipe.binary.parent() != Some(recipe.launch_dir.as_path()) || !recipe.launch_dir.is_dir() {
+        return Err(LoreError::CommandFailed(
+            "restart refused: launch directory no longer matches the server binary's directory"
+                .into(),
+        ));
+    }
+    if recipe.config_path.parent() != Some(recipe.config_dir.as_path()) {
+        return Err(LoreError::CommandFailed(
+            "restart refused: launch config path is not inside the launch config directory".into(),
+        ));
+    }
+    validate_server_binary(&recipe.binary)?;
     Ok(())
 }
 
@@ -3096,6 +3113,66 @@ mod tests {
         );
     }
 
+    /// SBAI-5841 (re-review): replay validation enforces the trusted-launch
+    /// BINDING — launch_dir is the binary's own directory, config_path lives
+    /// in config_dir, and the binary itself revalidates — not just
+    /// absoluteness of the stored fields.
+    #[test]
+    fn restart_recipe_rejects_binding_mismatches_and_invalid_binary() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = tmp.path();
+        let config_dir = store.join(".loregui-host");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let config_path = config_dir.join("local.toml");
+        std::fs::write(&config_path, "original").unwrap();
+        let binary = store.join("loreserver");
+        std::fs::write(&binary, vec![0u8; (MIN_SERVER_BINARY_BYTES + 1) as usize]).unwrap();
+        let recipe = |bin: PathBuf, launch: PathBuf, cfg_dir: PathBuf| RestartRecipe {
+            binary: bin,
+            launch_dir: launch,
+            config_dir: cfg_dir,
+            config_path: config_path.clone(),
+            config_toml: "original".into(),
+            expected_store_dir: store.to_path_buf(),
+            access_key_id: None,
+            secret_access_key: None,
+            region: None,
+        };
+
+        validate_restart_recipe(&recipe(
+            binary.clone(),
+            store.to_path_buf(),
+            config_dir.clone(),
+        ))
+        .expect("fully bound recipe validates");
+
+        // launch_dir drifted away from the binary's directory.
+        let error = validate_restart_recipe(&recipe(
+            binary.clone(),
+            config_dir.clone(),
+            config_dir.clone(),
+        ))
+        .expect_err("launch_dir != binary.parent must fail closed");
+        assert!(error.to_string().contains("launch directory"), "{error}");
+
+        // config_dir no longer contains config_path.
+        let elsewhere = store.join("elsewhere");
+        std::fs::create_dir_all(&elsewhere).unwrap();
+        let error =
+            validate_restart_recipe(&recipe(binary.clone(), store.to_path_buf(), elsewhere))
+                .expect_err("config_path outside config_dir must fail closed");
+        assert!(error.to_string().contains("launch config path"), "{error}");
+
+        // Binary vanished (or was quarantined) since the initial spawn.
+        let error = validate_restart_recipe(&recipe(
+            store.join("missing-loreserver"),
+            store.to_path_buf(),
+            config_dir.clone(),
+        ))
+        .expect_err("missing binary must fail closed before the child is killed");
+        assert!(error.to_string().contains("corrupt"), "{error}");
+    }
+
     /// SBAI-5841: a relative restart recipe must be refused before any
     /// filesystem access, not reinterpreted against the CWD at restart time.
     #[test]
@@ -3817,6 +3894,11 @@ mod tests {
         std::fs::create_dir_all(&config_dir).unwrap();
         let config_path = config_dir.join("local.toml");
         std::fs::write(&config_path, "exact-config").unwrap();
+        // Replay validation revalidates the recipe binary (size floor and
+        // all), so the fake recipe carries a real dummy binary in root —
+        // never spawned here, the tests inject their own spawners.
+        let binary = root.join("loreserver");
+        std::fs::write(&binary, vec![0u8; (MIN_SERVER_BINARY_BYTES + 1) as usize]).unwrap();
         let child = Command::new("sh").args(["-c", "sleep 30"]).spawn().unwrap();
         HostedServer {
             pid: child.id(),
@@ -3831,7 +3913,7 @@ mod tests {
             generation,
             restarted_from,
             restart: RestartRecipe {
-                binary: PathBuf::from("/bin/sh"),
+                binary,
                 launch_dir: root.to_path_buf(),
                 config_dir,
                 config_path,

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -1158,6 +1158,7 @@ fn advertise_url(port: u16, repository_name: Option<&str>) -> String {
 /// `$CARGO_HOME/git/checkouts/lore-*/<short-rev>/`. We read the rev from the
 /// workspace `Cargo.toml` and find the matching short-rev dir — exactly as the
 /// spike script does.
+#[cfg(debug_assertions)]
 fn lore_checkout() -> Result<PathBuf, LoreError> {
     // src-tauri/Cargo.toml is one level above this crate's manifest dir; the
     // pinned rev lives in the *workspace* Cargo.toml at the repo root.
@@ -1206,6 +1207,7 @@ fn lore_checkout() -> Result<PathBuf, LoreError> {
 }
 
 /// Extract the first 40-hex-char `rev = "..."` from a Cargo.toml string.
+#[cfg(debug_assertions)]
 fn parse_pinned_rev(cargo_toml: &str) -> Option<String> {
     for line in cargo_toml.lines() {
         if let Some(idx) = line.find("rev = \"") {
@@ -1222,6 +1224,7 @@ fn parse_pinned_rev(cargo_toml: &str) -> Option<String> {
 }
 
 /// Best-effort home directory (avoids pulling in the `dirs` crate).
+#[cfg(debug_assertions)]
 fn dirs_home() -> Option<PathBuf> {
     std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
@@ -1357,6 +1360,44 @@ fn resolve_server_binary() -> Result<PathBuf, LoreError> {
         ResolveOutcome::FallBackToDevCheckout => {}
     }
 
+    // SBAI-5841 (sb-secure release blocker): the dev fallback discovers a
+    // binary from the build environment — the pinned checkout via
+    // CARGO_MANIFEST_DIR / CARGO_HOME / HOME, its target/debug output, or a
+    // fresh `cargo build`. That is a DEBUG-BUILD convenience only. A release
+    // install whose bundled sidecar is missing is broken and must fail hard:
+    // falling back would let whoever can remove or quarantine the sidecar
+    // redirect "Host a server" to a binary found through the environment.
+    if !dev_fallback_permitted(cfg!(debug_assertions)) {
+        return Err(missing_sidecar_release_error(sidecar.as_deref()));
+    }
+    resolve_dev_fallback(sidecar.as_deref())
+}
+
+/// Whether this build flavor may fall back to the dev checkout when the
+/// bundled sidecar is unavailable. Parameterized (like
+/// `path_policy::classify`) so BOTH flavors are unit-testable from a debug
+/// test build: release must hard-fail, debug keeps the fallback.
+fn dev_fallback_permitted(debug_build: bool) -> bool {
+    debug_build
+}
+
+/// The release-build hard failure for a missing/unusable bundled sidecar.
+fn missing_sidecar_release_error(sidecar: Option<&Path>) -> LoreError {
+    let location = sidecar
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "next to the LoreGUI executable".into());
+    LoreError::CommandFailed(format!(
+        "bundled loreserver is missing or unusable (expected at {location}) — this release \
+         install is incomplete or was modified; reinstall LoreGUI from an official release, \
+         then retry Host a server"
+    ))
+}
+
+/// Dev-checkout fallback — compiled ONLY into debug builds, so release
+/// binaries contain no checkout discovery, no target/debug acceptance, and
+/// no cargo-build path at all.
+#[cfg(debug_assertions)]
+fn resolve_dev_fallback(_sidecar: Option<&Path>) -> Result<PathBuf, LoreError> {
     // 3. dev fallback: build from the pinned upstream checkout
     let checkout = lore_checkout()?;
     let bin_name = if cfg!(windows) {
@@ -1394,6 +1435,14 @@ fn resolve_server_binary() -> Result<PathBuf, LoreError> {
             built.display()
         )))
     }
+}
+
+/// Release builds: type-complete twin of the debug fallback. Unreachable in
+/// practice (the guard above returns first) — kept as a second hard-fail so
+/// a future refactor cannot silently reopen the environment-discovery path.
+#[cfg(not(debug_assertions))]
+fn resolve_dev_fallback(sidecar: Option<&Path>) -> Result<PathBuf, LoreError> {
+    Err(missing_sidecar_release_error(sidecar))
 }
 
 /// Candidate sidecar path next to the current executable.
@@ -3086,6 +3135,32 @@ mod tests {
                 "actionable error for {store:?}: {error}"
             );
         }
+    }
+
+    /// SBAI-5841 (sb-secure release blocker): a release build must hard-fail
+    /// when the bundled sidecar is unavailable — never discover a binary
+    /// from the build environment; debug builds keep the dev fallback.
+    #[test]
+    fn release_builds_never_fall_back_to_the_dev_checkout() {
+        assert!(
+            !dev_fallback_permitted(false),
+            "release builds must hard-fail without the bundled sidecar"
+        );
+        assert!(
+            dev_fallback_permitted(true),
+            "debug builds keep the dev-checkout fallback"
+        );
+        let text = missing_sidecar_release_error(Some(Path::new("/app/loreserver"))).to_string();
+        assert!(
+            text.contains("/app/loreserver"),
+            "names the location: {text}"
+        );
+        assert!(text.contains("reinstall"), "actionable remedy: {text}");
+        let text = missing_sidecar_release_error(None).to_string();
+        assert!(
+            text.contains("next to the LoreGUI executable"),
+            "unknown sidecar location still explained: {text}"
+        );
     }
 
     /// SBAI-5841 (gap 2): the LOREVM_SERVER_BIN override is only usable as a

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -1399,7 +1399,16 @@ fn missing_sidecar_release_error(sidecar: Option<&Path>) -> LoreError {
 #[cfg(debug_assertions)]
 fn resolve_dev_fallback(_sidecar: Option<&Path>) -> Result<PathBuf, LoreError> {
     // 3. dev fallback: build from the pinned upstream checkout
-    let checkout = lore_checkout()?;
+    resolve_dev_fallback_in(lore_checkout()?)
+}
+
+/// Compiled debug fallback BODY, parameterized on the discovered checkout —
+/// the production resolver above passes `lore_checkout()`; the hermetic
+/// regression invokes this same compiled body with a temp checkout holding a
+/// prebuilt binary (which also guarantees the cargo-build branch cannot
+/// run). No global env involved.
+#[cfg(debug_assertions)]
+fn resolve_dev_fallback_in(checkout: PathBuf) -> Result<PathBuf, LoreError> {
     let bin_name = if cfg!(windows) {
         "loreserver.exe"
     } else {
@@ -3160,15 +3169,33 @@ mod tests {
         assert!(text.contains("reinstall"), "actionable remedy: {text}");
     }
 
-    /// Debug twin: the dev-checkout fallback stays available to debug
-    /// builds (policy mirror; the real debug fallback needs a checkout, so
-    /// the permitted-flag is the debug-side assertion).
+    /// Debug twin (review fix on 2757faf, injected-helper form): invokes the
+    /// SAME compiled debug fallback body the production resolver calls
+    /// (`resolve_dev_fallback_in`), with a temp checkout holding a prebuilt
+    /// binary — hermetic: no global env mutation, no network, and the
+    /// cargo-build branch cannot run because the prebuilt exists.
     #[cfg(debug_assertions)]
     #[test]
-    fn debug_builds_keep_the_dev_fallback_available() {
+    fn debug_fallback_resolves_hermetic_prebuilt_checkout_binary() {
+        let checkout = tempfile::tempdir().expect("temp checkout");
+        let bin_name = if cfg!(windows) {
+            "loreserver.exe"
+        } else {
+            "loreserver"
+        };
+        let built = checkout.path().join("target").join("debug").join(bin_name);
+        std::fs::create_dir_all(built.parent().unwrap()).expect("checkout layout");
+        std::fs::write(&built, b"prebuilt").expect("prebuilt binary");
+
+        let resolved = resolve_dev_fallback_in(checkout.path().to_path_buf())
+            .expect("debug fallback body accepts the prebuilt target/debug binary");
+        assert_eq!(
+            resolved, built,
+            "the compiled debug body must return exactly the prebuilt path"
+        );
         assert!(
             dev_fallback_permitted(true),
-            "debug builds keep the dev-checkout fallback"
+            "policy mirror agrees debug builds keep the fallback"
         );
     }
 

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -3035,6 +3035,10 @@ mod tests {
         assert_eq!(advertise_url(41337, Some("  ")), "lore://127.0.0.1:41337");
     }
 
+    // SBAI-5841: `parse_pinned_rev` only exists in debug builds (the dev
+    // checkout chain is compile-time gated), so its test is gated the same
+    // way — release/--all-targets must stay compilable.
+    #[cfg(debug_assertions)]
     #[test]
     fn parse_pinned_rev_finds_40_hex() {
         let toml = r#"
@@ -3135,6 +3139,37 @@ mod tests {
                 "actionable error for {store:?}: {error}"
             );
         }
+    }
+
+    /// SBAI-5841 (release re-review): compiled ONLY into release test
+    /// builds (`cargo test --release`), this executes the ACTUAL
+    /// `#[cfg(not(debug_assertions))]` twin that ships — proving a missing
+    /// bundled sidecar hard-fails with no checkout discovery and no cargo
+    /// build, in the real compiled release fallback rather than a
+    /// parameterized stand-in.
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn release_fallback_twin_hard_fails_without_bundled_sidecar() {
+        let error = resolve_dev_fallback(Some(Path::new("/app/loreserver")))
+            .expect_err("the compiled release fallback must hard-fail");
+        let text = error.to_string();
+        assert!(
+            text.contains("/app/loreserver"),
+            "names the location: {text}"
+        );
+        assert!(text.contains("reinstall"), "actionable remedy: {text}");
+    }
+
+    /// Debug twin: the dev-checkout fallback stays available to debug
+    /// builds (policy mirror; the real debug fallback needs a checkout, so
+    /// the permitted-flag is the debug-side assertion).
+    #[cfg(debug_assertions)]
+    #[test]
+    fn debug_builds_keep_the_dev_fallback_available() {
+        assert!(
+            dev_fallback_permitted(true),
+            "debug builds keep the dev-checkout fallback"
+        );
     }
 
     /// SBAI-5841 (sb-secure release blocker): a release build must hard-fail


### PR DESCRIPTION
Resolves SBAI-5841 (v0.1.4 beta blocker): relative Host/Create/Open/Clone paths could resolve into the packaged process CWD — `C:\Windows\System32` on Start Menu/shell launches — for store/config writes, persisted context, and the loreserver child `current_dir`.

## What

**One shared backend policy** — new `src-tauri/src/path_policy.rs`, a purely lexical validator (no `canonicalize`; create targets need not exist) with explicit Windows semantics, unit-testable on Linux CI via a target-parameterized classifier:

| accepted | rejected |
|---|---|
| `C:\x`, `C:/x`, drive-root `C:\` | empty, `.`, `..`, `lore`, `./x` |
| UNC `\\server\share[\…]` | drive-relative `C:foo` |
| verbatim `\\?\C:\…`, `\\?\UNC\s\s` | driveless `\foo` (and `/foo` on Windows) |
| unix-rooted `/…` (on unix) | device NS `\\.\…`, incomplete UNC, other verbatim |

**Enforced before any write/config/spawn/state mutation** at every lifecycle seam: `open_repository`, legacy `create_repository`/`clone`, `repository_create(_with_metadata)`, `repository_clone`, `shared_store_create`, `storage_open`, `host_store_prepare`/`probe`, `resolve_config`, `prepare_local_store` (both dirs validated before either is created), `activate_repository` backstop, context selection. Host launch resolves config/`current_dir` exactly once from the validated absolute store; the `"."` parent fallback is now a hard error; restart recipes refuse non-absolute paths before touching disk. Persisted relative active-repository values are rejected and **cleared without probing the process CWD**.

**Frontend is supplemental UX only** (backend stays the trust boundary): `pathPolicy.ts` mirror, inline actionable errors with `aria-invalid` (existing `server-config-field-error` pattern/tokens) on PathField/BackendPicker/ClientClone, native pickers default to Documents→home instead of inheriting CWD, picker cancel is a no-op. No package.json/lockfile changes (SBAI-5819 owns those).

## Demonstrated, not asserted

The four new fake-System32 IPC-harness tests were grafted onto **unmodified `2d2912d`** and fail there — `host_store_prepare("lore")` created `./lore` under the fake System32 CWD and returned the relative path as "resolved"; a planted *valid* repository at a persisted relative name was activated. On this branch all four pass: rejection happens before any filesystem/IPC/spawn effect and the fake CWD stays byte-for-byte empty.

## Verification

- `cargo test -p loregui`: **142 passed, 0 failed** (14 new: 8 policy table, 2 server_host, 4 IPC-harness System32)
- vitest: **392 passed, 0 failed** (29 files; 44 new policy-table + picker-default/error specs)
- `cargo fmt --all --check` clean; frontend build green; palette parity unchanged (115/148 OK)

## Out of scope / follow-up gates

- **EROS packaged-Windows E2E** (DoD 7–8) is a separate acceptance gate per sb-lore — this PR must not close the ticket on CI alone.
- sb-secure's independent verdict stands (High/beta-blocker, no proven code-exec route); no updater/manifest/release changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)