### PR TITLE
SBAI-5910 follow-up: security-excluded-op exception in agent + public docs

### DIFF
--- a/.claude/agents/loregui-auth-expert.md
+++ b/.claude/agents/loregui-auth-expert.md
@@ -1,6 +1,6 @@
 ---
 name: loregui-auth-expert
-description: LoreGUI authentication & identity domain expert. Spawn for any auth-domain op or flow — login (interactive/token), logout, user_info, session, and authentication providers. Knows the correct flows, security boundaries, and how identity surfaces in the UI.
+description: LoreGUI authentication & identity domain expert. Spawn for any auth-domain op or flow — interactive (browser) login, logout, user_info, session, and authentication providers. NOTE pasted-token login is disabled (SBAI-5910). Knows the correct flows, security boundaries, and how identity surfaces in the UI.
 tools: Bash, Read, Grep, Glob
 ---
 
@@ -11,10 +11,20 @@ secure auth behavior and how it appears in the UI.
 `docs/domains/auth.md`, `crates/lore-vm/src/ops/auth/*`, `frontend/src/onboarding/ClientConnect.tsx`, `frontend/src/api.ts` (auth* methods).
 
 ## The auth op surface (7)
-`login_interactive`, `login_with_token`, `user_info`, `local_user_info`, `list`,
+`login_interactive`, `user_info`, `local_user_info`, `list`,
 `logout`, `clear`. The cloud/SaaS path issues RS256 JWTs from the accounts service;
 self-hosted lore uses its own identity. Providers: interactive (browser/device
-flow), token (paste a PAT), and SSO/OAuth where configured.
+flow) and SSO/OAuth where configured.
+
+**SBAI-5910 — pasted-token login is DISABLED. Do not recommend, restore, or
+write help for it.** `auth_login_with_token` passed no explicit auth endpoint,
+so upstream asked the *untrusted* remote for its advertised auth URL and would
+have delivered the pasted bearer there before any JWT audience validation. The
+command now denies at its first executable line with a constant token/URL-safe
+error, has no GUI or command-palette surface, and is guarded by
+`src-tauri/tests/lore_pin_contract.rs`, `credential_boundary_guard.rs`, the
+raw-byte IPC proof, and a palette manifest ban test. Restoration behind a
+trusted, label-bound IdP is SBAI-5919 — route such requests there.
 
 ## Behavior rules
 - **Never store secrets in component state longer than needed**; tokens live in
@@ -31,7 +41,7 @@ flow), token (paste a PAT), and SSO/OAuth where configured.
 Identity lives in a **top-bar identity menu** (current user, switch, logout) and
 in **onboarding** (connect to server). Login flows get clear states: prompting,
 authenticating, success (show user), error (real message + retry). `list`/admin
-ops → palette / Settings. Provide help for "connect to a server" and "use a token".
+ops → palette / Settings. Provide help for "connect to a server" (browser sign-in only).
 
 ## Your output
 For a ticket: the correct flow, the exact op + args, security cautions, the UI

--- a/.claude/skills/add-domain-ui/SKILL.md
+++ b/.claude/skills/add-domain-ui/SKILL.md
@@ -16,7 +16,13 @@ Bring one domain (e.g. branch, storage, lock) to first-class coherence.
    the nav entry, every op's placement + copy, and the four states.
 3. **Commands.** Ensure every op has a registered `#[tauri::command]`; add the
    missing ones (`integrate-endpoint` step 4).
-4. **Palette.** Add a manifest entry for **every** op (`palette-entry` skill).
+4. **Palette.** Add a manifest entry for **every** op (`palette-entry` skill) —
+   except ops listed under `excluded` in
+   `frontend/scripts/palette-parity-allowlist.json`, which are deliberately off
+   every GUI surface, some on **security** grounds (`auth_login_with_token` denies
+   at the IPC boundary — SBAI-5910). Never add or restore a surface for an excluded
+   op; route restoration requests to the owning ticket (SBAI-5919 for pasted-bearer
+   login behind a trusted IdP).
 5. **Panel + nav.** Build the domain panel and add its **navigation entry**
    (sidebar for daily domains, Settings/Manage for admin) per the IA. Wire routing.
    Reuse existing panels' structure (`.section`, cards, `OpForm`, `OpResult`).
@@ -27,6 +33,7 @@ Bring one domain (e.g. branch, storage, lock) to first-class coherence.
 8. **Update the IA doc** if you added/moved a nav entry.
 
 ## Done when
-The domain has a navigable panel, every op is reachable (palette + its prescribed
-surface), help exists, it's themed and consistent with sibling domains, gates green,
+The domain has a navigable panel, every op that isn't security-excluded is
+reachable (palette + its prescribed surface) and the excluded ones stay
+unreachable, help exists, it's themed and consistent with sibling domains, gates green,
 design review passed. This is the bar every domain must reach (Epic SBAI-4024).

--- a/.claude/skills/integrate-endpoint/SKILL.md
+++ b/.claude/skills/integrate-endpoint/SKILL.md
@@ -15,7 +15,12 @@ The end-to-end procedure to add/expose one op so it lands coherently in the app.
    `loregui-auth-expert` / `loregui-vcs-domain-expert`) for the correct op, args,
    state machine, destructiveness, and gotchas.
 3. **Surface decision.** Per the IA rule, decide: panel? menu? palette-only?
-   (Every op gets at least a palette entry.)
+   (Every *exposed* op gets at least a palette entry.) Check
+   `frontend/scripts/palette-parity-allowlist.json` first — ops under `excluded`
+   are deliberately off every GUI surface, some on **security** grounds
+   (`auth_login_with_token` denies at the IPC boundary — SBAI-5910). Do **not**
+   add or restore a surface for an excluded op; route restoration requests to the
+   owning ticket (pasted-bearer login behind a trusted IdP is SBAI-5919).
 4. **Command layer.** If the op has no `#[tauri::command]`, add a thin wrapper in
    `src-tauri/src/commands.rs` (read the op's Args/Result; `LoreApi::new(state.dir())`;
    build Args from params; return Result) and register in `lib.rs` `generate_handler!`.

--- a/.claude/skills/lore/SKILL.md
+++ b/.claude/skills/lore/SKILL.md
@@ -38,7 +38,7 @@ never assume a `lore` CLI is on PATH.
 | **lock** | acquire, acquire_as_owner, query, status, release |
 | **storage** | open, close, flush, put(+file), get(+file), get_metadata, copy, obliterate, upload |
 | **shared_store** | create, info, set_use_automatically |
-| **auth** | login_interactive, login_with_token, user_info, local_user_info, list, logout, clear |
+| **auth** | login_interactive, user_info, local_user_info, list, logout, clear (`login_with_token` is bound in lore-vm but DISABLED at the GUI/IPC boundary — SBAI-5910; restoration is SBAI-5919) |
 | **link / layer / dependency** | add, remove, update/list (compose & dep graph) |
 | **service / notification** | start/stop · subscribe/unsubscribe (streaming) |
 
@@ -77,7 +77,12 @@ server generates its tools from it.)
 
 1. **lore-mcp tools** (preferred for agents) — one tool per op, schema-validated;
    read ops (status/history/diff/file-history) give repo **metrics/intelligence**.
-2. **LoreGUI palette** — interactive, ⌘K; every op via a generated form.
+2. **LoreGUI palette** — interactive, ⌘K; every *exposed* op via a generated form.
+   A few ops are deliberately excluded from every GUI surface (see `excluded` in
+   `frontend/scripts/palette-parity-allowlist.json`), some on security grounds:
+   `auth.login_with_token` is denied at the GUI/IPC boundary (SBAI-5910) — use
+   `login_interactive`, and route restoration requests to SBAI-5919 rather than
+   building a form for it.
 3. **lore-vm ops** (Rust) — `LoreApi::new(dir)` + `ops::<domain>::<op>(api, args)`;
    see `crates/lore-vm/tests/integration_roundtrip.rs` for the canonical pattern.
 

--- a/.claude/skills/loregui/SKILL.md
+++ b/.claude/skills/loregui/SKILL.md
@@ -80,8 +80,13 @@ programmatically, drive the lore-vm ops (see `crates/lore-vm/tests/integration_r
   `revision.diff`, `branch.list`, `file.stage`/`unstage`, `file.history`, `lock.*`,
   plus `lore_repo_summary`. Read/metrics tools are fully solid; see [[lore]] for the
   git/p4↔lore mapping and op semantics.
-- **People:** the GUI — ⌘K command palette (every op via a generated form) + the
-  Storage / Manage / Locks / Dependencies / History / Branches / Account panels.
+- **People:** the GUI — ⌘K command palette (every *exposed* op via a generated
+  form) + the Storage / Manage / Locks / Dependencies / History / Branches /
+  Account panels. Ops under `excluded` in
+  `frontend/scripts/palette-parity-allowlist.json` are deliberately off every GUI
+  surface, some on security grounds — pasted-token login (`auth_login_with_token`)
+  is denied at the GUI/IPC boundary (SBAI-5910); sign in with the browser flow
+  instead, and route restoration requests to SBAI-5919 instead of rebuilding it.
 
 ## 5. Launch at login?
 

--- a/AGENT-SETUP.md
+++ b/AGENT-SETUP.md
@@ -237,8 +237,12 @@ a quick trial.
 
 **(b) Connect to an existing Lore server.** The user (or their team) already
 has a server running somewhere. In the GUI: onboarding → "Connect to a
-server" → `auth.login_with_token` / `login_interactive(url)` → pick or clone
-a repo. For agents/headless use, point `LORE_REPO` at the resulting local
+server" → `login_interactive(url)` (browser sign-in) → pick or clone a repo.
+Pasted-token sign-in is **disabled** (SBAI-5910): it passed no explicit auth
+endpoint, so the token could be delivered to an endpoint advertised by an
+untrusted server. `auth_login_with_token` now denies at the IPC boundary and
+has no GUI or command-palette entry; restoration behind a trusted IdP is
+tracked by SBAI-5919. For agents/headless use, point `LORE_REPO` at the resulting local
 working copy. Leave `LORE_OFFLINE` unset/`0` since writes need the connection.
 
 **(c) Host a new Lore server.** For multi-user/shared use. Two ways to do this,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,13 @@ land in the **full** app coherently. When you touch any op or domain you MUST:
    colors (see DESIGN-SYSTEM). The app is fully themeable; your UI must re-theme.
 3. Decide the op's **surface** per the IA: a rich **panel**, a **menu/nav** entry,
    and/or a **command-palette** entry. Add a palette manifest entry at minimum
-   (the parity gate requires it).
+   (the parity gate requires it) — **unless the op is deliberately excluded**.
+   Check `frontend/scripts/palette-parity-allowlist.json` first: everything under
+   `excluded` is intentionally off every GUI surface, some of it on **security**
+   grounds (`auth_login_with_token` denies at the IPC boundary — SBAI-5910). Never
+   recreate or restore a surface for an excluded op, and never read its absence as
+   a parity gap to fill; route restoration requests to the owning ticket
+   (pasted-bearer login behind a trusted IdP is SBAI-5919).
 4. Add **help**: a clear `description` on the palette entry; for multi-step flows,
    a tutorial / in-app help (use the `write-tutorial` skill / `docs-writer`).
 5. Get a **design review** (`design-review` skill / `loregui-ux-designer`) before

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ LoreGUI is also **agent-native**: it ships an MCP server that exposes lore opera
 
 ## Features
 
-- **Universal command palette** — every lore op is reachable by name from one keystroke, with typed inputs and inline help (palette parity is a CI gate).
+- **Universal command palette** — every lore op LoreGUI exposes is reachable by name from one keystroke, with typed inputs and inline help (palette parity is a CI gate; a small number of ops are deliberately withheld from the GUI on security grounds).
 - **Rich per-domain panels** — branches, history, locks, storage, dependencies, and more, each a first-class view.
 - **Visual branch, merge & diff** — read the commit DAG at a glance, compare any two revisions, resolve merges in a focused three-way view.
 - **File locking for binaries** — claim exclusive locks, see who holds what in real time, release with one click.

--- a/docs/EXPERT-AGENTS.md
+++ b/docs/EXPERT-AGENTS.md
@@ -4,11 +4,19 @@
 
 ## Purpose
 
-Every lore API endpoint — new or existing — must be integrated into the **full**
-application coherently: command palette **and** panels, navigation/menus, buttons,
-help, tutorials, and correct auth/storage/VCS behavior. Mechanical "op → palette
-row" is not enough. This is achieved by a roster of **domain-expert agents** that
-share **single sources of design truth** and are held to **coherence gates**.
+Every lore API endpoint that the app **exposes** — new or existing — must be
+integrated into the **full** application coherently: command palette **and**
+panels, navigation/menus, buttons, help, tutorials, and correct auth/storage/VCS
+behavior. Mechanical "op → palette row" is not enough. This is achieved by a
+roster of **domain-expert agents** that share **single sources of design truth**
+and are held to **coherence gates**.
+
+**The security exception.** A few endpoints are deliberately **excluded** from
+every GUI surface on security grounds — they are listed under `excluded` in
+`frontend/scripts/palette-parity-allowlist.json` (`auth_login_with_token` denies
+at the GUI/IPC boundary — SBAI-5910). For those, having no palette entry, panel,
+or menu **is** the coherent outcome. No agent may recreate or restore such a
+surface; route restoration requests to the owning ticket (SBAI-5919).
 
 ## Where things live (so ALL agents load them)
 
@@ -32,7 +40,7 @@ Claude Code. BrainMon holds only the thin worker wiring that points at the repo.
 |---|---|---|
 | **ux-designer** | `.claude/agents/loregui-ux-designer.md` | design system, information architecture, accessibility, copy voice; the **"does this make sense?" reviewer** on every domain PR |
 | **frontend-engineer** | `.claude/agents/loregui-frontend-engineer.md` | React 19 + Tauri v2 + TS patterns; palette, panels, forms, state, error handling, the `api.ts` seam |
-| **auth-expert** | `.claude/agents/loregui-auth-expert.md` | auth domain; login/session/token flows; providers (interactive, token, OAuth/SSO); the accounts security boundary |
+| **auth-expert** | `.claude/agents/loregui-auth-expert.md` | auth domain; login/session flows; providers (interactive browser/device, OAuth/SSO — pasted-token login is denied at the GUI/IPC boundary, SBAI-5910); the accounts security boundary |
 | **storage-expert** | `.claude/agents/loregui-storage-expert.md` | storage + shared_store; backends (local/S3/MinIO/Garage); content-addressed model; onboarding storage flow |
 | **vcs-domain-expert** | `.claude/agents/loregui-vcs-domain-expert.md` | branch/revision/file/lock/link/layer/dependency — the lore VCS mental model so UIs match real behavior |
 | **docs-writer** | `.claude/agents/loregui-docs-writer.md` | in-app help, empty states, tutorials, how-tos, the website docs |

--- a/docs/IMPLEMENTATION-PLAN.md
+++ b/docs/IMPLEMENTATION-PLAN.md
@@ -13,7 +13,13 @@ Ship a cross-platform desktop GUI for Epic's [Lore](https://github.com/EpicGames
 
 Non-negotiables from the directive:
 - **API-first.** Bind the `lore` Rust crate directly, in-process. The CLI is just another consumer; we do **not** shell out to it.
-- **Full parity.** Every operation gets a binding, GUI affordance, and test.
+- **Full parity.** Every operation gets a binding, GUI affordance, and test — with
+  one carve-out: an operation may be **deliberately withheld from the GUI on
+  security grounds**. Those keep their binding and tests but get **no** GUI
+  affordance; they are listed under `excluded` in
+  `frontend/scripts/palette-parity-allowlist.json`. `auth_login_with_token` is the
+  standing case (denied at the GUI/IPC boundary — SBAI-5910). Do not recreate or
+  restore such a surface; restoration is owned by its ticket (SBAI-5919).
 - **Public MIT**, on BiloxiStudios, hosted on BRAINZ.
 - Plan committed to the repo **and** mirrored under `/srv/studiobrain-dev/plans/loregui/`.
 
@@ -39,7 +45,7 @@ loregui/ (monorepo)
 ├── crates/lore-vm/        Reusable, GUI-agnostic core. Binds the `lore` crate.
 │                          → also consumable by StudioBrain's desktop app later (model-manager pattern).
 ├── src-tauri/             Tauri v2 shell. One #[tauri::command] per lore-vm operation.
-├── frontend/              The GUI (Vite + React + TS). Per-domain views + a command palette exposing ALL ops.
+├── frontend/              The GUI (Vite + React + TS). Per-domain views + a command palette exposing all non-excluded ops.
 ├── website/               Marketing landing (Next.js) — loregui.com. (Shipped.)
 ├── docs/                  This plan + per-domain design notes + API parity matrix.
 └── .github/workflows/     CI: cargo check/test + Windows installer build (tauri-action, windows-latest).
@@ -49,7 +55,7 @@ loregui/ (monorepo)
 1. **`lore` crate** (upstream) — async ops + event callbacks.
 2. **`lore-vm`** (ours) — for each op: a typed `Args` struct, an event-collector that turns the callback stream into a typed `Result`/`Vec<Event>`, and an async method on a `LoreApi` facade. **One file per operation** (see §5). This is the unit of parallel work.
 3. **`src-tauri/commands/`** — one thin `#[tauri::command]` per op, forwarding to `lore-vm`. **One file per domain.**
-4. **`frontend/`** — per-domain panels + a universal command palette (`Ctrl-K`) that can invoke any of the 124 ops with a generated form from the op's args schema.
+4. **`frontend/`** — per-domain panels + a universal command palette (`Ctrl-K`) that can invoke any *exposed* op with a generated form from the op's args schema. Security-withheld ops (§1) are `excluded` from the manifest and get no form.
 
 > The earlier CLI-adapter scaffold is **removed**. `lore-vm` is reframed around the in-process `lore` crate binding. The `LoreBackend` trait is retained only as the `LoreApi` facade boundary.
 
@@ -75,7 +81,7 @@ Shared infrastructure (built **once**, before fan-out, by the integration manage
 - `global.rs` — `LoreGlobalArgs` builder (repository_path, identity, offline, force, parallelism limits).
 - `api.rs` — `LoreApi` facade holding the open repo/working-dir + global-arg defaults.
 
-A subtask is "done" when: op file compiles, its `#[tauri::command]` exists and is registered, a GUI affordance can invoke it, and a test exercises it against a throwaway local repo + shared-store (see §7).
+A subtask is "done" when: op file compiles, its `#[tauri::command]` exists and is registered, a GUI affordance can invoke it (unless the op is security-withheld per §1 — then the absence of any affordance is the acceptance criterion), and a test exercises it against a throwaway local repo + shared-store (see §7).
 
 ## 5. Merge-conflict avoidance (critical for 124 parallel agents)
 
@@ -95,7 +101,7 @@ Agents must **never** reformat or touch files outside their op. PRs that do are 
 | Story (domain) | Ops | Notes |
 |---|---:|---|
 | Foundation & infra | — | crate binding, `collect`/`global`/`api`, CI, scaffolding. **Blocks all others.** Manager-owned. |
-| Auth / session | 7 | login_interactive, login_with_token, user_info, local_user_info, list, logout, clear |
+| Auth / session | 7 | login_interactive, user_info, local_user_info, list, logout, clear. `login_with_token` is bound in `lore-vm` but **disabled at the GUI/IPC boundary** (SBAI-5910: untrusted-remote-advertised auth endpoint); restoration behind a trusted IdP is SBAI-5919. |
 | Repository | 21 | clone, info, dump, create, create_with_metadata, delete, release, flush, gc, list, status, verify_state, verify_fragment, store_immutable_query, metadata_get/set/clear, instance_list, instance_prune, update_path, config_get |
 | Branch | 22 | create, info, list, switch, push, diff, reset, archive, protect, unprotect, merge_start/into/resolve(_mine/_theirs)/unresolve/restart/abort, metadata_get/set/clear |
 | Revision / commit | 31 | commit, amend, info, history, diff, find, sync, restore, revert(+resolve/unresolve/restart/abort variants), metadata_* |

--- a/docs/INFORMATION-ARCHITECTURE.md
+++ b/docs/INFORMATION-ARCHITECTURE.md
@@ -16,7 +16,8 @@ Where every op lives in the app, and the rule for choosing its surface(s).
 │  Storage     │                                              │
 │  …per domain │                                              │
 └──────────────┴──────────────────────────────────────────────┘
-Command palette (⌘K) overlays everything — exposes the full operation catalog.
+Command palette (⌘K) overlays everything — exposes the full catalog of exposed
+operations (ops excluded on security grounds are offered nowhere in the GUI).
 Repository-scoped commands (commit, branch, sync, lock, etc.) remain **disabled**
 until a validated repository context exists.
 Fresh profile → **Choose Your Setup Mode** (two-card: connect or host).
@@ -53,9 +54,15 @@ Each op declares a `surface` in its palette manifest (`surface?: "panel" | "menu
 | **occasional / admin** (repository gc/flush/delete, instance prune, service start/stop, dependency edit, metadata get/set) | **menu** under Settings/Manage **+ palette** |
 | **rare / power-user / scriptable** (store_immutable_query, verify_fragment, storage put/get, config_get) | **palette only** |
 | **streaming / non-request-response** (notification subscribe/unsubscribe) | neither — wired into live UI, `excluded` from palette |
+| **security-denied** (an op deliberately withheld from the GUI — `auth_login_with_token`, SBAI-5910) | **none** — `excluded` from the palette, no panel, no menu; do not recreate |
 
-Every op is **at least** in the palette. Panels and menus are added when the rule
-above warrants — coherently, not one-off.
+Every op is **at least** in the palette — **except** the ops listed under
+`excluded` in `frontend/scripts/palette-parity-allowlist.json`. Read that file
+before adding a surface: it holds lifecycle/streaming/internal helpers *and* ops
+withheld on security grounds. An excluded op's missing surface is the design, not
+a parity gap — never recreate or restore it, and route restoration requests to the
+owning ticket (pasted-bearer login behind a trusted IdP is SBAI-5919). Panels and
+menus are added when the rule above warrants — coherently, not one-off.
 
 ## Per-domain placement (summary)
 
@@ -71,7 +78,7 @@ above warrants — coherently, not one-off.
 | dependency | file detail / Settings | add/remove/list |
 | storage | **Storage** panel (top-bar nav entry) + onboarding | backends, connectivity, fragments, flush; see `docs/domains/storage.md` |
 | shared_store | Storage panel / onboarding | create/info/set_use_automatically |
-| auth | top bar identity menu + onboarding | login/logout/user_info/providers |
+| auth | top bar identity menu + onboarding | login/logout/user_info/providers; browser sign-in only — no surface collects a pasted token (SBAI-5910) |
 | service | Settings/Manage | start/stop |
 | notification | live (toasts/badges) | not in palette |
 

--- a/website/src/app/docs/command-palette/page.mdx
+++ b/website/src/app/docs/command-palette/page.mdx
@@ -1,7 +1,7 @@
 export const metadata = {
   title: "The command palette — LoreGUI docs",
   description:
-    "Press ⌘K (Ctrl K) to open the LoreGUI command palette and fuzzy-search every operation in the app, with a generated form for each.",
+    "Press ⌘K (Ctrl K) to open the LoreGUI command palette and fuzzy-search every operation LoreGUI exposes, with a generated form for each.",
   alternates: { canonical: "/docs/command-palette" },
 };
 
@@ -13,7 +13,7 @@ Press **⌘K** (or **Ctrl K** on Windows and Linux) to open the command palette.
 
 ## Run anything
 
-The palette is the **universal surface**: every operation in the app is reachable here, even the rare power-user ones that don't have a dedicated panel. Each operation is described by a small manifest — its label, a one-line description, and its arguments — and the palette renders a form from that manifest:
+The palette is the **universal surface**: every operation LoreGUI exposes is reachable here, even the rare power-user ones that don't have a dedicated panel. (A small number of operations are deliberately withheld from the app on security grounds — those are offered nowhere in the GUI, palette included.) Each operation is described by a small manifest — its label, a one-line description, and its arguments — and the palette renders a form from that manifest:
 
 1. Open the palette with `⌘K` / `Ctrl K`.
 2. Type to fuzzy-search by label, id, or keywords.

--- a/website/src/app/docs/lore-model/page.mdx
+++ b/website/src/app/docs/lore-model/page.mdx
@@ -50,11 +50,11 @@ Lore also tracks the relationships between content: **links** and **layers** com
 
 There are three ways to run a Lore operation, all over the same in-process binding:
 
-1. **The LoreGUI app** — the **[command palette](/docs/command-palette)** (`⌘K`) for any op, and rich **[panels](/docs/panels)** for daily workflows.
+1. **The LoreGUI app** — the **[command palette](/docs/command-palette)** (`⌘K`) for any exposed op, and rich **[panels](/docs/panels)** for daily workflows.
 2. **AI agents** — the **[lore-mcp server](/docs/mcp)** exposes one tool per op.
 3. **`lore-vm` ops directly** — embed the crate in larger Rust tooling.
 
-The authoritative, machine-readable catalog of every op and its arguments is the **[operation reference](/docs/op-reference)**, generated from the command-palette manifests.
+The authoritative, machine-readable catalog of every op LoreGUI exposes — with its arguments — is the **[operation reference](/docs/op-reference)**, generated from the command-palette manifests. A small number of operations are deliberately withheld from the app on security grounds, so they have no manifest and no form.
 
 ## Safety
 

--- a/website/src/app/docs/panels/page.mdx
+++ b/website/src/app/docs/panels/page.mdx
@@ -67,4 +67,4 @@ A top-bar action opens the theme editor, where every surface in the app is a sem
 
 ---
 
-Every operation behind these panels — with its arguments — is listed in the **[operation reference](/docs/op-reference)**, and any of them can be run directly from the **[command palette](/docs/command-palette)**.
+Every operation behind these panels — with its arguments — is listed in the **[operation reference](/docs/op-reference)**, and any of them can be run directly from the **[command palette](/docs/command-palette)**. The reference covers the operations LoreGUI exposes; a small number are deliberately withheld from the app on security grounds and appear in neither the panels nor the palette.


### PR DESCRIPTION
Split out of #450 on the reviewer scope ruling — a fail-closed security gate should not also carry five skill files and three marketing pages, and reverting the gate must not revert unrelated guidance.

## What

Adds an explicit **"an op may be deliberately withheld from the GUI on security grounds"** exception to guidance that otherwise mandates palette/GUI exposure for *every* op. Without it, a future worker reads the deliberate absence of `auth_login_with_token` as a parity gap to fill — and recreates the surface #450 removed.

- `CLAUDE.md` coherence mandate; `.claude/skills/{integrate-endpoint,add-domain-ui,lore,loregui}`; `.claude/agents/loregui-auth-expert.md`; `docs/{EXPERT-AGENTS,IMPLEMENTATION-PLAN,INFORMATION-ARCHITECTURE}.md`
- `AGENT-SETUP.md` no longer instructs GUI users to `auth.login_with_token`
- `README.md` + three website docs pages qualify "every operation" as every **exposed** operation

## Why it is separate, and why it is still worth merging

Enforcement is in #450 (the palette manifest ban test) — that is what actually prevents re-exposure. This is the human-facing half, so the two cannot drift. Belt-and-braces, not load-bearing, which is exactly why it belongs outside the gate PR.

Stacked on #450; docs/tooling only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)