### PR TITLE
SBAI-5908: fix LocksPanel double-scale timestamp by converting ms→s in Rust ops

### DIFF
--- a/crates/lore-vm/src/ops/lock/file_query.rs
+++ b/crates/lore-vm/src/ops/lock/file_query.rs
@@ -12,6 +12,13 @@ use lore::interface::{LoreEvent, LoreString};
 use lore::lock::LoreLockFileQueryArgs;
 use serde::{Deserialize, Serialize};
 
+/// Convert a Unix-millisecond timestamp (as emitted by the lore server) to
+/// Unix seconds so downstream consumers (e.g. `new Date(secs * 1000)` in the
+/// UI) render the correct date without double-scaling.
+fn ms_to_seconds(ms: u64) -> u64 {
+    ms / 1000
+}
+
 /// Arguments for [`file_query`].
 ///
 /// Mirrors `LoreLockFileQueryArgs` from the upstream `lore` crate
@@ -45,7 +52,8 @@ pub struct LockEntry {
     pub path: String,
     /// Owner of the lock (user ID).
     pub owner: String,
-    /// Timestamp when the lock was acquired (Unix timestamp in milliseconds).
+    /// Timestamp when the lock was acquired (Unix seconds; converted from
+    /// server-emitted milliseconds to avoid double-scaling in date formatting).
     pub locked_at: u64,
 }
 
@@ -90,7 +98,7 @@ pub async fn file_query(api: &LoreApi, args: FileQueryArgs) -> Result<FileQueryR
                     branch: data.branch.to_string(),
                     path: data.path.as_str().to_string(),
                     owner: data.owner.as_str().to_string(),
-                    locked_at: data.locked_at,
+                    locked_at: ms_to_seconds(data.locked_at),
                 });
             }
             _ => {}
@@ -98,4 +106,59 @@ pub async fn file_query(api: &LoreApi, args: FileQueryArgs) -> Result<FileQueryR
     }
 
     Ok(FileQueryResult { count, locks })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_deserialise_minimal() {
+        let args: FileQueryArgs =
+            serde_json::from_str(
+                r#"{"branch":"main","owner":"","path":""}"#,
+            )
+            .expect("deserialise");
+        assert_eq!(args.branch, "main");
+        assert_eq!(args.owner, "");
+        assert_eq!(args.path, "");
+    }
+
+    #[test]
+    fn args_deserialise_with_filters() {
+        let args: FileQueryArgs = serde_json::from_str(
+            r#"{"branch":"dev","owner":"alice","path":"Content/"}"#,
+        )
+        .expect("deserialise");
+        assert_eq!(args.branch, "dev");
+        assert_eq!(args.owner, "alice");
+        assert_eq!(args.path, "Content/");
+    }
+
+    #[test]
+    fn result_serialises() {
+        // 1718000000000 ms → 1718000000 s (2024-06-10)
+        let result = FileQueryResult {
+            count: 1,
+            locks: vec![LockEntry {
+                branch: "main".into(),
+                path: "Content/Maps/main.umap".into(),
+                owner: "user-42".into(),
+                locked_at: 1718000000,
+            }],
+        };
+        let json = serde_json::to_string(&result).expect("serialise");
+        assert!(json.contains("1718000000"));
+        assert!(!json.contains("1718000000000"));
+    }
+
+    #[test]
+    fn ms_to_seconds_converts_canonical_values() {
+        // Canonical millisecond timestamp from 2024-06-10
+        assert_eq!(ms_to_seconds(1718000000000), 1718000000);
+        // Zero stays zero
+        assert_eq!(ms_to_seconds(0), 0);
+        // Truncation toward zero (not rounding)
+        assert_eq!(ms_to_seconds(1718000000999), 1718000000);
+    }
 }

--- a/crates/lore-vm/src/ops/lock/file_status.rs
+++ b/crates/lore-vm/src/ops/lock/file_status.rs
@@ -12,6 +12,13 @@ use lore::interface::{LoreArray, LoreEvent, LoreString};
 use lore::lock::LoreLockFileStatusArgs;
 use serde::{Deserialize, Serialize};
 
+/// Convert a Unix-millisecond timestamp (as emitted by the lore server) to
+/// Unix seconds so downstream consumers (e.g. `new Date(secs * 1000)` in the
+/// UI) render the correct date without double-scaling.
+fn ms_to_seconds(ms: u64) -> u64 {
+    ms / 1000
+}
+
 /// Arguments for [`file_status`].
 ///
 /// Mirrors `LoreLockFileStatusArgs` from the upstream `lore` crate
@@ -45,7 +52,8 @@ pub struct LockStatus {
     pub path: String,
     /// Owner of the lock (user ID).
     pub owner: String,
-    /// Timestamp when the lock was acquired (Unix timestamp in milliseconds).
+    /// Timestamp when the lock was acquired (Unix seconds; converted from
+    /// server-emitted milliseconds to avoid double-scaling in date formatting).
     pub locked_at: u64,
 }
 
@@ -82,7 +90,7 @@ pub async fn file_status(api: &LoreApi, args: FileStatusArgs) -> Result<FileStat
             locks.push(LockStatus {
                 path: data.path.as_str().to_string(),
                 owner: data.owner.as_str().to_string(),
-                locked_at: data.locked_at,
+                locked_at: ms_to_seconds(data.locked_at),
             });
         }
     }
@@ -124,17 +132,18 @@ mod tests {
 
     #[test]
     fn result_serialises() {
+        // 1700000000000 ms → 1700000000 s (2023-11-14)
         let result = FileStatusResult {
             locks: vec![LockStatus {
                 path: "models/hero.fbx".into(),
                 owner: "user-42".into(),
-                locked_at: 1700000000000,
+                locked_at: 1700000000,
             }],
         };
         let json = serde_json::to_string(&result).expect("serialise");
         assert!(json.contains("models/hero.fbx"));
         assert!(json.contains("user-42"));
-        assert!(json.contains("1700000000000"));
+        assert!(json.contains("1700000000"));
     }
 
     #[test]
@@ -151,12 +160,12 @@ mod tests {
                 LockStatus {
                     path: "a.txt".into(),
                     owner: "alice".into(),
-                    locked_at: 100,
+                    locked_at: 1718000000, // 2024-06-10 in seconds
                 },
                 LockStatus {
                     path: "b.png".into(),
                     owner: "bob".into(),
-                    locked_at: 200,
+                    locked_at: 1718000100, // 100 s later
                 },
             ],
         };
@@ -165,5 +174,15 @@ mod tests {
         assert_eq!(back.locks.len(), 2);
         assert_eq!(back.locks[0].path, "a.txt");
         assert_eq!(back.locks[1].owner, "bob");
+    }
+
+    #[test]
+    fn ms_to_seconds_converts_canonical_values() {
+        // Canonical millisecond timestamp from 2024-06-10
+        assert_eq!(ms_to_seconds(1718000000000), 1718000000);
+        // Zero stays zero
+        assert_eq!(ms_to_seconds(0), 0);
+        // Truncation toward zero (not rounding)
+        assert_eq!(ms_to_seconds(1718000000999), 1718000000);
     }
 }


### PR DESCRIPTION
Resolves SBAI-5908

## Summary
The lore server emits lock timestamps as Unix **milliseconds**, but the frontend `LocksPanel.tsx` renders them as seconds (`new Date(secs * 1000)`), causing canonical timestamps like `1718000000000` to be multiplied again to `1718000000000000` — rendering a far-future/invalid date.

**Fix:** Convert milliseconds → seconds at the Rust boundary in `file_query` and `file_status` ops via a centralized `ms_to_seconds()` helper. This makes the frontend's existing `secs * 1000` math produce the correct date without touching any frontend files.

## Files Changed
- `crates/lore-vm/src/ops/lock/file_status.rs` — added `ms_to_seconds()` helper, applied to `locked_at` in event loop, updated struct doc comment from 'milliseconds' to 'seconds', updated tests
- `crates/lore-vm/src/ops/lock/file_query.rs` — same pattern + added new test module (`args_deserialise`, `result_serialises`, `ms_to_seconds_converts_canonical_values`)

## Testing
- `cargo check -p lore-vm` ✅ green
- `cargo test -p lore-vm` ✅ 769 tests passed, 0 failed
- Tests verify: canonical ms value 1718000000000 → 1718000000 s (2024-06-10), zero stays zero, truncation behavior

## Acceptance Criteria Met
1. ✅ Millisecond timestamps converted to seconds before serialization — no double-`* 1000`
2. ✅ `1718000000000` ms → `1718000000` s renders expected 2024 date via existing `new Date(secs * 1000)`
3. ✅ Zero/absent values preserved as 0 (→ epoch, handled by `if (!secs)` guard in `fmtTime`)
4. ✅ All lock timestamp paths covered: `file_query` (LockEntry) + `file_status` (LockStatus)
5. ✅ Defect kept separate from engine transition — only 2 .rs files in this PR

Generated with Qwen Code