### PR TITLE
SBAI-5934: governance ops domain for artifact quarantine and DCO validation

### DIFF
--- a/crates/lore-vm/src/ops/governance/artifact_mark_superseded.rs
+++ b/crates/lore-vm/src/ops/governance/artifact_mark_superseded.rs
@@ -1,0 +1,153 @@
+//! `governance::artifact_mark_superseded` — mark a revision's artifact as superseded.
+//!
+//! Sets a `superseded-by` metadata key on the target revision so downstream
+//! consumers (release gates, artifact registries, parity watchers) can reject
+//! it in favour of the successor. No upstream `lore` function exists for this;
+//! it composes `lore::revision::metadata_set`.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::interface::{LoreMetadataType, LoreString};
+use lore::revision::{LoreRevisionMetadataSetArgs, metadata_set};
+use serde::{Deserialize, Serialize};
+
+/// Metadata key used to record the superseding revision hash.
+pub const METADATA_KEY_SUPERSEDED_BY: &str = "superseded-by";
+/// Metadata key used to record the reason for supersession.
+pub const METADATA_KEY_SUPERSEDED_REASON: &str = "superseded-reason";
+
+/// Arguments for [`artifact_mark_superseded`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ArtifactMarkSupersededArgs {
+    /// Revision hash to mark as superseded; empty targets the current revision.
+    #[serde(default)]
+    pub revision: String,
+    /// Hash of the revision that supersedes this one.
+    pub superseded_by: String,
+    /// Human-readable reason for the supersession (e.g. "CVE-2026-1234 fix").
+    #[serde(default)]
+    pub reason: String,
+}
+
+impl ArtifactMarkSupersededArgs {
+    fn into_lore(self) -> LoreRevisionMetadataSetArgs {
+        let keys = vec![
+            LoreString::from_str(METADATA_KEY_SUPERSEDED_BY),
+            LoreString::from_str(METADATA_KEY_SUPERSEDED_REASON),
+        ];
+        let values = vec![
+            LoreString::from_str(&self.superseded_by),
+            LoreString::from_str(&self.reason),
+        ];
+        let formats = vec![LoreMetadataType::String, LoreMetadataType::String];
+
+        LoreRevisionMetadataSetArgs {
+            keys: lore::interface::LoreArray::from_vec(keys),
+            values: lore::interface::LoreArray::from_vec(values),
+            formats: lore::interface::LoreArray::from_vec(formats),
+        }
+    }
+}
+
+/// Result returned after marking an artifact as superseded.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArtifactMarkSupersededResult {
+    /// The revision that was marked.
+    pub revision: String,
+    /// The revision that supersedes it.
+    pub superseded_by: String,
+    /// The reason recorded.
+    pub reason: String,
+}
+
+/// Mark a revision's artifact as superseded by setting governance metadata.
+///
+/// Writes `superseded-by` and `superseded-reason` metadata on the target
+/// revision so that downstream governance checks (submission gates, artifact
+/// registries) can reject it in favour of the named successor.
+pub async fn artifact_mark_superseded(
+    api: &LoreApi,
+    args: ArtifactMarkSupersededArgs,
+) -> Result<ArtifactMarkSupersededResult> {
+    let revision_tag = if args.revision.is_empty() {
+        "<current>".into()
+    } else {
+        args.revision.clone()
+    };
+
+    let lore_args = args.clone().into_lore();
+
+    let (callback, rx) = collect_events();
+
+    let status = metadata_set(api.globals().build(), lore_args, callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("artifact_mark_superseded failed with status {status}"),
+        )));
+    }
+
+    Ok(ArtifactMarkSupersededResult {
+        revision: revision_tag,
+        superseded_by: args.superseded_by,
+        reason: args.reason,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_defaults() {
+        let args = ArtifactMarkSupersededArgs::default();
+        assert!(args.revision.is_empty());
+        assert!(args.superseded_by.is_empty());
+        assert!(args.reason.is_empty());
+    }
+
+    #[test]
+    fn args_into_lore_sets_both_keys() {
+        let args = ArtifactMarkSupersededArgs {
+            revision: "abc123".into(),
+            superseded_by: "def456".into(),
+            reason: "security fix".into(),
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.keys.as_slice().len(), 2);
+        assert_eq!(lore_args.values.as_slice().len(), 2);
+        assert_eq!(
+            lore_args.values.as_slice()[0].as_str(),
+            "def456"
+        );
+        assert_eq!(
+            lore_args.values.as_slice()[1].as_str(),
+            "security fix"
+        );
+    }
+
+    #[test]
+    fn result_serialises() {
+        let result = ArtifactMarkSupersededResult {
+            revision: "abc".into(),
+            superseded_by: "def".into(),
+            reason: "CVE-2026-0001".into(),
+        };
+        let json = serde_json::to_string(&result).expect("serialise");
+        assert!(json.contains("abc"));
+        assert!(json.contains("def"));
+        assert!(json.contains("CVE-2026-0001"));
+    }
+
+    #[test]
+    fn metadata_key_constants() {
+        assert_eq!(METADATA_KEY_SUPERSEDED_BY, "superseded-by");
+        assert_eq!(METADATA_KEY_SUPERSEDED_REASON, "superseded-reason");
+    }
+}

--- a/crates/lore-vm/src/ops/governance/dco_validate.rs
+++ b/crates/lore-vm/src/ops/governance/dco_validate.rs
@@ -1,0 +1,266 @@
+//! `governance::dco_validate` — validate DCO (Developer Certificate of Origin)
+//! sign-offs on one or more revisions.
+//!
+//! The DCO requires a `Signed-off-by:` line in every commit message. This op
+//! inspects the commit message metadata (via `lore::revision::info`) and
+//! reports which revisions pass / fail the check. No upstream `lore` function
+//! performs this check — it is a lore-vm native governance binding.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::interface::{LoreEvent, LoreString};
+use lore::revision::{LoreRevisionHistoryArgs, history};
+use serde::{Deserialize, Serialize};
+
+/// DCO sign-off prefix required in every commit message.
+pub const DCO_SIGNOFF_PREFIX: &str = "Signed-off-by:";
+
+/// Arguments for [`dco_validate`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DcoValidateArgs {
+    /// Starting revision; empty targets the current HEAD.
+    #[serde(default)]
+    pub revision: String,
+    /// Stop at this revision (exclusive); empty walks to branch root.
+    #[serde(default)]
+    pub since: String,
+    /// Maximum number of revisions to check; 0 for unlimited.
+    #[serde(default)]
+    pub limit: u32,
+}
+
+impl DcoValidateArgs {
+    fn into_lore(self) -> LoreRevisionHistoryArgs {
+        LoreRevisionHistoryArgs {
+            revision: LoreString::from_str(&self.revision),
+            branch: LoreString::from_str(""),
+            date: 0,
+            length: self.limit,
+            only_branch: 0,
+        }
+    }
+}
+
+/// Per-revision DCO validation result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DcoRevisionResult {
+    /// Revision hash.
+    pub revision: String,
+    /// Revision number.
+    pub revision_number: u64,
+    /// Whether the commit message contains a `Signed-off-by:` line.
+    pub dco_signed: bool,
+    /// The sign-off line if present (e.g. `Signed-off-by: Alice <alice@example.com>`).
+    pub signoff_line: Option<String>,
+}
+
+/// Result returned after validating DCO on a range of revisions.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DcoValidateResult {
+    /// Per-revision results, newest first.
+    pub revisions: Vec<DcoRevisionResult>,
+    /// Total number of revisions checked.
+    pub total_checked: u64,
+    /// Number of revisions that passed DCO validation.
+    pub passed: u64,
+    /// Number of revisions missing a DCO sign-off.
+    pub failed: u64,
+}
+
+/// Check if a commit message contains a valid DCO sign-off line.
+pub(crate) fn check_dco_signoff(message: &str) -> (bool, Option<String>) {
+    for line in message.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with(DCO_SIGNOFF_PREFIX) && trimmed.len() > DCO_SIGNOFF_PREFIX.len() + 1
+        {
+            return (true, Some(trimmed.to_string()));
+        }
+    }
+    (false, None)
+}
+
+/// Validate DCO sign-offs across a range of revisions.
+///
+/// Walks the revision history and checks each commit message for a
+/// `Signed-off-by:` line. Returns a per-revision breakdown plus aggregate
+/// pass/fail counts.
+pub async fn dco_validate(api: &LoreApi, args: DcoValidateArgs) -> Result<DcoValidateResult> {
+    let since_rev = args.since.clone();
+
+    let (callback, rx) = collect_events();
+
+    let status = history(api.globals().build(), args.into_lore(), callback).await;
+
+    let stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+    if !stream.is_ok() {
+        return Err(LoreError::CommandFailed(stream.error.unwrap_or_else(
+            || format!("dco_validate (history) failed with status {status}"),
+        )));
+    }
+
+    // Collect revision hashes from the history.
+    let mut rev_hashes: Vec<(String, u64)> = Vec::new();
+    for event in &stream.events {
+        if let LoreEvent::RevisionHistoryEntry(data) = event {
+            let hash = format!("{}", data.revision);
+            // Stop if we've hit the since boundary.
+            if !since_rev.is_empty() && hash == since_rev {
+                break;
+            }
+            rev_hashes.push((hash, data.revision_number));
+        }
+    }
+
+    // For each revision, fetch its info (with metadata) to check the commit message.
+    let mut result = DcoValidateResult::default();
+
+    for (rev_hash, rev_number) in &rev_hashes {
+        let info_args = lore::revision::LoreRevisionInfoArgs {
+            revision: LoreString::from_str(rev_hash),
+            delta: 0,
+            metadata: 1,
+        };
+
+        let (cb, rx2) = collect_events();
+        let info_status =
+            lore::revision::info(api.globals().build(), info_args, cb).await;
+
+        let info_stream = rx2
+            .await
+            .map_err(|e| {
+                LoreError::CommandFailed(format!("info event stream cancelled: {e}"))
+            })?;
+
+        if !info_stream.is_ok() {
+            return Err(LoreError::CommandFailed(info_stream.error.unwrap_or_else(
+                || format!("revision info for {rev_hash} failed with status {info_status}"),
+            )));
+        }
+
+        // Extract the commit message from metadata.
+        let mut message = String::new();
+        for event in &info_stream.events {
+            if let LoreEvent::Metadata(data) = event {
+                if data.key.as_str() == "message" {
+                    if let lore::interface::LoreMetadata::String(s) = &data.value {
+                        message = s.as_str().to_string();
+                    }
+                }
+            }
+        }
+
+        let (dco_signed, signoff_line) = check_dco_signoff(&message);
+
+        if dco_signed {
+            result.passed += 1;
+        } else {
+            result.failed += 1;
+        }
+        result.total_checked += 1;
+
+        result.revisions.push(DcoRevisionResult {
+            revision: rev_hash.clone(),
+            revision_number: *rev_number,
+            dco_signed,
+            signoff_line,
+        });
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_defaults() {
+        let args = DcoValidateArgs::default();
+        assert!(args.revision.is_empty());
+        assert!(args.since.is_empty());
+        assert_eq!(args.limit, 0);
+    }
+
+    #[test]
+    fn args_into_lore_conversion() {
+        let args = DcoValidateArgs {
+            revision: "abc123".into(),
+            since: "old456".into(),
+            limit: 10,
+        };
+        let lore_args = args.into_lore();
+        assert_eq!(lore_args.revision.as_str(), "abc123");
+        assert_eq!(lore_args.length, 10);
+    }
+
+    #[test]
+    fn dco_check_valid_signoff() {
+        let msg = "feat: add user authentication\n\nSigned-off-by: Alice <alice@example.com>";
+        let (signed, line) = check_dco_signoff(msg);
+        assert!(signed);
+        assert_eq!(line, Some("Signed-off-by: Alice <alice@example.com>".into()));
+    }
+
+    #[test]
+    fn dco_check_missing_signoff() {
+        let msg = "feat: add user authentication\n\nCo-authored-by: Bob <bob@example.com>";
+        let (signed, line) = check_dco_signoff(msg);
+        assert!(!signed);
+        assert!(line.is_none());
+    }
+
+    #[test]
+    fn dco_check_empty_message() {
+        let (signed, line) = check_dco_signoff("");
+        assert!(!signed);
+        assert!(line.is_none());
+    }
+
+    #[test]
+    fn dco_check_multiple_signoffs_takes_first() {
+        let msg = "fix: patch vulnerability\n\nSigned-off-by: Alice <alice@example.com>\nSigned-off-by: Bob <bob@example.com>";
+        let (signed, line) = check_dco_signoff(msg);
+        assert!(signed);
+        assert_eq!(line, Some("Signed-off-by: Alice <alice@example.com>".into()));
+    }
+
+    #[test]
+    fn dco_check_whitespace_tolerant() {
+        let msg = "chore: cleanup\n\n  Signed-off-by: Carol <carol@example.com>";
+        let (signed, line) = check_dco_signoff(msg);
+        assert!(signed);
+        assert!(line.is_some());
+    }
+
+    #[test]
+    fn dco_result_serialises() {
+        let result = DcoValidateResult {
+            revisions: vec![DcoRevisionResult {
+                revision: "abc".into(),
+                revision_number: 1,
+                dco_signed: true,
+                signoff_line: Some("Signed-off-by: Test <t@e.com>".into()),
+            }],
+            total_checked: 1,
+            passed: 1,
+            failed: 0,
+        };
+        let json = serde_json::to_string(&result).expect("serialise");
+        assert!(json.contains("abc"));
+        assert!(json.contains("total_checked"));
+    }
+
+    #[test]
+    fn result_defaults_are_zero() {
+        let result = DcoValidateResult::default();
+        assert!(result.revisions.is_empty());
+        assert_eq!(result.total_checked, 0);
+        assert_eq!(result.passed, 0);
+        assert_eq!(result.failed, 0);
+    }
+}

--- a/crates/lore-vm/src/ops/governance/evidence_preserve.rs
+++ b/crates/lore-vm/src/ops/governance/evidence_preserve.rs
@@ -1,0 +1,455 @@
+//! `governance::evidence_preserve` — capture and serialise worktree state as
+//! an evidence snapshot for audit / incident-response purposes.
+//!
+//! Collects revision info, working-directory status, and governance metadata
+//! into a single JSON-serialisable snapshot. This op does not call any
+//! upstream `lore` governance function (none exists) — it composes
+//! `lore::revision::info` and `lore::repository::status`.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::interface::{LoreEvent, LoreMetadata, LoreString};
+use lore::repository::{LoreRepositoryStatusArgs, status};
+use lore::revision::{LoreRevisionInfoArgs, info};
+use serde::{Deserialize, Serialize};
+
+use super::artifact_mark_superseded::{METADATA_KEY_SUPERSEDED_BY, METADATA_KEY_SUPERSEDED_REASON};
+
+/// Arguments for [`evidence_preserve`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EvidencePreserveArgs {
+    /// Snapshot label / incident identifier (e.g. "INC-2026-042").
+    #[serde(default)]
+    pub label: String,
+    /// Revision to snapshot; empty targets HEAD.
+    #[serde(default)]
+    pub revision: String,
+    /// Include per-file status in the snapshot. Default: true.
+    #[serde(default = "default_include_status")]
+    pub include_file_status: bool,
+}
+
+fn default_include_status() -> bool {
+    true
+}
+
+impl EvidencePreserveArgs {
+    fn status_args(&self) -> LoreRepositoryStatusArgs {
+        LoreRepositoryStatusArgs {
+            staged: 1,
+            scan: 1,
+            check_dirty: 0,
+            reset: 0,
+            sync_point: 1,
+            revision_only: 0,
+            count: 1,
+            paths: lore::interface::LoreArray::from_vec(vec![]),
+        }
+    }
+
+    fn info_args(&self) -> LoreRevisionInfoArgs {
+        LoreRevisionInfoArgs {
+            revision: LoreString::from_str(&self.revision),
+            delta: 0,
+            metadata: 1,
+        }
+    }
+}
+
+/// A file entry captured in the evidence snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvidenceFileEntry {
+    /// Repository-relative path.
+    pub path: String,
+    /// File size in bytes.
+    pub size: u64,
+    /// Change action.
+    pub action: String,
+    /// Whether the change is staged.
+    pub staged: bool,
+    /// Whether the file is in conflict.
+    pub conflict: bool,
+    /// Whether the file differs from recorded state.
+    pub dirty: bool,
+}
+
+/// Metadata key/value pair captured in the snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvidenceMetadataEntry {
+    pub key: String,
+    pub value: String,
+}
+
+/// Governance-specific fields captured in the snapshot.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EvidenceGovernance {
+    /// Whether the revision carries superseded-by metadata.
+    pub is_superseded: bool,
+    /// The superseding revision hash, if any.
+    pub superseded_by: Option<String>,
+    /// Reason for supersession, if any.
+    pub superseded_reason: Option<String>,
+    /// Whether the commit message contains a DCO sign-off.
+    pub dco_signed: bool,
+    /// The DCO sign-off line, if present.
+    pub dco_signoff_line: Option<String>,
+}
+
+/// A self-contained evidence snapshot of worktree state at a point in time.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EvidencePreserveResult {
+    /// Snapshot label (from args).
+    pub label: String,
+    /// Timestamp when the snapshot was captured (ISO 8601).
+    pub captured_at: String,
+    /// Repository identifier.
+    pub repository: String,
+    /// Branch name.
+    pub branch_name: String,
+    /// Revision hash.
+    pub revision: String,
+    /// Revision number.
+    pub revision_number: u64,
+    /// Staged revision hash (empty if none).
+    pub revision_staged: String,
+    /// Governance-specific fields.
+    pub governance: EvidenceGovernance,
+    /// Metadata key/value pairs from the revision.
+    pub metadata: Vec<EvidenceMetadataEntry>,
+    /// File status entries (when `include_file_status` is true).
+    pub files: Vec<EvidenceFileEntry>,
+    /// Total directory count at snapshot time.
+    pub dir_count: Option<u64>,
+    /// Total file count at snapshot time.
+    pub file_count: Option<u64>,
+}
+
+fn hash_or_empty(hash: &lore::interface::Hash) -> String {
+    if hash.is_zero() {
+        String::new()
+    } else {
+        format!("{hash}")
+    }
+}
+
+fn metadata_display(value: &LoreMetadata) -> String {
+    match value {
+        LoreMetadata::String(s) => s.as_str().to_string(),
+        LoreMetadata::Numeric(n) => n.to_string(),
+        other => serde_json::to_string(other).unwrap_or_default(),
+    }
+}
+
+/// Capture a self-contained evidence snapshot of worktree state.
+///
+/// Collects revision info, working-directory status, and governance metadata
+/// into a single serialisable result suitable for archival, incident response,
+/// or audit trails.
+pub async fn evidence_preserve(
+    api: &LoreApi,
+    args: EvidencePreserveArgs,
+) -> Result<EvidencePreserveResult> {
+    let captured_at = chrono_offset_datetime();
+    let mut result = EvidencePreserveResult {
+        label: args.label.clone(),
+        captured_at,
+        ..Default::default()
+    };
+
+    // 1. Revision info — get metadata (commit message, author, etc.).
+    let (cb, rx) = collect_events();
+    let info_status = info(api.globals().build(), args.info_args(), cb).await;
+
+    let info_stream = rx
+        .await
+        .map_err(|e| LoreError::CommandFailed(format!("info event stream cancelled: {e}")))?;
+
+    if !info_stream.is_ok() {
+        return Err(LoreError::CommandFailed(info_stream.error.unwrap_or_else(
+            || format!("evidence_preserve (info) failed with status {info_status}"),
+        )));
+    }
+
+    for event in &info_stream.events {
+        match event {
+            LoreEvent::RevisionInfo(data) => {
+                result.repository = format!("{}", data.repository);
+                result.revision = hash_or_empty(&data.revision);
+                result.revision_number = data.revision_number;
+                // branch_name and revision_staged come from the status call below
+            }
+            LoreEvent::Metadata(data) => {
+                let value = metadata_display(&data.value);
+                result.metadata.push(EvidenceMetadataEntry {
+                    key: data.key.as_str().to_string(),
+                    value: value.clone(),
+                });
+
+                // Governance: check for DCO sign-off.
+                if data.key.as_str() == "message" {
+                    let (signed, line) = super::dco_validate::check_dco_signoff(&value);
+                    result.governance.dco_signed = signed;
+                    result.governance.dco_signoff_line = line;
+                }
+
+                // Governance: check for superseded metadata.
+                if data.key.as_str() == METADATA_KEY_SUPERSEDED_BY {
+                    result.governance.is_superseded = true;
+                    result.governance.superseded_by = Some(value.clone());
+                }
+                if data.key.as_str() == METADATA_KEY_SUPERSEDED_REASON {
+                    result.governance.superseded_reason = Some(value);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // 2. Working directory status — if requested.
+    if args.include_file_status {
+        let (cb2, rx2) = collect_events();
+        let _status_val =
+            status(api.globals().build(), args.status_args(), cb2).await;
+
+        let status_stream = rx2.await.map_err(|e| {
+            LoreError::CommandFailed(format!("status event stream cancelled: {e}"))
+        })?;
+
+        if status_stream.is_ok() {
+            for event in &status_stream.events {
+                match event {
+                    LoreEvent::RepositoryStatusRevision(data) => {
+                        result.branch_name = data.branch_name.as_str().to_string();
+                        result.revision_staged = hash_or_empty(&data.revision_staged);
+                    }
+                    LoreEvent::RepositoryStatusFile(data) => {
+                        result.files.push(EvidenceFileEntry {
+                            path: data.path.as_str().to_string(),
+                            size: data.size,
+                            action: format!("{:?}", data.action),
+                            staged: data.flag_staged != 0,
+                            conflict: data.flag_conflict != 0,
+                            dirty: data.flag_dirty != 0,
+                        });
+                    }
+                    LoreEvent::RepositoryStatusCount(data) => {
+                        result.dir_count = Some(data.directories);
+                        result.file_count = Some(data.files);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        // Status failure is non-fatal for evidence capture — we still have
+        // revision info and metadata.
+    }
+
+    Ok(result)
+}
+
+/// Best-effort UTC timestamp in ISO 8601 format.
+///
+/// Uses `std::time::SystemTime` so we don't pull in `chrono` as a dependency.
+fn chrono_offset_datetime() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = duration.as_secs();
+    let nanos = duration.subsec_nanos();
+
+    // Calculate date/time from Unix timestamp (simplified UTC).
+    let (year, month, day, hour, minute, second) = unix_timestamp_to_utc(secs);
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:09}Z",
+        year, month, day, hour, minute, second, nanos
+    )
+}
+
+/// Convert a Unix timestamp to (year, month, day, hour, minute, second) in UTC.
+fn unix_timestamp_to_utc(secs: u64) -> (u32, u32, u32, u32, u32, u32) {
+    const SECS_PER_MINUTE: u64 = 60;
+    const SECS_PER_HOUR: u64 = 3600;
+    const SECS_PER_DAY: u64 = 86400;
+
+    let total_days = secs / SECS_PER_DAY;
+    let remaining_secs = secs % SECS_PER_DAY;
+
+    let hour = (remaining_secs / SECS_PER_HOUR) as u32;
+    let minute = ((remaining_secs % SECS_PER_HOUR) / SECS_PER_MINUTE) as u32;
+    let second = (remaining_secs % SECS_PER_MINUTE) as u32;
+
+    // Calculate year/month/day from total_days since epoch (1970-01-01).
+    let mut days = total_days as i64;
+    let mut year: i64 = 1970;
+
+    loop {
+        let days_in_year = if is_leap_year(year) { 366 } else { 365 };
+        if days < days_in_year {
+            break;
+        }
+        days -= days_in_year;
+        year += 1;
+    }
+
+    let month_days = if is_leap_year(year) {
+        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    } else {
+        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    };
+
+    let mut month: usize = 0;
+    for (i, &dm) in month_days.iter().enumerate() {
+        if days < dm as i64 {
+            month = i;
+            break;
+        }
+        days -= dm as i64;
+    }
+
+    (year as u32, (month + 1) as u32, (days + 1) as u32, hour, minute, second)
+}
+
+fn is_leap_year(year: i64) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_defaults() {
+        let json = r#"{}"#;
+        let args: EvidencePreserveArgs = serde_json::from_str(json).expect("should deserialize");
+        assert!(args.label.is_empty());
+        assert!(args.revision.is_empty());
+        assert!(args.include_file_status);
+    }
+
+    #[test]
+    fn args_with_label() {
+        let json = r#"{"label":"INC-2026-042","include_file_status":false}"#;
+        let args: EvidencePreserveArgs = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(args.label, "INC-2026-042");
+        assert!(!args.include_file_status);
+    }
+
+    #[test]
+    fn result_defaults() {
+        let result = EvidencePreserveResult::default();
+        assert!(result.label.is_empty());
+        // Default struct has empty captured_at; the real fn populates it.
+        assert!(result.files.is_empty());
+        assert!(result.metadata.is_empty());
+        assert!(!result.governance.is_superseded);
+        assert!(!result.governance.dco_signed);
+    }
+
+    #[test]
+    fn result_serialises() {
+        let result = EvidencePreserveResult {
+            label: "TEST-001".into(),
+            captured_at: "2026-08-02T12:00:00.000000000Z".into(),
+            repository: "repo1".into(),
+            branch_name: "main".into(),
+            revision: "abc123".into(),
+            revision_number: 42,
+            revision_staged: String::new(),
+            governance: EvidenceGovernance {
+                is_superseded: false,
+                superseded_by: None,
+                superseded_reason: None,
+                dco_signed: true,
+                dco_signoff_line: Some("Signed-off-by: Test <t@e.com>".into()),
+            },
+            metadata: vec![EvidenceMetadataEntry {
+                key: "message".into(),
+                value: "test commit".into(),
+            }],
+            files: vec![EvidenceFileEntry {
+                path: "src/lib.rs".into(),
+                size: 1024,
+                action: "Add".into(),
+                staged: true,
+                conflict: false,
+                dirty: false,
+            }],
+            dir_count: Some(5),
+            file_count: Some(20),
+        };
+        let json = serde_json::to_string(&result).expect("serialise");
+        assert!(json.contains("TEST-001"));
+        assert!(json.contains("abc123"));
+        assert!(json.contains("Signed-off-by"));
+        assert!(json.contains("src/lib.rs"));
+    }
+
+    #[test]
+    fn unix_timestamp_to_utc_epoch() {
+        let (y, m, d, h, min, s) = unix_timestamp_to_utc(0);
+        assert_eq!(y, 1970);
+        assert_eq!(m, 1);
+        assert_eq!(d, 1);
+        assert_eq!(h, 0);
+        assert_eq!(min, 0);
+        assert_eq!(s, 0);
+    }
+
+    #[test]
+    fn unix_timestamp_to_utc_known_date() {
+        // 2026-08-02 00:00:00 UTC = 20667 days from epoch
+        let secs: u64 = 1785628800;
+        let (y, m, d, h, min, s) = unix_timestamp_to_utc(secs);
+        assert_eq!(y, 2026);
+        assert_eq!(m, 8);
+        assert_eq!(d, 2);
+        assert_eq!(h, 0);
+        assert_eq!(min, 0);
+        assert_eq!(s, 0);
+    }
+
+    #[test]
+    fn is_leap_year_checks() {
+        assert!(is_leap_year(2024));
+        assert!(!is_leap_year(2025));
+        assert!(!is_leap_year(1900));
+        assert!(is_leap_year(2000));
+    }
+
+    #[test]
+    fn captured_at_is_iso8601() {
+        let ts = chrono_offset_datetime();
+        assert!(ts.ends_with('Z'));
+        assert!(ts.contains('T'));
+        assert!(ts.len() > 20);
+    }
+
+    #[test]
+    fn hash_or_empty_zero_is_empty() {
+        let zero = lore::interface::Hash::default();
+        assert!(hash_or_empty(&zero).is_empty());
+    }
+
+    #[test]
+    fn metadata_display_string_and_numeric() {
+        use lore::interface::LoreString;
+        assert_eq!(
+            metadata_display(&LoreMetadata::String(LoreString::from("hello"))),
+            "hello"
+        );
+        assert_eq!(metadata_display(&LoreMetadata::Numeric(42)), "42");
+    }
+
+    #[test]
+    fn governance_defaults_are_false() {
+        let gov = EvidenceGovernance::default();
+        assert!(!gov.is_superseded);
+        assert!(gov.superseded_by.is_none());
+        assert!(gov.superseded_reason.is_none());
+        assert!(!gov.dco_signed);
+        assert!(gov.dco_signoff_line.is_none());
+    }
+}

--- a/crates/lore-vm/src/ops/governance/mod.rs
+++ b/crates/lore-vm/src/ops/governance/mod.rs
@@ -1,0 +1,11 @@
+//! `governance`-domain operations — one sub-module per op.
+//!
+//! Governance/security ops that operate on lore worktree state. Unlike other
+//! domains, these are lore-vm native (no upstream `lore::governance` module)
+//! and compose existing lore primitives (revision info, metadata, status) to
+//! implement security-governance workflows.
+
+pub mod artifact_mark_superseded;
+pub mod dco_validate;
+pub mod evidence_preserve;
+pub mod submission_gate_check;

--- a/crates/lore-vm/src/ops/governance/submission_gate_check.rs
+++ b/crates/lore-vm/src/ops/governance/submission_gate_check.rs
@@ -1,0 +1,398 @@
+//! `governance::submission_gate_check` — check whether a branch is ready for
+//! submission / merge.
+//!
+//! Evaluates a set of gate conditions against the current worktree state:
+//! - No uncommitted changes (clean working directory)
+//! - No unresolved conflicts
+//! - DCO sign-off present on HEAD
+//! - No superseded-artifact metadata on HEAD
+//!
+//! All checks use lore primitives (`lore::repository::status`,
+//! `lore::revision::info`). No upstream `lore` function implements this gate.
+
+use crate::api::LoreApi;
+use crate::collect::collect_events;
+use crate::error::{LoreError, Result};
+
+use lore::interface::{LoreEvent, LoreMetadata, LoreString};
+use lore::repository::{LoreRepositoryStatusArgs, status};
+use lore::revision::{LoreRevisionInfoArgs, info};
+use serde::{Deserialize, Serialize};
+
+use super::artifact_mark_superseded::METADATA_KEY_SUPERSEDED_BY;
+use super::dco_validate::check_dco_signoff;
+
+/// Arguments for [`submission_gate_check`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SubmissionGateCheckArgs {
+    /// Require a DCO sign-off on HEAD. Default: true.
+    #[serde(default = "default_require_dco")]
+    pub require_dco: bool,
+    /// Reject if HEAD carries superseded-by metadata. Default: true.
+    #[serde(default = "default_reject_superseded")]
+    pub reject_superseded: bool,
+    /// Require a clean working directory (no uncommitted changes). Default: true.
+    #[serde(default = "default_require_clean")]
+    pub require_clean_workdir: bool,
+}
+
+fn default_require_dco() -> bool {
+    true
+}
+
+fn default_reject_superseded() -> bool {
+    true
+}
+
+fn default_require_clean() -> bool {
+    true
+}
+
+/// Individual gate check result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GateCheck {
+    /// Human-readable name of the check.
+    pub name: String,
+    /// Whether this check passed.
+    pub passed: bool,
+    /// Detail message (reason for failure or success note).
+    pub detail: String,
+}
+
+/// Result returned after evaluating all submission gate checks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubmissionGateCheckResult {
+    /// Whether ALL checks passed.
+    pub gate_open: bool,
+    /// Individual check results.
+    pub checks: Vec<GateCheck>,
+    /// Revision hash of HEAD at check time.
+    pub head_revision: String,
+    /// Branch name at check time.
+    pub branch_name: String,
+}
+
+/// Evaluate the submission gate for the current worktree.
+///
+/// Returns a `gate_open: bool` plus per-check details so callers can report
+/// exactly which conditions failed and why.
+pub async fn submission_gate_check(
+    api: &LoreApi,
+    args: SubmissionGateCheckArgs,
+) -> Result<SubmissionGateCheckResult> {
+    let mut checks: Vec<GateCheck> = Vec::new();
+    let mut head_revision = String::new();
+    let mut branch_name = String::new();
+
+    // 1. Check working directory cleanliness (no uncommitted changes, no conflicts).
+    if args.require_clean_workdir {
+        let (cb, rx) = collect_events();
+        let status_args = LoreRepositoryStatusArgs {
+            staged: 0,
+            scan: 1,
+            check_dirty: 0,
+            reset: 0,
+            sync_point: 0,
+            revision_only: 0,
+            count: 0,
+            paths: lore::interface::LoreArray::from_vec(vec![]),
+        };
+        let _status_val = status(api.globals().build(), status_args, cb).await;
+
+        let stream = rx
+            .await
+            .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+        if stream.is_ok() {
+            let mut dirty_count = 0u64;
+            let mut conflict_count = 0u64;
+
+            for event in &stream.events {
+                match event {
+                    LoreEvent::RepositoryStatusRevision(data) => {
+                        head_revision = format!("{}", data.revision);
+                        branch_name = data.branch_name.as_str().to_string();
+                    }
+                    LoreEvent::RepositoryStatusFile(data) => {
+                        if data.flag_dirty != 0 {
+                            dirty_count += 1;
+                        }
+                        if data.flag_conflict != 0 {
+                            conflict_count += 1;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            if dirty_count == 0 && conflict_count == 0 {
+                checks.push(GateCheck {
+                    name: "clean_workdir".into(),
+                    passed: true,
+                    detail: "no uncommitted changes or conflicts".into(),
+                });
+            } else {
+                checks.push(GateCheck {
+                    name: "clean_workdir".into(),
+                    passed: false,
+                    detail: format!("{dirty_count} dirty file(s), {conflict_count} conflict(s)"),
+                });
+            }
+        } else {
+            checks.push(GateCheck {
+                name: "clean_workdir".into(),
+                passed: false,
+                detail: stream
+                    .error
+                    .unwrap_or_else(|| "status check failed".into()),
+            });
+        }
+    } else {
+        // Still fetch revision info for head_revision / branch_name.
+        checks.push(GateCheck {
+            name: "clean_workdir".into(),
+            passed: true,
+            detail: "skipped (not required)".into(),
+        });
+    }
+
+    // If we didn't get head_revision from status, try revision info.
+    if head_revision.is_empty() {
+        let (cb2, rx2) = collect_events();
+        let info_args = LoreRevisionInfoArgs {
+            revision: LoreString::from_str(""),
+            delta: 0,
+            metadata: 1,
+        };
+        let _info_status = info(api.globals().build(), info_args, cb2).await;
+
+        let info_stream = rx2.await.map_err(|e| {
+            LoreError::CommandFailed(format!("info event stream cancelled: {e}"))
+        })?;
+
+        if info_stream.is_ok() {
+            for event in &info_stream.events {
+                if let LoreEvent::RevisionInfo(data) = event {
+                    head_revision = format!("{}", data.revision);
+                }
+            }
+        }
+    }
+
+    if branch_name.is_empty() {
+        branch_name = "<unknown>".into();
+    }
+
+    // 2. DCO sign-off check on HEAD.
+    if args.require_dco {
+        let (cb, rx) = collect_events();
+        let info_args = LoreRevisionInfoArgs {
+            revision: LoreString::from_str(""),
+            delta: 0,
+            metadata: 1,
+        };
+        let _dco_status = info(api.globals().build(), info_args, cb).await;
+
+        let dco_stream = rx
+            .await
+            .map_err(|e| LoreError::CommandFailed(format!("event stream cancelled: {e}")))?;
+
+        if dco_stream.is_ok() {
+            let mut message = String::new();
+            for event in &dco_stream.events {
+                if let LoreEvent::Metadata(data) = event {
+                    if data.key.as_str() == "message" {
+                        if let LoreMetadata::String(s) = &data.value {
+                            message = s.as_str().to_string();
+                        }
+                    }
+                }
+            }
+
+            let (signed, _) = check_dco_signoff(&message);
+            if signed {
+                checks.push(GateCheck {
+                    name: "dco_signoff".into(),
+                    passed: true,
+                    detail: "HEAD has Signed-off-by line".into(),
+                });
+            } else {
+                checks.push(GateCheck {
+                    name: "dco_signoff".into(),
+                    passed: false,
+                    detail: "HEAD commit message missing Signed-off-by line".into(),
+                });
+            }
+        } else {
+            checks.push(GateCheck {
+                name: "dco_signoff".into(),
+                passed: false,
+                detail: dco_stream
+                    .error
+                    .unwrap_or_else(|| "revision info failed".into()),
+            });
+        }
+    } else {
+        checks.push(GateCheck {
+            name: "dco_signoff".into(),
+            passed: true,
+            detail: "skipped (not required)".into(),
+        });
+    }
+
+    // 3. Superseded-artifact check on HEAD.
+    if args.reject_superseded {
+        let (cb, rx) = collect_events();
+        let info_args = LoreRevisionInfoArgs {
+            revision: LoreString::from_str(""),
+            delta: 0,
+            metadata: 1,
+        };
+        let _super_status = info(api.globals().build(), info_args, cb).await;
+
+        let super_stream = rx.await.map_err(|e| {
+            LoreError::CommandFailed(format!("event stream cancelled: {e}"))
+        })?;
+
+        if super_stream.is_ok() {
+            let mut is_superseded = false;
+            let mut superseded_by = String::new();
+
+            for event in &super_stream.events {
+                if let LoreEvent::Metadata(data) = event {
+                    if data.key.as_str() == METADATA_KEY_SUPERSEDED_BY {
+                        is_superseded = true;
+                        if let LoreMetadata::String(s) = &data.value {
+                            superseded_by = s.as_str().to_string();
+                        }
+                    }
+                }
+            }
+
+            if is_superseded {
+                checks.push(GateCheck {
+                    name: "not_superseded".into(),
+                    passed: false,
+                    detail: format!("HEAD is superseded by {superseded_by}"),
+                });
+            } else {
+                checks.push(GateCheck {
+                    name: "not_superseded".into(),
+                    passed: true,
+                    detail: "HEAD has no superseded-by metadata".into(),
+                });
+            }
+        } else {
+            checks.push(GateCheck {
+                name: "not_superseded".into(),
+                passed: false,
+                detail: super_stream
+                    .error
+                    .unwrap_or_else(|| "revision info failed".into()),
+            });
+        }
+    } else {
+        checks.push(GateCheck {
+            name: "not_superseded".into(),
+            passed: true,
+            detail: "skipped (not required)".into(),
+        });
+    }
+
+    let gate_open = checks.iter().all(|c| c.passed);
+
+    Ok(SubmissionGateCheckResult {
+        gate_open,
+        checks,
+        head_revision,
+        branch_name,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_defaults_all_true() {
+        let json = r#"{}"#;
+        let args: SubmissionGateCheckArgs =
+            serde_json::from_str(json).expect("should deserialize");
+        assert!(args.require_dco);
+        assert!(args.reject_superseded);
+        assert!(args.require_clean_workdir);
+    }
+
+    #[test]
+    fn args_can_disable_individual_checks() {
+        let json = r#"{"require_dco":false,"reject_superseded":false}"#;
+        let args: SubmissionGateCheckArgs =
+            serde_json::from_str(json).expect("should deserialize");
+        assert!(!args.require_dco);
+        assert!(!args.reject_superseded);
+        assert!(args.require_clean_workdir);
+    }
+
+    #[test]
+    fn gate_result_all_pass_is_open() {
+        let result = SubmissionGateCheckResult {
+            gate_open: true,
+            checks: vec![
+                GateCheck {
+                    name: "clean_workdir".into(),
+                    passed: true,
+                    detail: "ok".into(),
+                },
+                GateCheck {
+                    name: "dco_signoff".into(),
+                    passed: true,
+                    detail: "ok".into(),
+                },
+            ],
+            head_revision: "abc".into(),
+            branch_name: "main".into(),
+        };
+        assert!(result.gate_open);
+        assert!(result.checks.iter().all(|c| c.passed));
+    }
+
+    #[test]
+    fn gate_result_one_fail_is_closed() {
+        let result = SubmissionGateCheckResult {
+            gate_open: false,
+            checks: vec![
+                GateCheck {
+                    name: "clean_workdir".into(),
+                    passed: true,
+                    detail: "ok".into(),
+                },
+                GateCheck {
+                    name: "dco_signoff".into(),
+                    passed: false,
+                    detail: "missing signoff".into(),
+                },
+            ],
+            head_revision: "abc".into(),
+            branch_name: "main".into(),
+        };
+        assert!(!result.gate_open);
+    }
+
+    #[test]
+    fn result_serialises() {
+        let result = SubmissionGateCheckResult {
+            gate_open: true,
+            checks: vec![GateCheck {
+                name: "clean_workdir".into(),
+                passed: true,
+                detail: "clean".into(),
+            }],
+            head_revision: "rev1".into(),
+            branch_name: "feature".into(),
+        };
+        let json = serde_json::to_string(&result).expect("serialise");
+        assert!(json.contains("gate_open"));
+        assert!(json.contains("rev1"));
+        assert!(json.contains("feature"));
+    }
+}

--- a/crates/lore-vm/src/ops/mod.rs
+++ b/crates/lore-vm/src/ops/mod.rs
@@ -7,6 +7,7 @@ pub mod auth;
 pub mod branch;
 pub mod dependency;
 pub mod file;
+pub mod governance;
 pub mod layer;
 pub mod link;
 pub mod lock;


### PR DESCRIPTION
Resolves SBAI-5934. Added ops/governance/ with 4 ops: artifact_mark_superseded, dco_validate, submission_gate_check, evidence_preserve. 793 tests pass. See commit for details.