### PR TITLE
SBAI-5817: auto-release version stamp works on a fresh runner

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -19,6 +19,10 @@ on:
         description: "Release even if no new commits since last tag"
         required: false
         default: "false"
+      dry_run:
+        description: "SBAI-5817: prove the version-stamp path on this runner, then stop — no commit, no tag, no push, no publish (combine with force to exercise it without new commits)"
+        required: false
+        default: "false"
 
 permissions:
   contents: write
@@ -76,6 +80,15 @@ jobs:
           set -euo pipefail
           NEXT=${{ steps.decide.outputs.next }}
           V=${NEXT#v}
+          # SBAI-5817: a fresh GitHub-hosted runner has no cargo git cache, so
+          # `cargo update -w --offline` cannot even load the pinned
+          # EpicGames/lore source (run 30516568642). Populate the caches for
+          # the EXACT locked graph first, while the checkout is still
+          # pristine: --locked refuses to modify Cargo.lock, and doing it
+          # before the version seds means the lock still matches the
+          # manifests. The stamp below then runs fully offline, so dependency
+          # drift stays impossible (the SBAI-5436 intent, preserved).
+          cargo fetch --locked
           # Single source of truth: [workspace.package] version (src-tauri and
           # tauri.conf.json's explicit copy both track it).
           sed -i -E "0,/^version = \"[0-9.]+\"/s//version = \"$V\"/" Cargo.toml
@@ -87,6 +100,21 @@ jobs:
             echo "::error::Cargo.lock still has stale versions after cargo update -w (expected $V, got $LOCK_VERSIONS)"
             exit 1
           fi
+          # SBAI-5817: the lock diff must be exactly PR-#444-shaped — version
+          # stamp lines only. Any other changed line (source, checksum, a
+          # non-workspace version) means the pins drifted; refuse to release.
+          DRIFT=$(git diff -U0 -- Cargo.lock | grep -E '^[+-][^+-]' | grep -vE '^[+-]version = "[0-9.]+"$' || true)
+          if [ -n "$DRIFT" ]; then
+            echo "::error::Cargo.lock changed beyond workspace version stamps — refusing to release"
+            echo "$DRIFT"
+            exit 1
+          fi
+          if [ "${{ github.event.inputs.dry_run || 'false' }}" = "true" ]; then
+            echo "dry-run: version-stamp path verified on this runner; constrained diff:"
+            git --no-pager diff --stat
+            echo "dry-run: stopping before commit/tag/push."
+            exit 0
+          fi
           git config user.name "loregui-auto-release"
           git config user.email "brandon.f@graeinc.co"
           git add Cargo.toml Cargo.lock src-tauri/tauri.conf.json 2>/dev/null || true
@@ -96,7 +124,8 @@ jobs:
           echo "tag=$NEXT" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch release build on the tag
-        if: steps.decide.outputs.release == 'true'
+        # SBAI-5817: tag output is empty on a dry_run — skip everything that mutates.
+        if: steps.decide.outputs.release == 'true' && steps.tag.outputs.tag != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -105,7 +134,7 @@ jobs:
           gh workflow run release.yml -R "$GITHUB_REPOSITORY" --ref "${{ steps.tag.outputs.tag }}"
 
       - name: Wait for release build + verify asset contract + publish
-        if: steps.decide.outputs.release == 'true'
+        if: steps.decide.outputs.release == 'true' && steps.tag.outputs.tag != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Resolves SBAI-5817: scheduled auto-release run 30516568642 could not cut a stable release on a fresh runner — `cargo update -w --offline` in "Bump workspace version + tag" fails to load the pinned `EpicGames/lore` git source (surfaced via its `quinn-proto` patch) because a fresh GitHub-hosted runner has no warm cargo git cache.

## Change (one file: `.github/workflows/auto-release.yml`)

1. **`cargo fetch --locked` before the version seds** — populates registry + git caches for the *exact* locked graph while the checkout is pristine (`--locked` refuses to modify Cargo.lock; running it before the seds means lock and manifests still agree). The version stamp then runs fully **offline**, unchanged — the SBAI-5436 no-drift guarantee is preserved, not relaxed.
2. **Hard #444-shape guard** — after stamping, the `Cargo.lock` diff must contain only `version = "…"` lines; any source/checksum/non-workspace-version line refuses the release loudly (DoD 2).
3. **`dry_run` workflow_dispatch input** (DoD 3) — exercises decide + fetch + stamp + shape-guard on a real fresh runner, prints the constrained diff, and stops before commit/tag/push; all downstream mutating steps are now gated on `steps.tag.outputs.tag != ''`. Combine with `force` to run it without new commits.

## Demonstrated on a cold cache (empty `CARGO_HOME`, locally)

- **Old sequence** reproduces the exact ticket failure byte-for-byte: `failed to load source for dependency 'quinn-proto'` → `unable to update EpicGames/lore rev 9664606f5…` → `you are in the offline mode`.
- **New sequence** succeeds: `cargo fetch --locked` from empty cache, then the offline stamp updates exactly `lore-vm`/`loregui`/`lorevm-cli`/`lorevm-ffi` 0.1.4→0.1.5; full diff = 4 lock stamps + `Cargo.toml` + `tauri.conf.json`, drift check reports none — exactly the PR #444 reference shape.

## Remaining DoD (gated on the domain owner, not this PR)

DoD 4 — a real `workflow_dispatch` cutting the next tag and publishing after full asset-contract verification — is a prod mutation. Recommended sequence after merge: first a `dry_run=true, force=true` dispatch to prove the stamp path on a genuinely fresh runner, then the real cut at the lead's discretion. v0.1.4 itself already shipped manually via #444; the next auto cut will be v0.1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)