### PR TITLE
SBAI-5840: release.yml never triggers on branch pushes (trigger-control slice)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,11 @@ name: release
 # explicitly until the first stable `v*` release.
 # SBAI-5840: NO branch-push trigger — a merge to main must never arm a
 # release run (PR #445: a matrix leg could clobber nightly assets before
-# cancellation). Stable `v*` tag pushes and manual dispatch only; the trigger
-# contract is CI-enforced by src-tauri/tests/release_workflow_contract.rs,
-# which rejects any branches filter (or main reference) inside the on-block.
+# cancellation). Only stable `v*` tag pushes and explicit workflow_dispatch
+# (manual, or invoked/governed by auto-release.yml) trigger this workflow;
+# the trigger contract is CI-enforced by
+# src-tauri/tests/release_workflow_contract.rs, which rejects any branches
+# filter (or main reference) inside the on-block.
 on:
   push:
     tags: ["v*"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: release
 
 # Multi-platform installers published to GitHub Releases:
 #   - push of a tag `v*` → a proper versioned release (draft)
-#   - workflow_dispatch → manual run
+#   - workflow_dispatch → explicit dispatch: run manually, or invoked and
+#     governed by the scheduled auto-release.yml
+#     (`gh workflow run release.yml --ref <tag>`)
 #   (SBAI-5840: the old push-to-main nightly refresh is REMOVED — see the
 #   trigger contract below; nightly stays pinned until the release redesign.)
 # Windows + Linux build on GitHub-hosted runners; macOS builds on GitHub-hosted

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: release
 
 # Multi-platform installers published to GitHub Releases:
-#   - push to main  → refreshes the rolling `nightly` prerelease (current build)
 #   - push of a tag `v*` → a proper versioned release (draft)
+#   - workflow_dispatch → manual run
+#   (SBAI-5840: the old push-to-main nightly refresh is REMOVED — see the
+#   trigger contract below; nightly stays pinned until the release redesign.)
 # Windows + Linux build on GitHub-hosted runners; macOS builds on GitHub-hosted
 # macos-latest (ARM64) — matching StudioBrain's proven setup (SBAI-3263: macOS
 # moved OFF the self-hosted runner). Apple certs are imported from GH secrets
@@ -18,9 +20,13 @@ name: release
 # public key is committed in tauri.conf.json. NOTE: GitHub's `releases/latest`
 # redirect skips prereleases, so the endpoint must reference the `nightly` tag
 # explicitly until the first stable `v*` release.
+# SBAI-5840: NO branch-push trigger — a merge to main must never arm a
+# release run (PR #445: a matrix leg could clobber nightly assets before
+# cancellation). Stable `v*` tag pushes and manual dispatch only; the trigger
+# contract is CI-enforced by src-tauri/tests/release_workflow_contract.rs,
+# which rejects any branches filter (or main reference) inside the on-block.
 on:
   push:
-    branches: [main]
     tags: ["v*"]
   workflow_dispatch:
 

--- a/src-tauri/tests/release_workflow_contract.rs
+++ b/src-tauri/tests/release_workflow_contract.rs
@@ -144,97 +144,25 @@ fn check_trigger_contract(yaml: &str) -> Result<(), String> {
         return Err(format!("push filters must be exactly [tags], got {keys:?}"));
     }
     let tags = &filters[0];
-    // Exact positive enforcement (review finding on 1a194d3): the stable
-    // pattern must be the literal list member `v*`. A substring check passed
-    // decoys like `["not-v*"]` — a glob that never matches a normal v1.2.3
-    // tag and silently kills the stable release path.
-    let patterns = tag_patterns(tags)?;
-    if patterns != ["v*"] {
+    // Canonical-form enforcement (review addendum on a5d3820): the
+    // generalized quote/list parser kept yielding exact-value bypasses —
+    // recursive quote-trimming turned ["'v*'"] (a pattern whose real text
+    // is 'v*', quotes included) into v*. The workflow uses exactly ONE
+    // syntax; anything else — alternate quoting, scalars, sub-lists, extra
+    // members, extra bytes — fails closed until a reviewed contract change.
+    // Byte-exact: no comment mini-parser either — a trailing comment on the
+    // tags line is itself non-canonical and fails closed.
+    let value = tags.inline.trim();
+    if value != "[\"v*\"]" {
         return Err(format!(
-            "push.tags patterns must be exactly [\"v*\"], got {patterns:?}"
+            "push.tags must be exactly the canonical [\"v*\"] — got {value:?}; \
+             alternate formatting requires a reviewed contract change"
         ));
     }
-
+    if !tags.sub_lines.iter().all(|l| is_noise(l)) {
+        return Err("push.tags must be the inline canonical [\"v*\"] with no sub-lines".into());
+    }
     Ok(())
-}
-
-/// Cut a YAML fragment at its first UNQUOTED `#` (review finding on
-/// 0267091: comment stripping must happen BEFORE any bracket/scalar
-/// parsing, or `tags: # ["v*"]` — whose real value is null — passes the
-/// bracket search inside the comment).
-fn strip_unquoted_comment(fragment: &str) -> &str {
-    let mut in_double = false;
-    let mut in_single = false;
-    for (i, c) in fragment.char_indices() {
-        match c {
-            '"' if !in_single => in_double = !in_double,
-            '\'' if !in_double => in_single = !in_single,
-            '#' if !in_double && !in_single => return &fragment[..i],
-            _ => {}
-        }
-    }
-    fragment
-}
-
-/// Parse the tags filter's pattern list: inline `["a", "b"]`, scalar, or a
-/// `- "a"` sub-list. The first unquoted comment is stripped BEFORE any
-/// parsing; empty sequence members are violations, not ignorable noise.
-/// Fails closed on anything else.
-fn tag_patterns(tags: &Child) -> Result<Vec<String>, String> {
-    let unquote = |s: &str| s.trim().trim_matches(|c| c == '"' || c == '\'').to_string();
-    let inline = strip_unquoted_comment(&tags.inline).trim();
-    // An inline list must consume the ENTIRE trimmed value (review finding
-    // on a5d3820: bracket-searching anywhere let the valid scalar
-    // `release-only ["v*"]` pass on the bracket while its real YAML value
-    // is the whole scalar).
-    if inline.starts_with('[') || inline.ends_with(']') {
-        let body = inline
-            .strip_prefix('[')
-            .and_then(|rest| rest.strip_suffix(']'))
-            .ok_or_else(|| {
-                format!("tags value must be a complete [..] list or a scalar, got {inline:?}")
-            })?;
-        {
-            let mut patterns = Vec::new();
-            for member in body.split(',') {
-                let member = unquote(member);
-                if member.is_empty() {
-                    return Err(format!("tags list has an empty pattern member: {inline:?}"));
-                }
-                patterns.push(member);
-            }
-            return Ok(patterns);
-        }
-    }
-    if !inline.is_empty() {
-        // Scalar form `tags: v*` (comment already stripped above).
-        let scalar = unquote(inline);
-        if scalar.is_empty() {
-            return Err(format!("unparseable tags value {:?}", tags.inline));
-        }
-        return Ok(vec![scalar]);
-    }
-    let mut patterns = Vec::new();
-    for line in &tags.sub_lines {
-        let t = strip_unquoted_comment(line).trim();
-        if t.is_empty() {
-            continue;
-        }
-        let item = t
-            .strip_prefix('-')
-            .ok_or_else(|| format!("unexpected tags sub-line {t:?}"))?;
-        let item = unquote(item);
-        if item.is_empty() {
-            return Err(format!(
-                "tags sub-list has an empty pattern member: {line:?}"
-            ));
-        }
-        patterns.push(item);
-    }
-    if patterns.is_empty() {
-        return Err("tags filter has no patterns".into());
-    }
-    Ok(patterns)
 }
 
 fn release_workflow() -> String {
@@ -336,7 +264,7 @@ fn comment_hidden_and_empty_member_tag_values_fail() {
     let empty_member =
         "name: release\non:\n  push:\n    tags: [\"v*\", \"\"]\n  workflow_dispatch:\njobs: {}\n";
     let error = check_trigger_contract(empty_member).expect_err("empty member must fail");
-    assert!(error.contains("empty pattern member"), "{error}");
+    assert!(error.contains("canonical"), "{error}");
 }
 
 /// Review finding on a5d3820: `tags: release-only ["v*"]` is VALID YAML
@@ -350,4 +278,20 @@ fn scalar_prefixed_bracket_decoy_fails() {
         error.contains("complete") || error.contains("exactly"),
         "{error}"
     );
+}
+
+/// Review addendum on a5d3820: valid YAML whose real pattern text includes
+/// literal quote characters (so it is NOT v*) must fail — recursive
+/// quote-trimming used to normalize it into a false pass.
+#[test]
+fn nested_quote_tag_patterns_fail() {
+    let quoted_list =
+        "name: release\non:\n  push:\n    tags: [\"'v*'\"]\n  workflow_dispatch:\njobs: {}\n";
+    let error = check_trigger_contract(quoted_list).expect_err("nested-quote list must fail");
+    assert!(error.contains("canonical"), "{error}");
+
+    let quoted_scalar =
+        "name: release\non:\n  push:\n    tags: \"'v*'\"\n  workflow_dispatch:\njobs: {}\n";
+    let error = check_trigger_contract(quoted_scalar).expect_err("nested-quote scalar must fail");
+    assert!(error.contains("canonical"), "{error}");
 }

--- a/src-tauri/tests/release_workflow_contract.rs
+++ b/src-tauri/tests/release_workflow_contract.rs
@@ -183,10 +183,20 @@ fn strip_unquoted_comment(fragment: &str) -> &str {
 fn tag_patterns(tags: &Child) -> Result<Vec<String>, String> {
     let unquote = |s: &str| s.trim().trim_matches(|c| c == '"' || c == '\'').to_string();
     let inline = strip_unquoted_comment(&tags.inline).trim();
-    if let (Some(start), Some(end)) = (inline.find('['), inline.find(']')) {
-        if start < end {
+    // An inline list must consume the ENTIRE trimmed value (review finding
+    // on a5d3820: bracket-searching anywhere let the valid scalar
+    // `release-only ["v*"]` pass on the bracket while its real YAML value
+    // is the whole scalar).
+    if inline.starts_with('[') || inline.ends_with(']') {
+        let body = inline
+            .strip_prefix('[')
+            .and_then(|rest| rest.strip_suffix(']'))
+            .ok_or_else(|| {
+                format!("tags value must be a complete [..] list or a scalar, got {inline:?}")
+            })?;
+        {
             let mut patterns = Vec::new();
-            for member in inline[start + 1..end].split(',') {
+            for member in body.split(',') {
                 let member = unquote(member);
                 if member.is_empty() {
                     return Err(format!("tags list has an empty pattern member: {inline:?}"));
@@ -327,4 +337,17 @@ fn comment_hidden_and_empty_member_tag_values_fail() {
         "name: release\non:\n  push:\n    tags: [\"v*\", \"\"]\n  workflow_dispatch:\njobs: {}\n";
     let error = check_trigger_contract(empty_member).expect_err("empty member must fail");
     assert!(error.contains("empty pattern member"), "{error}");
+}
+
+/// Review finding on a5d3820: `tags: release-only ["v*"]` is VALID YAML
+/// whose real value is the whole scalar — the bracket content must not be
+/// parsed out of the middle of it.
+#[test]
+fn scalar_prefixed_bracket_decoy_fails() {
+    let fixture = "name: release\non:\n  push:\n    tags: release-only [\"v*\"]\n  workflow_dispatch:\njobs: {}\n";
+    let error = check_trigger_contract(fixture).expect_err("scalar-prefixed bracket must fail");
+    assert!(
+        error.contains("complete") || error.contains("exactly"),
+        "{error}"
+    );
 }

--- a/src-tauri/tests/release_workflow_contract.rs
+++ b/src-tauri/tests/release_workflow_contract.rs
@@ -1,0 +1,96 @@
+//! SBAI-5840: CI contract test for the release workflow's triggers.
+//!
+//! PR #445 proved that every merge to `main` armed the legacy `release.yml`
+//! main-push trigger, letting a matrix leg clobber nightly assets before
+//! cancellation. The binding trigger contract is therefore:
+//!
+//!   1. `release.yml` must NOT run on branch pushes (no `branches:` filter
+//!      under `on:` at all, and no reference to `main` there);
+//!   2. stable tag releases (`push.tags: v*`) must KEEP working;
+//!   3. manual `workflow_dispatch` must KEEP working.
+//!
+//! The test is a line-structural parse of the top-level `on:` block — no
+//! YAML dependency, so it cannot add Cargo manifest/lock churn. It runs
+//! under `cargo test -p loregui` (the tauri-e2e ipc-harness CI job), so a
+//! future edit that re-adds a main-push trigger fails CI, not review.
+
+use std::path::Path;
+
+fn release_workflow() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../.github/workflows/release.yml");
+    std::fs::read_to_string(&path).unwrap_or_else(|error| {
+        panic!(
+            "release workflow must exist at {} (contract test guards its triggers): {error}",
+            path.display()
+        )
+    })
+}
+
+/// The top-level `on:` block: every subsequent line that is indented, blank,
+/// or a comment, up to the next top-level key. Panics if the block is absent
+/// or empty so the assertions below can never pass vacuously.
+fn on_block(yaml: &str) -> String {
+    let mut block = String::new();
+    let mut in_on = false;
+    for line in yaml.lines() {
+        if line.trim_end() == "on:" {
+            in_on = true;
+            continue;
+        }
+        if in_on {
+            let is_top_level_key = !line.starts_with([' ', '\t'])
+                && !line.trim().is_empty()
+                && !line.trim_start().starts_with('#');
+            if is_top_level_key {
+                break;
+            }
+            block.push_str(line);
+            block.push('\n');
+        }
+    }
+    assert!(
+        in_on && !block.trim().is_empty(),
+        "release.yml must have a non-empty top-level `on:` block"
+    );
+    block
+}
+
+#[test]
+fn release_workflow_never_triggers_on_branch_pushes() {
+    let yaml = release_workflow();
+    assert!(
+        yaml.contains("name: release"),
+        "contract test must be reading the release workflow"
+    );
+    let on = on_block(&yaml);
+    assert!(
+        !on.contains("branches"),
+        "release.yml must not carry ANY branch-push trigger — a main merge \
+         must never arm a release run (SBAI-5840 / PR #445 incident). on-block:\n{on}"
+    );
+    assert!(
+        !on.contains("main"),
+        "no reference to main may remain in the on-block:\n{on}"
+    );
+}
+
+#[test]
+fn release_workflow_keeps_stable_tag_and_manual_dispatch_triggers() {
+    let on = on_block(&release_workflow());
+    assert!(
+        on.contains("push:"),
+        "tag pushes still ride the push event:\n{on}"
+    );
+    let tags_line = on
+        .lines()
+        .find(|line| line.trim_start().starts_with("tags:"))
+        .unwrap_or_else(|| panic!("push.tags filter must be present:\n{on}"));
+    assert!(
+        tags_line.contains("v*"),
+        "stable v* tag releases must keep working: {tags_line}"
+    );
+    assert!(
+        on.contains("workflow_dispatch"),
+        "manual dispatch must keep working:\n{on}"
+    );
+}

--- a/src-tauri/tests/release_workflow_contract.rs
+++ b/src-tauri/tests/release_workflow_contract.rs
@@ -144,14 +144,62 @@ fn check_trigger_contract(yaml: &str) -> Result<(), String> {
         return Err(format!("push filters must be exactly [tags], got {keys:?}"));
     }
     let tags = &filters[0];
-    let tags_text = format!("{}\n{}", tags.inline, tags.sub_lines.join("\n"));
-    if !tags_text.contains("v*") {
+    // Exact positive enforcement (review finding on 1a194d3): the stable
+    // pattern must be the literal list member `v*`. A substring check passed
+    // decoys like `["not-v*"]` — a glob that never matches a normal v1.2.3
+    // tag and silently kills the stable release path.
+    let patterns = tag_patterns(tags)?;
+    if patterns != ["v*"] {
         return Err(format!(
-            "push.tags must match stable v* tags, got {tags_text:?}"
+            "push.tags patterns must be exactly [\"v*\"], got {patterns:?}"
         ));
     }
 
     Ok(())
+}
+
+/// Parse the tags filter's pattern list: inline `["a", "b"]` (bracket
+/// extraction inherently drops trailing comments) or a `- "a"` sub-list.
+/// Fails closed on anything else.
+fn tag_patterns(tags: &Child) -> Result<Vec<String>, String> {
+    let unquote = |s: &str| s.trim().trim_matches(|c| c == '"' || c == '\'').to_string();
+    if let (Some(start), Some(end)) = (tags.inline.find('['), tags.inline.find(']')) {
+        if start < end {
+            return Ok(tags.inline[start + 1..end]
+                .split(',')
+                .map(unquote)
+                .filter(|s| !s.is_empty())
+                .collect());
+        }
+    }
+    if !tags.inline.is_empty() {
+        // Scalar form `tags: v*` — strip any trailing comment.
+        let scalar = tags.inline.split('#').next().unwrap_or("");
+        let scalar = unquote(scalar);
+        if scalar.is_empty() {
+            return Err(format!("unparseable tags value {:?}", tags.inline));
+        }
+        return Ok(vec![scalar]);
+    }
+    let mut patterns = Vec::new();
+    for line in &tags.sub_lines {
+        let t = line.trim();
+        if t.is_empty() || t.starts_with('#') {
+            continue;
+        }
+        let item = t
+            .strip_prefix('-')
+            .ok_or_else(|| format!("unexpected tags sub-line {t:?}"))?;
+        let item = item.split('#').next().unwrap_or("");
+        let item = unquote(item);
+        if !item.is_empty() {
+            patterns.push(item);
+        }
+    }
+    if patterns.is_empty() {
+        return Err("tags filter has no patterns".into());
+    }
+    Ok(patterns)
 }
 
 fn release_workflow() -> String {
@@ -216,4 +264,20 @@ fn extra_or_missing_triggers_fail() {
 
     let missing_dispatch = "name: release\non:\n  push:\n    tags: [\"v*\"]\njobs: {}\n";
     check_trigger_contract(missing_dispatch).expect_err("missing workflow_dispatch must fail");
+}
+
+/// Review finding on 1a194d3: `contains("v*")` passed the decoy pattern
+/// `["not-v*"]`, which never matches a real stable tag — the pattern list
+/// must be exactly `["v*"]`, and a comment cannot stand in for it.
+#[test]
+fn not_v_star_and_comment_decoy_tag_patterns_fail() {
+    let not_v_star =
+        "name: release\non:\n  push:\n    tags: [\"not-v*\"]\n  workflow_dispatch:\njobs: {}\n";
+    let error = check_trigger_contract(not_v_star).expect_err("not-v* decoy must fail");
+    assert!(error.contains("exactly"), "{error}");
+
+    let comment_decoy =
+        "name: release\non:\n  push:\n    tags: [\"release-only\"] # v*\n  workflow_dispatch:\njobs: {}\n";
+    let error = check_trigger_contract(comment_decoy).expect_err("comment decoy must fail");
+    assert!(error.contains("exactly"), "{error}");
 }

--- a/src-tauri/tests/release_workflow_contract.rs
+++ b/src-tauri/tests/release_workflow_contract.rs
@@ -2,19 +2,157 @@
 //!
 //! PR #445 proved that every merge to `main` armed the legacy `release.yml`
 //! main-push trigger, letting a matrix leg clobber nightly assets before
-//! cancellation. The binding trigger contract is therefore:
+//! cancellation. The binding trigger contract:
 //!
-//!   1. `release.yml` must NOT run on branch pushes (no `branches:` filter
-//!      under `on:` at all, and no reference to `main` there);
-//!   2. stable tag releases (`push.tags: v*`) must KEEP working;
-//!   3. manual `workflow_dispatch` must KEEP working.
+//!   1. `release.yml` must NOT run on branch pushes — no `branches:` filter,
+//!      no `main` reference, and no EMPTY/unfiltered `push:` (an empty push
+//!      trigger re-arms every branch);
+//!   2. stable tag releases must keep working: `push` carries a DIRECT
+//!      `tags:` child matching `v*`, and nothing else;
+//!   3. manual `workflow_dispatch` must keep working as a DIRECT child of
+//!      `on:` — a `tags`-shaped string elsewhere (e.g. a dispatch input)
+//!      must never satisfy requirement 2.
 //!
-//! The test is a line-structural parse of the top-level `on:` block — no
-//! YAML dependency, so it cannot add Cargo manifest/lock churn. It runs
-//! under `cargo test -p loregui` (the tauri-e2e ipc-harness CI job), so a
-//! future edit that re-adds a main-push trigger fails CI, not review.
+//! The checks parse the DIRECT-CHILD structure of the `on:` block (review
+//! finding on 3a1d7b3: independent substring searches were fail-open — an
+//! empty `push:` plus `workflow_dispatch.inputs.tags: v*` passed). The
+//! seeded bypass fixtures below must FAIL the contract forever. No YAML
+//! dependency, so the test adds zero Cargo manifest/lock churn. Runs under
+//! `cargo test -p loregui` (the tauri-e2e ipc-harness CI job).
 
 use std::path::Path;
+
+/// One parsed direct child of a block: key, inline value (after the colon),
+/// and its indented sub-lines.
+struct Child {
+    key: String,
+    inline: String,
+    sub_lines: Vec<String>,
+}
+
+fn content_indent(line: &str) -> usize {
+    line.len() - line.trim_start().len()
+}
+
+fn is_noise(line: &str) -> bool {
+    let t = line.trim_start();
+    t.is_empty() || t.starts_with('#')
+}
+
+/// Split a block's lines into direct children (all content at the block's
+/// first indent level) with their sub-lines. Fails closed on any structure
+/// it does not recognize.
+fn direct_children(lines: &[String]) -> Result<Vec<Child>, String> {
+    let first = lines
+        .iter()
+        .find(|l| !is_noise(l))
+        .ok_or("block has no content")?;
+    let child_indent = content_indent(first);
+    let mut children: Vec<Child> = Vec::new();
+    for line in lines {
+        if is_noise(line) {
+            continue;
+        }
+        let indent = content_indent(line);
+        if indent == child_indent {
+            let t = line.trim();
+            let (key, inline) = t
+                .split_once(':')
+                .ok_or_else(|| format!("unexpected non-key line in block: {t:?}"))?;
+            children.push(Child {
+                key: key.trim().to_string(),
+                inline: inline.trim().to_string(),
+                sub_lines: Vec::new(),
+            });
+        } else if indent > child_indent {
+            children
+                .last_mut()
+                .ok_or_else(|| format!("indented line before any child key: {line:?}"))?
+                .sub_lines
+                .push(line.clone());
+        } else {
+            return Err(format!("inconsistent indentation in block: {line:?}"));
+        }
+    }
+    Ok(children)
+}
+
+/// The full trigger contract, returning `Err(reason)` instead of panicking
+/// so the seeded bypass fixtures can assert failure in-process.
+fn check_trigger_contract(yaml: &str) -> Result<(), String> {
+    if !yaml.contains("name: release") {
+        return Err("not the release workflow".into());
+    }
+
+    // Collect the top-level `on:` block.
+    let mut in_on = false;
+    let mut on_lines: Vec<String> = Vec::new();
+    for line in yaml.lines() {
+        if line.trim_end() == "on:" {
+            in_on = true;
+            continue;
+        }
+        if in_on {
+            let top_level = !line.starts_with([' ', '\t']) && !is_noise(line);
+            if top_level {
+                break;
+            }
+            on_lines.push(line.to_string());
+        }
+    }
+    if !in_on {
+        return Err("missing top-level on: block".into());
+    }
+
+    // Belt: nothing branch-shaped or main-shaped anywhere in the block, not
+    // even commented out.
+    let joined = on_lines.join("\n");
+    if joined.contains("branches") {
+        return Err(format!("branches filter present in on-block:\n{joined}"));
+    }
+    if joined.contains("main") {
+        return Err(format!("`main` referenced in on-block:\n{joined}"));
+    }
+
+    // Structural core: the on-block's DIRECT children must be exactly
+    // `push` and `workflow_dispatch` — any third trigger is a contract
+    // change that needs a new ruling, not a silent pass.
+    let triggers = direct_children(&on_lines).map_err(|e| format!("on-block: {e}"))?;
+    let mut keys: Vec<&str> = triggers.iter().map(|c| c.key.as_str()).collect();
+    keys.sort_unstable();
+    if keys != ["push", "workflow_dispatch"] {
+        return Err(format!(
+            "on-block triggers must be exactly push + workflow_dispatch, got {keys:?}"
+        ));
+    }
+
+    // `push` must be NONEMPTY (empty = unfiltered = every branch) and its
+    // direct children must be exactly one `tags` filter carrying v*.
+    let push = triggers.iter().find(|c| c.key == "push").expect("checked");
+    if !push.inline.is_empty() {
+        return Err(format!(
+            "push must be a mapping with a tags filter, got inline value {:?}",
+            push.inline
+        ));
+    }
+    if push.sub_lines.iter().all(|l| is_noise(l)) {
+        return Err("push: is EMPTY — an unfiltered push trigger re-arms every branch".into());
+    }
+    let filters = direct_children(&push.sub_lines).map_err(|e| format!("push block: {e}"))?;
+    if filters.len() != 1 || filters[0].key != "tags" {
+        let keys: Vec<&str> = filters.iter().map(|c| c.key.as_str()).collect();
+        return Err(format!("push filters must be exactly [tags], got {keys:?}"));
+    }
+    let tags = &filters[0];
+    let tags_text = format!("{}\n{}", tags.inline, tags.sub_lines.join("\n"));
+    if !tags_text.contains("v*") {
+        return Err(format!(
+            "push.tags must match stable v* tags, got {tags_text:?}"
+        ));
+    }
+
+    Ok(())
+}
 
 fn release_workflow() -> String {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../.github/workflows/release.yml");
@@ -26,71 +164,56 @@ fn release_workflow() -> String {
     })
 }
 
-/// The top-level `on:` block: every subsequent line that is indented, blank,
-/// or a comment, up to the next top-level key. Panics if the block is absent
-/// or empty so the assertions below can never pass vacuously.
-fn on_block(yaml: &str) -> String {
-    let mut block = String::new();
-    let mut in_on = false;
-    for line in yaml.lines() {
-        if line.trim_end() == "on:" {
-            in_on = true;
-            continue;
-        }
-        if in_on {
-            let is_top_level_key = !line.starts_with([' ', '\t'])
-                && !line.trim().is_empty()
-                && !line.trim_start().starts_with('#');
-            if is_top_level_key {
-                break;
-            }
-            block.push_str(line);
-            block.push('\n');
-        }
+#[test]
+fn release_workflow_satisfies_the_trigger_contract() {
+    if let Err(reason) = check_trigger_contract(&release_workflow()) {
+        panic!("release.yml violates the SBAI-5840 trigger contract: {reason}");
     }
-    assert!(
-        in_on && !block.trim().is_empty(),
-        "release.yml must have a non-empty top-level `on:` block"
-    );
-    block
 }
 
+/// Review finding on 3a1d7b3, kept forever as a seeded bypass: an EMPTY
+/// `push:` (which re-arms every branch) combined with a `tags: v*` string
+/// hidden under `workflow_dispatch.inputs` fooled substring checks. The
+/// structural contract must reject it.
 #[test]
-fn release_workflow_never_triggers_on_branch_pushes() {
-    let yaml = release_workflow();
+fn empty_push_with_dispatch_input_tags_decoy_fails() {
+    let fixture = "name: release\non:\n  push:\n  workflow_dispatch:\n    inputs:\n      tags:\n        description: \"release v* tag\"\njobs: {}\n";
+    let error = check_trigger_contract(fixture).expect_err("bypass fixture must fail");
     assert!(
-        yaml.contains("name: release"),
-        "contract test must be reading the release workflow"
-    );
-    let on = on_block(&yaml);
-    assert!(
-        !on.contains("branches"),
-        "release.yml must not carry ANY branch-push trigger — a main merge \
-         must never arm a release run (SBAI-5840 / PR #445 incident). on-block:\n{on}"
-    );
-    assert!(
-        !on.contains("main"),
-        "no reference to main may remain in the on-block:\n{on}"
+        error.contains("EMPTY"),
+        "names the empty-push defect: {error}"
     );
 }
 
+/// The legacy pre-SBAI-5840 shape (the PR #445 incident) must keep failing.
 #[test]
-fn release_workflow_keeps_stable_tag_and_manual_dispatch_triggers() {
-    let on = on_block(&release_workflow());
+fn legacy_main_branch_trigger_fails() {
+    let fixture =
+        "name: release\non:\n  push:\n    branches: [main]\n    tags: [\"v*\"]\n  workflow_dispatch:\njobs: {}\n";
+    let error = check_trigger_contract(fixture).expect_err("legacy shape must fail");
+    assert!(error.contains("branches"), "{error}");
+}
+
+/// A tags filter that is not a DIRECT child of push satisfies nothing.
+#[test]
+fn tags_outside_push_fails() {
+    let fixture =
+        "name: release\non:\n  push:\n    paths: [\"src/**\"]\n  tags: [\"v*\"]\n  workflow_dispatch:\njobs: {}\n";
+    let error = check_trigger_contract(fixture).expect_err("misplaced tags must fail");
     assert!(
-        on.contains("push:"),
-        "tag pushes still ride the push event:\n{on}"
+        error.contains("exactly push + workflow_dispatch") || error.contains("exactly [tags]"),
+        "{error}"
     );
-    let tags_line = on
-        .lines()
-        .find(|line| line.trim_start().starts_with("tags:"))
-        .unwrap_or_else(|| panic!("push.tags filter must be present:\n{on}"));
-    assert!(
-        tags_line.contains("v*"),
-        "stable v* tag releases must keep working: {tags_line}"
-    );
-    assert!(
-        on.contains("workflow_dispatch"),
-        "manual dispatch must keep working:\n{on}"
-    );
+}
+
+/// Any third trigger, or a missing manual dispatch, is a contract change
+/// that must fail CI rather than pass silently.
+#[test]
+fn extra_or_missing_triggers_fail() {
+    let extra =
+        "name: release\non:\n  push:\n    tags: [\"v*\"]\n  workflow_dispatch:\n  schedule:\n    - cron: \"0 0 * * *\"\njobs: {}\n";
+    check_trigger_contract(extra).expect_err("a third trigger must fail");
+
+    let missing_dispatch = "name: release\non:\n  push:\n    tags: [\"v*\"]\njobs: {}\n";
+    check_trigger_contract(missing_dispatch).expect_err("missing workflow_dispatch must fail");
 }

--- a/src-tauri/tests/release_workflow_contract.rs
+++ b/src-tauri/tests/release_workflow_contract.rs
@@ -158,24 +158,47 @@ fn check_trigger_contract(yaml: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Parse the tags filter's pattern list: inline `["a", "b"]` (bracket
-/// extraction inherently drops trailing comments) or a `- "a"` sub-list.
+/// Cut a YAML fragment at its first UNQUOTED `#` (review finding on
+/// 0267091: comment stripping must happen BEFORE any bracket/scalar
+/// parsing, or `tags: # ["v*"]` — whose real value is null — passes the
+/// bracket search inside the comment).
+fn strip_unquoted_comment(fragment: &str) -> &str {
+    let mut in_double = false;
+    let mut in_single = false;
+    for (i, c) in fragment.char_indices() {
+        match c {
+            '"' if !in_single => in_double = !in_double,
+            '\'' if !in_double => in_single = !in_single,
+            '#' if !in_double && !in_single => return &fragment[..i],
+            _ => {}
+        }
+    }
+    fragment
+}
+
+/// Parse the tags filter's pattern list: inline `["a", "b"]`, scalar, or a
+/// `- "a"` sub-list. The first unquoted comment is stripped BEFORE any
+/// parsing; empty sequence members are violations, not ignorable noise.
 /// Fails closed on anything else.
 fn tag_patterns(tags: &Child) -> Result<Vec<String>, String> {
     let unquote = |s: &str| s.trim().trim_matches(|c| c == '"' || c == '\'').to_string();
-    if let (Some(start), Some(end)) = (tags.inline.find('['), tags.inline.find(']')) {
+    let inline = strip_unquoted_comment(&tags.inline).trim();
+    if let (Some(start), Some(end)) = (inline.find('['), inline.find(']')) {
         if start < end {
-            return Ok(tags.inline[start + 1..end]
-                .split(',')
-                .map(unquote)
-                .filter(|s| !s.is_empty())
-                .collect());
+            let mut patterns = Vec::new();
+            for member in inline[start + 1..end].split(',') {
+                let member = unquote(member);
+                if member.is_empty() {
+                    return Err(format!("tags list has an empty pattern member: {inline:?}"));
+                }
+                patterns.push(member);
+            }
+            return Ok(patterns);
         }
     }
-    if !tags.inline.is_empty() {
-        // Scalar form `tags: v*` — strip any trailing comment.
-        let scalar = tags.inline.split('#').next().unwrap_or("");
-        let scalar = unquote(scalar);
+    if !inline.is_empty() {
+        // Scalar form `tags: v*` (comment already stripped above).
+        let scalar = unquote(inline);
         if scalar.is_empty() {
             return Err(format!("unparseable tags value {:?}", tags.inline));
         }
@@ -183,18 +206,20 @@ fn tag_patterns(tags: &Child) -> Result<Vec<String>, String> {
     }
     let mut patterns = Vec::new();
     for line in &tags.sub_lines {
-        let t = line.trim();
-        if t.is_empty() || t.starts_with('#') {
+        let t = strip_unquoted_comment(line).trim();
+        if t.is_empty() {
             continue;
         }
         let item = t
             .strip_prefix('-')
             .ok_or_else(|| format!("unexpected tags sub-line {t:?}"))?;
-        let item = item.split('#').next().unwrap_or("");
         let item = unquote(item);
-        if !item.is_empty() {
-            patterns.push(item);
+        if item.is_empty() {
+            return Err(format!(
+                "tags sub-list has an empty pattern member: {line:?}"
+            ));
         }
+        patterns.push(item);
     }
     if patterns.is_empty() {
         return Err("tags filter has no patterns".into());
@@ -280,4 +305,26 @@ fn not_v_star_and_comment_decoy_tag_patterns_fail() {
         "name: release\non:\n  push:\n    tags: [\"release-only\"] # v*\n  workflow_dispatch:\njobs: {}\n";
     let error = check_trigger_contract(comment_decoy).expect_err("comment decoy must fail");
     assert!(error.contains("exactly"), "{error}");
+}
+
+/// Review finding on 0267091, all three proven fail-open by compiling the
+/// prior parser against them: comments hid the real (null/scalar) tags
+/// value from the bracket search, and empty members were silently dropped.
+#[test]
+fn comment_hidden_and_empty_member_tag_values_fail() {
+    // Real value is NULL — the ["v*"] lives entirely inside a comment.
+    let null_value =
+        "name: release\non:\n  push:\n    tags: # [\"v*\"]\n  workflow_dispatch:\njobs: {}\n";
+    check_trigger_contract(null_value).expect_err("comment-only tags value must fail");
+
+    // Real value is the scalar `release-only`; the comment carries the decoy.
+    let scalar_decoy = "name: release\non:\n  push:\n    tags: release-only # [\"v*\"]\n  workflow_dispatch:\njobs: {}\n";
+    let error = check_trigger_contract(scalar_decoy).expect_err("scalar decoy must fail");
+    assert!(error.contains("release-only"), "{error}");
+
+    // Empty sequence member violates the exact-list contract.
+    let empty_member =
+        "name: release\non:\n  push:\n    tags: [\"v*\", \"\"]\n  workflow_dispatch:\njobs: {}\n";
+    let error = check_trigger_contract(empty_member).expect_err("empty member must fail");
+    assert!(error.contains("empty pattern member"), "{error}");
 }


### PR DESCRIPTION
The minimal binding slice of SBAI-5840, per sb-lore's traffic ruling — the change that lets the repo-wide merge freeze lift.

## What

- **Removes ONLY `push.branches: [main]`** from `.github/workflows/release.yml`. `push.tags: ["v*"]` and `workflow_dispatch` are preserved verbatim — with a tags-only push filter, branch pushes no longer trigger the workflow at all (PR #445 proved a main merge could arm a matrix leg that clobbers nightly assets before cancellation).
- **New CI contract test** `src-tauri/tests/release_workflow_contract.rs`: a line-structural parse of the top-level `on:` block (deliberately no YAML dependency — zero Cargo manifest/lock churn) proving the trigger shape: no `branches` filter and no `main` reference in the on-block; the `v*` tag trigger present; `workflow_dispatch` present. It runs under `cargo test -p loregui` (the tauri-e2e ipc-harness job), so any future edit re-adding a branch-push trigger fails CI, not review.
- Header comment updated to stop claiming the removed push-to-main nightly refresh; nightly stays pinned until the broader release redesign.

## Demonstrated, not asserted

The contract test was run against the **unmodified** workflow first and failed exactly on the branch-push assertion; after the trigger removal it passes 2/2. Workflow YAML validates; `cargo fmt --check` clean.

## Scope guarantees

Two files only: `release.yml` (triggers + comment) and the new test. No manifest (`latest.json`), release, tag, publish, or stable-asset mutation of any kind; the v0.1.4 Darwin assets are untouched. `release.yml` itself remains enabled. Files are disjoint from PR #446.

## Sequencing (sb-lore's ruling)

This PR lands **first**, under sb-lore review/traffic control — no self-merge, freeze stands until then. Preferred post-approval protection: merge with the workflow still enabled, then immediately verify zero release run started for the merge commit (it no longer matches any trigger); momentary disable only under a new per-merge ruling if evidence demands. Broader SBAI-5840 work queues behind this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)