### PR TITLE
SBAI-5934: enforce the Option A governance submission gate

### DIFF
--- a/crates/lore-vm/src/dispatch.rs
+++ b/crates/lore-vm/src/dispatch.rs
@@ -82,6 +82,10 @@ const SUPPORTED_OPS: &[&str] = &[
     "lock.file_acquire_as_owner",
     "lock.file_message_send",
     "lock.file_release",
+    // ---- governance -----------------------------------------------------
+    "governance.dco_validate",
+    "governance.evidence_preserve",
+    "governance.submission_gate_check",
 ];
 
 /// The set of `"<domain>.<op>"` ids [`dispatch`] can route.
@@ -115,6 +119,7 @@ const MUTATING_OPS: &[&str] = &[
     "lock.file_message_send",
     "lock.file_release",
     "auth.login_with_token",
+    "governance.evidence_preserve",
 ];
 
 /// True when `op_id` mutates durable on-disk state (see [`MUTATING_OPS`]). A
@@ -320,6 +325,20 @@ pub async fn dispatch(api: &LoreApi, op_id: &str, args: Value) -> Result<Value, 
         "lock.file_release" => op!(
             ops::lock::file_release::file_release,
             ops::lock::file_release::FileReleaseArgs
+        ),
+
+        // ---- governance -------------------------------------------------
+        "governance.dco_validate" => op!(
+            ops::governance::dco_validate::dco_validate,
+            ops::governance::contract::DcoValidateRequest
+        ),
+        "governance.evidence_preserve" => op!(
+            ops::governance::evidence_preserve::evidence_preserve,
+            ops::governance::contract::EvidencePreserveRequest
+        ),
+        "governance.submission_gate_check" => op!(
+            ops::governance::submission_gate_check::submission_gate_check,
+            ops::governance::contract::SubmissionGateCheckRequest
         ),
 
         unknown => Err(LoreError::Parse(format!(

--- a/crates/lore-vm/src/ops/governance/contract.rs
+++ b/crates/lore-vm/src/ops/governance/contract.rs
@@ -1,0 +1,118 @@
+//! The single authoritative serde boundary for SBAI-5934 Option-A governance.
+
+use serde::{Deserialize, Serialize};
+
+/// Prefix for a strict v1 supersession record, followed by its canonical
+/// artifact identity.
+pub const SUPERSESSION_MARKER_PREFIX: &str = "studiobrain.governance.v1.superseded.";
+/// The sole fixed v1 per-revision immutable-evidence pointer key.
+pub const EVIDENCE_POINTER_KEY: &str = "studiobrain.governance.v1.evidence";
+/// The largest complete candidate-side first-parent stream accepted by policy.
+pub const MAX_GOVERNANCE_HISTORY_REVISIONS: usize = 1000;
+
+/// The exact revision binding shared by every governance operation.
+pub trait ExactRevisionRequest {
+    /// The staged revision the caller observed and is asking to govern.
+    fn expected_staged_revision(&self) -> &str;
+    /// The fetched base revision that bounds the candidate-side DAG.
+    fn target_base_revision(&self) -> &str;
+}
+
+macro_rules! strict_exact_request {
+    ($name:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+        #[serde(deny_unknown_fields)]
+        pub struct $name {
+            pub expected_staged_revision: String,
+            pub target_base_revision: String,
+        }
+
+        impl ExactRevisionRequest for $name {
+            fn expected_staged_revision(&self) -> &str {
+                &self.expected_staged_revision
+            }
+
+            fn target_base_revision(&self) -> &str {
+                &self.target_base_revision
+            }
+        }
+    };
+}
+
+strict_exact_request!(ArtifactMarkSupersededRequest);
+strict_exact_request!(DcoValidateRequest);
+strict_exact_request!(EvidencePreserveRequest);
+strict_exact_request!(SubmissionGateCheckRequest);
+
+/// Strict v1 metadata payload for a superseded canonical artifact identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SupersessionMarkerV1 {
+    pub version: String,
+    pub identity: String,
+}
+
+/// Result returned by an authoritative supersession write.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactMarkSupersededResult {
+    pub source_staged_revision: String,
+    pub result_staged_revision: String,
+    pub identity: String,
+}
+
+/// Strict v1 immutable evidence pointer attached to one staged revision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidencePointerV1 {
+    pub version: String,
+    pub address: String,
+}
+
+/// Result returned after a durable evidence-preservation attempt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidencePreserveResult {
+    pub source_staged_revision: String,
+    pub result_staged_revision: String,
+    pub evidence_address: String,
+}
+
+/// The exact, finite inventory used by submission-gate results.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GovernanceCriterion {
+    ExactSubject,
+    HistoryComplete,
+    DcoValid,
+    NotSuperseded,
+    LocksClear,
+    WorktreeClean,
+    EvidenceValid,
+}
+
+/// One deterministic criterion observation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CriterionResult {
+    pub criterion: GovernanceCriterion,
+    pub passed: bool,
+    pub failure_code: Option<String>,
+}
+
+/// Strict result schema for the eventual canonical submission gate operation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubmissionGateCheckResult {
+    pub gate_open: bool,
+    pub criteria: Vec<CriterionResult>,
+}
+
+/// Strict result schema for a DCO-only operation using the shared evaluator.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DcoValidateResult {
+    pub valid: bool,
+    pub pending_revisions: Vec<String>,
+    pub failure_codes: Vec<String>,
+}

--- a/crates/lore-vm/src/ops/governance/contract.rs
+++ b/crates/lore-vm/src/ops/governance/contract.rs
@@ -39,12 +39,104 @@ macro_rules! strict_exact_request {
     };
 }
 
-strict_exact_request!(ArtifactMarkSupersededRequest);
 strict_exact_request!(DcoValidateRequest);
-strict_exact_request!(EvidencePreserveRequest);
 strict_exact_request!(SubmissionGateCheckRequest);
 
+/// Evidence publication cannot create an attempt for an unrepresentable empty
+/// subject. Serde and direct operation entry both call the same validator.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct EvidencePreserveRequest {
+    pub expected_staged_revision: String,
+    pub target_base_revision: String,
+}
+
+impl EvidencePreserveRequest {
+    pub fn validate(&self) -> std::result::Result<(), &'static str> {
+        if self.expected_staged_revision.is_empty() || self.target_base_revision.is_empty() {
+            Err("evidence preserve requires nonempty exact revisions")
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn validated(
+        &self,
+    ) -> std::result::Result<ValidatedEvidencePreserveRequestV1<'_>, &'static str> {
+        self.validate()?;
+        Ok(ValidatedEvidencePreserveRequestV1 { request: self })
+    }
+}
+
+/// Unforgeable state-machine entrance. Its field is private and its sole
+/// constructor reuses the strict direct/serde request validator.
+pub(crate) struct ValidatedEvidencePreserveRequestV1<'a> {
+    request: &'a EvidencePreserveRequest,
+}
+
+impl<'de> Deserialize<'de> for EvidencePreserveRequest {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Wire {
+            expected_staged_revision: String,
+            target_base_revision: String,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        let request = Self {
+            expected_staged_revision: wire.expected_staged_revision,
+            target_base_revision: wire.target_base_revision,
+        };
+        request.validate().map_err(serde::de::Error::custom)?;
+        Ok(request)
+    }
+}
+
+impl ExactRevisionRequest for EvidencePreserveRequest {
+    fn expected_staged_revision(&self) -> &str {
+        &self.expected_staged_revision
+    }
+
+    fn target_base_revision(&self) -> &str {
+        &self.target_base_revision
+    }
+}
+
+/// Strict future request for the authoritative v2 supersession writer.
+///
+/// Task 2 intentionally exposes no writer or dispatch route.  The mandatory
+/// path selector prevents a future implementation from choosing an arbitrary
+/// identity when the exact candidate tree contains more than one file; v2 must
+/// resolve this path to exactly one canonical identity before it may write.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactMarkSupersededRequest {
+    pub expected_staged_revision: String,
+    pub target_base_revision: String,
+    pub target_path: String,
+}
+
+impl ExactRevisionRequest for ArtifactMarkSupersededRequest {
+    fn expected_staged_revision(&self) -> &str {
+        &self.expected_staged_revision
+    }
+
+    fn target_base_revision(&self) -> &str {
+        &self.target_base_revision
+    }
+}
+
 /// Strict v1 metadata payload for a superseded canonical artifact identity.
+///
+/// The Option-A supersession guarantee is monotonic only across the complete
+/// parent DAG reachable from the exact staged subject at evidence-preserve
+/// time; any post-preserve change must fail live re-evaluation. Explicit or
+/// forced sync, branch reset, force push, forced restore, and cross-line
+/// cherry-pick are outside that reachable-DAG guarantee and require the
+/// provenance/external-prior-state follow-up tracked by SBAI-6011.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SupersessionMarkerV1 {
@@ -69,13 +161,2192 @@ pub struct EvidencePointerV1 {
     pub address: String,
 }
 
-/// Result returned after a durable evidence-preservation attempt.
+/// One strict supersession record observed at an exact revision.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct EvidencePreserveResult {
+pub struct SupersessionObservation {
+    pub revision: String,
+    pub key: String,
+    pub value: String,
+    pub identity: String,
+}
+
+/// Exact DCO trailer, author identities, and resolved correspondence inputs for
+/// one pending revision. These are observations, not a pass/fail assertion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DcoObservation {
+    pub revision: String,
+    pub message: String,
+    pub trailer: String,
+    pub signer_name: String,
+    pub signer_email: String,
+    pub created_by: String,
+    pub committed_by: Option<String>,
+    pub resolved_authors: Vec<ResolvedAuthor>,
+}
+
+/// Exact DCO-relevant metadata cardinality observed for one pending revision.
+/// Vectors retain duplicate values so ambiguity cannot be normalized away.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DcoMetadataObservation {
+    pub revision: String,
+    pub messages: Vec<String>,
+    pub created_by: Vec<String>,
+    pub committed_by: Vec<String>,
+}
+
+/// Exact request and raw replies from one completed author-resolution call.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthorResolutionObservation {
+    pub requested: Vec<String>,
+    pub replies: Vec<ResolvedAuthor>,
+}
+
+/// Exact result of one whole-ancestry revision-metadata query. An entry is
+/// retained even when `metadata` is empty so a witness can prove that every
+/// reachable revision was queried instead of trusting a marker summary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SupersessionMetadataQueryObservation {
+    pub revision: String,
+    pub metadata: Vec<MetadataEntry>,
+}
+
+/// All raw deterministic inputs actually observed by one evaluator run.
+/// Optional fields stay absent when the dependency could not be observed; the
+/// corresponding exact failure is recorded in `dependency_observations`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GovernanceObservations {
+    pub expected_staged_revision: String,
+    pub target_base_revision: String,
+    pub status: Option<StatusSnapshot>,
+    pub base_revision_info: Option<RevisionInfo>,
+    /// Exact candidate-to-roots graph used only for whole-ancestry
+    /// supersession. The pending submission graph below excludes the base.
+    pub supersession_ancestry: Vec<RevisionInfo>,
+    pub supersession_ancestry_observed: bool,
+    pub revision_graph: Vec<RevisionInfo>,
+    pub first_parent_history: Vec<String>,
+    pub base_files: Vec<FileIdentity>,
+    /// True only after the exact base tree stream and all file identities
+    /// completed successfully. An empty tree is otherwise ambiguous.
+    pub base_tree_observed: bool,
+    pub candidate_files: Vec<FileIdentity>,
+    /// True only after the exact candidate tree stream and all file identities
+    /// completed successfully. An empty tree is otherwise ambiguous.
+    pub candidate_tree_observed: bool,
+    /// Effective capture-time identities. Selected filesystem-backed paths use
+    /// the exact local content hash plus staged context; unselected paths use
+    /// the exact revision identity.
+    pub current_files: Vec<FileIdentity>,
+    pub upstream_revision_diff: Vec<RevisionDiffObservation>,
+    pub revision_diff: Vec<AffectedPath>,
+    /// True only after the complete exact base-to-candidate diff was observed.
+    pub revision_diff_observed: bool,
+    pub affected_paths: Vec<String>,
+    pub supersession_markers: Vec<SupersessionObservation>,
+    /// One raw metadata-query result for every revision in
+    /// `supersession_ancestry`, including revisions whose result was empty.
+    pub supersession_metadata_queries: Vec<SupersessionMetadataQueryObservation>,
+    /// True only after marker metadata for every whole-ancestry revision was
+    /// completely observed. This is dependency presence, not a verdict.
+    pub supersession_metadata_observed: bool,
+    pub dco_metadata: Vec<DcoMetadataObservation>,
+    pub author_resolution: Option<AuthorResolutionObservation>,
+    pub dco: Vec<DcoObservation>,
+    pub lock_queries: Vec<LockQuery>,
+    pub lock_status: Option<LockStatusResponse>,
+    /// Evaluator diagnostic only. Witness decisions derive the scope and
+    /// remediation exclusively from the validated N+1 raw graph.
+    pub history_overflow_scope: Option<HistoryOverflowScope>,
+    pub dependency_observations: Vec<String>,
+}
+
+impl GovernanceObservations {
+    pub fn new(
+        expected_staged_revision: impl Into<String>,
+        target_base_revision: impl Into<String>,
+    ) -> Self {
+        Self {
+            expected_staged_revision: expected_staged_revision.into(),
+            target_base_revision: target_base_revision.into(),
+            status: None,
+            base_revision_info: None,
+            supersession_ancestry: Vec::new(),
+            supersession_ancestry_observed: false,
+            revision_graph: Vec::new(),
+            first_parent_history: Vec::new(),
+            base_files: Vec::new(),
+            base_tree_observed: false,
+            candidate_files: Vec::new(),
+            candidate_tree_observed: false,
+            current_files: Vec::new(),
+            upstream_revision_diff: Vec::new(),
+            revision_diff: Vec::new(),
+            revision_diff_observed: false,
+            affected_paths: Vec::new(),
+            supersession_markers: Vec::new(),
+            supersession_metadata_queries: Vec::new(),
+            supersession_metadata_observed: false,
+            dco_metadata: Vec::new(),
+            author_resolution: None,
+            dco: Vec::new(),
+            lock_queries: Vec::new(),
+            lock_status: None,
+            history_overflow_scope: None,
+            dependency_observations: Vec::new(),
+        }
+    }
+}
+
+/// Typed revision reference used only in canonical evidence.  The one staged
+/// subject is the sole revision allowed to change during pointer attach.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(
+    deny_unknown_fields,
+    rename_all = "snake_case",
+    tag = "kind",
+    content = "revision"
+)]
+pub enum CanonicalRevisionRefV1 {
+    StagedSubject,
+    Exact(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CanonicalStatusObservationV1 {
+    pub branch: String,
+    pub staged_revisions: Vec<CanonicalRevisionRefV1>,
+    pub scanned_staged_revisions: Vec<CanonicalRevisionRefV1>,
+    pub post_scan_staged_revisions: Vec<CanonicalRevisionRefV1>,
+    pub staged_paths: Vec<String>,
+    pub staged_changes: Vec<StagedPathObservation>,
+    pub worktree_files: Vec<CanonicalWorktreeFileObservationV1>,
+    pub worktree_clean: bool,
+    pub scan_performed: bool,
+}
+
+/// Exact staged-revision and local-filesystem values used to prove that one
+/// tracked path did not change after staging. No derived cleanliness claim is
+/// embedded in this record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CanonicalWorktreeFileObservationV1 {
+    pub path: String,
+    pub revision: CanonicalRevisionRefV1,
+    pub revision_hash: String,
+    pub revision_context: String,
+    pub revision_size: u64,
+    pub local_hash: String,
+    pub local_size: u64,
+    pub filtered_revision_size: u64,
+    pub flag_modified: bool,
+    pub flag_deleted: bool,
+    pub flag_added: bool,
+    pub flag_conflict: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CanonicalRevisionInfoV1 {
+    pub revision: CanonicalRevisionRefV1,
+    pub parents: Vec<CanonicalRevisionRefV1>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CanonicalFileIdentityV1 {
+    pub path: String,
+    pub revision: CanonicalRevisionRefV1,
+    pub hash: String,
+    pub context: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CanonicalSupersessionObservationV1 {
+    pub revision: CanonicalRevisionRefV1,
+    pub key: String,
+    pub value: String,
+    pub identity: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CanonicalDcoObservationV1 {
+    pub revision: CanonicalRevisionRefV1,
+    pub message: String,
+    pub trailer: String,
+    pub signer_name: String,
+    pub signer_email: String,
+    pub created_by: String,
+    pub committed_by: Option<String>,
+    pub resolved_authors: Vec<ResolvedAuthor>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CanonicalDcoMetadataObservationV1 {
+    pub revision: CanonicalRevisionRefV1,
+    pub messages: Vec<String>,
+    pub created_by: Vec<String>,
+    pub committed_by: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CanonicalSupersessionMetadataQueryObservationV1 {
+    pub revision: CanonicalRevisionRefV1,
+    pub metadata: Vec<MetadataEntry>,
+}
+
+/// Canonical, self-reference-free evidence bytes stored before pointer attach.
+///
+/// Every raw evaluator fact is retained byte-exact except the one known-mutable
+/// staged subject.  Exact occurrences of that subject become the typed
+/// [`CanonicalRevisionRefV1::StagedSubject`]; its source/result hashes are
+/// carried by [`EvidencePointerDeltaV1`].  The pointer cannot be part of its own
+/// pre-attach bytes, so its sole allowed key/value delta is also carried by that
+/// typed structure. No other field is normalized or omitted. Every vector is
+/// sorted and compared byte-for-byte by producer and witness. The snapshot has
+/// no actor-issued verdict, pass, validity, or gate decision. This v1
+/// representation is a strict subset that v2 subsumes without redefining.
+///
+/// `evidence_preserve` is the content freeze point; `stage` is not. Under
+/// Lore's path/flag staging semantics the pre-preserve window is unbounded.
+/// The guarantee is "what was PRESERVED is what is evaluated", never "what
+/// was STAGED is what is evaluated".
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CanonicalEvidenceSnapshotV1 {
+    pub version: String,
+    pub target_base_revision: String,
+    pub status: CanonicalStatusObservationV1,
+    pub base_revision_info: CanonicalRevisionInfoV1,
+    pub supersession_ancestry: Vec<CanonicalRevisionInfoV1>,
+    pub supersession_ancestry_observed: bool,
+    pub revision_graph: Vec<CanonicalRevisionInfoV1>,
+    pub first_parent_history: Vec<CanonicalRevisionRefV1>,
+    pub base_files: Vec<CanonicalFileIdentityV1>,
+    pub base_tree_observed: bool,
+    pub candidate_files: Vec<CanonicalFileIdentityV1>,
+    pub candidate_tree_observed: bool,
+    pub current_files: Vec<CanonicalFileIdentityV1>,
+    /// Raw exact-terminal stream returned by upstream revision diff.
+    pub upstream_revision_diff: Vec<RevisionDiffObservation>,
+    /// Exact change endpoints structurally derived from stable identities.
+    pub revision_diff: Vec<AffectedPath>,
+    pub revision_diff_observed: bool,
+    pub affected_paths: Vec<String>,
+    pub supersession_markers: Vec<CanonicalSupersessionObservationV1>,
+    pub supersession_metadata_queries: Vec<CanonicalSupersessionMetadataQueryObservationV1>,
+    pub supersession_metadata_observed: bool,
+    pub dco_metadata: Vec<CanonicalDcoMetadataObservationV1>,
+    pub author_resolution: AuthorResolutionObservation,
+    pub dco: Vec<CanonicalDcoObservationV1>,
+    pub lock_queries: Vec<LockQuery>,
+    pub lock_status: LockStatusResponse,
+    pub dependency_observations: Vec<String>,
+}
+
+/// The complete allowlist of state that may change while attaching one v1
+/// evidence pointer.  It is verification data, never an authorization claim.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidencePointerDeltaV1 {
+    pub version: String,
+    pub key: String,
     pub source_staged_revision: String,
     pub result_staged_revision: String,
+    pub pointer: EvidencePointerV1,
+}
+
+/// Structural role at the governance mutation boundary.  Actor evidence is a
+/// non-authoritative claim; only a witness re-evaluation can open the gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GovernanceRole {
+    Actor,
+    Witness,
+}
+
+/// One raw immutable-put item retained until exact cardinality validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImmutablePutItem {
+    pub id: u64,
+    pub address: String,
+    pub ok: bool,
+}
+
+/// One raw immutable-get item retained until exact address/size/byte checks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImmutableGetItem {
+    pub id: u64,
+    pub address: String,
+    pub size: u64,
+    pub data: Vec<u8>,
+    pub ok: bool,
+}
+
+/// Raw classification of one operation which may mutate after dispatch.
+/// `OutcomeUnknown` is a lower-bound observation: the hidden effect may or may
+/// not have happened, and callers must never reconstruct it as no effect.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MutationObservation<T> {
+    NotDispatched { code: String },
+    Completed(T),
+    OutcomeUnknown { code: String, observed: T },
+}
+
+/// Raw classification of one read. Read unavailability cannot prove or undo a
+/// publication, so it is distinct from a mutation's unknown effect.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReadObservation<T> {
+    NotDispatched { code: String },
+    Completed(T),
+    Unavailable { code: String },
+}
+
+/// The only three policy rejections that are known before any publication
+/// effect boundary is entered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceRejectionCodeV1 {
+    ActorRoleRequired,
+    InitialGovernanceClosed,
+    PointerAlreadyPresent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceRejectionStopV1 {
+    pub reason: EvidenceRejectionCodeV1,
+    pub code: String,
+}
+
+/// Exact operation stop. Whether the stop is verification-incomplete or has
+/// an unknown publication effect is checked against the top-level outcome,
+/// publication state, and close state during serde.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidencePreserveStopCodeV1 {
+    InitialEvaluation,
+    SourceMetadata,
+    SnapshotSerialization,
+    StorageOpenNotDispatched,
+    StorageOpenOutcome,
+    ActorRoleBeforePut,
+    StoragePutNotDispatched,
+    StoragePutOutcome,
+    StoragePutResponseMalformed,
+    PreattachEvaluation,
+    ActorRoleBeforeAttach,
+    PointerSerialization,
+    PointerAttachNotDispatched,
+    PointerAttachOutcome,
+    PostattachGetUnavailable,
+    PostattachGetMalformed,
+    PostattachBytesMismatch,
+    ResultStatusUnavailable,
+    ResultStatusInvalid,
+    ResultMetadataUnavailable,
+    PointerDeltaInvalid,
+    PointerSchemaInvalid,
+    PostattachEvaluation,
+    PostattachDrift,
+    StorageCloseNotDispatched,
+    StorageCloseOutcome,
+}
+
+impl EvidencePreserveStopCodeV1 {
+    fn publication_rank(self) -> u8 {
+        match self {
+            Self::InitialEvaluation
+            | Self::SourceMetadata
+            | Self::SnapshotSerialization
+            | Self::StorageOpenNotDispatched
+            | Self::StorageOpenOutcome
+            | Self::ActorRoleBeforePut
+            | Self::StoragePutNotDispatched
+            | Self::StoragePutOutcome
+            | Self::StoragePutResponseMalformed => 0,
+            Self::PreattachEvaluation
+            | Self::ActorRoleBeforeAttach
+            | Self::PointerSerialization
+            | Self::PointerAttachNotDispatched
+            | Self::PointerAttachOutcome => 1,
+            Self::PostattachGetUnavailable
+            | Self::PostattachGetMalformed
+            | Self::PostattachBytesMismatch => 2,
+            Self::ResultStatusUnavailable | Self::ResultStatusInvalid => 3,
+            Self::ResultMetadataUnavailable
+            | Self::PointerDeltaInvalid
+            | Self::PointerSchemaInvalid => 4,
+            Self::PostattachEvaluation | Self::PostattachDrift => 5,
+            Self::StorageCloseNotDispatched | Self::StorageCloseOutcome => 6,
+        }
+    }
+
+    fn is_unknown_effect(self) -> bool {
+        matches!(
+            self,
+            Self::StorageOpenOutcome
+                | Self::StoragePutOutcome
+                | Self::StoragePutResponseMalformed
+                | Self::PointerAttachOutcome
+                | Self::StorageCloseOutcome
+        )
+    }
+
+    fn occurs_before_snapshot_hash(self) -> bool {
+        matches!(
+            self,
+            Self::InitialEvaluation | Self::SourceMetadata | Self::SnapshotSerialization
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidencePreserveStopV1 {
+    pub stage: EvidencePreserveStopCodeV1,
+    pub code: String,
+}
+
+/// Close observation. `OpenOutcomeUnknown` means open was dispatched but no
+/// usable handle can be proven; the other close outcomes require a usable
+/// handle returned by an exact successful open.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case", deny_unknown_fields)]
+pub enum EvidenceCloseStateV1 {
+    NotOpened,
+    OpenOutcomeUnknown { code: String },
+    Closed,
+    CloseNotDispatched { code: String },
+    CloseOutcomeUnknown { code: String },
+}
+
+/// Monotonic lower bound on publication facts observed by the actor. Internal
+/// code reaches these variants only through consuming forward-only typestate
+/// transitions; this public form is a strict diagnostic wire projection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case", deny_unknown_fields)]
+pub enum EvidencePublicationStateV1 {
+    None,
+    BlobPublished {
+        evidence_address: String,
+    },
+    PointerAttachAcknowledged {
+        evidence_address: String,
+        pointer: EvidencePointerV1,
+    },
+    BlobReadbackVerified {
+        evidence_address: String,
+        pointer: EvidencePointerV1,
+    },
+    ResultSubjectObserved {
+        evidence_address: String,
+        pointer: EvidencePointerV1,
+        result_staged_revision: String,
+    },
+    PointerDeltaObserved {
+        evidence_address: String,
+        pointer: EvidencePointerV1,
+        result_staged_revision: String,
+    },
+    PostattachEquivalent {
+        evidence_address: String,
+        pointer: EvidencePointerV1,
+        result_staged_revision: String,
+    },
+}
+
+struct PublicationFacts<'a> {
+    rank: u8,
+    address: Option<&'a str>,
+    pointer: Option<&'a EvidencePointerV1>,
+    result_revision: Option<&'a str>,
+}
+
+impl EvidencePublicationStateV1 {
+    fn validate(&self, source_revision: &str) -> std::result::Result<PublicationFacts<'_>, String> {
+        let facts = match self {
+            Self::None => PublicationFacts {
+                rank: 0,
+                address: None,
+                pointer: None,
+                result_revision: None,
+            },
+            Self::BlobPublished { evidence_address } => PublicationFacts {
+                rank: 1,
+                address: Some(evidence_address),
+                pointer: None,
+                result_revision: None,
+            },
+            Self::PointerAttachAcknowledged {
+                evidence_address,
+                pointer,
+            } => PublicationFacts {
+                rank: 2,
+                address: Some(evidence_address),
+                pointer: Some(pointer),
+                result_revision: None,
+            },
+            Self::BlobReadbackVerified {
+                evidence_address,
+                pointer,
+            } => PublicationFacts {
+                rank: 3,
+                address: Some(evidence_address),
+                pointer: Some(pointer),
+                result_revision: None,
+            },
+            Self::ResultSubjectObserved {
+                evidence_address,
+                pointer,
+                result_staged_revision,
+            } => PublicationFacts {
+                rank: 4,
+                address: Some(evidence_address),
+                pointer: Some(pointer),
+                result_revision: Some(result_staged_revision),
+            },
+            Self::PointerDeltaObserved {
+                evidence_address,
+                pointer,
+                result_staged_revision,
+            } => PublicationFacts {
+                rank: 5,
+                address: Some(evidence_address),
+                pointer: Some(pointer),
+                result_revision: Some(result_staged_revision),
+            },
+            Self::PostattachEquivalent {
+                evidence_address,
+                pointer,
+                result_staged_revision,
+            } => PublicationFacts {
+                rank: 6,
+                address: Some(evidence_address),
+                pointer: Some(pointer),
+                result_revision: Some(result_staged_revision),
+            },
+        };
+        if let Some(address) = facts.address {
+            if !canonical_evidence_address(address) {
+                return Err("publication address is not canonical".into());
+            }
+        }
+        if let Some(pointer) = facts.pointer {
+            if pointer.version != "v1" || Some(pointer.address.as_str()) != facts.address {
+                return Err("publication pointer does not bind the exact address".into());
+            }
+        }
+        if let Some(result) = facts.result_revision {
+            if result.is_empty() || result == source_revision {
+                return Err("result staged revision did not advance".into());
+            }
+        }
+        Ok(facts)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidencePreserveRejectedV1 {
+    pub version: String,
+    pub attempt_id: String,
+    pub source_staged_revision: String,
+    pub target_base_revision: String,
+    pub snapshot_sha256: Option<String>,
+    pub observed_candidate_addresses: Vec<String>,
+    pub stopped_at: EvidenceRejectionStopV1,
+    pub close: EvidenceCloseStateV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidencePreserveResidualV1 {
+    pub version: String,
+    pub attempt_id: String,
+    pub source_staged_revision: String,
+    pub target_base_revision: String,
+    pub snapshot_sha256: Option<String>,
+    pub observed_candidate_addresses: Vec<String>,
+    pub stopped_at: EvidencePreserveStopV1,
+    pub last_confirmed_publication: EvidencePublicationStateV1,
+    pub close: EvidenceCloseStateV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidencePreserveVerifiedV1 {
+    pub version: String,
+    pub attempt_id: String,
+    pub source_staged_revision: String,
+    pub target_base_revision: String,
+    pub snapshot_sha256: Option<String>,
+    pub observed_candidate_addresses: Vec<String>,
+    pub result_staged_revision: String,
     pub evidence_address: String,
+    pub pointer: EvidencePointerV1,
+    pub last_confirmed_publication: EvidencePublicationStateV1,
+    pub close: EvidenceCloseStateV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case", deny_unknown_fields)]
+pub enum EvidencePreserveDispositionV1 {
+    RejectedBeforePublication(EvidencePreserveRejectedV1),
+    Unknown(EvidencePreserveResidualV1),
+    VerificationIncomplete(EvidencePreserveResidualV1),
+    Verified(EvidencePreserveVerifiedV1),
+}
+
+/// Strict checked actor residual state. Actor output never contains a policy
+/// verdict and remains non-authoritative until an independent Witness replays
+/// every fact. The private wrapper prevents unchecked construction; both serde
+/// directions validate the full outcome/publication/close cross-product.
+/// Internal typestate and pending reason types are not part of the public API:
+///
+/// ```compile_fail
+/// use lore_vm::ops::governance::contract::{
+///     EvidencePublicationAttemptV1, PendingEvidencePreserveOutcomeV1,
+///     VerificationIncompleteReasonV1,
+/// };
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvidencePreserveOutcomeV1(EvidencePreserveDispositionV1);
+
+pub(crate) type EvidenceOutcomeBuildResultV1 =
+    std::result::Result<EvidencePreserveOutcomeV1, String>;
+
+impl EvidencePreserveOutcomeV1 {
+    pub fn disposition(&self) -> &EvidencePreserveDispositionV1 {
+        &self.0
+    }
+
+    pub fn verified(&self) -> Option<&EvidencePreserveVerifiedV1> {
+        match &self.0 {
+            EvidencePreserveDispositionV1::Verified(verified) => Some(verified),
+            EvidencePreserveDispositionV1::RejectedBeforePublication(_)
+            | EvidencePreserveDispositionV1::Unknown(_)
+            | EvidencePreserveDispositionV1::VerificationIncomplete(_) => None,
+        }
+    }
+
+    pub fn rejected(&self) -> Option<&EvidencePreserveRejectedV1> {
+        match &self.0 {
+            EvidencePreserveDispositionV1::RejectedBeforePublication(rejected) => Some(rejected),
+            EvidencePreserveDispositionV1::Unknown(_)
+            | EvidencePreserveDispositionV1::VerificationIncomplete(_)
+            | EvidencePreserveDispositionV1::Verified(_) => None,
+        }
+    }
+
+    pub fn residual(&self) -> Option<&EvidencePreserveResidualV1> {
+        match &self.0 {
+            EvidencePreserveDispositionV1::Unknown(residual)
+            | EvidencePreserveDispositionV1::VerificationIncomplete(residual) => Some(residual),
+            EvidencePreserveDispositionV1::RejectedBeforePublication(_)
+            | EvidencePreserveDispositionV1::Verified(_) => None,
+        }
+    }
+
+    fn checked(disposition: EvidencePreserveDispositionV1) -> std::result::Result<Self, String> {
+        validate_evidence_preserve_disposition(&disposition)?;
+        Ok(Self(disposition))
+    }
+}
+
+impl Serialize for EvidencePreserveOutcomeV1 {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        validate_evidence_preserve_disposition(&self.0).map_err(serde::ser::Error::custom)?;
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for EvidencePreserveOutcomeV1 {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let disposition = EvidencePreserveDispositionV1::deserialize(deserializer)?;
+        Self::checked(disposition).map_err(serde::de::Error::custom)
+    }
+}
+
+fn canonical_lower_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+fn canonical_evidence_address(value: &str) -> bool {
+    value.len() == 97
+        && value.as_bytes()[64] == b'-'
+        && canonical_lower_hex(&value[..64], 64)
+        && canonical_lower_hex(&value[65..], 32)
+}
+
+fn validate_close(close: &EvidenceCloseStateV1) -> std::result::Result<(), String> {
+    match close {
+        EvidenceCloseStateV1::OpenOutcomeUnknown { code }
+        | EvidenceCloseStateV1::CloseNotDispatched { code }
+        | EvidenceCloseStateV1::CloseOutcomeUnknown { code }
+            if code.is_empty() =>
+        {
+            Err("close diagnostic code is empty".into())
+        }
+        EvidenceCloseStateV1::NotOpened
+        | EvidenceCloseStateV1::OpenOutcomeUnknown { .. }
+        | EvidenceCloseStateV1::Closed
+        | EvidenceCloseStateV1::CloseNotDispatched { .. }
+        | EvidenceCloseStateV1::CloseOutcomeUnknown { .. } => Ok(()),
+    }
+}
+
+fn validate_common(
+    version: &str,
+    attempt_id: &str,
+    source: &str,
+    base: &str,
+    snapshot_sha256: Option<&str>,
+) -> std::result::Result<(), String> {
+    if version != "v1"
+        || !canonical_lower_hex(attempt_id, 64)
+        || source.is_empty()
+        || base.is_empty()
+        || snapshot_sha256.is_some_and(|hash| !canonical_lower_hex(hash, 64))
+    {
+        return Err("invalid evidence outcome common fields".into());
+    }
+    Ok(())
+}
+
+fn validate_candidates(
+    candidates: &[String],
+    facts: &PublicationFacts<'_>,
+) -> std::result::Result<(), String> {
+    if facts.rank > 0 {
+        let Some(address) = facts.address else {
+            return Err("published state lacks an evidence address".into());
+        };
+        if candidates != [address] {
+            return Err("published address does not match the sole put candidate".into());
+        }
+    }
+    Ok(())
+}
+
+fn validate_evidence_preserve_disposition(
+    disposition: &EvidencePreserveDispositionV1,
+) -> std::result::Result<(), String> {
+    match disposition {
+        EvidencePreserveDispositionV1::RejectedBeforePublication(outcome) => {
+            validate_common(
+                &outcome.version,
+                &outcome.attempt_id,
+                &outcome.source_staged_revision,
+                &outcome.target_base_revision,
+                outcome.snapshot_sha256.as_deref(),
+            )?;
+            validate_close(&outcome.close)?;
+            if outcome.snapshot_sha256.is_some()
+                || !outcome.observed_candidate_addresses.is_empty()
+                || !matches!(outcome.close, EvidenceCloseStateV1::NotOpened)
+                || outcome.stopped_at.code.is_empty()
+            {
+                return Err("rejection claimed state beyond pre-dispatch facts".into());
+            }
+        }
+        EvidencePreserveDispositionV1::VerificationIncomplete(outcome) => {
+            validate_residual(outcome, false)?;
+        }
+        EvidencePreserveDispositionV1::Unknown(outcome) => {
+            validate_residual(outcome, true)?;
+        }
+        EvidencePreserveDispositionV1::Verified(outcome) => {
+            validate_common(
+                &outcome.version,
+                &outcome.attempt_id,
+                &outcome.source_staged_revision,
+                &outcome.target_base_revision,
+                outcome.snapshot_sha256.as_deref(),
+            )?;
+            validate_close(&outcome.close)?;
+            let facts = outcome
+                .last_confirmed_publication
+                .validate(&outcome.source_staged_revision)?;
+            validate_candidates(&outcome.observed_candidate_addresses, &facts)?;
+            if outcome.snapshot_sha256.is_none()
+                || facts.rank != 6
+                || facts.address != Some(outcome.evidence_address.as_str())
+                || facts.pointer != Some(&outcome.pointer)
+                || facts.result_revision != Some(outcome.result_staged_revision.as_str())
+                || !matches!(outcome.close, EvidenceCloseStateV1::Closed)
+                || outcome.pointer.version != "v1"
+                || outcome.pointer.address != outcome.evidence_address
+            {
+                return Err("verified outcome did not prove the full closed chain".into());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_residual(
+    outcome: &EvidencePreserveResidualV1,
+    top_level_unknown: bool,
+) -> std::result::Result<(), String> {
+    validate_common(
+        &outcome.version,
+        &outcome.attempt_id,
+        &outcome.source_staged_revision,
+        &outcome.target_base_revision,
+        outcome.snapshot_sha256.as_deref(),
+    )?;
+    validate_close(&outcome.close)?;
+    if outcome.stopped_at.code.is_empty() {
+        return Err("stop diagnostic code is empty".into());
+    }
+    let facts = outcome
+        .last_confirmed_publication
+        .validate(&outcome.source_staged_revision)?;
+    validate_candidates(&outcome.observed_candidate_addresses, &facts)?;
+    if facts.rank != outcome.stopped_at.stage.publication_rank() {
+        return Err("stop and publication state disagree".into());
+    }
+
+    if top_level_unknown {
+        if outcome.snapshot_sha256.is_none() {
+            return Err("post-dispatch unknown lacks snapshot hash".into());
+        }
+        if outcome.stopped_at.stage.is_unknown_effect() {
+            match outcome.stopped_at.stage {
+                EvidencePreserveStopCodeV1::StorageOpenOutcome => {
+                    if !matches!(
+                        outcome.close,
+                        EvidenceCloseStateV1::OpenOutcomeUnknown { .. }
+                    ) {
+                        return Err("open-outcome unknown has an impossible close state".into());
+                    }
+                }
+                EvidencePreserveStopCodeV1::StorageCloseOutcome => {
+                    if !matches!(
+                        outcome.close,
+                        EvidenceCloseStateV1::CloseOutcomeUnknown { .. }
+                    ) {
+                        return Err("close-outcome unknown lacks close uncertainty".into());
+                    }
+                }
+                EvidencePreserveStopCodeV1::StoragePutOutcome
+                | EvidencePreserveStopCodeV1::StoragePutResponseMalformed
+                | EvidencePreserveStopCodeV1::PointerAttachOutcome => {
+                    if matches!(
+                        outcome.close,
+                        EvidenceCloseStateV1::NotOpened
+                            | EvidenceCloseStateV1::OpenOutcomeUnknown { .. }
+                    ) {
+                        return Err("usable-handle unknown has an impossible close state".into());
+                    }
+                }
+                EvidencePreserveStopCodeV1::InitialEvaluation
+                | EvidencePreserveStopCodeV1::SourceMetadata
+                | EvidencePreserveStopCodeV1::SnapshotSerialization
+                | EvidencePreserveStopCodeV1::StorageOpenNotDispatched
+                | EvidencePreserveStopCodeV1::ActorRoleBeforePut
+                | EvidencePreserveStopCodeV1::StoragePutNotDispatched
+                | EvidencePreserveStopCodeV1::PreattachEvaluation
+                | EvidencePreserveStopCodeV1::ActorRoleBeforeAttach
+                | EvidencePreserveStopCodeV1::PointerSerialization
+                | EvidencePreserveStopCodeV1::PointerAttachNotDispatched
+                | EvidencePreserveStopCodeV1::PostattachGetUnavailable
+                | EvidencePreserveStopCodeV1::PostattachGetMalformed
+                | EvidencePreserveStopCodeV1::PostattachBytesMismatch
+                | EvidencePreserveStopCodeV1::ResultStatusUnavailable
+                | EvidencePreserveStopCodeV1::ResultStatusInvalid
+                | EvidencePreserveStopCodeV1::ResultMetadataUnavailable
+                | EvidencePreserveStopCodeV1::PointerDeltaInvalid
+                | EvidencePreserveStopCodeV1::PointerSchemaInvalid
+                | EvidencePreserveStopCodeV1::PostattachEvaluation
+                | EvidencePreserveStopCodeV1::PostattachDrift
+                | EvidencePreserveStopCodeV1::StorageCloseNotDispatched => {
+                    return Err("unknown outcome used a deterministic stop".into())
+                }
+            }
+        } else if !matches!(
+            outcome.close,
+            EvidenceCloseStateV1::CloseOutcomeUnknown { .. }
+        ) || matches!(
+            outcome.stopped_at.stage,
+            EvidencePreserveStopCodeV1::InitialEvaluation
+                | EvidencePreserveStopCodeV1::SourceMetadata
+                | EvidencePreserveStopCodeV1::SnapshotSerialization
+                | EvidencePreserveStopCodeV1::StorageOpenNotDispatched
+        ) {
+            return Err(
+                "verification stop can become unknown only through close uncertainty".into(),
+            );
+        }
+    } else {
+        if outcome.stopped_at.stage.is_unknown_effect()
+            || outcome.snapshot_sha256.is_some()
+                == outcome.stopped_at.stage.occurs_before_snapshot_hash()
+        {
+            return Err("verification-incomplete stop has inconsistent diagnostics".into());
+        }
+        let before_open = matches!(
+            outcome.stopped_at.stage,
+            EvidencePreserveStopCodeV1::InitialEvaluation
+                | EvidencePreserveStopCodeV1::SourceMetadata
+                | EvidencePreserveStopCodeV1::SnapshotSerialization
+                | EvidencePreserveStopCodeV1::StorageOpenNotDispatched
+        );
+        if before_open != matches!(outcome.close, EvidenceCloseStateV1::NotOpened)
+            || matches!(
+                outcome.close,
+                EvidenceCloseStateV1::OpenOutcomeUnknown { .. }
+                    | EvidenceCloseStateV1::CloseOutcomeUnknown { .. }
+            )
+            || (outcome.stopped_at.stage == EvidencePreserveStopCodeV1::StorageCloseNotDispatched
+                && !matches!(
+                    outcome.close,
+                    EvidenceCloseStateV1::CloseNotDispatched { .. }
+                ))
+        {
+            return Err("verification-incomplete close state is impossible".into());
+        }
+    }
+
+    if facts.rank == 0
+        && !matches!(
+            outcome.stopped_at.stage,
+            EvidencePreserveStopCodeV1::StoragePutOutcome
+                | EvidencePreserveStopCodeV1::StoragePutResponseMalformed
+        )
+        && !outcome.observed_candidate_addresses.is_empty()
+    {
+        return Err("candidate addresses appeared before a put observation".into());
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct EvidenceAttemptCommonV1 {
+    attempt_id: String,
+    source_staged_revision: String,
+    target_base_revision: String,
+    snapshot_sha256: Option<String>,
+    observed_candidate_addresses: Vec<String>,
+}
+
+impl EvidenceAttemptCommonV1 {
+    fn residual(
+        self,
+        stopped_at: EvidencePreserveStopV1,
+        last_confirmed_publication: EvidencePublicationStateV1,
+        close: EvidenceCloseStateV1,
+    ) -> EvidencePreserveResidualV1 {
+        EvidencePreserveResidualV1 {
+            version: "v1".into(),
+            attempt_id: self.attempt_id,
+            source_staged_revision: self.source_staged_revision,
+            target_base_revision: self.target_base_revision,
+            snapshot_sha256: self.snapshot_sha256,
+            observed_candidate_addresses: self.observed_candidate_addresses,
+            stopped_at,
+            last_confirmed_publication,
+            close,
+        }
+    }
+}
+
+/// Sole authority which can construct `RejectedBeforePublication`. Consuming
+/// `enter_effect_boundary` destroys this authority, so no post-dispatch path
+/// has a rejection constructor to select accidentally.
+pub(crate) struct PredispatchEvidenceAttemptV1 {
+    common: EvidenceAttemptCommonV1,
+}
+
+enum PredispatchIncompleteReasonV1 {
+    InitialEvaluation,
+    SourceMetadata,
+    SnapshotSerialization,
+}
+
+impl PredispatchIncompleteReasonV1 {
+    fn stop(&self) -> EvidencePreserveStopCodeV1 {
+        match self {
+            Self::InitialEvaluation => EvidencePreserveStopCodeV1::InitialEvaluation,
+            Self::SourceMetadata => EvidencePreserveStopCodeV1::SourceMetadata,
+            Self::SnapshotSerialization => EvidencePreserveStopCodeV1::SnapshotSerialization,
+        }
+    }
+
+    fn fallback_code(&self) -> &'static str {
+        match self {
+            Self::InitialEvaluation => "initial_evaluation_without_code",
+            Self::SourceMetadata => "source_metadata_without_code",
+            Self::SnapshotSerialization => "snapshot_serialization_without_code",
+        }
+    }
+}
+
+impl PredispatchEvidenceAttemptV1 {
+    pub(crate) fn new(attempt_id: String, request: ValidatedEvidencePreserveRequestV1<'_>) -> Self {
+        Self {
+            common: EvidenceAttemptCommonV1 {
+                attempt_id,
+                source_staged_revision: request.request.expected_staged_revision.clone(),
+                target_base_revision: request.request.target_base_revision.clone(),
+                snapshot_sha256: None,
+                observed_candidate_addresses: Vec::new(),
+            },
+        }
+    }
+
+    fn reject(
+        self,
+        reason: EvidenceRejectionCodeV1,
+        code: impl Into<String>,
+    ) -> EvidenceOutcomeBuildResultV1 {
+        let fallback = match reason {
+            EvidenceRejectionCodeV1::ActorRoleRequired => "actor_role_required_without_code",
+            EvidenceRejectionCodeV1::InitialGovernanceClosed => {
+                "initial_governance_closed_without_code"
+            }
+            EvidenceRejectionCodeV1::PointerAlreadyPresent => {
+                "pointer_already_present_without_code"
+            }
+        };
+        checked_outcome(EvidencePreserveDispositionV1::RejectedBeforePublication(
+            EvidencePreserveRejectedV1 {
+                version: "v1".into(),
+                attempt_id: self.common.attempt_id,
+                source_staged_revision: self.common.source_staged_revision,
+                target_base_revision: self.common.target_base_revision,
+                snapshot_sha256: None,
+                observed_candidate_addresses: Vec::new(),
+                stopped_at: EvidenceRejectionStopV1 {
+                    reason,
+                    code: nonempty_diagnostic(code, fallback),
+                },
+                close: EvidenceCloseStateV1::NotOpened,
+            },
+        ))
+    }
+
+    fn verification_incomplete(
+        self,
+        reason: PredispatchIncompleteReasonV1,
+        code: impl Into<String>,
+    ) -> EvidenceOutcomeBuildResultV1 {
+        let code = nonempty_diagnostic(code, reason.fallback_code());
+        let residual = self.common.residual(
+            EvidencePreserveStopV1 {
+                stage: reason.stop(),
+                code,
+            },
+            EvidencePublicationStateV1::None,
+            EvidenceCloseStateV1::NotOpened,
+        );
+        checked_outcome(EvidencePreserveDispositionV1::VerificationIncomplete(
+            residual,
+        ))
+    }
+
+    pub(crate) fn actor_role_rejected(
+        self,
+        code: impl Into<String>,
+    ) -> EvidenceOutcomeBuildResultV1 {
+        self.reject(EvidenceRejectionCodeV1::ActorRoleRequired, code)
+    }
+
+    pub(crate) fn initial_governance_rejected(
+        self,
+        code: impl Into<String>,
+    ) -> EvidenceOutcomeBuildResultV1 {
+        self.reject(EvidenceRejectionCodeV1::InitialGovernanceClosed, code)
+    }
+
+    pub(crate) fn pointer_already_present_rejected(
+        self,
+        code: impl Into<String>,
+    ) -> EvidenceOutcomeBuildResultV1 {
+        self.reject(EvidenceRejectionCodeV1::PointerAlreadyPresent, code)
+    }
+
+    pub(crate) fn initial_evaluation_incomplete(
+        self,
+        code: impl Into<String>,
+    ) -> EvidenceOutcomeBuildResultV1 {
+        self.verification_incomplete(PredispatchIncompleteReasonV1::InitialEvaluation, code)
+    }
+
+    pub(crate) fn source_metadata_incomplete(
+        self,
+        code: impl Into<String>,
+    ) -> EvidenceOutcomeBuildResultV1 {
+        self.verification_incomplete(PredispatchIncompleteReasonV1::SourceMetadata, code)
+    }
+
+    pub(crate) fn snapshot_serialization_incomplete(
+        self,
+        code: impl Into<String>,
+    ) -> EvidenceOutcomeBuildResultV1 {
+        self.verification_incomplete(PredispatchIncompleteReasonV1::SnapshotSerialization, code)
+    }
+
+    pub(crate) fn with_snapshot_sha256(mut self, snapshot_sha256: String) -> Self {
+        self.common.snapshot_sha256 = Some(snapshot_sha256);
+        self
+    }
+
+    pub(crate) fn enter_effect_boundary(self) -> EvidencePublicationAttemptV1<NoPublicationV1> {
+        EvidencePublicationAttemptV1 {
+            common: self.common,
+            stage: NoPublicationV1,
+        }
+    }
+}
+
+pub(crate) trait PublicationStageV1 {
+    fn wire_state(&self) -> EvidencePublicationStateV1;
+}
+
+pub(crate) struct NoPublicationV1;
+
+impl PublicationStageV1 for NoPublicationV1 {
+    fn wire_state(&self) -> EvidencePublicationStateV1 {
+        EvidencePublicationStateV1::None
+    }
+}
+
+pub(crate) struct PutObservedV1;
+
+impl PublicationStageV1 for PutObservedV1 {
+    fn wire_state(&self) -> EvidencePublicationStateV1 {
+        EvidencePublicationStateV1::None
+    }
+}
+
+pub(crate) struct BlobPublishedV1 {
+    evidence_address: String,
+}
+
+impl PublicationStageV1 for BlobPublishedV1 {
+    fn wire_state(&self) -> EvidencePublicationStateV1 {
+        EvidencePublicationStateV1::BlobPublished {
+            evidence_address: self.evidence_address.clone(),
+        }
+    }
+}
+
+pub(crate) struct PointerAttachAcknowledgedV1 {
+    evidence_address: String,
+    pointer: EvidencePointerV1,
+}
+
+impl PublicationStageV1 for PointerAttachAcknowledgedV1 {
+    fn wire_state(&self) -> EvidencePublicationStateV1 {
+        EvidencePublicationStateV1::PointerAttachAcknowledged {
+            evidence_address: self.evidence_address.clone(),
+            pointer: self.pointer.clone(),
+        }
+    }
+}
+
+pub(crate) struct BlobReadbackVerifiedV1 {
+    evidence_address: String,
+    pointer: EvidencePointerV1,
+}
+
+impl PublicationStageV1 for BlobReadbackVerifiedV1 {
+    fn wire_state(&self) -> EvidencePublicationStateV1 {
+        EvidencePublicationStateV1::BlobReadbackVerified {
+            evidence_address: self.evidence_address.clone(),
+            pointer: self.pointer.clone(),
+        }
+    }
+}
+
+pub(crate) struct ResultSubjectObservedV1 {
+    evidence_address: String,
+    pointer: EvidencePointerV1,
+    result_staged_revision: String,
+}
+
+impl PublicationStageV1 for ResultSubjectObservedV1 {
+    fn wire_state(&self) -> EvidencePublicationStateV1 {
+        EvidencePublicationStateV1::ResultSubjectObserved {
+            evidence_address: self.evidence_address.clone(),
+            pointer: self.pointer.clone(),
+            result_staged_revision: self.result_staged_revision.clone(),
+        }
+    }
+}
+
+pub(crate) struct PointerDeltaObservedV1 {
+    evidence_address: String,
+    pointer: EvidencePointerV1,
+    result_staged_revision: String,
+}
+
+impl PublicationStageV1 for PointerDeltaObservedV1 {
+    fn wire_state(&self) -> EvidencePublicationStateV1 {
+        EvidencePublicationStateV1::PointerDeltaObserved {
+            evidence_address: self.evidence_address.clone(),
+            pointer: self.pointer.clone(),
+            result_staged_revision: self.result_staged_revision.clone(),
+        }
+    }
+}
+
+pub(crate) struct PostattachEquivalentV1 {
+    evidence_address: String,
+    pointer: EvidencePointerV1,
+    result_staged_revision: String,
+}
+
+impl PublicationStageV1 for PostattachEquivalentV1 {
+    fn wire_state(&self) -> EvidencePublicationStateV1 {
+        EvidencePublicationStateV1::PostattachEquivalent {
+            evidence_address: self.evidence_address.clone(),
+            pointer: self.pointer.clone(),
+            result_staged_revision: self.result_staged_revision.clone(),
+        }
+    }
+}
+
+/// Forward-only publication state. There is intentionally no generic state
+/// constructor and no backward/skip transition; adding a future stage requires
+/// an explicit sealed mapping and transition or compilation fails.
+pub(crate) struct EvidencePublicationAttemptV1<S: PublicationStageV1> {
+    common: EvidenceAttemptCommonV1,
+    stage: S,
+}
+
+impl EvidencePublicationAttemptV1<NoPublicationV1> {
+    pub(crate) fn storage_open_not_dispatched(
+        self,
+        code: impl Into<String>,
+    ) -> EvidenceOutcomeBuildResultV1 {
+        let code = nonempty_diagnostic(code, "storage_open_not_dispatched_without_code");
+        let residual = self.common.residual(
+            EvidencePreserveStopV1 {
+                stage: EvidencePreserveStopCodeV1::StorageOpenNotDispatched,
+                code,
+            },
+            EvidencePublicationStateV1::None,
+            EvidenceCloseStateV1::NotOpened,
+        );
+        checked_outcome(EvidencePreserveDispositionV1::VerificationIncomplete(
+            residual,
+        ))
+    }
+
+    pub(crate) fn storage_open_outcome_unknown(
+        self,
+        code: impl Into<String>,
+    ) -> EvidenceOutcomeBuildResultV1 {
+        let code = nonempty_diagnostic(code, "storage_open_outcome_unknown_without_code");
+        let residual = self.common.residual(
+            EvidencePreserveStopV1 {
+                stage: EvidencePreserveStopCodeV1::StorageOpenOutcome,
+                code: code.clone(),
+            },
+            EvidencePublicationStateV1::None,
+            EvidenceCloseStateV1::OpenOutcomeUnknown { code },
+        );
+        checked_outcome(EvidencePreserveDispositionV1::Unknown(residual))
+    }
+
+    pub(crate) fn put_observed(
+        mut self,
+        observed_candidate_addresses: Vec<String>,
+    ) -> EvidencePublicationAttemptV1<PutObservedV1> {
+        self.common.observed_candidate_addresses = observed_candidate_addresses;
+        EvidencePublicationAttemptV1 {
+            common: self.common,
+            stage: PutObservedV1,
+        }
+    }
+
+    pub(crate) fn actor_role_before_put(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::no_publication_incomplete(
+            PendingVerificationIncompleteV1::new(
+                self,
+                NoPublicationIncompleteReasonV1::ActorRoleBeforePut,
+                code,
+            ),
+        )
+    }
+
+    pub(crate) fn storage_put_not_dispatched(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::no_publication_incomplete(
+            PendingVerificationIncompleteV1::new(
+                self,
+                NoPublicationIncompleteReasonV1::StoragePutNotDispatched,
+                code,
+            ),
+        )
+    }
+}
+
+impl EvidencePublicationAttemptV1<PutObservedV1> {
+    pub(crate) fn blob_published(
+        self,
+        evidence_address: String,
+    ) -> EvidencePublicationAttemptV1<BlobPublishedV1> {
+        EvidencePublicationAttemptV1 {
+            common: self.common,
+            stage: BlobPublishedV1 { evidence_address },
+        }
+    }
+
+    pub(crate) fn storage_put_outcome_unknown(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::put_observed_unknown(PendingUnknownV1::new(
+            self,
+            PutObservedUnknownReasonV1::StoragePutOutcome,
+            code,
+        ))
+    }
+
+    pub(crate) fn storage_put_response_malformed(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::put_observed_unknown(PendingUnknownV1::new(
+            self,
+            PutObservedUnknownReasonV1::StoragePutResponseMalformed,
+            code,
+        ))
+    }
+}
+
+impl EvidencePublicationAttemptV1<BlobPublishedV1> {
+    pub(crate) fn pointer_attach_acknowledged(
+        self,
+        pointer: EvidencePointerV1,
+    ) -> EvidencePublicationAttemptV1<PointerAttachAcknowledgedV1> {
+        EvidencePublicationAttemptV1 {
+            common: self.common,
+            stage: PointerAttachAcknowledgedV1 {
+                evidence_address: self.stage.evidence_address,
+                pointer,
+            },
+        }
+    }
+
+    pub(crate) fn preattach_evaluation_incomplete(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::blob_published_incomplete(
+            PendingVerificationIncompleteV1::new(
+                self,
+                BlobPublishedIncompleteReasonV1::PreattachEvaluation,
+                code,
+            ),
+        )
+    }
+
+    pub(crate) fn actor_role_before_attach(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::blob_published_incomplete(
+            PendingVerificationIncompleteV1::new(
+                self,
+                BlobPublishedIncompleteReasonV1::ActorRoleBeforeAttach,
+                code,
+            ),
+        )
+    }
+
+    pub(crate) fn pointer_serialization_incomplete(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::blob_published_incomplete(
+            PendingVerificationIncompleteV1::new(
+                self,
+                BlobPublishedIncompleteReasonV1::PointerSerialization,
+                code,
+            ),
+        )
+    }
+
+    pub(crate) fn pointer_attach_not_dispatched(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::blob_published_incomplete(
+            PendingVerificationIncompleteV1::new(
+                self,
+                BlobPublishedIncompleteReasonV1::PointerAttachNotDispatched,
+                code,
+            ),
+        )
+    }
+
+    pub(crate) fn pointer_attach_outcome_unknown(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::blob_published_unknown(PendingUnknownV1::new(
+            self,
+            BlobPublishedUnknownReasonV1,
+            code,
+        ))
+    }
+}
+
+impl EvidencePublicationAttemptV1<PointerAttachAcknowledgedV1> {
+    pub(crate) fn blob_readback_verified(
+        self,
+    ) -> EvidencePublicationAttemptV1<BlobReadbackVerifiedV1> {
+        EvidencePublicationAttemptV1 {
+            common: self.common,
+            stage: BlobReadbackVerifiedV1 {
+                evidence_address: self.stage.evidence_address,
+                pointer: self.stage.pointer,
+            },
+        }
+    }
+
+    pub(crate) fn postattach_get_unavailable(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::pointer_attach_acknowledged_incomplete(
+            PendingVerificationIncompleteV1::new(
+                self,
+                PointerAttachAcknowledgedIncompleteReasonV1::GetUnavailable,
+                code,
+            ),
+        )
+    }
+
+    pub(crate) fn postattach_get_malformed(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::pointer_attach_acknowledged_incomplete(
+            PendingVerificationIncompleteV1::new(
+                self,
+                PointerAttachAcknowledgedIncompleteReasonV1::GetMalformed,
+                code,
+            ),
+        )
+    }
+
+    pub(crate) fn postattach_bytes_mismatch(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::pointer_attach_acknowledged_incomplete(
+            PendingVerificationIncompleteV1::new(
+                self,
+                PointerAttachAcknowledgedIncompleteReasonV1::BytesMismatch,
+                code,
+            ),
+        )
+    }
+}
+
+impl EvidencePublicationAttemptV1<BlobReadbackVerifiedV1> {
+    pub(crate) fn result_subject_observed(
+        self,
+        result_staged_revision: String,
+    ) -> EvidencePublicationAttemptV1<ResultSubjectObservedV1> {
+        EvidencePublicationAttemptV1 {
+            common: self.common,
+            stage: ResultSubjectObservedV1 {
+                evidence_address: self.stage.evidence_address,
+                pointer: self.stage.pointer,
+                result_staged_revision,
+            },
+        }
+    }
+
+    pub(crate) fn result_status_unavailable(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::blob_readback_verified_incomplete(
+            PendingVerificationIncompleteV1::new(
+                self,
+                BlobReadbackVerifiedIncompleteReasonV1::ResultStatusUnavailable,
+                code,
+            ),
+        )
+    }
+
+    pub(crate) fn result_status_invalid(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::blob_readback_verified_incomplete(
+            PendingVerificationIncompleteV1::new(
+                self,
+                BlobReadbackVerifiedIncompleteReasonV1::ResultStatusInvalid,
+                code,
+            ),
+        )
+    }
+}
+
+impl EvidencePublicationAttemptV1<ResultSubjectObservedV1> {
+    pub(crate) fn pointer_delta_observed(
+        self,
+    ) -> EvidencePublicationAttemptV1<PointerDeltaObservedV1> {
+        EvidencePublicationAttemptV1 {
+            common: self.common,
+            stage: PointerDeltaObservedV1 {
+                evidence_address: self.stage.evidence_address,
+                pointer: self.stage.pointer,
+                result_staged_revision: self.stage.result_staged_revision,
+            },
+        }
+    }
+
+    pub(crate) fn result_metadata_unavailable(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::result_subject_observed_incomplete(
+            PendingVerificationIncompleteV1::new(
+                self,
+                ResultSubjectObservedIncompleteReasonV1::ResultMetadataUnavailable,
+                code,
+            ),
+        )
+    }
+
+    pub(crate) fn pointer_delta_invalid(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::result_subject_observed_incomplete(
+            PendingVerificationIncompleteV1::new(
+                self,
+                ResultSubjectObservedIncompleteReasonV1::PointerDeltaInvalid,
+                code,
+            ),
+        )
+    }
+
+    pub(crate) fn pointer_schema_invalid(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::result_subject_observed_incomplete(
+            PendingVerificationIncompleteV1::new(
+                self,
+                ResultSubjectObservedIncompleteReasonV1::PointerSchemaInvalid,
+                code,
+            ),
+        )
+    }
+}
+
+impl EvidencePublicationAttemptV1<PointerDeltaObservedV1> {
+    pub(crate) fn postattach_equivalent(
+        self,
+    ) -> EvidencePublicationAttemptV1<PostattachEquivalentV1> {
+        EvidencePublicationAttemptV1 {
+            common: self.common,
+            stage: PostattachEquivalentV1 {
+                evidence_address: self.stage.evidence_address,
+                pointer: self.stage.pointer,
+                result_staged_revision: self.stage.result_staged_revision,
+            },
+        }
+    }
+
+    pub(crate) fn postattach_evaluation_incomplete(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::pointer_delta_observed_incomplete(
+            PendingVerificationIncompleteV1::new(
+                self,
+                PointerDeltaObservedIncompleteReasonV1::PostattachEvaluation,
+                code,
+            ),
+        )
+    }
+
+    pub(crate) fn postattach_drift(
+        self,
+        code: impl Into<String>,
+    ) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::pointer_delta_observed_incomplete(
+            PendingVerificationIncompleteV1::new(
+                self,
+                PointerDeltaObservedIncompleteReasonV1::PostattachDrift,
+                code,
+            ),
+        )
+    }
+}
+
+impl EvidencePublicationAttemptV1<PostattachEquivalentV1> {
+    pub(crate) fn ready_to_close(self) -> PendingEvidencePreserveOutcomeV1 {
+        PendingEvidencePreserveOutcomeV1::ready(ReadyToCloseV1 { attempt: self })
+    }
+}
+
+pub(crate) enum EvidenceCloseEffectV1 {
+    Closed,
+    NotDispatched { code: String },
+    OutcomeUnknown { code: String },
+}
+
+fn nonempty_diagnostic(code: impl Into<String>, fallback: &'static str) -> String {
+    let code = code.into();
+    if code.trim().is_empty() {
+        fallback.into()
+    } else {
+        code
+    }
+}
+
+trait VerificationIncompleteReasonV1<S: PublicationStageV1> {
+    fn stop(&self) -> EvidencePreserveStopCodeV1;
+    fn fallback_code(&self) -> &'static str;
+}
+
+trait UnknownReasonV1<S: PublicationStageV1> {
+    fn stop(&self) -> EvidencePreserveStopCodeV1;
+    fn fallback_code(&self) -> &'static str;
+}
+
+enum NoPublicationIncompleteReasonV1 {
+    ActorRoleBeforePut,
+    StoragePutNotDispatched,
+}
+
+impl VerificationIncompleteReasonV1<NoPublicationV1> for NoPublicationIncompleteReasonV1 {
+    fn stop(&self) -> EvidencePreserveStopCodeV1 {
+        match self {
+            Self::ActorRoleBeforePut => EvidencePreserveStopCodeV1::ActorRoleBeforePut,
+            Self::StoragePutNotDispatched => EvidencePreserveStopCodeV1::StoragePutNotDispatched,
+        }
+    }
+
+    fn fallback_code(&self) -> &'static str {
+        match self {
+            Self::ActorRoleBeforePut => "actor_role_before_put_without_code",
+            Self::StoragePutNotDispatched => "storage_put_not_dispatched_without_code",
+        }
+    }
+}
+
+enum PutObservedUnknownReasonV1 {
+    StoragePutOutcome,
+    StoragePutResponseMalformed,
+}
+
+impl UnknownReasonV1<PutObservedV1> for PutObservedUnknownReasonV1 {
+    fn stop(&self) -> EvidencePreserveStopCodeV1 {
+        match self {
+            Self::StoragePutOutcome => EvidencePreserveStopCodeV1::StoragePutOutcome,
+            Self::StoragePutResponseMalformed => {
+                EvidencePreserveStopCodeV1::StoragePutResponseMalformed
+            }
+        }
+    }
+
+    fn fallback_code(&self) -> &'static str {
+        match self {
+            Self::StoragePutOutcome => "storage_put_outcome_unknown_without_code",
+            Self::StoragePutResponseMalformed => "storage_put_response_malformed_without_code",
+        }
+    }
+}
+
+enum BlobPublishedIncompleteReasonV1 {
+    PreattachEvaluation,
+    ActorRoleBeforeAttach,
+    PointerSerialization,
+    PointerAttachNotDispatched,
+}
+
+impl VerificationIncompleteReasonV1<BlobPublishedV1> for BlobPublishedIncompleteReasonV1 {
+    fn stop(&self) -> EvidencePreserveStopCodeV1 {
+        match self {
+            Self::PreattachEvaluation => EvidencePreserveStopCodeV1::PreattachEvaluation,
+            Self::ActorRoleBeforeAttach => EvidencePreserveStopCodeV1::ActorRoleBeforeAttach,
+            Self::PointerSerialization => EvidencePreserveStopCodeV1::PointerSerialization,
+            Self::PointerAttachNotDispatched => {
+                EvidencePreserveStopCodeV1::PointerAttachNotDispatched
+            }
+        }
+    }
+
+    fn fallback_code(&self) -> &'static str {
+        match self {
+            Self::PreattachEvaluation => "preattach_evaluation_without_code",
+            Self::ActorRoleBeforeAttach => "actor_role_before_attach_without_code",
+            Self::PointerSerialization => "pointer_serialization_without_code",
+            Self::PointerAttachNotDispatched => "pointer_attach_not_dispatched_without_code",
+        }
+    }
+}
+
+struct BlobPublishedUnknownReasonV1;
+
+impl UnknownReasonV1<BlobPublishedV1> for BlobPublishedUnknownReasonV1 {
+    fn stop(&self) -> EvidencePreserveStopCodeV1 {
+        EvidencePreserveStopCodeV1::PointerAttachOutcome
+    }
+
+    fn fallback_code(&self) -> &'static str {
+        "pointer_attach_outcome_unknown_without_code"
+    }
+}
+
+enum PointerAttachAcknowledgedIncompleteReasonV1 {
+    GetUnavailable,
+    GetMalformed,
+    BytesMismatch,
+}
+
+impl VerificationIncompleteReasonV1<PointerAttachAcknowledgedV1>
+    for PointerAttachAcknowledgedIncompleteReasonV1
+{
+    fn stop(&self) -> EvidencePreserveStopCodeV1 {
+        match self {
+            Self::GetUnavailable => EvidencePreserveStopCodeV1::PostattachGetUnavailable,
+            Self::GetMalformed => EvidencePreserveStopCodeV1::PostattachGetMalformed,
+            Self::BytesMismatch => EvidencePreserveStopCodeV1::PostattachBytesMismatch,
+        }
+    }
+
+    fn fallback_code(&self) -> &'static str {
+        match self {
+            Self::GetUnavailable => "postattach_get_unavailable_without_code",
+            Self::GetMalformed => "postattach_get_malformed_without_code",
+            Self::BytesMismatch => "postattach_bytes_mismatch_without_code",
+        }
+    }
+}
+
+enum BlobReadbackVerifiedIncompleteReasonV1 {
+    ResultStatusUnavailable,
+    ResultStatusInvalid,
+}
+
+impl VerificationIncompleteReasonV1<BlobReadbackVerifiedV1>
+    for BlobReadbackVerifiedIncompleteReasonV1
+{
+    fn stop(&self) -> EvidencePreserveStopCodeV1 {
+        match self {
+            Self::ResultStatusUnavailable => EvidencePreserveStopCodeV1::ResultStatusUnavailable,
+            Self::ResultStatusInvalid => EvidencePreserveStopCodeV1::ResultStatusInvalid,
+        }
+    }
+
+    fn fallback_code(&self) -> &'static str {
+        match self {
+            Self::ResultStatusUnavailable => "result_status_unavailable_without_code",
+            Self::ResultStatusInvalid => "result_status_invalid_without_code",
+        }
+    }
+}
+
+enum ResultSubjectObservedIncompleteReasonV1 {
+    ResultMetadataUnavailable,
+    PointerDeltaInvalid,
+    PointerSchemaInvalid,
+}
+
+impl VerificationIncompleteReasonV1<ResultSubjectObservedV1>
+    for ResultSubjectObservedIncompleteReasonV1
+{
+    fn stop(&self) -> EvidencePreserveStopCodeV1 {
+        match self {
+            Self::ResultMetadataUnavailable => {
+                EvidencePreserveStopCodeV1::ResultMetadataUnavailable
+            }
+            Self::PointerDeltaInvalid => EvidencePreserveStopCodeV1::PointerDeltaInvalid,
+            Self::PointerSchemaInvalid => EvidencePreserveStopCodeV1::PointerSchemaInvalid,
+        }
+    }
+
+    fn fallback_code(&self) -> &'static str {
+        match self {
+            Self::ResultMetadataUnavailable => "result_metadata_unavailable_without_code",
+            Self::PointerDeltaInvalid => "pointer_delta_invalid_without_code",
+            Self::PointerSchemaInvalid => "pointer_schema_invalid_without_code",
+        }
+    }
+}
+
+enum PointerDeltaObservedIncompleteReasonV1 {
+    PostattachEvaluation,
+    PostattachDrift,
+}
+
+impl VerificationIncompleteReasonV1<PointerDeltaObservedV1>
+    for PointerDeltaObservedIncompleteReasonV1
+{
+    fn stop(&self) -> EvidencePreserveStopCodeV1 {
+        match self {
+            Self::PostattachEvaluation => EvidencePreserveStopCodeV1::PostattachEvaluation,
+            Self::PostattachDrift => EvidencePreserveStopCodeV1::PostattachDrift,
+        }
+    }
+
+    fn fallback_code(&self) -> &'static str {
+        match self {
+            Self::PostattachEvaluation => "postattach_evaluation_without_code",
+            Self::PostattachDrift => "postattach_drift_without_code",
+        }
+    }
+}
+
+struct PendingVerificationIncompleteV1<S, R>
+where
+    S: PublicationStageV1,
+    R: VerificationIncompleteReasonV1<S>,
+{
+    attempt: EvidencePublicationAttemptV1<S>,
+    reason: R,
+    code: String,
+}
+
+impl<S, R> PendingVerificationIncompleteV1<S, R>
+where
+    S: PublicationStageV1,
+    R: VerificationIncompleteReasonV1<S>,
+{
+    fn new(attempt: EvidencePublicationAttemptV1<S>, reason: R, code: impl Into<String>) -> Self {
+        let code = nonempty_diagnostic(code, reason.fallback_code());
+        Self {
+            attempt,
+            reason,
+            code,
+        }
+    }
+
+    fn finalize(self, close_effect: EvidenceCloseEffectV1) -> EvidenceOutcomeBuildResultV1 {
+        let stop = EvidencePreserveStopV1 {
+            stage: self.reason.stop(),
+            code: self.code,
+        };
+        let publication = self.attempt.stage.wire_state();
+        let common = self.attempt.common;
+        let (disposition_unknown, close) = match close_effect.normalized() {
+            EvidenceCloseEffectV1::Closed => (false, EvidenceCloseStateV1::Closed),
+            EvidenceCloseEffectV1::NotDispatched { code } => {
+                (false, EvidenceCloseStateV1::CloseNotDispatched { code })
+            }
+            EvidenceCloseEffectV1::OutcomeUnknown { code } => {
+                (true, EvidenceCloseStateV1::CloseOutcomeUnknown { code })
+            }
+        };
+        let residual = common.residual(stop, publication, close);
+        if disposition_unknown {
+            checked_outcome(EvidencePreserveDispositionV1::Unknown(residual))
+        } else {
+            checked_outcome(EvidencePreserveDispositionV1::VerificationIncomplete(
+                residual,
+            ))
+        }
+    }
+}
+
+struct PendingUnknownV1<S, R>
+where
+    S: PublicationStageV1,
+    R: UnknownReasonV1<S>,
+{
+    attempt: EvidencePublicationAttemptV1<S>,
+    reason: R,
+    code: String,
+}
+
+impl<S, R> PendingUnknownV1<S, R>
+where
+    S: PublicationStageV1,
+    R: UnknownReasonV1<S>,
+{
+    fn new(attempt: EvidencePublicationAttemptV1<S>, reason: R, code: impl Into<String>) -> Self {
+        let code = nonempty_diagnostic(code, reason.fallback_code());
+        Self {
+            attempt,
+            reason,
+            code,
+        }
+    }
+
+    fn finalize(self, close_effect: EvidenceCloseEffectV1) -> EvidenceOutcomeBuildResultV1 {
+        let stop = EvidencePreserveStopV1 {
+            stage: self.reason.stop(),
+            code: self.code,
+        };
+        let publication = self.attempt.stage.wire_state();
+        let common = self.attempt.common;
+        let close = match close_effect.normalized() {
+            EvidenceCloseEffectV1::Closed => EvidenceCloseStateV1::Closed,
+            EvidenceCloseEffectV1::NotDispatched { code } => {
+                EvidenceCloseStateV1::CloseNotDispatched { code }
+            }
+            EvidenceCloseEffectV1::OutcomeUnknown { code } => {
+                EvidenceCloseStateV1::CloseOutcomeUnknown { code }
+            }
+        };
+        checked_outcome(EvidencePreserveDispositionV1::Unknown(common.residual(
+            stop,
+            publication,
+            close,
+        )))
+    }
+}
+
+struct ReadyToCloseV1 {
+    attempt: EvidencePublicationAttemptV1<PostattachEquivalentV1>,
+}
+
+impl ReadyToCloseV1 {
+    fn finalize(self, close_effect: EvidenceCloseEffectV1) -> EvidenceOutcomeBuildResultV1 {
+        let EvidencePublicationAttemptV1 { common, stage } = self.attempt;
+        let publication = stage.wire_state();
+        match close_effect.normalized() {
+            EvidenceCloseEffectV1::Closed => {
+                let PostattachEquivalentV1 {
+                    evidence_address,
+                    pointer,
+                    result_staged_revision,
+                } = stage;
+                checked_outcome(EvidencePreserveDispositionV1::Verified(
+                    EvidencePreserveVerifiedV1 {
+                        version: "v1".into(),
+                        attempt_id: common.attempt_id,
+                        source_staged_revision: common.source_staged_revision,
+                        target_base_revision: common.target_base_revision,
+                        snapshot_sha256: common.snapshot_sha256,
+                        observed_candidate_addresses: common.observed_candidate_addresses,
+                        result_staged_revision,
+                        evidence_address,
+                        pointer,
+                        last_confirmed_publication: publication,
+                        close: EvidenceCloseStateV1::Closed,
+                    },
+                ))
+            }
+            EvidenceCloseEffectV1::NotDispatched { code } => {
+                let residual = common.residual(
+                    EvidencePreserveStopV1 {
+                        stage: EvidencePreserveStopCodeV1::StorageCloseNotDispatched,
+                        code: code.clone(),
+                    },
+                    publication,
+                    EvidenceCloseStateV1::CloseNotDispatched { code },
+                );
+                checked_outcome(EvidencePreserveDispositionV1::VerificationIncomplete(
+                    residual,
+                ))
+            }
+            EvidenceCloseEffectV1::OutcomeUnknown { code } => {
+                let residual = common.residual(
+                    EvidencePreserveStopV1 {
+                        stage: EvidencePreserveStopCodeV1::StorageCloseOutcome,
+                        code: code.clone(),
+                    },
+                    publication,
+                    EvidenceCloseStateV1::CloseOutcomeUnknown { code },
+                );
+                checked_outcome(EvidencePreserveDispositionV1::Unknown(residual))
+            }
+        }
+    }
+}
+
+impl EvidenceCloseEffectV1 {
+    fn normalized(self) -> Self {
+        match self {
+            Self::Closed => Self::Closed,
+            Self::NotDispatched { code } => Self::NotDispatched {
+                code: nonempty_diagnostic(code, "storage_close_not_dispatched_without_code"),
+            },
+            Self::OutcomeUnknown { code } => Self::OutcomeUnknown {
+                code: nonempty_diagnostic(code, "storage_close_outcome_unknown_without_code"),
+            },
+        }
+    }
+}
+
+/// The only close-finalizable states. Each private variant retains a concrete
+/// publication stage and a reason type whose trait implementation fixes the
+/// outcome class; no runtime `(stage, class)` pair exists to mismatch or leak
+/// through the crate's public API.
+enum PendingEvidencePreserveStateV1 {
+    NoPublicationIncomplete(
+        PendingVerificationIncompleteV1<NoPublicationV1, NoPublicationIncompleteReasonV1>,
+    ),
+    PutObservedUnknown(PendingUnknownV1<PutObservedV1, PutObservedUnknownReasonV1>),
+    BlobPublishedIncomplete(
+        PendingVerificationIncompleteV1<BlobPublishedV1, BlobPublishedIncompleteReasonV1>,
+    ),
+    BlobPublishedUnknown(PendingUnknownV1<BlobPublishedV1, BlobPublishedUnknownReasonV1>),
+    PointerAttachAcknowledgedIncomplete(
+        PendingVerificationIncompleteV1<
+            PointerAttachAcknowledgedV1,
+            PointerAttachAcknowledgedIncompleteReasonV1,
+        >,
+    ),
+    BlobReadbackVerifiedIncomplete(
+        PendingVerificationIncompleteV1<
+            BlobReadbackVerifiedV1,
+            BlobReadbackVerifiedIncompleteReasonV1,
+        >,
+    ),
+    ResultSubjectObservedIncomplete(
+        PendingVerificationIncompleteV1<
+            ResultSubjectObservedV1,
+            ResultSubjectObservedIncompleteReasonV1,
+        >,
+    ),
+    PointerDeltaObservedIncomplete(
+        PendingVerificationIncompleteV1<
+            PointerDeltaObservedV1,
+            PointerDeltaObservedIncompleteReasonV1,
+        >,
+    ),
+    Ready(ReadyToCloseV1),
+}
+
+pub(crate) struct PendingEvidencePreserveOutcomeV1(PendingEvidencePreserveStateV1);
+
+impl PendingEvidencePreserveOutcomeV1 {
+    fn no_publication_incomplete(
+        pending: PendingVerificationIncompleteV1<NoPublicationV1, NoPublicationIncompleteReasonV1>,
+    ) -> Self {
+        Self(PendingEvidencePreserveStateV1::NoPublicationIncomplete(
+            pending,
+        ))
+    }
+
+    fn put_observed_unknown(
+        pending: PendingUnknownV1<PutObservedV1, PutObservedUnknownReasonV1>,
+    ) -> Self {
+        Self(PendingEvidencePreserveStateV1::PutObservedUnknown(pending))
+    }
+
+    fn blob_published_incomplete(
+        pending: PendingVerificationIncompleteV1<BlobPublishedV1, BlobPublishedIncompleteReasonV1>,
+    ) -> Self {
+        Self(PendingEvidencePreserveStateV1::BlobPublishedIncomplete(
+            pending,
+        ))
+    }
+
+    fn blob_published_unknown(
+        pending: PendingUnknownV1<BlobPublishedV1, BlobPublishedUnknownReasonV1>,
+    ) -> Self {
+        Self(PendingEvidencePreserveStateV1::BlobPublishedUnknown(
+            pending,
+        ))
+    }
+
+    fn pointer_attach_acknowledged_incomplete(
+        pending: PendingVerificationIncompleteV1<
+            PointerAttachAcknowledgedV1,
+            PointerAttachAcknowledgedIncompleteReasonV1,
+        >,
+    ) -> Self {
+        Self(PendingEvidencePreserveStateV1::PointerAttachAcknowledgedIncomplete(pending))
+    }
+
+    fn blob_readback_verified_incomplete(
+        pending: PendingVerificationIncompleteV1<
+            BlobReadbackVerifiedV1,
+            BlobReadbackVerifiedIncompleteReasonV1,
+        >,
+    ) -> Self {
+        Self(PendingEvidencePreserveStateV1::BlobReadbackVerifiedIncomplete(pending))
+    }
+
+    fn result_subject_observed_incomplete(
+        pending: PendingVerificationIncompleteV1<
+            ResultSubjectObservedV1,
+            ResultSubjectObservedIncompleteReasonV1,
+        >,
+    ) -> Self {
+        Self(PendingEvidencePreserveStateV1::ResultSubjectObservedIncomplete(pending))
+    }
+
+    fn pointer_delta_observed_incomplete(
+        pending: PendingVerificationIncompleteV1<
+            PointerDeltaObservedV1,
+            PointerDeltaObservedIncompleteReasonV1,
+        >,
+    ) -> Self {
+        Self(PendingEvidencePreserveStateV1::PointerDeltaObservedIncomplete(pending))
+    }
+
+    fn ready(pending: ReadyToCloseV1) -> Self {
+        Self(PendingEvidencePreserveStateV1::Ready(pending))
+    }
+
+    pub(crate) fn finalize(
+        self,
+        close_effect: EvidenceCloseEffectV1,
+    ) -> EvidenceOutcomeBuildResultV1 {
+        match self.0 {
+            PendingEvidencePreserveStateV1::NoPublicationIncomplete(pending) => {
+                pending.finalize(close_effect)
+            }
+            PendingEvidencePreserveStateV1::PutObservedUnknown(pending) => {
+                pending.finalize(close_effect)
+            }
+            PendingEvidencePreserveStateV1::BlobPublishedIncomplete(pending) => {
+                pending.finalize(close_effect)
+            }
+            PendingEvidencePreserveStateV1::BlobPublishedUnknown(pending) => {
+                pending.finalize(close_effect)
+            }
+            PendingEvidencePreserveStateV1::PointerAttachAcknowledgedIncomplete(pending) => {
+                pending.finalize(close_effect)
+            }
+            PendingEvidencePreserveStateV1::BlobReadbackVerifiedIncomplete(pending) => {
+                pending.finalize(close_effect)
+            }
+            PendingEvidencePreserveStateV1::ResultSubjectObservedIncomplete(pending) => {
+                pending.finalize(close_effect)
+            }
+            PendingEvidencePreserveStateV1::PointerDeltaObservedIncomplete(pending) => {
+                pending.finalize(close_effect)
+            }
+            PendingEvidencePreserveStateV1::Ready(pending) => pending.finalize(close_effect),
+        }
+    }
+}
+
+fn checked_outcome(disposition: EvidencePreserveDispositionV1) -> EvidenceOutcomeBuildResultV1 {
+    EvidencePreserveOutcomeV1::checked(disposition)
 }
 
 /// The exact, finite inventory used by submission-gate results.
@@ -91,6 +2362,30 @@ pub enum GovernanceCriterion {
     EvidenceValid,
 }
 
+/// Exact traversal whose independently fixed 1000-revision ceiling overflowed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HistoryOverflowScope {
+    PendingDco,
+    SupersessionAncestry,
+}
+
+/// Fixed, machine-actionable remediation codes for the two ratified overflow
+/// scopes. Non-overflow failures carry no remediation record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GovernanceRemediationCode {
+    SplitSubmissionOrAdvanceTargetBase,
+    MigrateSupersessionIndex,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GovernanceRemediation {
+    pub code: GovernanceRemediationCode,
+    pub ticket: Option<String>,
+}
+
 /// One deterministic criterion observation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -98,6 +2393,7 @@ pub struct CriterionResult {
     pub criterion: GovernanceCriterion,
     pub passed: bool,
     pub failure_code: Option<String>,
+    pub remediation: Option<GovernanceRemediation>,
 }
 
 /// Strict result schema for the eventual canonical submission gate operation.
@@ -115,6 +2411,7 @@ pub struct DcoValidateResult {
     pub valid: bool,
     pub pending_revisions: Vec<String>,
     pub failure_codes: Vec<String>,
+    pub remediation: Option<GovernanceRemediation>,
 }
 
 /// A dependency failure reported by a production Lore adapter.
@@ -136,6 +2433,8 @@ impl AdapterError {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusSnapshot {
+    /// Exact current branch identity used by both lock-query legs.
+    pub branch: String,
     /// Exact revision-only subject read before the scan.
     pub staged_revisions: Vec<String>,
     /// Subject reported by the full staged filesystem scan.
@@ -143,8 +2442,68 @@ pub struct StatusSnapshot {
     /// Exact revision-only subject reread after the scan.
     pub post_scan_staged_revisions: Vec<String>,
     pub staged_paths: Vec<String>,
+    pub staged_changes: Vec<StagedPathObservation>,
+    /// Exact content and filesystem facts for every tracked staged-revision
+    /// file, sorted by repository-relative path.
+    pub worktree_files: Vec<WorktreeFileObservation>,
     pub worktree_clean: bool,
     pub scan_performed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GovernancePathAction {
+    Modify,
+    Add,
+    Delete,
+    Move,
+    Copy,
+}
+
+/// Raw staged status event with both endpoints retained for moves. `Copy`
+/// remains representable only so pinned-production-inexpressible input can be
+/// retained and rejected with `copy_semantics_unavailable`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StagedPathObservation {
+    pub path: String,
+    pub from_path: Option<String>,
+    pub action: GovernancePathAction,
+    pub dirty: bool,
+    pub conflict: bool,
+}
+
+/// One raw file event from an exact, terminally-complete upstream revision
+/// diff. Pinned Lore projects a staged move as an exact Delete(source) plus
+/// Add(target) pair. It cannot project staged Copy; that variant is retained
+/// only to reject a future/synthetic raw shape explicitly.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RevisionDiffObservation {
+    pub path: String,
+    pub action: GovernancePathAction,
+    pub old_is_file: bool,
+    pub new_is_file: bool,
+    pub old_address: String,
+    pub new_address: String,
+}
+
+/// Raw staged-revision and local-filesystem values observed for one path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorktreeFileObservation {
+    pub path: String,
+    pub revision: String,
+    pub revision_hash: String,
+    pub revision_context: String,
+    pub revision_size: u64,
+    pub local_hash: String,
+    pub local_size: u64,
+    pub filtered_revision_size: u64,
+    pub flag_modified: bool,
+    pub flag_deleted: bool,
+    pub flag_added: bool,
+    pub flag_conflict: bool,
 }
 
 /// Exact revision information required for graph traversal.
@@ -170,20 +2529,48 @@ impl RevisionInfoResponse {
     }
 }
 
-/// One exact revision metadata pair.
+/// Exact kind of one revision-metadata value emitted by pinned Lore.
+///
+/// Inline `Binary` is deliberately absent: Lore 9664606 drops that kind before
+/// the public metadata callback. SBAI-6012 owns making that boundary observable,
+/// paired with SBAI-6011's provenance/external-prior-state work; until both are
+/// resolved, v1 must not pretend Binary state was observed. Every representable
+/// emitted kind remains distinct here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataKind {
+    Address,
+    Boolean,
+    Context,
+    Hash,
+    Numeric,
+    String,
+}
+
+/// One exact typed revision metadata pair.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MetadataEntry {
     pub key: String,
+    pub kind: MetadataKind,
     pub value: String,
 }
 
 impl MetadataEntry {
     pub fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self::with_kind(key, MetadataKind::String, value)
+    }
+
+    pub fn with_kind(key: impl Into<String>, kind: MetadataKind, value: impl Into<String>) -> Self {
         Self {
             key: key.into(),
+            kind,
             value: value.into(),
         }
+    }
+
+    pub fn string_value(&self) -> Option<&str> {
+        (self.kind == MetadataKind::String).then_some(self.value.as_str())
     }
 }
 
@@ -393,4 +2780,11 @@ pub struct EvaluationResult {
     pub identities: Vec<String>,
     pub superseded_identities: Vec<String>,
     pub failure_codes: Vec<String>,
+    pub remediation: Option<GovernanceRemediation>,
+    pub observations: GovernanceObservations,
 }
+
+// The authoritative writer -> marker -> evaluator chain remains deliberately
+// unproven until the v2 writer lands.  Authenticated remote success coverage is
+// tracked by SBAI-6001; until then the reviewed hybrid fixture is corroboration,
+// never substitution, and any missing future fixture must fail loudly, not skip.

--- a/crates/lore-vm/src/ops/governance/contract.rs
+++ b/crates/lore-vm/src/ops/governance/contract.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub const SUPERSESSION_MARKER_PREFIX: &str = "studiobrain.governance.v1.superseded.";
 /// The sole fixed v1 per-revision immutable-evidence pointer key.
 pub const EVIDENCE_POINTER_KEY: &str = "studiobrain.governance.v1.evidence";
-/// The largest complete candidate-side first-parent stream accepted by policy.
+/// The largest complete unique candidate-side pending DAG accepted by policy.
 pub const MAX_GOVERNANCE_HISTORY_REVISIONS: usize = 1000;
 
 /// The exact revision binding shared by every governance operation.
@@ -114,5 +114,283 @@ pub struct SubmissionGateCheckResult {
 pub struct DcoValidateResult {
     pub valid: bool,
     pub pending_revisions: Vec<String>,
+    pub failure_codes: Vec<String>,
+}
+
+/// A dependency failure reported by a production Lore adapter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AdapterError {
+    pub message: String,
+}
+
+impl AdapterError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+/// Exact staged state and proof of the full status scan used by governance.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StatusSnapshot {
+    /// Exact revision-only subject read before the scan.
+    pub staged_revisions: Vec<String>,
+    /// Subject reported by the full staged filesystem scan.
+    pub scanned_staged_revisions: Vec<String>,
+    /// Exact revision-only subject reread after the scan.
+    pub post_scan_staged_revisions: Vec<String>,
+    pub staged_paths: Vec<String>,
+    pub worktree_clean: bool,
+    pub scan_performed: bool,
+}
+
+/// Exact revision information required for graph traversal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RevisionInfo {
+    pub revision: String,
+    pub parents: Vec<String>,
+}
+
+/// Every raw `RevisionInfo` event observed through the terminal `End` event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RevisionInfoResponse {
+    pub revisions: Vec<RevisionInfo>,
+}
+
+impl RevisionInfoResponse {
+    pub fn exact(info: RevisionInfo) -> Self {
+        Self {
+            revisions: vec![info],
+        }
+    }
+}
+
+/// One exact revision metadata pair.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetadataEntry {
+    pub key: String,
+    pub value: String,
+}
+
+impl MetadataEntry {
+    pub fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+}
+
+/// A file identity read at one explicit revision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FileIdentity {
+    pub path: String,
+    pub revision: String,
+    pub hash: String,
+    pub context: String,
+}
+
+impl FileIdentity {
+    pub fn new(
+        path: impl Into<String>,
+        revision: impl Into<String>,
+        hash: impl Into<String>,
+        context: impl Into<String>,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            revision: revision.into(),
+            hash: hash.into(),
+            context: context.into(),
+        }
+    }
+
+    pub fn canonical_id(&self) -> String {
+        format!("{}:{}", self.hash, self.context)
+    }
+}
+
+/// An exact base-to-candidate changed path, including rename endpoints.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AffectedPath {
+    pub source_path: Option<String>,
+    pub target_path: Option<String>,
+}
+
+impl AffectedPath {
+    pub fn modified(path: impl Into<String>) -> Self {
+        let path = path.into();
+        Self {
+            source_path: Some(path.clone()),
+            target_path: Some(path),
+        }
+    }
+}
+
+/// One author resolution response from `auth.resolve_user_info`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResolvedAuthor {
+    pub identity: String,
+    pub display_name: String,
+}
+
+impl ResolvedAuthor {
+    pub fn new(identity: impl Into<String>, display_name: impl Into<String>) -> Self {
+        Self {
+            identity: identity.into(),
+            display_name: display_name.into(),
+        }
+    }
+}
+
+/// Complete response for a single lock query, including the requested identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LockQuery {
+    pub path: String,
+    pub begin_events: usize,
+    pub expected_count: usize,
+    pub completed: bool,
+    pub ignored_paths: Vec<String>,
+    pub owners: Vec<String>,
+}
+
+impl LockQuery {
+    pub fn unlocked(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            begin_events: 1,
+            expected_count: 0,
+            completed: true,
+            ignored_paths: Vec::new(),
+            owners: Vec::new(),
+        }
+    }
+
+    pub fn incomplete(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            begin_events: 0,
+            expected_count: 0,
+            completed: false,
+            ignored_paths: Vec::new(),
+            owners: Vec::new(),
+        }
+    }
+
+    pub fn with_owners(
+        path: impl Into<String>,
+        expected_count: usize,
+        owners: Vec<String>,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            begin_events: 1,
+            expected_count,
+            completed: true,
+            ignored_paths: Vec::new(),
+            owners,
+        }
+    }
+}
+
+/// One response in the complete lock-status stream.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LockStatus {
+    pub path: String,
+    pub owner: Option<String>,
+}
+
+impl LockStatus {
+    pub fn unlocked(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            owner: None,
+        }
+    }
+
+    pub fn locked(path: impl Into<String>, owner: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            owner: Some(owner.into()),
+        }
+    }
+}
+
+/// Raw, terminally verified lock-status stream. `statuses` contains lock
+/// events only; an unlocked path is proved by a zero-count successful stream
+/// with no ignored paths, not by fabricating an unlocked event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LockStatusResponse {
+    pub begin_events: usize,
+    pub expected_count: usize,
+    pub completed: bool,
+    pub ignored_paths: Vec<String>,
+    pub statuses: Vec<LockStatus>,
+}
+
+impl LockStatusResponse {
+    pub fn unlocked() -> Self {
+        Self {
+            begin_events: 1,
+            expected_count: 0,
+            completed: true,
+            ignored_paths: Vec::new(),
+            statuses: Vec::new(),
+        }
+    }
+
+    pub fn incomplete() -> Self {
+        Self {
+            begin_events: 0,
+            expected_count: 0,
+            completed: false,
+            ignored_paths: Vec::new(),
+            statuses: Vec::new(),
+        }
+    }
+
+    pub fn with_locks(expected_count: usize, statuses: Vec<LockStatus>) -> Self {
+        Self {
+            begin_events: 1,
+            expected_count,
+            completed: true,
+            ignored_paths: Vec::new(),
+            statuses,
+        }
+    }
+
+    pub fn ignored(path: impl Into<String>) -> Self {
+        Self {
+            begin_events: 1,
+            expected_count: 0,
+            completed: true,
+            ignored_paths: vec![path.into()],
+            statuses: Vec::new(),
+        }
+    }
+}
+
+/// Deterministic evaluator result. A dependency failure is represented as a
+/// closed result so callers cannot accidentally convert it into an open gate.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvaluationResult {
+    pub open: bool,
+    pub pending_revisions: Vec<String>,
+    pub affected_paths: Vec<String>,
+    pub identities: Vec<String>,
+    pub superseded_identities: Vec<String>,
     pub failure_codes: Vec<String>,
 }

--- a/crates/lore-vm/src/ops/governance/dco_validate.rs
+++ b/crates/lore-vm/src/ops/governance/dco_validate.rs
@@ -1,0 +1,17 @@
+//! Strict DCO validation operation backed by the shared governance evaluator.
+
+use super::contract::{DcoValidateRequest, DcoValidateResult};
+use super::evaluator::{evaluate_dco, GovernanceAdapter, ProductionLoreAdapter};
+use crate::api::LoreApi;
+use crate::error::Result;
+
+pub async fn dco_validate_with_adapter<A: GovernanceAdapter + Sync>(
+    adapter: &A,
+    request: &DcoValidateRequest,
+) -> DcoValidateResult {
+    evaluate_dco(adapter, request).await
+}
+
+pub async fn dco_validate(api: &LoreApi, request: DcoValidateRequest) -> Result<DcoValidateResult> {
+    Ok(dco_validate_with_adapter(&ProductionLoreAdapter::new(api, ""), &request).await)
+}

--- a/crates/lore-vm/src/ops/governance/evaluator.rs
+++ b/crates/lore-vm/src/ops/governance/evaluator.rs
@@ -965,12 +965,52 @@ fn parse_dco_signer(message: &str) -> Option<String> {
         return None;
     }
     let signer = signers[0];
-    let (name, email_with_bracket) = signer.rsplit_once(" <")?;
-    let email = email_with_bracket.strip_suffix('>')?;
-    if name.trim().is_empty() || email.is_empty() || email.contains(char::is_whitespace) {
+    let identity = signer.strip_suffix('>')?;
+    let (name, email) = identity.split_once(" <")?;
+    let first_name_char = name.chars().next()?;
+    let last_name_char = name.chars().last()?;
+    if first_name_char.is_whitespace()
+        || last_name_char.is_whitespace()
+        || name
+            .chars()
+            .any(|character| character.is_control() || matches!(character, '<' | '>'))
+        || !is_canonical_dco_email(email)
+    {
         return None;
     }
-    Some(name.trim().to_string())
+    Some(name.to_string())
+}
+
+fn is_canonical_dco_email(email: &str) -> bool {
+    if email.is_empty()
+        || email.chars().any(|character| {
+            character.is_whitespace() || character.is_control() || matches!(character, '<' | '>')
+        })
+    {
+        return false;
+    }
+
+    let mut address_parts = email.split('@');
+    let Some(local) = address_parts.next() else {
+        return false;
+    };
+    let Some(domain) = address_parts.next() else {
+        return false;
+    };
+    if local.is_empty() || domain.is_empty() || address_parts.next().is_some() {
+        return false;
+    }
+
+    domain.split('.').all(|label| {
+        let (Some(first), Some(last)) = (label.as_bytes().first(), label.as_bytes().last()) else {
+            return false;
+        };
+        first.is_ascii_alphanumeric()
+            && last.is_ascii_alphanumeric()
+            && label
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    })
 }
 
 fn parse_trailer(line: &str) -> Option<(&str, &str)> {

--- a/crates/lore-vm/src/ops/governance/evaluator.rs
+++ b/crates/lore-vm/src/ops/governance/evaluator.rs
@@ -1,0 +1,1286 @@
+//! Injectable, fail-closed Option-A evaluator.
+
+use super::contract::{
+    ExactRevisionRequest, SupersessionMarkerV1, MAX_GOVERNANCE_HISTORY_REVISIONS,
+    SUPERSESSION_MARKER_PREFIX,
+};
+use crate::api::LoreApi;
+use crate::ops::{auth, file, revision};
+use lore::interface::{LoreArray, LoreEvent, LoreEventCallback, LoreString};
+use lore::lock::{LoreLockFileQueryArgs, LoreLockFileStatusArgs};
+use lore::repository::{LoreRepositoryDumpArgs, LoreRepositoryStatusArgs};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Mutex};
+use tokio::sync::oneshot;
+
+/// A dependency failure reported by a production Lore adapter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AdapterError {
+    pub message: String,
+}
+
+impl AdapterError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+/// Exact staged state returned by the production status adapter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StatusSnapshot {
+    pub staged_revisions: Vec<String>,
+    pub staged_paths: Vec<String>,
+    pub worktree_clean: bool,
+}
+
+/// Exact revision information required for graph traversal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RevisionInfo {
+    pub revision: String,
+    pub parents: Vec<String>,
+}
+
+/// One exact revision metadata pair.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetadataEntry {
+    pub key: String,
+    pub value: String,
+}
+
+impl MetadataEntry {
+    pub fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+}
+
+/// A file identity read at one explicit revision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FileIdentity {
+    pub path: String,
+    pub revision: String,
+    pub hash: String,
+    pub context: String,
+}
+
+impl FileIdentity {
+    pub fn new(
+        path: impl Into<String>,
+        revision: impl Into<String>,
+        hash: impl Into<String>,
+        context: impl Into<String>,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            revision: revision.into(),
+            hash: hash.into(),
+            context: context.into(),
+        }
+    }
+
+    pub fn canonical_id(&self) -> String {
+        format!("{}:{}", self.hash, self.context)
+    }
+}
+
+/// An exact base-to-candidate changed path, including rename endpoints.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AffectedPath {
+    pub source_path: Option<String>,
+    pub target_path: Option<String>,
+}
+
+impl AffectedPath {
+    pub fn modified(path: impl Into<String>) -> Self {
+        let path = path.into();
+        Self {
+            source_path: Some(path.clone()),
+            target_path: Some(path),
+        }
+    }
+}
+
+/// One author resolution response from `auth.resolve_user_info`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResolvedAuthor {
+    pub identity: String,
+    pub display_name: String,
+}
+
+impl ResolvedAuthor {
+    pub fn new(identity: impl Into<String>, display_name: impl Into<String>) -> Self {
+        Self {
+            identity: identity.into(),
+            display_name: display_name.into(),
+        }
+    }
+}
+
+/// Complete response for a single lock query, including the requested identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LockQuery {
+    pub path: String,
+    pub begin_events: usize,
+    pub expected_count: usize,
+    pub completed: bool,
+    pub ignored_paths: Vec<String>,
+    pub owners: Vec<String>,
+}
+
+impl LockQuery {
+    pub fn unlocked(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            begin_events: 1,
+            expected_count: 0,
+            completed: true,
+            ignored_paths: Vec::new(),
+            owners: Vec::new(),
+        }
+    }
+
+    pub fn incomplete(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            begin_events: 0,
+            expected_count: 0,
+            completed: false,
+            ignored_paths: Vec::new(),
+            owners: Vec::new(),
+        }
+    }
+
+    pub fn with_owners(
+        path: impl Into<String>,
+        expected_count: usize,
+        owners: Vec<String>,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            begin_events: 1,
+            expected_count,
+            completed: true,
+            ignored_paths: Vec::new(),
+            owners,
+        }
+    }
+}
+
+/// One response in the complete lock-status stream.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LockStatus {
+    pub path: String,
+    pub owner: Option<String>,
+}
+
+impl LockStatus {
+    pub fn unlocked(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            owner: None,
+        }
+    }
+
+    pub fn locked(path: impl Into<String>, owner: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            owner: Some(owner.into()),
+        }
+    }
+}
+
+/// Raw, terminally verified lock-status stream. `statuses` contains lock
+/// events only; an unlocked path is proved by a zero-count successful stream
+/// with no ignored paths, not by fabricating an unlocked event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LockStatusResponse {
+    pub begin_events: usize,
+    pub expected_count: usize,
+    pub completed: bool,
+    pub ignored_paths: Vec<String>,
+    pub statuses: Vec<LockStatus>,
+}
+
+impl LockStatusResponse {
+    pub fn unlocked() -> Self {
+        Self {
+            begin_events: 1,
+            expected_count: 0,
+            completed: true,
+            ignored_paths: Vec::new(),
+            statuses: Vec::new(),
+        }
+    }
+
+    pub fn incomplete() -> Self {
+        Self {
+            begin_events: 0,
+            expected_count: 0,
+            completed: false,
+            ignored_paths: Vec::new(),
+            statuses: Vec::new(),
+        }
+    }
+
+    pub fn with_locks(expected_count: usize, statuses: Vec<LockStatus>) -> Self {
+        Self {
+            begin_events: 1,
+            expected_count,
+            completed: true,
+            ignored_paths: Vec::new(),
+            statuses,
+        }
+    }
+
+    pub fn ignored(path: impl Into<String>) -> Self {
+        Self {
+            begin_events: 1,
+            expected_count: 0,
+            completed: true,
+            ignored_paths: vec![path.into()],
+            statuses: Vec::new(),
+        }
+    }
+}
+
+/// The production Lore adapter interface. Implementations must bind every call
+/// to the explicit revisions and paths supplied by this evaluator.
+#[async_trait::async_trait]
+pub trait GovernanceAdapter {
+    async fn status(&self) -> Result<StatusSnapshot, AdapterError>;
+    async fn revision_info(&self, revision: &str) -> Result<RevisionInfo, AdapterError>;
+    async fn revision_metadata(&self, revision: &str) -> Result<Vec<MetadataEntry>, AdapterError>;
+    /// Return candidate-side first-parent revisions only, not the target base,
+    /// with the supplied sentinel limit applied at the Lore boundary.
+    async fn first_parent_history(
+        &self,
+        candidate: &str,
+        target_base: &str,
+        max_revisions: usize,
+    ) -> Result<Vec<String>, AdapterError>;
+    /// Enumerate exact repository-relative paths for `revision`.
+    async fn repository_dump(&self, revision: &str) -> Result<Vec<String>, AdapterError>;
+    /// Return exactly one exact-revision identity per requested path.
+    async fn file_info(
+        &self,
+        revision: &str,
+        paths: &[String],
+    ) -> Result<Vec<FileIdentity>, AdapterError>;
+    async fn revision_diff(
+        &self,
+        base: &str,
+        candidate: &str,
+    ) -> Result<Vec<AffectedPath>, AdapterError>;
+    async fn resolve_authors(
+        &self,
+        identities: &[String],
+    ) -> Result<Vec<ResolvedAuthor>, AdapterError>;
+    async fn lock_file_query(&self, path: &str) -> Result<LockQuery, AdapterError>;
+    async fn lock_file_status(&self, paths: &[String]) -> Result<LockStatusResponse, AdapterError>;
+}
+
+/// In-process production adapter for the shipped Lore API. It uses the
+/// existing typed bindings where their event contract is lossless, and retains
+/// raw lock events through `End` where the older convenience wrappers discard
+/// counts and ignored-path evidence.
+pub struct ProductionLoreAdapter<'a> {
+    api: &'a LoreApi,
+    branch: String,
+}
+
+impl<'a> ProductionLoreAdapter<'a> {
+    pub fn new(api: &'a LoreApi, branch: impl Into<String>) -> Self {
+        Self {
+            api,
+            branch: branch.into(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl GovernanceAdapter for ProductionLoreAdapter<'_> {
+    async fn status(&self) -> Result<StatusSnapshot, AdapterError> {
+        let (callback, receiver) = raw_event_collector();
+        let returned = lore::repository::status(
+            self.api.globals().build(),
+            LoreRepositoryStatusArgs {
+                staged: 0,
+                scan: 0,
+                check_dirty: 0,
+                reset: 0,
+                sync_point: 0,
+                revision_only: 1,
+                count: 0,
+                paths: LoreArray::from_vec(Vec::new()),
+            },
+            callback,
+        )
+        .await;
+        let stream = finished_raw_stream(receiver, returned).await?;
+        let revisions: Vec<_> = stream
+            .events
+            .into_iter()
+            .filter_map(|event| match event {
+                LoreEvent::RepositoryStatusRevision(data) => Some(data),
+                _ => None,
+            })
+            .collect();
+        if revisions.len() != 1 {
+            return Err(AdapterError::new(
+                "repository status did not emit exactly one revision",
+            ));
+        }
+        let staged_revisions = (!revisions[0].revision_staged.is_zero())
+            .then_some(format!("{}", revisions[0].revision_staged))
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        let (callback, receiver) = raw_event_collector();
+        let returned = lore::repository::status(
+            self.api.globals().build(),
+            LoreRepositoryStatusArgs {
+                staged: 0,
+                scan: 0,
+                check_dirty: 0,
+                reset: 0,
+                sync_point: 0,
+                revision_only: 0,
+                count: 0,
+                paths: LoreArray::from_vec(Vec::new()),
+            },
+            callback,
+        )
+        .await;
+        let stream = finished_raw_stream(receiver, returned).await?;
+        let mut detail_revisions = Vec::new();
+        let mut staged_paths = BTreeSet::new();
+        let mut worktree_clean = true;
+        for event in stream.events {
+            match event {
+                LoreEvent::RepositoryStatusRevision(data) => detail_revisions.push(data),
+                LoreEvent::RepositoryStatusFile(data) => {
+                    if data.flag_staged != 0 {
+                        if !data.path.is_empty() {
+                            staged_paths.insert(data.path.as_str().to_string());
+                        }
+                        if !data.from_path.is_empty() {
+                            staged_paths.insert(data.from_path.as_str().to_string());
+                        }
+                    }
+                    if data.flag_dirty != 0 || data.flag_conflict != 0 {
+                        worktree_clean = false;
+                    }
+                }
+                LoreEvent::PathIgnore(_) => {
+                    return Err(AdapterError::new(
+                        "repository status ignored a path during worktree verification",
+                    ));
+                }
+                _ => {}
+            }
+        }
+        if detail_revisions.len() != 1 {
+            return Err(AdapterError::new(
+                "worktree status did not emit exactly one revision",
+            ));
+        }
+        let detail_staged = (!detail_revisions[0].revision_staged.is_zero())
+            .then_some(format!("{}", detail_revisions[0].revision_staged));
+        if detail_staged.as_deref() != staged_revisions.first().map(String::as_str) {
+            return Err(AdapterError::new(
+                "worktree status changed the exact staged subject",
+            ));
+        }
+        Ok(StatusSnapshot {
+            staged_revisions,
+            staged_paths: staged_paths.into_iter().collect(),
+            worktree_clean,
+        })
+    }
+
+    async fn revision_info(&self, revision_id: &str) -> Result<RevisionInfo, AdapterError> {
+        let result = revision::info::info(
+            self.api,
+            revision::info::RevisionInfoArgs {
+                revision: revision_id.into(),
+                delta: false,
+                metadata: false,
+            },
+        )
+        .await
+        .map_err(adapter_error)?;
+        let info = result
+            .info
+            .ok_or_else(|| AdapterError::new("revision info emitted no revision"))?;
+        Ok(RevisionInfo {
+            revision: info.revision,
+            parents: info.parents,
+        })
+    }
+
+    async fn revision_metadata(
+        &self,
+        revision_id: &str,
+    ) -> Result<Vec<MetadataEntry>, AdapterError> {
+        let result = revision::metadata_list::metadata_list(
+            self.api,
+            revision::metadata_list::MetadataListArgs {
+                revision: revision_id.into(),
+            },
+        )
+        .await
+        .map_err(adapter_error)?;
+        Ok(result
+            .entries
+            .into_iter()
+            .map(|entry| MetadataEntry::new(entry.key, entry.value))
+            .collect())
+    }
+
+    async fn first_parent_history(
+        &self,
+        candidate: &str,
+        target_base: &str,
+        max_revisions: usize,
+    ) -> Result<Vec<String>, AdapterError> {
+        let length = u32::try_from(max_revisions)
+            .map_err(|_| AdapterError::new("history sentinel exceeds upstream limit"))?;
+        let result = revision::history::history(
+            self.api,
+            revision::history::RevisionHistoryArgs {
+                revision: candidate.into(),
+                branch: String::new(),
+                date: 0,
+                length,
+                only_branch: false,
+            },
+        )
+        .await
+        .map_err(adapter_error)?;
+        let mut entries = Vec::new();
+        for entry in result.entries {
+            if entry.revision == target_base {
+                break;
+            }
+            entries.push(entry.revision);
+        }
+        Ok(entries)
+    }
+
+    async fn repository_dump(&self, revision_id: &str) -> Result<Vec<String>, AdapterError> {
+        let (callback, receiver) = raw_event_collector();
+        let returned = lore::repository::dump(
+            self.api.globals().build(),
+            LoreRepositoryDumpArgs {
+                revision: LoreString::from_str(revision_id),
+                path: LoreString::default(),
+                max_depth: 0,
+            },
+            callback,
+        )
+        .await;
+        let stream = finished_raw_stream(receiver, returned).await?;
+        let mut begin = 0;
+        let mut state = 0;
+        let mut end = 0;
+        let mut paths = BTreeSet::new();
+        for event in stream.events {
+            match event {
+                LoreEvent::RepositoryDumpBegin(data) => {
+                    begin += 1;
+                    if format!("{}", data.revision) != revision_id {
+                        return Err(AdapterError::new(
+                            "repository dump fell back from exact revision",
+                        ));
+                    }
+                }
+                LoreEvent::RepositoryStateDump(data) => {
+                    state += 1;
+                    if format!("{}", data.revision) != revision_id {
+                        return Err(AdapterError::new(
+                            "repository dump state did not match exact revision",
+                        ));
+                    }
+                }
+                LoreEvent::RepositoryStateDumpNode(data) => {
+                    let path = data.name.as_str().to_string();
+                    if data.type_data.as_str().starts_with("addr ")
+                        && (path.is_empty() || path.ends_with('/') || !paths.insert(path))
+                    {
+                        return Err(AdapterError::new(
+                            "repository dump emitted malformed or duplicate file path",
+                        ));
+                    }
+                }
+                LoreEvent::RepositoryDumpEnd(_) => end += 1,
+                _ => {}
+            }
+        }
+        if begin != 1 || state != 1 || end != 1 {
+            return Err(AdapterError::new("repository dump stream was incomplete"));
+        }
+        Ok(paths.into_iter().collect())
+    }
+
+    async fn file_info(
+        &self,
+        revision_id: &str,
+        paths: &[String],
+    ) -> Result<Vec<FileIdentity>, AdapterError> {
+        let result = file::info::info(
+            self.api,
+            file::info::FileInfoArgs {
+                paths: paths.to_vec(),
+                revision: revision_id.into(),
+                local: false,
+                filtered: false,
+            },
+        )
+        .await
+        .map_err(adapter_error)?;
+        if result.entries.iter().any(|entry| !entry.is_file) {
+            return Err(AdapterError::new(
+                "file info did not return files for every dump path",
+            ));
+        }
+        Ok(result
+            .entries
+            .into_iter()
+            .map(|entry| FileIdentity::new(entry.path, revision_id, entry.hash, entry.context))
+            .collect())
+    }
+
+    async fn revision_diff(
+        &self,
+        base: &str,
+        candidate: &str,
+    ) -> Result<Vec<AffectedPath>, AdapterError> {
+        let result = revision::diff::diff(
+            self.api,
+            revision::diff::RevisionDiffArgs {
+                revision_source: base.into(),
+                revision_target: candidate.into(),
+                paths: Vec::new(),
+            },
+        )
+        .await
+        .map_err(adapter_error)?;
+        Ok(result
+            .files
+            .into_iter()
+            .map(|file| AffectedPath::modified(file.path))
+            .collect())
+    }
+
+    async fn resolve_authors(
+        &self,
+        identities: &[String],
+    ) -> Result<Vec<ResolvedAuthor>, AdapterError> {
+        let result = auth::resolve_user_info::resolve_user_info(
+            self.api,
+            auth::resolve_user_info::ResolveUserInfoArgs {
+                user_ids: identities.to_vec(),
+            },
+        )
+        .await
+        .map_err(adapter_error)?;
+        Ok(result
+            .users
+            .into_iter()
+            .map(|user| ResolvedAuthor::new(user.user_id, user.display_name))
+            .collect())
+    }
+
+    async fn lock_file_query(&self, path: &str) -> Result<LockQuery, AdapterError> {
+        let (callback, receiver) = raw_event_collector();
+        let returned = lore::lock::file_query(
+            self.api.globals().build(),
+            LoreLockFileQueryArgs {
+                branch: LoreString::from_str(&self.branch),
+                owner: LoreString::default(),
+                path: LoreString::from_str(path),
+            },
+            callback,
+        )
+        .await;
+        let stream = finished_raw_stream(receiver, returned).await?;
+        let mut begins = 0;
+        let mut expected = None;
+        let mut owners = Vec::new();
+        let mut ignored = Vec::new();
+        for event in stream.events {
+            match event {
+                LoreEvent::LockFileQueryBegin(data) => {
+                    begins += 1;
+                    expected = Some(data.count);
+                }
+                LoreEvent::LockFileQuery(data) => {
+                    if data.path.as_str() != path {
+                        return Err(AdapterError::new("lock query returned a foreign path"));
+                    }
+                    owners.push(data.owner.as_str().to_string());
+                }
+                LoreEvent::PathIgnore(data) => ignored.push(data.path.as_str().to_string()),
+                _ => {}
+            }
+        }
+        let expected_count = expected
+            .ok_or_else(|| AdapterError::new("lock query emitted no begin event"))?
+            .try_into()
+            .map_err(|_| AdapterError::new("lock query count overflow"))?;
+        if begins != 1 || !ignored.is_empty() || expected_count != owners.len() {
+            return Err(AdapterError::new("lock query stream was incomplete"));
+        }
+        Ok(LockQuery {
+            path: path.into(),
+            begin_events: begins,
+            expected_count,
+            completed: true,
+            ignored_paths: ignored,
+            owners,
+        })
+    }
+
+    async fn lock_file_status(&self, paths: &[String]) -> Result<LockStatusResponse, AdapterError> {
+        let (callback, receiver) = raw_event_collector();
+        let returned = lore::lock::file_status(
+            self.api.globals().build(),
+            LoreLockFileStatusArgs {
+                paths: LoreArray::from_vec(
+                    paths
+                        .iter()
+                        .map(|path| LoreString::from_str(path))
+                        .collect(),
+                ),
+                branch: LoreString::from_str(&self.branch),
+            },
+            callback,
+        )
+        .await;
+        let stream = finished_raw_stream(receiver, returned).await?;
+        let requested: BTreeSet<&str> = paths.iter().map(String::as_str).collect();
+        let mut begins = 0;
+        let mut expected = None;
+        let mut statuses = Vec::new();
+        let mut ignored = Vec::new();
+        for event in stream.events {
+            match event {
+                LoreEvent::LockFileStatusBegin(data) => {
+                    begins += 1;
+                    expected = Some(data.count);
+                }
+                LoreEvent::LockFileStatus(data) => {
+                    let path = data.path.as_str().to_string();
+                    if !requested.contains(path.as_str()) {
+                        return Err(AdapterError::new("lock status returned a foreign path"));
+                    }
+                    statuses.push(LockStatus::locked(path, data.owner.as_str()));
+                }
+                LoreEvent::PathIgnore(data) => ignored.push(data.path.as_str().to_string()),
+                _ => {}
+            }
+        }
+        let expected_count = expected
+            .ok_or_else(|| AdapterError::new("lock status emitted no begin event"))?
+            .try_into()
+            .map_err(|_| AdapterError::new("lock status count overflow"))?;
+        if begins != 1 || !ignored.is_empty() || expected_count != statuses.len() {
+            return Err(AdapterError::new("lock status stream was incomplete"));
+        }
+        Ok(LockStatusResponse {
+            begin_events: begins,
+            expected_count,
+            completed: true,
+            ignored_paths: ignored,
+            statuses,
+        })
+    }
+}
+
+fn adapter_error(error: impl std::fmt::Display) -> AdapterError {
+    AdapterError::new(error.to_string())
+}
+
+#[derive(Default)]
+struct RawEventStream {
+    events: Vec<LoreEvent>,
+    complete_events: usize,
+    complete_status: Option<i32>,
+    error_events: usize,
+    end_events: usize,
+}
+
+fn raw_event_collector() -> (LoreEventCallback, oneshot::Receiver<RawEventStream>) {
+    let (sender, receiver) = oneshot::channel();
+    let stream = Arc::new(Mutex::new(RawEventStream::default()));
+    let sender = Arc::new(Mutex::new(Some(sender)));
+    let callback = Box::new(move |event: &LoreEvent| {
+        let mut locked = stream.lock().expect("raw event collector mutex poisoned");
+        match event {
+            LoreEvent::Complete(data) => {
+                locked.complete_events += 1;
+                locked.complete_status = Some(data.status);
+            }
+            LoreEvent::Error(_) => locked.error_events += 1,
+            LoreEvent::End(_) => locked.end_events += 1,
+            _ => {}
+        }
+        locked.events.push(event.clone());
+        if matches!(event, LoreEvent::End(_)) {
+            let final_stream = std::mem::take(&mut *locked);
+            drop(locked);
+            if let Some(sender) = sender
+                .lock()
+                .expect("raw event sender mutex poisoned")
+                .take()
+            {
+                let _ = sender.send(final_stream);
+            }
+        }
+    });
+    (Some(callback), receiver)
+}
+
+async fn finished_raw_stream(
+    receiver: oneshot::Receiver<RawEventStream>,
+    returned: i32,
+) -> Result<RawEventStream, AdapterError> {
+    let stream = receiver.await.map_err(|error| {
+        AdapterError::new(format!("raw event stream ended before End: {error}"))
+    })?;
+    if returned != 0
+        || stream.end_events != 1
+        || stream.complete_events != 1
+        || stream.complete_status != Some(0)
+        || stream.error_events != 0
+    {
+        return Err(AdapterError::new(
+            "raw Lore stream failed terminal validation",
+        ));
+    }
+    Ok(stream)
+}
+
+/// Deterministic evaluator result. A dependency failure is represented as a
+/// closed result so callers cannot accidentally convert it into an open gate.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvaluationResult {
+    pub open: bool,
+    pub pending_revisions: Vec<String>,
+    pub affected_paths: Vec<String>,
+    pub identities: Vec<String>,
+    pub superseded_identities: Vec<String>,
+    pub failure_codes: Vec<String>,
+}
+
+impl EvaluationResult {
+    fn closed(code: impl Into<String>) -> Self {
+        Self {
+            open: false,
+            pending_revisions: Vec::new(),
+            affected_paths: Vec::new(),
+            identities: Vec::new(),
+            superseded_identities: Vec::new(),
+            failure_codes: vec![code.into()],
+        }
+    }
+}
+
+/// Evaluate the strict Option-A request through an injectable production
+/// adapter. Every unavailable or ambiguous dependency closes the result.
+pub async fn evaluate<A, R>(adapter: &A, request: &R) -> EvaluationResult
+where
+    A: GovernanceAdapter,
+    R: ExactRevisionRequest,
+{
+    let expected = request.expected_staged_revision();
+    let base = request.target_base_revision();
+    if expected.is_empty() || base.is_empty() {
+        return EvaluationResult::closed("exact_subject_failed");
+    }
+
+    let status = match adapter.status().await {
+        Ok(status) => status,
+        Err(_) => return EvaluationResult::closed("status_unavailable"),
+    };
+    if status.staged_revisions.len() != 1
+        || status.staged_revisions[0].is_empty()
+        || status.staged_revisions[0] != expected
+    {
+        return EvaluationResult::closed("exact_subject_failed");
+    }
+
+    let base_info = match exact_info(adapter, base).await {
+        Ok(info) => info,
+        Err(()) => return EvaluationResult::closed("history_incomplete"),
+    };
+    if base_info.revision != base {
+        return EvaluationResult::closed("history_incomplete");
+    }
+
+    let pending = match pending_dag(adapter, expected, base).await {
+        Ok(revisions) => revisions,
+        Err(()) => return EvaluationResult::closed("history_incomplete"),
+    };
+
+    let history = match adapter
+        .first_parent_history(expected, base, MAX_GOVERNANCE_HISTORY_REVISIONS + 1)
+        .await
+    {
+        Ok(history) => history,
+        Err(_) => return EvaluationResult::closed("history_incomplete"),
+    };
+    if history.len() >= MAX_GOVERNANCE_HISTORY_REVISIONS + 1 {
+        return EvaluationResult::closed("history_depth_exceeded");
+    }
+    let expected_history = match first_parent_history(adapter, expected, base).await {
+        Ok(history) => history,
+        Err(()) => return EvaluationResult::closed("history_incomplete"),
+    };
+    if history != expected_history || history.is_empty() {
+        return EvaluationResult::closed("history_incomplete");
+    }
+
+    let superseded = match validate_metadata_and_dco(adapter, &pending).await {
+        Ok(superseded) => superseded,
+        Err(Failure::Metadata) => return EvaluationResult::closed("metadata_unavailable"),
+        Err(Failure::Dco) => return EvaluationResult::closed("dco_invalid"),
+        Err(Failure::Auth) => return EvaluationResult::closed("auth_unavailable"),
+        Err(Failure::Supersession) => return EvaluationResult::closed("supersession_invalid"),
+    };
+
+    let candidate_tree = match exact_tree(adapter, expected).await {
+        Ok(tree) => tree,
+        Err(TreeFailure::Dependency) => return EvaluationResult::closed("tree_unavailable"),
+        Err(TreeFailure::FileInfo) => return EvaluationResult::closed("file_info_unavailable"),
+        Err(TreeFailure::Invalid) => return EvaluationResult::closed("tree_invalid"),
+    };
+    let base_tree = match exact_tree(adapter, base).await {
+        Ok(tree) => tree,
+        Err(TreeFailure::Dependency) => return EvaluationResult::closed("tree_unavailable"),
+        Err(TreeFailure::FileInfo) => return EvaluationResult::closed("file_info_unavailable"),
+        Err(TreeFailure::Invalid) => return EvaluationResult::closed("tree_invalid"),
+    };
+
+    let mut identities: Vec<String> = candidate_tree.values().cloned().collect();
+    identities.sort();
+    if superseded
+        .iter()
+        .any(|identity| candidate_tree.values().any(|id| id == identity))
+    {
+        return EvaluationResult::closed("not_superseded_failed");
+    }
+
+    let affected_paths = match affected_paths(
+        adapter,
+        base,
+        expected,
+        &status,
+        &base_tree,
+        &candidate_tree,
+    )
+    .await
+    {
+        Ok(paths) => paths,
+        Err(()) => return EvaluationResult::closed("affected_paths_unavailable"),
+    };
+    if affected_paths.is_empty() {
+        return EvaluationResult::closed("empty_submission");
+    }
+
+    match validate_locks(adapter, &affected_paths).await {
+        Ok(()) => {}
+        Err(LockFailure::Dependency) => return EvaluationResult::closed("locks_unavailable"),
+        Err(LockFailure::Locked) => return EvaluationResult::closed("locks_clear_failed"),
+    }
+
+    if !status.worktree_clean {
+        return EvaluationResult::closed("worktree_dirty");
+    }
+
+    EvaluationResult {
+        open: true,
+        pending_revisions: pending,
+        affected_paths,
+        identities,
+        superseded_identities: superseded,
+        failure_codes: Vec::new(),
+    }
+}
+
+async fn exact_info<A: GovernanceAdapter>(adapter: &A, revision: &str) -> Result<RevisionInfo, ()> {
+    let info = adapter.revision_info(revision).await.map_err(|_| ())?;
+    if info.revision.is_empty() || info.revision != revision {
+        return Err(());
+    }
+    Ok(info)
+}
+
+async fn pending_dag<A: GovernanceAdapter>(
+    adapter: &A,
+    candidate: &str,
+    base: &str,
+) -> Result<Vec<String>, ()> {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Visit {
+        Active,
+        Complete,
+    }
+
+    let mut visit = BTreeMap::<String, Visit>::new();
+    let mut pending = BTreeSet::new();
+    let mut stack = vec![(candidate.to_string(), false)];
+
+    while let Some((revision, leaving)) = stack.pop() {
+        if revision == base {
+            continue;
+        }
+        if leaving {
+            visit.insert(revision, Visit::Complete);
+            continue;
+        }
+        match visit.get(&revision) {
+            Some(Visit::Active) => return Err(()),
+            Some(Visit::Complete) => continue,
+            None => {}
+        }
+
+        let info = exact_info(adapter, &revision).await?;
+        if info.parents.is_empty()
+            || info
+                .parents
+                .iter()
+                .any(|parent| parent.is_empty() || parent == &revision)
+        {
+            return Err(());
+        }
+        visit.insert(revision.clone(), Visit::Active);
+        pending.insert(revision.clone());
+        stack.push((revision, true));
+        for parent in info.parents.into_iter().rev() {
+            stack.push((parent, false));
+        }
+    }
+
+    if pending.is_empty() {
+        return Err(());
+    }
+    Ok(pending.into_iter().collect())
+}
+
+async fn first_parent_history<A: GovernanceAdapter>(
+    adapter: &A,
+    candidate: &str,
+    base: &str,
+) -> Result<Vec<String>, ()> {
+    let mut revisions = Vec::new();
+    let mut seen = BTreeSet::new();
+    let mut revision = candidate.to_string();
+
+    while revision != base {
+        if !seen.insert(revision.clone()) || revisions.len() >= MAX_GOVERNANCE_HISTORY_REVISIONS + 1
+        {
+            return Err(());
+        }
+        let info = exact_info(adapter, &revision).await?;
+        let Some(parent) = info.parents.first() else {
+            return Err(());
+        };
+        if parent.is_empty() {
+            return Err(());
+        }
+        revisions.push(revision);
+        revision = parent.clone();
+    }
+
+    Ok(revisions)
+}
+
+enum Failure {
+    Metadata,
+    Dco,
+    Auth,
+    Supersession,
+}
+
+async fn validate_metadata_and_dco<A: GovernanceAdapter>(
+    adapter: &A,
+    pending: &[String],
+) -> Result<Vec<String>, Failure> {
+    let mut records = BTreeMap::<String, String>::new();
+    let mut authors = BTreeSet::new();
+    let mut revision_signers = Vec::<(String, Vec<String>)>::new();
+
+    for revision in pending {
+        let metadata = adapter
+            .revision_metadata(revision)
+            .await
+            .map_err(|_| Failure::Metadata)?;
+        let mut grouped = BTreeMap::<String, Vec<String>>::new();
+        for entry in metadata {
+            if entry.key.starts_with(SUPERSESSION_MARKER_PREFIX) {
+                let identity = entry.key[SUPERSESSION_MARKER_PREFIX.len()..].to_string();
+                let marker: SupersessionMarkerV1 =
+                    serde_json::from_str(&entry.value).map_err(|_| Failure::Supersession)?;
+                if identity.is_empty()
+                    || marker.version != "v1"
+                    || marker.identity.is_empty()
+                    || marker.identity != identity
+                {
+                    return Err(Failure::Supersession);
+                }
+                match records.get(&identity) {
+                    Some(existing) if existing != &entry.value => {
+                        return Err(Failure::Supersession)
+                    }
+                    _ => {
+                        records.insert(identity, entry.value.clone());
+                    }
+                }
+            }
+            grouped.entry(entry.key).or_default().push(entry.value);
+        }
+
+        let message = exactly_one(&grouped, "message").ok_or(Failure::Dco)?;
+        let created_by = exactly_one(&grouped, "created-by").ok_or(Failure::Dco)?;
+        if created_by.is_empty()
+            || grouped
+                .get("committed-by")
+                .is_some_and(|values| values.len() != 1)
+        {
+            return Err(Failure::Dco);
+        }
+        let mut revision_authors = vec![created_by.to_string()];
+        if let Some(committed_by) = grouped
+            .get("committed-by")
+            .and_then(|values| values.first())
+        {
+            if committed_by.is_empty() {
+                return Err(Failure::Dco);
+            }
+            revision_authors.push(committed_by.clone());
+        }
+        let signer = parse_dco_signer(message).ok_or(Failure::Dco)?;
+        authors.extend(revision_authors.iter().cloned());
+        revision_signers.push((signer, revision_authors));
+    }
+
+    if authors.is_empty() {
+        return Err(Failure::Dco);
+    }
+    let requested: Vec<String> = authors.into_iter().collect();
+    let replies = adapter
+        .resolve_authors(&requested)
+        .await
+        .map_err(|_| Failure::Auth)?;
+    if replies.len() != requested.len() {
+        return Err(Failure::Dco);
+    }
+    let mut resolved = BTreeMap::new();
+    for reply in replies {
+        if reply.identity.is_empty()
+            || reply.display_name.is_empty()
+            || !requested.contains(&reply.identity)
+            || resolved
+                .insert(reply.identity, reply.display_name)
+                .is_some()
+        {
+            return Err(Failure::Dco);
+        }
+    }
+    for (signer, identities) in revision_signers {
+        if identities
+            .iter()
+            .any(|identity| resolved.get(identity).is_none_or(|name| name != &signer))
+        {
+            return Err(Failure::Dco);
+        }
+    }
+
+    Ok(records.into_keys().collect())
+}
+
+fn exactly_one<'a>(metadata: &'a BTreeMap<String, Vec<String>>, key: &str) -> Option<&'a str> {
+    let values = metadata.get(key)?;
+    (values.len() == 1).then(|| values[0].as_str())
+}
+
+fn parse_dco_signer(message: &str) -> Option<String> {
+    let prefix = "Signed-off-by: ";
+    let signers: Vec<&str> = message
+        .lines()
+        .filter_map(|line| line.strip_prefix(prefix))
+        .collect();
+    if signers.len() != 1 {
+        return None;
+    }
+    let signer = signers[0];
+    let (name, email_with_bracket) = signer.rsplit_once(" <")?;
+    let email = email_with_bracket.strip_suffix('>')?;
+    if name.trim().is_empty() || email.is_empty() || email.contains(char::is_whitespace) {
+        return None;
+    }
+    Some(name.trim().to_string())
+}
+
+enum TreeFailure {
+    Dependency,
+    FileInfo,
+    Invalid,
+}
+
+async fn exact_tree<A: GovernanceAdapter>(
+    adapter: &A,
+    revision: &str,
+) -> Result<BTreeMap<String, String>, TreeFailure> {
+    let paths = adapter
+        .repository_dump(revision)
+        .await
+        .map_err(|_| TreeFailure::Dependency)?;
+    let expected_paths: BTreeSet<String> = paths.iter().cloned().collect();
+    if paths.iter().any(|path| path.is_empty()) || expected_paths.len() != paths.len() {
+        return Err(TreeFailure::Invalid);
+    }
+    // `file.info` with an empty path set must never be used as a root/tree
+    // enumerator. The exact `repository.dump` enumeration above is authoritative.
+    if paths.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    let identities = adapter
+        .file_info(revision, &paths)
+        .await
+        .map_err(|_| TreeFailure::FileInfo)?;
+    if identities.len() != paths.len() {
+        return Err(TreeFailure::Invalid);
+    }
+
+    let mut tree = BTreeMap::new();
+    let mut canonical_ids = BTreeSet::new();
+    for identity in identities {
+        if identity.revision != revision
+            || identity.path.is_empty()
+            || identity.hash.is_empty()
+            || identity.context.is_empty()
+            || !expected_paths.contains(&identity.path)
+        {
+            return Err(TreeFailure::Invalid);
+        }
+        let canonical_id = identity.canonical_id();
+        if tree.insert(identity.path, canonical_id.clone()).is_some()
+            || !canonical_ids.insert(canonical_id)
+        {
+            return Err(TreeFailure::Invalid);
+        }
+    }
+    if tree.len() != expected_paths.len() {
+        return Err(TreeFailure::Invalid);
+    }
+    Ok(tree)
+}
+
+async fn affected_paths<A: GovernanceAdapter>(
+    adapter: &A,
+    base: &str,
+    candidate: &str,
+    status: &StatusSnapshot,
+    base_tree: &BTreeMap<String, String>,
+    candidate_tree: &BTreeMap<String, String>,
+) -> Result<Vec<String>, ()> {
+    let diff = adapter
+        .revision_diff(base, candidate)
+        .await
+        .map_err(|_| ())?;
+    let mut paths = BTreeSet::new();
+    for file in diff {
+        if let Some(source) = file.source_path.filter(|path| !path.is_empty()) {
+            paths.insert(source);
+        }
+        if let Some(target) = file.target_path.filter(|path| !path.is_empty()) {
+            paths.insert(target);
+        }
+    }
+    paths.extend(
+        status
+            .staged_paths
+            .iter()
+            .filter(|path| !path.is_empty())
+            .cloned(),
+    );
+    for path in base_tree.keys().chain(candidate_tree.keys()) {
+        if base_tree.get(path) != candidate_tree.get(path) {
+            paths.insert(path.clone());
+        }
+    }
+    Ok(paths.into_iter().collect())
+}
+
+enum LockFailure {
+    Dependency,
+    Locked,
+}
+
+async fn validate_locks<A: GovernanceAdapter>(
+    adapter: &A,
+    paths: &[String],
+) -> Result<(), LockFailure> {
+    let requested: BTreeSet<String> = paths.iter().cloned().collect();
+    if requested.len() != paths.len() || requested.is_empty() {
+        return Err(LockFailure::Dependency);
+    }
+    for path in paths {
+        let query = adapter
+            .lock_file_query(path)
+            .await
+            .map_err(|_| LockFailure::Dependency)?;
+        if query.path != *path {
+            return Err(LockFailure::Dependency);
+        }
+        if query.begin_events != 1
+            || !query.completed
+            || !query.ignored_paths.is_empty()
+            || query.expected_count != query.owners.len()
+        {
+            return Err(LockFailure::Dependency);
+        }
+        if !query.owners.is_empty() {
+            return Err(LockFailure::Locked);
+        }
+    }
+    let status = adapter
+        .lock_file_status(paths)
+        .await
+        .map_err(|_| LockFailure::Dependency)?;
+    if status.begin_events != 1
+        || !status.completed
+        || !status.ignored_paths.is_empty()
+        || status.expected_count != status.statuses.len()
+    {
+        return Err(LockFailure::Dependency);
+    }
+    let mut observed = BTreeSet::new();
+    for record in status.statuses {
+        if !requested.contains(&record.path) || !observed.insert(record.path) {
+            return Err(LockFailure::Dependency);
+        }
+        if record.owner.is_some() {
+            return Err(LockFailure::Locked);
+        }
+    }
+    Ok(())
+}

--- a/crates/lore-vm/src/ops/governance/evaluator.rs
+++ b/crates/lore-vm/src/ops/governance/evaluator.rs
@@ -1,7 +1,9 @@
 //! Injectable, fail-closed Option-A evaluator.
 
 use super::contract::{
-    ExactRevisionRequest, SupersessionMarkerV1, MAX_GOVERNANCE_HISTORY_REVISIONS,
+    AdapterError, AffectedPath, EvaluationResult, ExactRevisionRequest, FileIdentity, LockQuery,
+    LockStatus, LockStatusResponse, MetadataEntry, ResolvedAuthor, RevisionInfo,
+    RevisionInfoResponse, StatusSnapshot, SupersessionMarkerV1, MAX_GOVERNANCE_HISTORY_REVISIONS,
     SUPERSESSION_MARKER_PREFIX,
 };
 use crate::api::LoreApi;
@@ -9,261 +11,17 @@ use crate::ops::{auth, file, revision};
 use lore::interface::{LoreArray, LoreEvent, LoreEventCallback, LoreString};
 use lore::lock::{LoreLockFileQueryArgs, LoreLockFileStatusArgs};
 use lore::repository::{LoreRepositoryDumpArgs, LoreRepositoryStatusArgs};
-use serde::{Deserialize, Serialize};
+use lore::revision::LoreRevisionInfoArgs;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 use tokio::sync::oneshot;
-
-/// A dependency failure reported by a production Lore adapter.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct AdapterError {
-    pub message: String,
-}
-
-impl AdapterError {
-    pub fn new(message: impl Into<String>) -> Self {
-        Self {
-            message: message.into(),
-        }
-    }
-}
-
-/// Exact staged state returned by the production status adapter.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct StatusSnapshot {
-    pub staged_revisions: Vec<String>,
-    pub staged_paths: Vec<String>,
-    pub worktree_clean: bool,
-}
-
-/// Exact revision information required for graph traversal.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct RevisionInfo {
-    pub revision: String,
-    pub parents: Vec<String>,
-}
-
-/// One exact revision metadata pair.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct MetadataEntry {
-    pub key: String,
-    pub value: String,
-}
-
-impl MetadataEntry {
-    pub fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
-        Self {
-            key: key.into(),
-            value: value.into(),
-        }
-    }
-}
-
-/// A file identity read at one explicit revision.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct FileIdentity {
-    pub path: String,
-    pub revision: String,
-    pub hash: String,
-    pub context: String,
-}
-
-impl FileIdentity {
-    pub fn new(
-        path: impl Into<String>,
-        revision: impl Into<String>,
-        hash: impl Into<String>,
-        context: impl Into<String>,
-    ) -> Self {
-        Self {
-            path: path.into(),
-            revision: revision.into(),
-            hash: hash.into(),
-            context: context.into(),
-        }
-    }
-
-    pub fn canonical_id(&self) -> String {
-        format!("{}:{}", self.hash, self.context)
-    }
-}
-
-/// An exact base-to-candidate changed path, including rename endpoints.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct AffectedPath {
-    pub source_path: Option<String>,
-    pub target_path: Option<String>,
-}
-
-impl AffectedPath {
-    pub fn modified(path: impl Into<String>) -> Self {
-        let path = path.into();
-        Self {
-            source_path: Some(path.clone()),
-            target_path: Some(path),
-        }
-    }
-}
-
-/// One author resolution response from `auth.resolve_user_info`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct ResolvedAuthor {
-    pub identity: String,
-    pub display_name: String,
-}
-
-impl ResolvedAuthor {
-    pub fn new(identity: impl Into<String>, display_name: impl Into<String>) -> Self {
-        Self {
-            identity: identity.into(),
-            display_name: display_name.into(),
-        }
-    }
-}
-
-/// Complete response for a single lock query, including the requested identity.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct LockQuery {
-    pub path: String,
-    pub begin_events: usize,
-    pub expected_count: usize,
-    pub completed: bool,
-    pub ignored_paths: Vec<String>,
-    pub owners: Vec<String>,
-}
-
-impl LockQuery {
-    pub fn unlocked(path: impl Into<String>) -> Self {
-        Self {
-            path: path.into(),
-            begin_events: 1,
-            expected_count: 0,
-            completed: true,
-            ignored_paths: Vec::new(),
-            owners: Vec::new(),
-        }
-    }
-
-    pub fn incomplete(path: impl Into<String>) -> Self {
-        Self {
-            path: path.into(),
-            begin_events: 0,
-            expected_count: 0,
-            completed: false,
-            ignored_paths: Vec::new(),
-            owners: Vec::new(),
-        }
-    }
-
-    pub fn with_owners(
-        path: impl Into<String>,
-        expected_count: usize,
-        owners: Vec<String>,
-    ) -> Self {
-        Self {
-            path: path.into(),
-            begin_events: 1,
-            expected_count,
-            completed: true,
-            ignored_paths: Vec::new(),
-            owners,
-        }
-    }
-}
-
-/// One response in the complete lock-status stream.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct LockStatus {
-    pub path: String,
-    pub owner: Option<String>,
-}
-
-impl LockStatus {
-    pub fn unlocked(path: impl Into<String>) -> Self {
-        Self {
-            path: path.into(),
-            owner: None,
-        }
-    }
-
-    pub fn locked(path: impl Into<String>, owner: impl Into<String>) -> Self {
-        Self {
-            path: path.into(),
-            owner: Some(owner.into()),
-        }
-    }
-}
-
-/// Raw, terminally verified lock-status stream. `statuses` contains lock
-/// events only; an unlocked path is proved by a zero-count successful stream
-/// with no ignored paths, not by fabricating an unlocked event.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct LockStatusResponse {
-    pub begin_events: usize,
-    pub expected_count: usize,
-    pub completed: bool,
-    pub ignored_paths: Vec<String>,
-    pub statuses: Vec<LockStatus>,
-}
-
-impl LockStatusResponse {
-    pub fn unlocked() -> Self {
-        Self {
-            begin_events: 1,
-            expected_count: 0,
-            completed: true,
-            ignored_paths: Vec::new(),
-            statuses: Vec::new(),
-        }
-    }
-
-    pub fn incomplete() -> Self {
-        Self {
-            begin_events: 0,
-            expected_count: 0,
-            completed: false,
-            ignored_paths: Vec::new(),
-            statuses: Vec::new(),
-        }
-    }
-
-    pub fn with_locks(expected_count: usize, statuses: Vec<LockStatus>) -> Self {
-        Self {
-            begin_events: 1,
-            expected_count,
-            completed: true,
-            ignored_paths: Vec::new(),
-            statuses,
-        }
-    }
-
-    pub fn ignored(path: impl Into<String>) -> Self {
-        Self {
-            begin_events: 1,
-            expected_count: 0,
-            completed: true,
-            ignored_paths: vec![path.into()],
-            statuses: Vec::new(),
-        }
-    }
-}
 
 /// The production Lore adapter interface. Implementations must bind every call
 /// to the explicit revisions and paths supplied by this evaluator.
 #[async_trait::async_trait]
 pub trait GovernanceAdapter {
     async fn status(&self) -> Result<StatusSnapshot, AdapterError>;
-    async fn revision_info(&self, revision: &str) -> Result<RevisionInfo, AdapterError>;
+    async fn revision_info(&self, revision: &str) -> Result<RevisionInfoResponse, AdapterError>;
     async fn revision_metadata(&self, revision: &str) -> Result<Vec<MetadataEntry>, AdapterError>;
     /// Return candidate-side first-parent revisions only, not the target base,
     /// with the supplied sentinel limit applied at the Lore boundary.
@@ -312,67 +70,78 @@ impl<'a> ProductionLoreAdapter<'a> {
     }
 }
 
+fn revision_only_status_args() -> LoreRepositoryStatusArgs {
+    LoreRepositoryStatusArgs {
+        staged: 0,
+        scan: 0,
+        check_dirty: 0,
+        reset: 0,
+        sync_point: 0,
+        revision_only: 1,
+        count: 0,
+        paths: LoreArray::from_vec(Vec::new()),
+    }
+}
+
+fn scanned_status_args() -> LoreRepositoryStatusArgs {
+    LoreRepositoryStatusArgs {
+        staged: 1,
+        scan: 1,
+        check_dirty: 0,
+        reset: 0,
+        sync_point: 0,
+        revision_only: 0,
+        count: 0,
+        paths: LoreArray::from_vec(Vec::new()),
+    }
+}
+
+async fn repository_status_stream(
+    api: &LoreApi,
+    args: LoreRepositoryStatusArgs,
+) -> Result<RawEventStream, AdapterError> {
+    let (callback, receiver) = raw_event_collector();
+    let returned = lore::repository::status(api.globals().build(), args, callback).await;
+    finished_raw_stream(receiver, returned).await
+}
+
+fn status_staged_revisions(
+    stream: &RawEventStream,
+    context: &str,
+) -> Result<Vec<String>, AdapterError> {
+    let revisions: Vec<_> = stream
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            LoreEvent::RepositoryStatusRevision(data) => Some(data),
+            _ => None,
+        })
+        .collect();
+    if revisions.len() != 1 {
+        return Err(AdapterError::new(format!(
+            "{context} did not emit exactly one status revision"
+        )));
+    }
+    Ok((!revisions[0].revision_staged.is_zero())
+        .then_some(format!("{}", revisions[0].revision_staged))
+        .into_iter()
+        .collect())
+}
+
 #[async_trait::async_trait]
 impl GovernanceAdapter for ProductionLoreAdapter<'_> {
     async fn status(&self) -> Result<StatusSnapshot, AdapterError> {
-        let (callback, receiver) = raw_event_collector();
-        let returned = lore::repository::status(
-            self.api.globals().build(),
-            LoreRepositoryStatusArgs {
-                staged: 0,
-                scan: 0,
-                check_dirty: 0,
-                reset: 0,
-                sync_point: 0,
-                revision_only: 1,
-                count: 0,
-                paths: LoreArray::from_vec(Vec::new()),
-            },
-            callback,
-        )
-        .await;
-        let stream = finished_raw_stream(receiver, returned).await?;
-        let revisions: Vec<_> = stream
-            .events
-            .into_iter()
-            .filter_map(|event| match event {
-                LoreEvent::RepositoryStatusRevision(data) => Some(data),
-                _ => None,
-            })
-            .collect();
-        if revisions.len() != 1 {
-            return Err(AdapterError::new(
-                "repository status did not emit exactly one revision",
-            ));
-        }
-        let staged_revisions = (!revisions[0].revision_staged.is_zero())
-            .then_some(format!("{}", revisions[0].revision_staged))
-            .into_iter()
-            .collect::<Vec<_>>();
+        let initial_stream =
+            repository_status_stream(self.api, revision_only_status_args()).await?;
+        let staged_revisions = status_staged_revisions(&initial_stream, "initial exact status")?;
 
-        let (callback, receiver) = raw_event_collector();
-        let returned = lore::repository::status(
-            self.api.globals().build(),
-            LoreRepositoryStatusArgs {
-                staged: 0,
-                scan: 0,
-                check_dirty: 0,
-                reset: 0,
-                sync_point: 0,
-                revision_only: 0,
-                count: 0,
-                paths: LoreArray::from_vec(Vec::new()),
-            },
-            callback,
-        )
-        .await;
-        let stream = finished_raw_stream(receiver, returned).await?;
-        let mut detail_revisions = Vec::new();
+        let scanned_stream = repository_status_stream(self.api, scanned_status_args()).await?;
+        let scanned_staged_revisions =
+            status_staged_revisions(&scanned_stream, "full scanned status")?;
         let mut staged_paths = BTreeSet::new();
         let mut worktree_clean = true;
-        for event in stream.events {
+        for event in scanned_stream.events {
             match event {
-                LoreEvent::RepositoryStatusRevision(data) => detail_revisions.push(data),
                 LoreEvent::RepositoryStatusFile(data) => {
                     if data.flag_staged != 0 {
                         if !data.path.is_empty() {
@@ -394,43 +163,59 @@ impl GovernanceAdapter for ProductionLoreAdapter<'_> {
                 _ => {}
             }
         }
-        if detail_revisions.len() != 1 {
+
+        let post_scan_stream =
+            repository_status_stream(self.api, revision_only_status_args()).await?;
+        let post_scan_staged_revisions =
+            status_staged_revisions(&post_scan_stream, "post-scan exact status")?;
+        if scanned_staged_revisions != staged_revisions
+            || post_scan_staged_revisions != staged_revisions
+        {
             return Err(AdapterError::new(
-                "worktree status did not emit exactly one revision",
+                "full status scan changed the exact staged subject",
             ));
         }
-        let detail_staged = (!detail_revisions[0].revision_staged.is_zero())
-            .then_some(format!("{}", detail_revisions[0].revision_staged));
-        if detail_staged.as_deref() != staged_revisions.first().map(String::as_str) {
-            return Err(AdapterError::new(
-                "worktree status changed the exact staged subject",
-            ));
-        }
+
         Ok(StatusSnapshot {
             staged_revisions,
+            scanned_staged_revisions,
+            post_scan_staged_revisions,
             staged_paths: staged_paths.into_iter().collect(),
             worktree_clean,
+            scan_performed: true,
         })
     }
 
-    async fn revision_info(&self, revision_id: &str) -> Result<RevisionInfo, AdapterError> {
-        let result = revision::info::info(
-            self.api,
-            revision::info::RevisionInfoArgs {
-                revision: revision_id.into(),
-                delta: false,
-                metadata: false,
+    async fn revision_info(&self, revision_id: &str) -> Result<RevisionInfoResponse, AdapterError> {
+        let (callback, receiver) = raw_event_collector();
+        let returned = lore::revision::info(
+            self.api.globals().build(),
+            LoreRevisionInfoArgs {
+                revision: LoreString::from_str(revision_id),
+                delta: 0,
+                metadata: 0,
             },
+            callback,
         )
-        .await
-        .map_err(adapter_error)?;
-        let info = result
-            .info
-            .ok_or_else(|| AdapterError::new("revision info emitted no revision"))?;
-        Ok(RevisionInfo {
-            revision: info.revision,
-            parents: info.parents,
-        })
+        .await;
+        let stream = finished_raw_stream(receiver, returned).await?;
+        let revisions = stream
+            .events
+            .into_iter()
+            .filter_map(|event| match event {
+                LoreEvent::RevisionInfo(data) => Some(RevisionInfo {
+                    revision: format!("{}", data.revision),
+                    parents: data
+                        .parent
+                        .iter()
+                        .filter(|parent| !parent.is_zero())
+                        .map(|parent| format!("{parent}"))
+                        .collect(),
+                }),
+                _ => None,
+            })
+            .collect();
+        Ok(RevisionInfoResponse { revisions })
     }
 
     async fn revision_metadata(
@@ -776,19 +561,6 @@ async fn finished_raw_stream(
     Ok(stream)
 }
 
-/// Deterministic evaluator result. A dependency failure is represented as a
-/// closed result so callers cannot accidentally convert it into an open gate.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct EvaluationResult {
-    pub open: bool,
-    pub pending_revisions: Vec<String>,
-    pub affected_paths: Vec<String>,
-    pub identities: Vec<String>,
-    pub superseded_identities: Vec<String>,
-    pub failure_codes: Vec<String>,
-}
-
 impl EvaluationResult {
     fn closed(code: impl Into<String>) -> Self {
         Self {
@@ -819,9 +591,16 @@ where
         Ok(status) => status,
         Err(_) => return EvaluationResult::closed("status_unavailable"),
     };
-    if status.staged_revisions.len() != 1
-        || status.staged_revisions[0].is_empty()
-        || status.staged_revisions[0] != expected
+    if !status.scan_performed {
+        return EvaluationResult::closed("worktree_unverified");
+    }
+    if [
+        &status.staged_revisions,
+        &status.scanned_staged_revisions,
+        &status.post_scan_staged_revisions,
+    ]
+    .into_iter()
+    .any(|revisions| revisions.len() != 1 || revisions[0].is_empty() || revisions[0] != expected)
     {
         return EvaluationResult::closed("exact_subject_failed");
     }
@@ -836,7 +615,8 @@ where
 
     let pending = match pending_dag(adapter, expected, base).await {
         Ok(revisions) => revisions,
-        Err(()) => return EvaluationResult::closed("history_incomplete"),
+        Err(GraphFailure::Incomplete) => return EvaluationResult::closed("history_incomplete"),
+        Err(GraphFailure::Depth) => return EvaluationResult::closed("history_depth_exceeded"),
     };
 
     let history = match adapter
@@ -857,7 +637,7 @@ where
         return EvaluationResult::closed("history_incomplete");
     }
 
-    let superseded = match validate_metadata_and_dco(adapter, &pending).await {
+    let superseded = match validate_metadata_and_dco(adapter, base, &pending).await {
         Ok(superseded) => superseded,
         Err(Failure::Metadata) => return EvaluationResult::closed("metadata_unavailable"),
         Err(Failure::Dco) => return EvaluationResult::closed("dco_invalid"),
@@ -925,18 +705,27 @@ where
 }
 
 async fn exact_info<A: GovernanceAdapter>(adapter: &A, revision: &str) -> Result<RevisionInfo, ()> {
-    let info = adapter.revision_info(revision).await.map_err(|_| ())?;
+    let response = adapter.revision_info(revision).await.map_err(|_| ())?;
+    if response.revisions.len() != 1 {
+        return Err(());
+    }
+    let info = response.revisions.into_iter().next().ok_or(())?;
     if info.revision.is_empty() || info.revision != revision {
         return Err(());
     }
     Ok(info)
 }
 
+enum GraphFailure {
+    Incomplete,
+    Depth,
+}
+
 async fn pending_dag<A: GovernanceAdapter>(
     adapter: &A,
     candidate: &str,
     base: &str,
-) -> Result<Vec<String>, ()> {
+) -> Result<Vec<String>, GraphFailure> {
     #[derive(Clone, Copy, PartialEq, Eq)]
     enum Visit {
         Active,
@@ -956,19 +745,26 @@ async fn pending_dag<A: GovernanceAdapter>(
             continue;
         }
         match visit.get(&revision) {
-            Some(Visit::Active) => return Err(()),
+            Some(Visit::Active) => return Err(GraphFailure::Incomplete),
             Some(Visit::Complete) => continue,
             None => {}
         }
 
-        let info = exact_info(adapter, &revision).await?;
+        // Fetch and exact-verify the 1001st unique revision as the overflow
+        // sentinel, then stop without walking the rest of the arbitrary DAG.
+        let info = exact_info(adapter, &revision)
+            .await
+            .map_err(|_| GraphFailure::Incomplete)?;
         if info.parents.is_empty()
             || info
                 .parents
                 .iter()
                 .any(|parent| parent.is_empty() || parent == &revision)
         {
-            return Err(());
+            return Err(GraphFailure::Incomplete);
+        }
+        if pending.len() == MAX_GOVERNANCE_HISTORY_REVISIONS {
+            return Err(GraphFailure::Depth);
         }
         visit.insert(revision.clone(), Visit::Active);
         pending.insert(revision.clone());
@@ -979,7 +775,7 @@ async fn pending_dag<A: GovernanceAdapter>(
     }
 
     if pending.is_empty() {
-        return Err(());
+        return Err(GraphFailure::Incomplete);
     }
     Ok(pending.into_iter().collect())
 }
@@ -1021,39 +817,27 @@ enum Failure {
 
 async fn validate_metadata_and_dco<A: GovernanceAdapter>(
     adapter: &A,
+    base: &str,
     pending: &[String],
 ) -> Result<Vec<String>, Failure> {
     let mut records = BTreeMap::<String, String>::new();
     let mut authors = BTreeSet::new();
     let mut revision_signers = Vec::<(String, Vec<String>)>::new();
 
+    let base_metadata = adapter
+        .revision_metadata(base)
+        .await
+        .map_err(|_| Failure::Metadata)?;
+    scan_supersession_entries(&base_metadata, &mut records)?;
+
     for revision in pending {
         let metadata = adapter
             .revision_metadata(revision)
             .await
             .map_err(|_| Failure::Metadata)?;
+        scan_supersession_entries(&metadata, &mut records)?;
         let mut grouped = BTreeMap::<String, Vec<String>>::new();
         for entry in metadata {
-            if entry.key.starts_with(SUPERSESSION_MARKER_PREFIX) {
-                let identity = entry.key[SUPERSESSION_MARKER_PREFIX.len()..].to_string();
-                let marker: SupersessionMarkerV1 =
-                    serde_json::from_str(&entry.value).map_err(|_| Failure::Supersession)?;
-                if identity.is_empty()
-                    || marker.version != "v1"
-                    || marker.identity.is_empty()
-                    || marker.identity != identity
-                {
-                    return Err(Failure::Supersession);
-                }
-                match records.get(&identity) {
-                    Some(existing) if existing != &entry.value => {
-                        return Err(Failure::Supersession)
-                    }
-                    _ => {
-                        records.insert(identity, entry.value.clone());
-                    }
-                }
-            }
             grouped.entry(entry.key).or_default().push(entry.value);
         }
 
@@ -1116,16 +900,66 @@ async fn validate_metadata_and_dco<A: GovernanceAdapter>(
     Ok(records.into_keys().collect())
 }
 
+fn scan_supersession_entries(
+    metadata: &[MetadataEntry],
+    records: &mut BTreeMap<String, String>,
+) -> Result<(), Failure> {
+    for entry in metadata {
+        if !entry.key.starts_with(SUPERSESSION_MARKER_PREFIX) {
+            continue;
+        }
+        let identity = entry.key[SUPERSESSION_MARKER_PREFIX.len()..].to_string();
+        let marker: SupersessionMarkerV1 =
+            serde_json::from_str(&entry.value).map_err(|_| Failure::Supersession)?;
+        if identity.is_empty()
+            || marker.version != "v1"
+            || marker.identity.is_empty()
+            || marker.identity != identity
+        {
+            return Err(Failure::Supersession);
+        }
+        match records.get(&identity) {
+            Some(existing) if existing != &entry.value => return Err(Failure::Supersession),
+            _ => {
+                records.insert(identity, entry.value.clone());
+            }
+        }
+    }
+    Ok(())
+}
+
 fn exactly_one<'a>(metadata: &'a BTreeMap<String, Vec<String>>, key: &str) -> Option<&'a str> {
     let values = metadata.get(key)?;
     (values.len() == 1).then(|| values[0].as_str())
 }
 
 fn parse_dco_signer(message: &str) -> Option<String> {
-    let prefix = "Signed-off-by: ";
-    let signers: Vec<&str> = message
-        .lines()
-        .filter_map(|line| line.strip_prefix(prefix))
+    let mut lines: Vec<&str> = message.lines().collect();
+    while lines.last().is_some_and(|line| line.is_empty()) {
+        lines.pop();
+    }
+    let end = lines.len();
+    let mut start = end;
+    while start > 0 && parse_trailer(lines[start - 1]).is_some() {
+        start -= 1;
+    }
+    if start == end
+        || start == 0
+        || !lines[start - 1].is_empty()
+        || !lines[..start - 1].iter().any(|line| !line.is_empty())
+        || lines[..start]
+            .iter()
+            .any(|line| line.starts_with("Signed-off-by:"))
+    {
+        return None;
+    }
+
+    let signers: Vec<&str> = lines[start..end]
+        .iter()
+        .filter_map(|line| {
+            let (key, value) = parse_trailer(line)?;
+            (key == "Signed-off-by").then_some(value)
+        })
         .collect();
     if signers.len() != 1 {
         return None;
@@ -1137,6 +971,21 @@ fn parse_dco_signer(message: &str) -> Option<String> {
         return None;
     }
     Some(name.trim().to_string())
+}
+
+fn parse_trailer(line: &str) -> Option<(&str, &str)> {
+    let (key, value) = line.split_once(": ")?;
+    if key.is_empty()
+        || !key.as_bytes()[0].is_ascii_alphanumeric()
+        || !key
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        || value.is_empty()
+        || value.trim() != value
+    {
+        return None;
+    }
+    Some((key, value))
 }
 
 enum TreeFailure {
@@ -1283,4 +1132,42 @@ async fn validate_locks<A: GovernanceAdapter>(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{revision_only_status_args, scanned_status_args};
+
+    #[test]
+    fn production_status_arguments_pin_exact_reads_and_full_scan() {
+        let exact = revision_only_status_args();
+        assert_eq!(
+            (
+                exact.staged,
+                exact.scan,
+                exact.check_dirty,
+                exact.reset,
+                exact.sync_point,
+                exact.revision_only,
+                exact.count,
+            ),
+            (0, 0, 0, 0, 0, 1, 0)
+        );
+        assert!(exact.paths.is_empty());
+
+        let scan = scanned_status_args();
+        assert_eq!(
+            (
+                scan.staged,
+                scan.scan,
+                scan.check_dirty,
+                scan.reset,
+                scan.sync_point,
+                scan.revision_only,
+                scan.count,
+            ),
+            (1, 1, 0, 0, 0, 0, 0)
+        );
+        assert!(scan.paths.is_empty());
+    }
 }

--- a/crates/lore-vm/src/ops/governance/evaluator.rs
+++ b/crates/lore-vm/src/ops/governance/evaluator.rs
@@ -1,25 +1,38 @@
 //! Injectable, fail-closed Option-A evaluator.
 
 use super::contract::{
-    AdapterError, AffectedPath, EvaluationResult, ExactRevisionRequest, FileIdentity, LockQuery,
-    LockStatus, LockStatusResponse, MetadataEntry, ResolvedAuthor, RevisionInfo,
-    RevisionInfoResponse, StatusSnapshot, SupersessionMarkerV1, MAX_GOVERNANCE_HISTORY_REVISIONS,
-    SUPERSESSION_MARKER_PREFIX,
+    AdapterError, AffectedPath, AuthorResolutionObservation, DcoMetadataObservation,
+    DcoObservation, DcoValidateResult, EvaluationResult, ExactRevisionRequest, FileIdentity,
+    GovernanceObservations, GovernancePathAction, GovernanceRemediation, GovernanceRemediationCode,
+    HistoryOverflowScope, LockQuery, LockStatus, LockStatusResponse, MetadataEntry, MetadataKind,
+    ResolvedAuthor, RevisionDiffObservation, RevisionInfo, RevisionInfoResponse,
+    StagedPathObservation, StatusSnapshot, SupersessionMarkerV1,
+    SupersessionMetadataQueryObservation, SupersessionObservation, WorktreeFileObservation,
+    MAX_GOVERNANCE_HISTORY_REVISIONS, SUPERSESSION_MARKER_PREFIX,
 };
 use crate::api::LoreApi;
-use crate::ops::{auth, file, revision};
-use lore::interface::{LoreArray, LoreEvent, LoreEventCallback, LoreString};
+use lore::auth::LoreAuthUserInfoArgs;
+use lore::file::LoreFileInfoArgs;
+use lore::interface::{LoreArray, LoreEvent, LoreEventCallback, LoreMetadata, LoreString};
 use lore::lock::{LoreLockFileQueryArgs, LoreLockFileStatusArgs};
 use lore::repository::{LoreRepositoryDumpArgs, LoreRepositoryStatusArgs};
-use lore::revision::LoreRevisionInfoArgs;
+use lore::revision::{
+    LoreRevisionDiffArgs, LoreRevisionHistoryArgs, LoreRevisionInfoArgs,
+    LoreRevisionMetadataListArgs,
+};
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
 use std::sync::{Arc, Mutex};
-use tokio::sync::oneshot;
 
 /// The production Lore adapter interface. Implementations must bind every call
 /// to the explicit revisions and paths supplied by this evaluator.
 #[async_trait::async_trait]
 pub trait GovernanceAdapter {
+    /// Read only the exact staged subject. Production overrides this with a
+    /// revision-only call so DCO does not depend on a filesystem scan.
+    async fn exact_staged_revisions(&self) -> Result<Vec<String>, AdapterError> {
+        Ok(self.status().await?.staged_revisions)
+    }
     async fn status(&self) -> Result<StatusSnapshot, AdapterError>;
     async fn revision_info(&self, revision: &str) -> Result<RevisionInfoResponse, AdapterError>;
     async fn revision_metadata(&self, revision: &str) -> Result<Vec<MetadataEntry>, AdapterError>;
@@ -43,13 +56,17 @@ pub trait GovernanceAdapter {
         &self,
         base: &str,
         candidate: &str,
-    ) -> Result<Vec<AffectedPath>, AdapterError>;
+    ) -> Result<Vec<RevisionDiffObservation>, AdapterError>;
     async fn resolve_authors(
         &self,
         identities: &[String],
     ) -> Result<Vec<ResolvedAuthor>, AdapterError>;
-    async fn lock_file_query(&self, path: &str) -> Result<LockQuery, AdapterError>;
-    async fn lock_file_status(&self, paths: &[String]) -> Result<LockStatusResponse, AdapterError>;
+    async fn lock_file_query(&self, branch: &str, path: &str) -> Result<LockQuery, AdapterError>;
+    async fn lock_file_status(
+        &self,
+        branch: &str,
+        paths: &[String],
+    ) -> Result<LockStatusResponse, AdapterError>;
 }
 
 /// In-process production adapter for the shipped Lore API. It uses the
@@ -58,15 +75,11 @@ pub trait GovernanceAdapter {
 /// counts and ignored-path evidence.
 pub struct ProductionLoreAdapter<'a> {
     api: &'a LoreApi,
-    branch: String,
 }
 
 impl<'a> ProductionLoreAdapter<'a> {
-    pub fn new(api: &'a LoreApi, branch: impl Into<String>) -> Self {
-        Self {
-            api,
-            branch: branch.into(),
-        }
+    pub fn new(api: &'a LoreApi, _branch: impl Into<String>) -> Self {
+        Self { api }
     }
 }
 
@@ -100,9 +113,9 @@ async fn repository_status_stream(
     api: &LoreApi,
     args: LoreRepositoryStatusArgs,
 ) -> Result<RawEventStream, AdapterError> {
-    let (callback, receiver) = raw_event_collector();
+    let (callback, stream) = raw_event_collector();
     let returned = lore::repository::status(api.globals().build(), args, callback).await;
-    finished_raw_stream(receiver, returned).await
+    finished_raw_stream(stream, returned)
 }
 
 fn status_staged_revisions(
@@ -128,17 +141,244 @@ fn status_staged_revisions(
         .collect())
 }
 
+fn status_branch(stream: &RawEventStream, context: &str) -> Result<String, AdapterError> {
+    let branches: Vec<_> = stream
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            LoreEvent::RepositoryStatusRevision(data) => Some(&data.branch),
+            _ => None,
+        })
+        .collect();
+    if branches.len() != 1 || branches[0].is_zero() {
+        return Err(AdapterError::new(format!(
+            "{context} did not emit exactly one nonzero branch"
+        )));
+    }
+    Ok(format!("{}", branches[0]))
+}
+
+#[derive(Debug)]
+struct RawFileInfoEntry {
+    path: String,
+    context: String,
+    hash: String,
+    is_file: bool,
+    flag_modified: bool,
+    flag_deleted: bool,
+    flag_added: bool,
+    flag_conflict: bool,
+    size: u64,
+    local_size: u64,
+    local_hash: String,
+    filter_size: u64,
+}
+
+fn lore_file_info_path(path: &str, repository_path: &Path) -> LoreString {
+    if Path::new(path).is_absolute() {
+        LoreString::from_str(path)
+    } else {
+        LoreString::from_path(repository_path.join(path))
+    }
+}
+
+async fn raw_file_info(
+    api: &LoreApi,
+    paths: &[String],
+    revision: &str,
+    local: bool,
+    filtered: bool,
+) -> Result<Vec<RawFileInfoEntry>, AdapterError> {
+    let globals = api.globals();
+    let repository_path = globals.repository_path.clone();
+    let (callback, stream) = raw_event_collector();
+    let returned = lore::file::info(
+        globals.build(),
+        LoreFileInfoArgs {
+            paths: LoreArray::from_vec(
+                paths
+                    .iter()
+                    .map(|path| lore_file_info_path(path, &repository_path))
+                    .collect(),
+            ),
+            revision: LoreString::from_str(revision),
+            local: u8::from(local),
+            filtered: u8::from(filtered),
+        },
+        callback,
+    )
+    .await;
+    let stream = finished_raw_stream(stream, returned)?;
+    let mut entries = Vec::new();
+    for event in stream.events {
+        match event {
+            LoreEvent::FileInfo(data) => entries.push(RawFileInfoEntry {
+                path: data.path.as_str().to_string(),
+                context: format!("{}", data.context),
+                hash: format!("{}", data.hash),
+                is_file: data.is_file != 0,
+                flag_modified: data.flag_modified != 0,
+                flag_deleted: data.flag_deleted != 0,
+                flag_added: data.flag_added != 0,
+                flag_conflict: data.flag_conflict != 0,
+                size: data.size,
+                local_size: data.local_size,
+                local_hash: format!("{}", data.local_hash),
+                filter_size: data.filter_size,
+            }),
+            LoreEvent::PathIgnore(_) => {
+                return Err(AdapterError::new("file info ignored a requested path"))
+            }
+            _ => {}
+        }
+    }
+    Ok(entries)
+}
+
+#[derive(Default)]
+struct RawMetadataStream {
+    entries: Vec<MetadataEntry>,
+    event_count: usize,
+    complete_events: usize,
+    complete_status: Option<i32>,
+    complete_position: Option<usize>,
+    error_events: usize,
+    end_events: usize,
+    end_position: Option<usize>,
+    last_was_end: bool,
+    unrepresentable: bool,
+}
+
+fn raw_metadata_collector() -> (LoreEventCallback, Arc<Mutex<RawMetadataStream>>) {
+    let stream = Arc::new(Mutex::new(RawMetadataStream::default()));
+    let observed = Arc::clone(&stream);
+    let callback = Box::new(move |event: &LoreEvent| {
+        let mut locked = observed
+            .lock()
+            .expect("raw metadata collector mutex poisoned");
+        let position = locked.event_count;
+        locked.event_count += 1;
+        locked.last_was_end = matches!(event, LoreEvent::End(_));
+        match event {
+            LoreEvent::Metadata(data) => {
+                let key = data.key.as_str().to_string();
+                let entry = match &data.value {
+                    LoreMetadata::Address(value) => Some(MetadataEntry::with_kind(
+                        key,
+                        MetadataKind::Address,
+                        format!("{value}"),
+                    )),
+                    LoreMetadata::Boolean(value) => Some(MetadataEntry::with_kind(
+                        key,
+                        MetadataKind::Boolean,
+                        if *value == 0 { "false" } else { "true" },
+                    )),
+                    LoreMetadata::Context(value) => Some(MetadataEntry::with_kind(
+                        key,
+                        MetadataKind::Context,
+                        format!("{value}"),
+                    )),
+                    LoreMetadata::Hash(value) => Some(MetadataEntry::with_kind(
+                        key,
+                        MetadataKind::Hash,
+                        format!("{value}"),
+                    )),
+                    LoreMetadata::Numeric(value) => Some(MetadataEntry::with_kind(
+                        key,
+                        MetadataKind::Numeric,
+                        value.to_string(),
+                    )),
+                    LoreMetadata::String(value) => Some(MetadataEntry::with_kind(
+                        key,
+                        MetadataKind::String,
+                        value.as_str(),
+                    )),
+                    // Pinned Lore's metadata-list emitter omits inline Binary
+                    // before callback delivery. SBAI-6012 owns making that
+                    // boundary observable, paired with SBAI-6011's provenance
+                    // work; a future emitting pin must fail closed until then.
+                    LoreMetadata::Binary(_) => {
+                        locked.unrepresentable = true;
+                        None
+                    }
+                };
+                if let Some(entry) = entry {
+                    locked.entries.push(entry);
+                }
+            }
+            LoreEvent::Complete(data) => {
+                locked.complete_events += 1;
+                locked.complete_status = Some(data.status);
+                locked.complete_position = Some(position);
+            }
+            LoreEvent::Error(_) => locked.error_events += 1,
+            LoreEvent::End(_) => {
+                locked.end_events += 1;
+                locked.end_position = Some(position);
+            }
+            _ => {}
+        }
+    });
+    (Some(callback), stream)
+}
+
+fn finished_raw_metadata(
+    observed: Arc<Mutex<RawMetadataStream>>,
+    returned: i32,
+) -> Result<Vec<MetadataEntry>, AdapterError> {
+    let stream = std::mem::take(
+        &mut *observed
+            .lock()
+            .expect("raw metadata collector mutex poisoned"),
+    );
+    if returned != 0
+        || stream.complete_events != 1
+        || stream.complete_status != Some(0)
+        || stream.error_events != 0
+        || stream.end_events != 1
+        || stream
+            .complete_position
+            .zip(stream.end_position)
+            .is_none_or(|(complete, end)| complete + 1 != end || end + 1 != stream.event_count)
+        || !stream.last_was_end
+        || stream.unrepresentable
+    {
+        return Err(AdapterError::new(
+            "raw revision metadata stream failed exact validation",
+        ));
+    }
+    let mut keys = BTreeSet::new();
+    if stream
+        .entries
+        .iter()
+        .any(|entry| entry.key.is_empty() || !keys.insert(entry.key.as_str()))
+    {
+        return Err(AdapterError::new(
+            "raw revision metadata emitted a duplicate or empty key",
+        ));
+    }
+    Ok(stream.entries)
+}
+
 #[async_trait::async_trait]
 impl GovernanceAdapter for ProductionLoreAdapter<'_> {
+    async fn exact_staged_revisions(&self) -> Result<Vec<String>, AdapterError> {
+        let stream = repository_status_stream(self.api, revision_only_status_args()).await?;
+        status_staged_revisions(&stream, "exact DCO status")
+    }
+
     async fn status(&self) -> Result<StatusSnapshot, AdapterError> {
         let initial_stream =
             repository_status_stream(self.api, revision_only_status_args()).await?;
         let staged_revisions = status_staged_revisions(&initial_stream, "initial exact status")?;
+        let branch = status_branch(&initial_stream, "initial exact status")?;
 
         let scanned_stream = repository_status_stream(self.api, scanned_status_args()).await?;
         let scanned_staged_revisions =
             status_staged_revisions(&scanned_stream, "full scanned status")?;
+        let scanned_branch = status_branch(&scanned_stream, "full scanned status")?;
         let mut staged_paths = BTreeSet::new();
+        let mut staged_changes = Vec::new();
         let mut worktree_clean = true;
         for event in scanned_stream.events {
             match event {
@@ -150,8 +390,30 @@ impl GovernanceAdapter for ProductionLoreAdapter<'_> {
                         if !data.from_path.is_empty() {
                             staged_paths.insert(data.from_path.as_str().to_string());
                         }
+                        staged_changes.push(StagedPathObservation {
+                            path: data.path.as_str().to_string(),
+                            from_path: (!data.from_path.is_empty())
+                                .then(|| data.from_path.as_str().to_string()),
+                            action: match data.action {
+                                lore::interface::LoreFileAction::Keep => {
+                                    GovernancePathAction::Modify
+                                }
+                                lore::interface::LoreFileAction::Add => GovernancePathAction::Add,
+                                lore::interface::LoreFileAction::Delete => {
+                                    GovernancePathAction::Delete
+                                }
+                                lore::interface::LoreFileAction::Move => GovernancePathAction::Move,
+                                lore::interface::LoreFileAction::Copy => GovernancePathAction::Copy,
+                            },
+                            dirty: data.flag_dirty != 0,
+                            conflict: data.flag_conflict != 0,
+                        });
                     }
-                    if data.flag_dirty != 0 || data.flag_conflict != 0 {
+                    // A staged change is, by definition, different from the
+                    // committed revision and upstream may retain its dirty
+                    // bit on the staged-diff event. Only a dirty-only event is
+                    // an unstaged worktree delta; conflicts always close.
+                    if (data.flag_dirty != 0 && data.flag_staged == 0) || data.flag_conflict != 0 {
                         worktree_clean = false;
                     }
                 }
@@ -163,31 +425,137 @@ impl GovernanceAdapter for ProductionLoreAdapter<'_> {
                 _ => {}
             }
         }
+        staged_changes.sort();
+        if staged_changes.windows(2).any(|pair| pair[0] == pair[1]) {
+            return Err(AdapterError::new(
+                "repository status emitted a duplicate staged change",
+            ));
+        }
+        let mut staged_endpoints = BTreeSet::new();
+        for change in &staged_changes {
+            let from_valid = match change.action {
+                GovernancePathAction::Move | GovernancePathAction::Copy => change
+                    .from_path
+                    .as_ref()
+                    .is_some_and(|from| !from.is_empty() && from != &change.path),
+                _ => change.from_path.is_none(),
+            };
+            if change.path.is_empty()
+                || !from_valid
+                || !staged_endpoints.insert(change.path.as_str())
+                || change
+                    .from_path
+                    .as_ref()
+                    .is_some_and(|from| !staged_endpoints.insert(from.as_str()))
+            {
+                return Err(AdapterError::new(
+                    "repository status emitted ambiguous staged endpoints",
+                ));
+            }
+        }
+        if staged_endpoints.len() != staged_paths.len() {
+            return Err(AdapterError::new(
+                "repository status collapsed a staged endpoint",
+            ));
+        }
 
         let post_scan_stream =
             repository_status_stream(self.api, revision_only_status_args()).await?;
         let post_scan_staged_revisions =
             status_staged_revisions(&post_scan_stream, "post-scan exact status")?;
+        let post_scan_branch = status_branch(&post_scan_stream, "post-scan exact status")?;
         if scanned_staged_revisions != staged_revisions
             || post_scan_staged_revisions != staged_revisions
+            || scanned_branch != branch
+            || post_scan_branch != branch
         {
             return Err(AdapterError::new(
                 "full status scan changed the exact staged subject",
             ));
         }
 
+        // Lore 9664606 stages path/flag selections, not immutable content:
+        // repository/status.rs documents staged hashes as zero/current and
+        // commit writes selected paths from the live filesystem. Therefore a
+        // same-path edit before evidence capture is part of the selected
+        // submission, not a distinguishable unstaged delta. Retain every exact
+        // local fingerprint here so evidence binds the capture-time bytes and
+        // a witness can reject any later change. Non-selected paths must still
+        // match their staged-tree identity immediately.
+        let mut worktree_files = Vec::new();
+        if let [staged_revision] = staged_revisions.as_slice() {
+            let paths = self.repository_dump(staged_revision).await?;
+            if !paths.is_empty() {
+                let entries = raw_file_info(self.api, &paths, staged_revision, true, true).await?;
+                if entries.len() != paths.len() {
+                    return Err(AdapterError::new(
+                        "worktree file info cardinality did not match the staged tree",
+                    ));
+                }
+                let expected_paths: BTreeSet<_> = paths.into_iter().collect();
+                let mut observed_paths = BTreeSet::new();
+                for entry in entries {
+                    if !entry.is_file
+                        || entry.path.is_empty()
+                        || entry.hash.is_empty()
+                        || entry.context.is_empty()
+                        || entry.local_hash.is_empty()
+                        || !expected_paths.contains(&entry.path)
+                        || !observed_paths.insert(entry.path.clone())
+                    {
+                        return Err(AdapterError::new(
+                            "worktree file info did not exactly cover the staged tree",
+                        ));
+                    }
+                    let is_staged_path = staged_paths.contains(&entry.path);
+                    if (!is_staged_path
+                        && (entry.hash != entry.local_hash
+                            || entry.flag_modified
+                            || entry.flag_added))
+                        || entry.flag_deleted
+                        || entry.flag_conflict
+                    {
+                        worktree_clean = false;
+                    }
+                    worktree_files.push(WorktreeFileObservation {
+                        path: entry.path,
+                        revision: staged_revision.clone(),
+                        revision_hash: entry.hash,
+                        revision_context: entry.context,
+                        revision_size: entry.size,
+                        local_hash: entry.local_hash,
+                        local_size: entry.local_size,
+                        filtered_revision_size: entry.filter_size,
+                        flag_modified: entry.flag_modified,
+                        flag_deleted: entry.flag_deleted,
+                        flag_added: entry.flag_added,
+                        flag_conflict: entry.flag_conflict,
+                    });
+                }
+                if observed_paths != expected_paths {
+                    return Err(AdapterError::new(
+                        "worktree file info omitted a staged tree path",
+                    ));
+                }
+                worktree_files.sort_by(|left, right| left.path.cmp(&right.path));
+            }
+        }
+
         Ok(StatusSnapshot {
+            branch,
             staged_revisions,
             scanned_staged_revisions,
             post_scan_staged_revisions,
             staged_paths: staged_paths.into_iter().collect(),
+            staged_changes,
+            worktree_files,
             worktree_clean,
             scan_performed: true,
         })
     }
 
     async fn revision_info(&self, revision_id: &str) -> Result<RevisionInfoResponse, AdapterError> {
-        let (callback, receiver) = raw_event_collector();
+        let (callback, stream) = raw_event_collector();
         let returned = lore::revision::info(
             self.api.globals().build(),
             LoreRevisionInfoArgs {
@@ -198,7 +566,7 @@ impl GovernanceAdapter for ProductionLoreAdapter<'_> {
             callback,
         )
         .await;
-        let stream = finished_raw_stream(receiver, returned).await?;
+        let stream = finished_raw_stream(stream, returned)?;
         let revisions = stream
             .events
             .into_iter()
@@ -222,19 +590,16 @@ impl GovernanceAdapter for ProductionLoreAdapter<'_> {
         &self,
         revision_id: &str,
     ) -> Result<Vec<MetadataEntry>, AdapterError> {
-        let result = revision::metadata_list::metadata_list(
-            self.api,
-            revision::metadata_list::MetadataListArgs {
-                revision: revision_id.into(),
+        let (callback, stream) = raw_metadata_collector();
+        let returned = lore::revision::metadata_list(
+            self.api.globals().build(),
+            LoreRevisionMetadataListArgs {
+                revision: LoreString::from_str(revision_id),
             },
+            callback,
         )
-        .await
-        .map_err(adapter_error)?;
-        Ok(result
-            .entries
-            .into_iter()
-            .map(|entry| MetadataEntry::new(entry.key, entry.value))
-            .collect())
+        .await;
+        finished_raw_metadata(stream, returned)
     }
 
     async fn first_parent_history(
@@ -243,32 +608,86 @@ impl GovernanceAdapter for ProductionLoreAdapter<'_> {
         target_base: &str,
         max_revisions: usize,
     ) -> Result<Vec<String>, AdapterError> {
+        if candidate == target_base {
+            return Ok(Vec::new());
+        }
+        let candidate_info = self.revision_info(candidate).await?;
+        if candidate_info.revisions.len() != 1
+            || candidate_info.revisions[0].revision != candidate
+            || candidate_info.revisions[0].parents.is_empty()
+        {
+            return Err(AdapterError::new(
+                "history candidate did not resolve to one exact first parent",
+            ));
+        }
+        let first_parent = candidate_info.revisions[0].parents[0].clone();
+        if first_parent.is_empty() {
+            return Err(AdapterError::new("history candidate had an empty parent"));
+        }
         let length = u32::try_from(max_revisions)
             .map_err(|_| AdapterError::new("history sentinel exceeds upstream limit"))?;
-        let result = revision::history::history(
-            self.api,
-            revision::history::RevisionHistoryArgs {
-                revision: candidate.into(),
-                branch: String::new(),
+        let (callback, stream) = raw_event_collector();
+        let returned = lore::revision::history(
+            self.api.globals().build(),
+            LoreRevisionHistoryArgs {
+                // Upstream history requires branch metadata and therefore
+                // rejects an uncommitted staged hash. Query its exact first
+                // parent, then retain the staged head explicitly below.
+                revision: LoreString::from_str(&first_parent),
+                branch: LoreString::default(),
                 date: 0,
                 length,
-                only_branch: false,
+                only_branch: 0,
             },
+            callback,
         )
-        .await
-        .map_err(adapter_error)?;
-        let mut entries = Vec::new();
-        for entry in result.entries {
-            if entry.revision == target_base {
+        .await;
+        let stream = finished_raw_stream(stream, returned)?;
+        let headers = stream
+            .events
+            .iter()
+            .filter(|event| matches!(event, LoreEvent::RevisionHistory(_)))
+            .count();
+        if headers != 1 {
+            return Err(AdapterError::new(
+                "revision history emitted an inexact header count",
+            ));
+        }
+        // Upstream history starts at the committed ancestor when `candidate`
+        // is the staged subject. Preserve that real response but explicitly
+        // retain the exact staged head the caller requested; the evaluator
+        // independently reconstructs and compares the first-parent chain.
+        let history_revisions: Vec<_> = stream
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                LoreEvent::RevisionHistoryEntry(entry) => Some(format!("{}", entry.revision)),
+                _ => None,
+            })
+            .collect();
+        let mut unique_history = BTreeSet::new();
+        if history_revisions
+            .iter()
+            .any(|revision| revision.is_empty() || !unique_history.insert(revision.as_str()))
+        {
+            return Err(AdapterError::new(
+                "revision history emitted a duplicate or empty revision",
+            ));
+        }
+        let mut entries = vec![candidate.to_string()];
+        for revision in history_revisions {
+            if revision == target_base {
                 break;
             }
-            entries.push(entry.revision);
+            if revision != candidate {
+                entries.push(revision);
+            }
         }
         Ok(entries)
     }
 
     async fn repository_dump(&self, revision_id: &str) -> Result<Vec<String>, AdapterError> {
-        let (callback, receiver) = raw_event_collector();
+        let (callback, stream) = raw_event_collector();
         let returned = lore::repository::dump(
             self.api.globals().build(),
             LoreRepositoryDumpArgs {
@@ -279,7 +698,7 @@ impl GovernanceAdapter for ProductionLoreAdapter<'_> {
             callback,
         )
         .await;
-        let stream = finished_raw_stream(receiver, returned).await?;
+        let stream = finished_raw_stream(stream, returned)?;
         let mut begin = 0;
         let mut state = 0;
         let mut end = 0;
@@ -327,24 +746,13 @@ impl GovernanceAdapter for ProductionLoreAdapter<'_> {
         revision_id: &str,
         paths: &[String],
     ) -> Result<Vec<FileIdentity>, AdapterError> {
-        let result = file::info::info(
-            self.api,
-            file::info::FileInfoArgs {
-                paths: paths.to_vec(),
-                revision: revision_id.into(),
-                local: false,
-                filtered: false,
-            },
-        )
-        .await
-        .map_err(adapter_error)?;
-        if result.entries.iter().any(|entry| !entry.is_file) {
+        let entries = raw_file_info(self.api, paths, revision_id, false, false).await?;
+        if entries.iter().any(|entry| !entry.is_file) {
             return Err(AdapterError::new(
                 "file info did not return files for every dump path",
             ));
         }
-        Ok(result
-            .entries
+        Ok(entries
             .into_iter()
             .map(|entry| FileIdentity::new(entry.path, revision_id, entry.hash, entry.context))
             .collect())
@@ -354,56 +762,85 @@ impl GovernanceAdapter for ProductionLoreAdapter<'_> {
         &self,
         base: &str,
         candidate: &str,
-    ) -> Result<Vec<AffectedPath>, AdapterError> {
-        let result = revision::diff::diff(
-            self.api,
-            revision::diff::RevisionDiffArgs {
-                revision_source: base.into(),
-                revision_target: candidate.into(),
-                paths: Vec::new(),
+    ) -> Result<Vec<RevisionDiffObservation>, AdapterError> {
+        let (callback, stream) = raw_event_collector();
+        let returned = lore::revision::diff(
+            self.api.globals().build(),
+            LoreRevisionDiffArgs {
+                revision_source: LoreString::from_str(base),
+                revision_target: LoreString::from_str(candidate),
+                paths: LoreArray::from_vec(Vec::new()),
             },
+            callback,
         )
-        .await
-        .map_err(adapter_error)?;
-        Ok(result
-            .files
-            .into_iter()
-            .map(|file| AffectedPath::modified(file.path))
-            .collect())
+        .await;
+        let stream = finished_raw_stream(stream, returned)?;
+        let mut observations = Vec::new();
+        for event in stream.events {
+            if let LoreEvent::RevisionDiffFile(data) = event {
+                observations.push(RevisionDiffObservation {
+                    path: data.path.as_str().to_string(),
+                    action: match data.action {
+                        lore::interface::LoreFileAction::Keep => GovernancePathAction::Modify,
+                        lore::interface::LoreFileAction::Add => GovernancePathAction::Add,
+                        lore::interface::LoreFileAction::Delete => GovernancePathAction::Delete,
+                        lore::interface::LoreFileAction::Move => GovernancePathAction::Move,
+                        lore::interface::LoreFileAction::Copy => GovernancePathAction::Copy,
+                    },
+                    old_is_file: data.old_is_file != 0,
+                    new_is_file: data.new_is_file != 0,
+                    old_address: format!("{}", data.old_address),
+                    new_address: format!("{}", data.new_address),
+                });
+            }
+        }
+        Ok(observations)
     }
 
     async fn resolve_authors(
         &self,
         identities: &[String],
     ) -> Result<Vec<ResolvedAuthor>, AdapterError> {
-        let result = auth::resolve_user_info::resolve_user_info(
-            self.api,
-            auth::resolve_user_info::ResolveUserInfoArgs {
-                user_ids: identities.to_vec(),
+        let (callback, stream) = raw_event_collector();
+        let returned = lore::auth::resolve_user_info(
+            self.api.globals().build(),
+            LoreAuthUserInfoArgs {
+                user_ids: LoreArray::from_vec(
+                    identities
+                        .iter()
+                        .map(|identity| LoreString::from_str(identity))
+                        .collect(),
+                ),
             },
+            callback,
         )
-        .await
-        .map_err(adapter_error)?;
-        Ok(result
-            .users
+        .await;
+        let stream = finished_raw_stream(stream, returned)?;
+        Ok(stream
+            .events
             .into_iter()
-            .map(|user| ResolvedAuthor::new(user.user_id, user.display_name))
+            .filter_map(|event| match event {
+                LoreEvent::AuthUserInfo(user) => {
+                    Some(ResolvedAuthor::new(user.id.as_str(), user.name.as_str()))
+                }
+                _ => None,
+            })
             .collect())
     }
 
-    async fn lock_file_query(&self, path: &str) -> Result<LockQuery, AdapterError> {
-        let (callback, receiver) = raw_event_collector();
+    async fn lock_file_query(&self, branch: &str, path: &str) -> Result<LockQuery, AdapterError> {
+        let (callback, stream) = raw_event_collector();
         let returned = lore::lock::file_query(
             self.api.globals().build(),
             LoreLockFileQueryArgs {
-                branch: LoreString::from_str(&self.branch),
+                branch: LoreString::from_str(branch),
                 owner: LoreString::default(),
                 path: LoreString::from_str(path),
             },
             callback,
         )
         .await;
-        let stream = finished_raw_stream(receiver, returned).await?;
+        let stream = finished_raw_stream(stream, returned)?;
         let mut begins = 0;
         let mut expected = None;
         let mut owners = Vec::new();
@@ -441,8 +878,12 @@ impl GovernanceAdapter for ProductionLoreAdapter<'_> {
         })
     }
 
-    async fn lock_file_status(&self, paths: &[String]) -> Result<LockStatusResponse, AdapterError> {
-        let (callback, receiver) = raw_event_collector();
+    async fn lock_file_status(
+        &self,
+        branch: &str,
+        paths: &[String],
+    ) -> Result<LockStatusResponse, AdapterError> {
+        let (callback, stream) = raw_event_collector();
         let returned = lore::lock::file_status(
             self.api.globals().build(),
             LoreLockFileStatusArgs {
@@ -452,12 +893,12 @@ impl GovernanceAdapter for ProductionLoreAdapter<'_> {
                         .map(|path| LoreString::from_str(path))
                         .collect(),
                 ),
-                branch: LoreString::from_str(&self.branch),
+                branch: LoreString::from_str(branch),
             },
             callback,
         )
         .await;
-        let stream = finished_raw_stream(receiver, returned).await?;
+        let stream = finished_raw_stream(stream, returned)?;
         let requested: BTreeSet<&str> = paths.iter().map(String::as_str).collect();
         let mut begins = 0;
         let mut expected = None;
@@ -497,25 +938,20 @@ impl GovernanceAdapter for ProductionLoreAdapter<'_> {
     }
 }
 
-fn adapter_error(error: impl std::fmt::Display) -> AdapterError {
-    AdapterError::new(error.to_string())
-}
-
 #[derive(Default)]
-struct RawEventStream {
-    events: Vec<LoreEvent>,
-    complete_events: usize,
-    complete_status: Option<i32>,
-    error_events: usize,
-    end_events: usize,
+pub(crate) struct RawEventStream {
+    pub(crate) events: Vec<LoreEvent>,
+    pub(crate) complete_events: usize,
+    pub(crate) complete_status: Option<i32>,
+    pub(crate) error_events: usize,
+    pub(crate) end_events: usize,
 }
 
-fn raw_event_collector() -> (LoreEventCallback, oneshot::Receiver<RawEventStream>) {
-    let (sender, receiver) = oneshot::channel();
+pub(crate) fn raw_event_collector() -> (LoreEventCallback, Arc<Mutex<RawEventStream>>) {
     let stream = Arc::new(Mutex::new(RawEventStream::default()));
-    let sender = Arc::new(Mutex::new(Some(sender)));
+    let observed = Arc::clone(&stream);
     let callback = Box::new(move |event: &LoreEvent| {
-        let mut locked = stream.lock().expect("raw event collector mutex poisoned");
+        let mut locked = observed.lock().expect("raw event collector mutex poisoned");
         match event {
             LoreEvent::Complete(data) => {
                 locked.complete_events += 1;
@@ -526,34 +962,20 @@ fn raw_event_collector() -> (LoreEventCallback, oneshot::Receiver<RawEventStream
             _ => {}
         }
         locked.events.push(event.clone());
-        if matches!(event, LoreEvent::End(_)) {
-            let final_stream = std::mem::take(&mut *locked);
-            drop(locked);
-            if let Some(sender) = sender
-                .lock()
-                .expect("raw event sender mutex poisoned")
-                .take()
-            {
-                let _ = sender.send(final_stream);
-            }
-        }
     });
-    (Some(callback), receiver)
+    (Some(callback), stream)
 }
 
-async fn finished_raw_stream(
-    receiver: oneshot::Receiver<RawEventStream>,
+pub(crate) fn finished_raw_stream(
+    observed: Arc<Mutex<RawEventStream>>,
     returned: i32,
 ) -> Result<RawEventStream, AdapterError> {
-    let stream = receiver.await.map_err(|error| {
-        AdapterError::new(format!("raw event stream ended before End: {error}"))
-    })?;
-    if returned != 0
-        || stream.end_events != 1
-        || stream.complete_events != 1
-        || stream.complete_status != Some(0)
-        || stream.error_events != 0
-    {
+    // Upstream interface calls are awaited before this snapshot, so every
+    // synchronous callback through API return is retained. In particular, a
+    // duplicate End or any event after End cannot disappear into a fresh
+    // post-send buffer as it could with a first-End oneshot collector.
+    let stream = take_raw_stream(observed);
+    if !raw_stream_completed_exactly(&stream, returned) {
         return Err(AdapterError::new(
             "raw Lore stream failed terminal validation",
         ));
@@ -561,16 +983,73 @@ async fn finished_raw_stream(
     Ok(stream)
 }
 
+pub(crate) fn take_raw_stream(observed: Arc<Mutex<RawEventStream>>) -> RawEventStream {
+    std::mem::take(&mut *observed.lock().expect("raw event collector mutex poisoned"))
+}
+
+pub(crate) fn raw_stream_completed_exactly(stream: &RawEventStream, returned: i32) -> bool {
+    returned == 0
+        && stream.end_events == 1
+        && stream.complete_events == 1
+        && stream.complete_status == Some(0)
+        && stream.error_events == 0
+        && matches!(
+            stream.events.get(stream.events.len().saturating_sub(2)),
+            Some(LoreEvent::Complete(_))
+        )
+        && matches!(stream.events.last(), Some(LoreEvent::End(_)))
+}
+
 impl EvaluationResult {
-    fn closed(code: impl Into<String>) -> Self {
+    fn closed(code: impl Into<String>, mut observations: GovernanceObservations) -> Self {
+        let code = code.into();
+        observations.dependency_observations.push(code.clone());
+        observations.dependency_observations.sort();
+        observations.dependency_observations.dedup();
         Self {
             open: false,
             pending_revisions: Vec::new(),
             affected_paths: Vec::new(),
             identities: Vec::new(),
             superseded_identities: Vec::new(),
-            failure_codes: vec![code.into()],
+            failure_codes: vec![code],
+            remediation: None,
+            observations,
         }
+    }
+
+    fn history_overflow(
+        scope: HistoryOverflowScope,
+        mut observations: GovernanceObservations,
+    ) -> Self {
+        let code = "history_depth_exceeded".to_string();
+        observations.history_overflow_scope = Some(scope);
+        observations.dependency_observations.push(code.clone());
+        observations.dependency_observations.sort();
+        observations.dependency_observations.dedup();
+        Self {
+            open: false,
+            pending_revisions: Vec::new(),
+            affected_paths: Vec::new(),
+            identities: Vec::new(),
+            superseded_identities: Vec::new(),
+            failure_codes: vec![code],
+            remediation: Some(remediation_for_overflow(scope)),
+            observations,
+        }
+    }
+}
+
+pub(crate) fn remediation_for_overflow(scope: HistoryOverflowScope) -> GovernanceRemediation {
+    match scope {
+        HistoryOverflowScope::PendingDco => GovernanceRemediation {
+            code: GovernanceRemediationCode::SplitSubmissionOrAdvanceTargetBase,
+            ticket: None,
+        },
+        HistoryOverflowScope::SupersessionAncestry => GovernanceRemediation {
+            code: GovernanceRemediationCode::MigrateSupersessionIndex,
+            ticket: Some("SBAI-6010".into()),
+        },
     }
 }
 
@@ -583,16 +1062,18 @@ where
 {
     let expected = request.expected_staged_revision();
     let base = request.target_base_revision();
+    let mut observations = GovernanceObservations::new(expected, base);
     if expected.is_empty() || base.is_empty() {
-        return EvaluationResult::closed("exact_subject_failed");
+        return EvaluationResult::closed("exact_subject_failed", observations);
     }
 
     let status = match adapter.status().await {
         Ok(status) => status,
-        Err(_) => return EvaluationResult::closed("status_unavailable"),
+        Err(_) => return EvaluationResult::closed("status_unavailable", observations),
     };
+    observations.status = Some(status.clone());
     if !status.scan_performed {
-        return EvaluationResult::closed("worktree_unverified");
+        return EvaluationResult::closed("worktree_unverified", observations);
     }
     if [
         &status.staged_revisions,
@@ -602,21 +1083,46 @@ where
     .into_iter()
     .any(|revisions| revisions.len() != 1 || revisions[0].is_empty() || revisions[0] != expected)
     {
-        return EvaluationResult::closed("exact_subject_failed");
+        return EvaluationResult::closed("exact_subject_failed", observations);
     }
-
+    // Pinned Lore 9664606 cannot project a source-backed staged Copy. Its
+    // dirty_copy lifecycle projects a target-only Add whose identity remains
+    // zero/unresolved until commit. Treat any Copy event as unsupported rather
+    // than granting the fake adapter capabilities absent from production.
+    if status
+        .staged_changes
+        .iter()
+        .any(|change| change.action == GovernancePathAction::Copy)
+    {
+        return EvaluationResult::closed("copy_semantics_unavailable", observations);
+    }
+    if !production_expressible_staged_changes(&status) {
+        return EvaluationResult::closed("affected_paths_unavailable", observations);
+    }
     let base_info = match exact_info(adapter, base).await {
         Ok(info) => info,
-        Err(()) => return EvaluationResult::closed("history_incomplete"),
+        Err(()) => return EvaluationResult::closed("history_incomplete", observations),
     };
-    if base_info.revision != base {
-        return EvaluationResult::closed("history_incomplete");
+    if base_info.revision != base || !exact_parent_shape(&base_info, true) {
+        return EvaluationResult::closed("history_incomplete", observations);
     }
+    observations.base_revision_info = Some(base_info.clone());
 
     let pending = match pending_dag(adapter, expected, base).await {
-        Ok(revisions) => revisions,
-        Err(GraphFailure::Incomplete) => return EvaluationResult::closed("history_incomplete"),
-        Err(GraphFailure::Depth) => return EvaluationResult::closed("history_depth_exceeded"),
+        Ok((revisions, graph)) => {
+            observations.revision_graph = graph;
+            revisions
+        }
+        Err(GraphFailure::Incomplete) => {
+            return EvaluationResult::closed("history_incomplete", observations)
+        }
+        Err(GraphFailure::Depth(graph)) => {
+            observations.revision_graph = graph;
+            return EvaluationResult::history_overflow(
+                HistoryOverflowScope::PendingDco,
+                observations,
+            );
+        }
     };
 
     let history = match adapter
@@ -624,74 +1130,156 @@ where
         .await
     {
         Ok(history) => history,
-        Err(_) => return EvaluationResult::closed("history_incomplete"),
+        Err(_) => return EvaluationResult::closed("history_incomplete", observations),
     };
-    if history.len() >= MAX_GOVERNANCE_HISTORY_REVISIONS + 1 {
-        return EvaluationResult::closed("history_depth_exceeded");
+    observations.first_parent_history = history.clone();
+    if history.len() > MAX_GOVERNANCE_HISTORY_REVISIONS {
+        // The exact pending DAG above is authoritative for this ceiling. A
+        // contradictory convenience-history stream is an incomplete
+        // dependency, not graph-backed overflow evidence.
+        return EvaluationResult::closed("history_incomplete", observations);
     }
     let expected_history = match first_parent_history(adapter, expected, base).await {
         Ok(history) => history,
-        Err(()) => return EvaluationResult::closed("history_incomplete"),
+        Err(()) => return EvaluationResult::closed("history_incomplete", observations),
     };
     if history != expected_history || history.is_empty() {
-        return EvaluationResult::closed("history_incomplete");
+        return EvaluationResult::closed("history_incomplete", observations);
     }
 
-    let superseded = match validate_metadata_and_dco(adapter, base, &pending).await {
-        Ok(superseded) => superseded,
-        Err(Failure::Metadata) => return EvaluationResult::closed("metadata_unavailable"),
-        Err(Failure::Dco) => return EvaluationResult::closed("dco_invalid"),
-        Err(Failure::Auth) => return EvaluationResult::closed("auth_unavailable"),
-        Err(Failure::Supersession) => return EvaluationResult::closed("supersession_invalid"),
+    let ancestry = match complete_supersession_ancestry(adapter, expected).await {
+        Ok(ancestry) => ancestry,
+        Err(GraphFailure::Incomplete) => {
+            return EvaluationResult::closed("history_incomplete", observations)
+        }
+        Err(GraphFailure::Depth(ancestry)) => {
+            observations.supersession_ancestry = ancestry;
+            observations.supersession_ancestry_observed = true;
+            return EvaluationResult::history_overflow(
+                HistoryOverflowScope::SupersessionAncestry,
+                observations,
+            );
+        }
     };
+    if ancestry
+        .iter()
+        .find(|info| info.revision == base)
+        .is_none_or(|info| info != &base_info)
+    {
+        return EvaluationResult::closed("history_incomplete", observations);
+    }
+    observations.supersession_ancestry = ancestry.clone();
+    observations.supersession_ancestry_observed = true;
+
+    let dco_facts = observe_dco(adapter, &pending).await;
+    observations.dco_metadata = dco_facts.metadata_observations.clone();
+    observations.author_resolution = dco_facts.author_resolution.clone();
+    observations.dco = dco_facts.observations.clone();
+    match dco_facts.failure {
+        Some(Failure::Metadata) => {
+            return EvaluationResult::closed("metadata_unavailable", observations)
+        }
+        Some(Failure::Dco) => return EvaluationResult::closed("dco_invalid", observations),
+        Some(Failure::Auth) => return EvaluationResult::closed("auth_unavailable", observations),
+        None => {}
+    }
+    let metadata_facts = match validate_supersession_metadata(adapter, &ancestry).await {
+        Ok(facts) => facts,
+        Err(()) => return EvaluationResult::closed("metadata_unavailable", observations),
+    };
+    observations.supersession_markers = metadata_facts.observations;
+    observations.supersession_metadata_queries = metadata_facts.metadata_queries;
+    observations.supersession_metadata_observed = true;
+    if !metadata_facts.valid {
+        return EvaluationResult::closed("supersession_invalid", observations);
+    }
+    let superseded = metadata_facts.identities;
 
     let candidate_tree = match exact_tree(adapter, expected).await {
         Ok(tree) => tree,
-        Err(TreeFailure::Dependency) => return EvaluationResult::closed("tree_unavailable"),
-        Err(TreeFailure::FileInfo) => return EvaluationResult::closed("file_info_unavailable"),
-        Err(TreeFailure::Invalid) => return EvaluationResult::closed("tree_invalid"),
+        Err(TreeFailure::Dependency) => {
+            return EvaluationResult::closed("tree_unavailable", observations)
+        }
+        Err(TreeFailure::FileInfo) => {
+            return EvaluationResult::closed("file_info_unavailable", observations)
+        }
+        Err(TreeFailure::Invalid) => return EvaluationResult::closed("tree_invalid", observations),
     };
+    observations.candidate_files = candidate_tree.files.clone();
+    observations.candidate_tree_observed = true;
+    let current_files = match derive_current_files(&status, &candidate_tree.files, expected) {
+        Ok(files) => files,
+        Err(()) => return EvaluationResult::closed("worktree_dirty", observations),
+    };
+    observations.current_files = current_files.clone();
     let base_tree = match exact_tree(adapter, base).await {
         Ok(tree) => tree,
-        Err(TreeFailure::Dependency) => return EvaluationResult::closed("tree_unavailable"),
-        Err(TreeFailure::FileInfo) => return EvaluationResult::closed("file_info_unavailable"),
-        Err(TreeFailure::Invalid) => return EvaluationResult::closed("tree_invalid"),
+        Err(TreeFailure::Dependency) => {
+            return EvaluationResult::closed("tree_unavailable", observations)
+        }
+        Err(TreeFailure::FileInfo) => {
+            return EvaluationResult::closed("file_info_unavailable", observations)
+        }
+        Err(TreeFailure::Invalid) => return EvaluationResult::closed("tree_invalid", observations),
     };
+    observations.base_files = base_tree.files.clone();
+    observations.base_tree_observed = true;
 
-    let mut identities: Vec<String> = candidate_tree.values().cloned().collect();
+    let mut identities: Vec<String> = current_files
+        .iter()
+        .map(FileIdentity::canonical_id)
+        .collect();
     identities.sort();
     if superseded
         .iter()
-        .any(|identity| candidate_tree.values().any(|id| id == identity))
+        .any(|identity| identities.iter().any(|current| current == identity))
     {
-        return EvaluationResult::closed("not_superseded_failed");
+        return EvaluationResult::closed("not_superseded_failed", observations);
     }
 
-    let affected_paths = match affected_paths(
+    let affected_facts = match affected_paths(
         adapter,
         base,
         expected,
         &status,
-        &base_tree,
-        &candidate_tree,
+        &base_tree.files,
+        &candidate_tree.files,
+        &current_files,
     )
     .await
     {
-        Ok(paths) => paths,
-        Err(()) => return EvaluationResult::closed("affected_paths_unavailable"),
+        Ok(facts) => facts,
+        Err(AffectedFailure::Unavailable) => {
+            return EvaluationResult::closed("affected_paths_unavailable", observations)
+        }
+        Err(AffectedFailure::CopySemanticsUnavailable) => {
+            return EvaluationResult::closed("copy_semantics_unavailable", observations)
+        }
     };
+    observations.upstream_revision_diff = affected_facts.upstream_diff;
+    observations.revision_diff = affected_facts.diff;
+    observations.revision_diff_observed = true;
+    let affected_paths = affected_facts.paths;
+    observations.affected_paths = affected_paths.clone();
     if affected_paths.is_empty() {
-        return EvaluationResult::closed("empty_submission");
+        return EvaluationResult::closed("empty_submission", observations);
     }
 
-    match validate_locks(adapter, &affected_paths).await {
-        Ok(()) => {}
-        Err(LockFailure::Dependency) => return EvaluationResult::closed("locks_unavailable"),
-        Err(LockFailure::Locked) => return EvaluationResult::closed("locks_clear_failed"),
-    }
-
-    if !status.worktree_clean {
-        return EvaluationResult::closed("worktree_dirty");
+    match validate_locks(adapter, &status.branch, &affected_paths).await {
+        Ok(facts) => {
+            observations.lock_queries = facts.queries;
+            observations.lock_status = facts.status;
+        }
+        Err((LockFailure::Dependency, facts)) => {
+            observations.lock_queries = facts.queries;
+            observations.lock_status = facts.status;
+            return EvaluationResult::closed("locks_unavailable", observations);
+        }
+        Err((LockFailure::Locked, facts)) => {
+            observations.lock_queries = facts.queries;
+            observations.lock_status = facts.status;
+            return EvaluationResult::closed("locks_clear_failed", observations);
+        }
     }
 
     EvaluationResult {
@@ -701,7 +1289,236 @@ where
         identities,
         superseded_identities: superseded,
         failure_codes: Vec::new(),
+        remediation: None,
+        observations,
     }
+}
+
+fn canonical_lower_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+/// Reapply the production status adapter's endpoint rules at the shared
+/// evaluator boundary so an injected/fake adapter cannot authorize a staged
+/// event shape that pinned Lore cannot emit.
+fn production_expressible_staged_changes(status: &StatusSnapshot) -> bool {
+    let staged_paths: BTreeSet<_> = status.staged_paths.iter().map(String::as_str).collect();
+    if staged_paths.len() != status.staged_paths.len()
+        || staged_paths.iter().any(|path| path.is_empty())
+    {
+        return false;
+    }
+    let mut endpoints = BTreeSet::new();
+    for change in &status.staged_changes {
+        let exact_from = match change.action {
+            GovernancePathAction::Move => change
+                .from_path
+                .as_ref()
+                .is_some_and(|from| !from.is_empty() && from != &change.path),
+            GovernancePathAction::Copy => false,
+            GovernancePathAction::Modify
+            | GovernancePathAction::Add
+            | GovernancePathAction::Delete => change.from_path.is_none(),
+        };
+        if change.path.is_empty()
+            || !exact_from
+            || !endpoints.insert(change.path.as_str())
+            || change
+                .from_path
+                .as_ref()
+                .is_some_and(|from| !endpoints.insert(from.as_str()))
+        {
+            return false;
+        }
+    }
+    endpoints == staged_paths
+}
+
+pub(crate) fn canonical_artifact_identity(identity: &str) -> bool {
+    let Some((hash, context)) = identity.split_once(':') else {
+        return false;
+    };
+    canonical_lower_hex(hash, 64)
+        && canonical_lower_hex(context, 32)
+        && !context.bytes().all(|byte| byte == b'0')
+}
+
+pub(crate) fn derive_current_files(
+    status: &StatusSnapshot,
+    candidate_files: &[FileIdentity],
+    expected_revision: &str,
+) -> Result<Vec<FileIdentity>, ()> {
+    if !exact_worktree_clean(status, candidate_files, expected_revision) {
+        return Err(());
+    }
+    let staged_paths: BTreeSet<_> = status.staged_paths.iter().map(String::as_str).collect();
+    let worktree: BTreeMap<_, _> = status
+        .worktree_files
+        .iter()
+        .map(|file| (file.path.as_str(), file))
+        .collect();
+    let mut identities = BTreeSet::new();
+    let mut current = Vec::with_capacity(candidate_files.len());
+    for file in candidate_files {
+        let observed = worktree.get(file.path.as_str()).ok_or(())?;
+        let hash = if staged_paths.contains(file.path.as_str()) {
+            observed.local_hash.clone()
+        } else {
+            file.hash.clone()
+        };
+        if !canonical_lower_hex(&hash, 64)
+            || !canonical_lower_hex(&file.context, 32)
+            || file.context.bytes().all(|byte| byte == b'0')
+        {
+            return Err(());
+        }
+        let identity = format!("{hash}:{}", file.context);
+        if !identities.insert(identity) {
+            return Err(());
+        }
+        current.push(FileIdentity::new(
+            &file.path,
+            expected_revision,
+            hash,
+            &file.context,
+        ));
+    }
+    current.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(current)
+}
+
+/// Evaluate only the ratified DCO dependency set. This deliberately shares
+/// exact-subject, DAG/history, metadata parsing, and author-resolution helpers
+/// with the full gate evaluator while never querying marker metadata, trees,
+/// diffs, locks, or worktree scan state.
+pub(crate) async fn evaluate_dco<A, R>(adapter: &A, request: &R) -> DcoValidateResult
+where
+    A: GovernanceAdapter + Sync,
+    R: ExactRevisionRequest,
+{
+    let expected = request.expected_staged_revision();
+    let base = request.target_base_revision();
+    let closed = |code: &str, pending_revisions: Vec<String>| DcoValidateResult {
+        valid: false,
+        pending_revisions,
+        failure_codes: vec![code.into()],
+        remediation: None,
+    };
+    let overflow = |pending_revisions: Vec<String>| DcoValidateResult {
+        valid: false,
+        pending_revisions,
+        failure_codes: vec!["history_depth_exceeded".into()],
+        remediation: Some(remediation_for_overflow(HistoryOverflowScope::PendingDco)),
+    };
+    if expected.is_empty() || base.is_empty() {
+        return closed("exact_subject_failed", Vec::new());
+    }
+    let staged = match adapter.exact_staged_revisions().await {
+        Ok(staged) => staged,
+        Err(_) => return closed("status_unavailable", Vec::new()),
+    };
+    if staged.as_slice() != [expected] {
+        return closed("exact_subject_failed", Vec::new());
+    }
+    match exact_info(adapter, base).await {
+        Ok(info) if exact_parent_shape(&info, true) => {}
+        _ => return closed("history_incomplete", Vec::new()),
+    }
+    let (pending, _) = match pending_dag(adapter, expected, base).await {
+        Ok(facts) => facts,
+        Err(GraphFailure::Incomplete) => return closed("history_incomplete", Vec::new()),
+        Err(GraphFailure::Depth(graph)) => {
+            return overflow(graph.into_iter().map(|info| info.revision).collect())
+        }
+    };
+    let history = match adapter
+        .first_parent_history(expected, base, MAX_GOVERNANCE_HISTORY_REVISIONS + 1)
+        .await
+    {
+        Ok(history) => history,
+        Err(_) => return closed("history_incomplete", pending),
+    };
+    if history.len() > MAX_GOVERNANCE_HISTORY_REVISIONS {
+        return closed("history_incomplete", pending);
+    }
+    let reconstructed = match first_parent_history(adapter, expected, base).await {
+        Ok(history) => history,
+        Err(_) => return closed("history_incomplete", pending),
+    };
+    if history.is_empty() || history != reconstructed {
+        return closed("history_incomplete", pending);
+    }
+
+    let facts = observe_dco(adapter, &pending).await;
+    if let Some(failure) = facts.failure {
+        return closed(
+            match failure {
+                Failure::Metadata => "metadata_unavailable",
+                Failure::Dco => "dco_invalid",
+                Failure::Auth => "auth_unavailable",
+            },
+            pending,
+        );
+    }
+    if facts.metadata_observations.len() != pending.len()
+        || facts.observations.len() != pending.len()
+        || facts.author_resolution.is_none()
+    {
+        return closed("dco_dependency_incomplete", pending);
+    }
+    DcoValidateResult {
+        valid: true,
+        pending_revisions: pending,
+        failure_codes: Vec::new(),
+        remediation: None,
+    }
+}
+
+pub(crate) fn exact_worktree_clean(
+    status: &StatusSnapshot,
+    candidate_files: &[FileIdentity],
+    expected_revision: &str,
+) -> bool {
+    if !status.scan_performed || !status.worktree_clean {
+        return false;
+    }
+    let expected: BTreeMap<_, _> = candidate_files
+        .iter()
+        .map(|file| (file.path.as_str(), file))
+        .collect();
+    if expected.len() != candidate_files.len() || status.worktree_files.len() != expected.len() {
+        return false;
+    }
+    let mut observed = BTreeSet::new();
+    let staged_paths: BTreeSet<_> = status.staged_paths.iter().map(String::as_str).collect();
+    if staged_paths.len() != status.staged_paths.len()
+        || staged_paths.iter().any(|path| path.is_empty())
+    {
+        return false;
+    }
+    status.worktree_files.iter().all(|file| {
+        let Some(candidate) = expected.get(file.path.as_str()) else {
+            return false;
+        };
+        let is_staged_path = staged_paths.contains(file.path.as_str());
+        !file.path.is_empty()
+            && observed.insert(file.path.as_str())
+            && file.revision == expected_revision
+            && file.revision_hash == candidate.hash
+            && file.revision_context == candidate.context
+            && !file.revision_hash.is_empty()
+            && !file.revision_context.is_empty()
+            && !file.local_hash.is_empty()
+            && (is_staged_path
+                || (file.local_hash == file.revision_hash
+                    && !file.flag_modified
+                    && !file.flag_added))
+            && !file.flag_deleted
+            && !file.flag_conflict
+    })
 }
 
 async fn exact_info<A: GovernanceAdapter>(adapter: &A, revision: &str) -> Result<RevisionInfo, ()> {
@@ -718,14 +1535,76 @@ async fn exact_info<A: GovernanceAdapter>(adapter: &A, revision: &str) -> Result
 
 enum GraphFailure {
     Incomplete,
-    Depth,
+    /// The exact, shape-validated N+1 prefix retained as raw overflow
+    /// evidence. Its frontier may reference revisions outside the prefix.
+    Depth(Vec<RevisionInfo>),
+}
+
+fn exact_parent_shape(info: &RevisionInfo, allow_root: bool) -> bool {
+    let parents: BTreeSet<_> = info.parents.iter().map(String::as_str).collect();
+    (allow_root || !info.parents.is_empty())
+        && info.parents.len() <= 2
+        && parents.len() == info.parents.len()
+        && info
+            .parents
+            .iter()
+            .all(|parent| !parent.is_empty() && parent != &info.revision)
+}
+
+/// Independent whole-ancestry traversal for supersession. Unlike the pending
+/// DCO graph, this includes the candidate, explicit base, all older ancestors,
+/// and every merge parent through roots. The 1001st unique revision is fetched
+/// and shape-validated as the overflow sentinel, but is not accepted.
+async fn complete_supersession_ancestry<A: GovernanceAdapter>(
+    adapter: &A,
+    candidate: &str,
+) -> Result<Vec<RevisionInfo>, GraphFailure> {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Visit {
+        Active,
+        Complete,
+    }
+
+    let mut visit = BTreeMap::<String, Visit>::new();
+    let mut graph = BTreeMap::<String, RevisionInfo>::new();
+    let mut stack = vec![(candidate.to_string(), false)];
+    while let Some((revision, leaving)) = stack.pop() {
+        if leaving {
+            visit.insert(revision, Visit::Complete);
+            continue;
+        }
+        match visit.get(&revision) {
+            Some(Visit::Active) => return Err(GraphFailure::Incomplete),
+            Some(Visit::Complete) => continue,
+            None => {}
+        }
+        let info = exact_info(adapter, &revision)
+            .await
+            .map_err(|_| GraphFailure::Incomplete)?;
+        if !exact_parent_shape(&info, true) {
+            return Err(GraphFailure::Incomplete);
+        }
+        graph.insert(revision.clone(), info.clone());
+        if graph.len() == MAX_GOVERNANCE_HISTORY_REVISIONS + 1 {
+            return Err(GraphFailure::Depth(graph.into_values().collect()));
+        }
+        visit.insert(revision.clone(), Visit::Active);
+        stack.push((revision, true));
+        for parent in info.parents.into_iter().rev() {
+            stack.push((parent, false));
+        }
+    }
+    if graph.is_empty() {
+        return Err(GraphFailure::Incomplete);
+    }
+    Ok(graph.into_values().collect())
 }
 
 async fn pending_dag<A: GovernanceAdapter>(
     adapter: &A,
     candidate: &str,
     base: &str,
-) -> Result<Vec<String>, GraphFailure> {
+) -> Result<(Vec<String>, Vec<RevisionInfo>), GraphFailure> {
     #[derive(Clone, Copy, PartialEq, Eq)]
     enum Visit {
         Active,
@@ -734,6 +1613,7 @@ async fn pending_dag<A: GovernanceAdapter>(
 
     let mut visit = BTreeMap::<String, Visit>::new();
     let mut pending = BTreeSet::new();
+    let mut graph = BTreeMap::<String, RevisionInfo>::new();
     let mut stack = vec![(candidate.to_string(), false)];
 
     while let Some((revision, leaving)) = stack.pop() {
@@ -755,19 +1635,15 @@ async fn pending_dag<A: GovernanceAdapter>(
         let info = exact_info(adapter, &revision)
             .await
             .map_err(|_| GraphFailure::Incomplete)?;
-        if info.parents.is_empty()
-            || info
-                .parents
-                .iter()
-                .any(|parent| parent.is_empty() || parent == &revision)
-        {
+        if !exact_parent_shape(&info, false) {
             return Err(GraphFailure::Incomplete);
         }
-        if pending.len() == MAX_GOVERNANCE_HISTORY_REVISIONS {
-            return Err(GraphFailure::Depth);
+        graph.insert(revision.clone(), info.clone());
+        pending.insert(revision.clone());
+        if pending.len() == MAX_GOVERNANCE_HISTORY_REVISIONS + 1 {
+            return Err(GraphFailure::Depth(graph.into_values().collect()));
         }
         visit.insert(revision.clone(), Visit::Active);
-        pending.insert(revision.clone());
         stack.push((revision, true));
         for parent in info.parents.into_iter().rev() {
             stack.push((parent, false));
@@ -777,7 +1653,7 @@ async fn pending_dag<A: GovernanceAdapter>(
     if pending.is_empty() {
         return Err(GraphFailure::Incomplete);
     }
-    Ok(pending.into_iter().collect())
+    Ok((pending.into_iter().collect(), graph.into_values().collect()))
 }
 
 async fn first_parent_history<A: GovernanceAdapter>(
@@ -790,11 +1666,13 @@ async fn first_parent_history<A: GovernanceAdapter>(
     let mut revision = candidate.to_string();
 
     while revision != base {
-        if !seen.insert(revision.clone()) || revisions.len() >= MAX_GOVERNANCE_HISTORY_REVISIONS + 1
-        {
+        if !seen.insert(revision.clone()) || revisions.len() > MAX_GOVERNANCE_HISTORY_REVISIONS {
             return Err(());
         }
         let info = exact_info(adapter, &revision).await?;
+        if !exact_parent_shape(&info, false) {
+            return Err(());
+        }
         let Some(parent) = info.parents.first() else {
             return Err(());
         };
@@ -808,73 +1686,127 @@ async fn first_parent_history<A: GovernanceAdapter>(
     Ok(revisions)
 }
 
+#[derive(Clone, Copy)]
 enum Failure {
     Metadata,
     Dco,
     Auth,
-    Supersession,
 }
 
-async fn validate_metadata_and_dco<A: GovernanceAdapter>(
-    adapter: &A,
-    base: &str,
-    pending: &[String],
-) -> Result<Vec<String>, Failure> {
-    let mut records = BTreeMap::<String, String>::new();
-    let mut authors = BTreeSet::new();
-    let mut revision_signers = Vec::<(String, Vec<String>)>::new();
+struct DcoFacts {
+    metadata_observations: Vec<DcoMetadataObservation>,
+    author_resolution: Option<AuthorResolutionObservation>,
+    observations: Vec<DcoObservation>,
+    failure: Option<Failure>,
+}
 
-    let base_metadata = adapter
-        .revision_metadata(base)
-        .await
-        .map_err(|_| Failure::Metadata)?;
-    scan_supersession_entries(&base_metadata, &mut records)?;
+async fn observe_dco<A: GovernanceAdapter>(adapter: &A, pending: &[String]) -> DcoFacts {
+    let mut facts = DcoFacts {
+        metadata_observations: Vec::new(),
+        author_resolution: None,
+        observations: Vec::new(),
+        failure: None,
+    };
+    let mut authors = BTreeSet::new();
 
     for revision in pending {
-        let metadata = adapter
-            .revision_metadata(revision)
-            .await
-            .map_err(|_| Failure::Metadata)?;
-        scan_supersession_entries(&metadata, &mut records)?;
-        let mut grouped = BTreeMap::<String, Vec<String>>::new();
-        for entry in metadata {
-            grouped.entry(entry.key).or_default().push(entry.value);
-        }
-
-        let message = exactly_one(&grouped, "message").ok_or(Failure::Dco)?;
-        let created_by = exactly_one(&grouped, "created-by").ok_or(Failure::Dco)?;
-        if created_by.is_empty()
-            || grouped
-                .get("committed-by")
-                .is_some_and(|values| values.len() != 1)
-        {
-            return Err(Failure::Dco);
-        }
-        let mut revision_authors = vec![created_by.to_string()];
-        if let Some(committed_by) = grouped
-            .get("committed-by")
-            .and_then(|values| values.first())
-        {
-            if committed_by.is_empty() {
-                return Err(Failure::Dco);
+        let metadata = match adapter.revision_metadata(revision).await {
+            Ok(metadata) => metadata,
+            Err(_) => {
+                facts.failure = Some(Failure::Metadata);
+                return facts;
             }
-            revision_authors.push(committed_by.clone());
+        };
+        let mut grouped = BTreeMap::<String, Vec<String>>::new();
+        for entry in &metadata {
+            if matches!(
+                entry.key.as_str(),
+                "message" | "created-by" | "committed-by"
+            ) && entry.kind != MetadataKind::String
+            {
+                facts.failure = Some(Failure::Dco);
+                return facts;
+            }
+            grouped
+                .entry(entry.key.clone())
+                .or_default()
+                .push(entry.value.clone());
         }
-        let signer = parse_dco_signer(message).ok_or(Failure::Dco)?;
-        authors.extend(revision_authors.iter().cloned());
-        revision_signers.push((signer, revision_authors));
+        let mut observation = DcoMetadataObservation {
+            revision: revision.clone(),
+            messages: grouped.remove("message").unwrap_or_default(),
+            created_by: grouped.remove("created-by").unwrap_or_default(),
+            committed_by: grouped.remove("committed-by").unwrap_or_default(),
+        };
+        observation.messages.sort();
+        observation.created_by.sort();
+        observation.committed_by.sort();
+        facts.metadata_observations.push(observation);
+    }
+    facts
+        .metadata_observations
+        .sort_by(|left, right| left.revision.cmp(&right.revision));
+
+    for raw in &facts.metadata_observations {
+        let ([message], [created_by], committed_by) = (
+            raw.messages.as_slice(),
+            raw.created_by.as_slice(),
+            raw.committed_by.as_slice(),
+        ) else {
+            facts.failure = Some(Failure::Dco);
+            return facts;
+        };
+        let committed_by = match committed_by {
+            [] => None,
+            [identity] if !identity.is_empty() => Some(identity.clone()),
+            _ => {
+                facts.failure = Some(Failure::Dco);
+                return facts;
+            }
+        };
+        if created_by.is_empty() {
+            facts.failure = Some(Failure::Dco);
+            return facts;
+        }
+        let Some(signer) = parse_dco_signer(message) else {
+            facts.failure = Some(Failure::Dco);
+            return facts;
+        };
+        authors.insert(created_by.clone());
+        if let Some(identity) = &committed_by {
+            authors.insert(identity.clone());
+        }
+        facts.observations.push(DcoObservation {
+            revision: raw.revision.clone(),
+            message: message.clone(),
+            trailer: signer.trailer,
+            signer_name: signer.name,
+            signer_email: signer.email,
+            created_by: created_by.clone(),
+            committed_by,
+            resolved_authors: Vec::new(),
+        });
     }
 
     if authors.is_empty() {
-        return Err(Failure::Dco);
+        facts.failure = Some(Failure::Dco);
+        return facts;
     }
     let requested: Vec<String> = authors.into_iter().collect();
-    let replies = adapter
-        .resolve_authors(&requested)
-        .await
-        .map_err(|_| Failure::Auth)?;
+    let replies = match adapter.resolve_authors(&requested).await {
+        Ok(replies) => replies,
+        Err(_) => {
+            facts.failure = Some(Failure::Auth);
+            return facts;
+        }
+    };
+    facts.author_resolution = Some(AuthorResolutionObservation {
+        requested: requested.clone(),
+        replies: replies.clone(),
+    });
     if replies.len() != requested.len() {
-        return Err(Failure::Dco);
+        facts.failure = Some(Failure::Dco);
+        return facts;
     }
     let mut resolved = BTreeMap::new();
     for reply in replies {
@@ -885,55 +1817,135 @@ async fn validate_metadata_and_dco<A: GovernanceAdapter>(
                 .insert(reply.identity, reply.display_name)
                 .is_some()
         {
-            return Err(Failure::Dco);
+            facts.failure = Some(Failure::Dco);
+            return facts;
         }
     }
-    for (signer, identities) in revision_signers {
-        if identities
+    for observation in &mut facts.observations {
+        let identities: BTreeSet<String> = std::iter::once(observation.created_by.clone())
+            .chain(observation.committed_by.iter().cloned())
+            .collect();
+        observation.resolved_authors = identities
             .iter()
-            .any(|identity| resolved.get(identity).is_none_or(|name| name != &signer))
+            .filter_map(|identity| {
+                resolved
+                    .get(identity)
+                    .map(|name| ResolvedAuthor::new(identity, name))
+            })
+            .collect();
+        if observation.resolved_authors.len() != identities.len()
+            || observation
+                .resolved_authors
+                .iter()
+                .any(|author| author.display_name != observation.signer_name)
         {
-            return Err(Failure::Dco);
+            facts.failure = Some(Failure::Dco);
+            return facts;
         }
     }
 
-    Ok(records.into_keys().collect())
+    facts
+        .observations
+        .sort_by(|left, right| left.revision.cmp(&right.revision));
+    facts
+}
+
+struct SupersessionFacts {
+    identities: Vec<String>,
+    observations: Vec<SupersessionObservation>,
+    metadata_queries: Vec<SupersessionMetadataQueryObservation>,
+    valid: bool,
+}
+
+async fn validate_supersession_metadata<A: GovernanceAdapter>(
+    adapter: &A,
+    ancestry: &[RevisionInfo],
+) -> Result<SupersessionFacts, ()> {
+    let mut records = BTreeMap::<String, String>::new();
+    let mut observations = Vec::new();
+    let mut metadata_queries = Vec::with_capacity(ancestry.len());
+    let mut valid = true;
+    for info in ancestry {
+        let metadata = adapter
+            .revision_metadata(&info.revision)
+            .await
+            .map_err(|_| ())?;
+        metadata_queries.push(SupersessionMetadataQueryObservation {
+            revision: info.revision.clone(),
+            metadata: metadata.clone(),
+        });
+        valid &=
+            scan_supersession_entries(&info.revision, &metadata, &mut records, &mut observations)
+                .is_ok();
+    }
+    observations.sort_by(|left, right| {
+        (&left.revision, &left.key, &left.value, &left.identity).cmp(&(
+            &right.revision,
+            &right.key,
+            &right.value,
+            &right.identity,
+        ))
+    });
+    Ok(SupersessionFacts {
+        identities: records.into_keys().collect(),
+        observations,
+        metadata_queries,
+        valid,
+    })
 }
 
 fn scan_supersession_entries(
+    revision: &str,
     metadata: &[MetadataEntry],
     records: &mut BTreeMap<String, String>,
-) -> Result<(), Failure> {
+    observations: &mut Vec<SupersessionObservation>,
+) -> Result<(), ()> {
+    let mut valid = true;
     for entry in metadata {
         if !entry.key.starts_with(SUPERSESSION_MARKER_PREFIX) {
             continue;
         }
         let identity = entry.key[SUPERSESSION_MARKER_PREFIX.len()..].to_string();
-        let marker: SupersessionMarkerV1 =
-            serde_json::from_str(&entry.value).map_err(|_| Failure::Supersession)?;
-        if identity.is_empty()
-            || marker.version != "v1"
-            || marker.identity.is_empty()
-            || marker.identity != identity
+        observations.push(SupersessionObservation {
+            revision: revision.into(),
+            key: entry.key.clone(),
+            value: entry.value.clone(),
+            identity: identity.clone(),
+        });
+        match entry
+            .string_value()
+            .and_then(|value| serde_json::from_str::<SupersessionMarkerV1>(value).ok())
         {
-            return Err(Failure::Supersession);
-        }
-        match records.get(&identity) {
-            Some(existing) if existing != &entry.value => return Err(Failure::Supersession),
-            _ => {
-                records.insert(identity, entry.value.clone());
+            Some(marker)
+                if canonical_artifact_identity(&identity)
+                    && marker.version == "v1"
+                    && !marker.identity.is_empty()
+                    && marker.identity == identity =>
+            {
+                match records.get(&identity) {
+                    Some(existing) if existing != &entry.value => valid = false,
+                    _ => {
+                        records.insert(identity, entry.value.clone());
+                    }
+                }
             }
+            _ => valid = false,
         }
     }
-    Ok(())
+    if valid {
+        Ok(())
+    } else {
+        Err(())
+    }
 }
 
-fn exactly_one<'a>(metadata: &'a BTreeMap<String, Vec<String>>, key: &str) -> Option<&'a str> {
-    let values = metadata.get(key)?;
-    (values.len() == 1).then(|| values[0].as_str())
+struct ParsedDco {
+    trailer: String,
+    name: String,
+    email: String,
 }
 
-fn parse_dco_signer(message: &str) -> Option<String> {
+fn parse_dco_signer(message: &str) -> Option<ParsedDco> {
     let mut lines: Vec<&str> = message.lines().collect();
     while lines.last().is_some_and(|line| line.is_empty()) {
         lines.pop();
@@ -978,7 +1990,11 @@ fn parse_dco_signer(message: &str) -> Option<String> {
     {
         return None;
     }
-    Some(name.to_string())
+    Some(ParsedDco {
+        trailer: format!("Signed-off-by: {signer}"),
+        name: name.to_string(),
+        email: email.to_string(),
+    })
 }
 
 fn is_canonical_dco_email(email: &str) -> bool {
@@ -1034,10 +2050,14 @@ enum TreeFailure {
     Invalid,
 }
 
+struct ExactTree {
+    files: Vec<FileIdentity>,
+}
+
 async fn exact_tree<A: GovernanceAdapter>(
     adapter: &A,
     revision: &str,
-) -> Result<BTreeMap<String, String>, TreeFailure> {
+) -> Result<ExactTree, TreeFailure> {
     let paths = adapter
         .repository_dump(revision)
         .await
@@ -1049,9 +2069,9 @@ async fn exact_tree<A: GovernanceAdapter>(
     // `file.info` with an empty path set must never be used as a root/tree
     // enumerator. The exact `repository.dump` enumeration above is authoritative.
     if paths.is_empty() {
-        return Ok(BTreeMap::new());
+        return Ok(ExactTree { files: Vec::new() });
     }
-    let identities = adapter
+    let mut identities = adapter
         .file_info(revision, &paths)
         .await
         .map_err(|_| TreeFailure::FileInfo)?;
@@ -1061,17 +2081,28 @@ async fn exact_tree<A: GovernanceAdapter>(
 
     let mut tree = BTreeMap::new();
     let mut canonical_ids = BTreeSet::new();
-    for identity in identities {
+    identities.sort_by(|left, right| {
+        (&left.path, &left.revision, &left.hash, &left.context).cmp(&(
+            &right.path,
+            &right.revision,
+            &right.hash,
+            &right.context,
+        ))
+    });
+    for identity in &identities {
         if identity.revision != revision
             || identity.path.is_empty()
-            || identity.hash.is_empty()
-            || identity.context.is_empty()
+            || !canonical_lower_hex(&identity.hash, 64)
+            || !canonical_lower_hex(&identity.context, 32)
+            || identity.context.bytes().all(|byte| byte == b'0')
             || !expected_paths.contains(&identity.path)
         {
             return Err(TreeFailure::Invalid);
         }
         let canonical_id = identity.canonical_id();
-        if tree.insert(identity.path, canonical_id.clone()).is_some()
+        if tree
+            .insert(identity.path.clone(), canonical_id.clone())
+            .is_some()
             || !canonical_ids.insert(canonical_id)
         {
             return Err(TreeFailure::Invalid);
@@ -1080,7 +2111,24 @@ async fn exact_tree<A: GovernanceAdapter>(
     if tree.len() != expected_paths.len() {
         return Err(TreeFailure::Invalid);
     }
-    Ok(tree)
+    Ok(ExactTree { files: identities })
+}
+
+struct AffectedFacts {
+    upstream_diff: Vec<RevisionDiffObservation>,
+    diff: Vec<AffectedPath>,
+    paths: Vec<String>,
+}
+
+enum AffectedFailure {
+    Unavailable,
+    CopySemanticsUnavailable,
+}
+
+impl From<()> for AffectedFailure {
+    fn from(_: ()) -> Self {
+        Self::Unavailable
+    }
 }
 
 async fn affected_paths<A: GovernanceAdapter>(
@@ -1088,35 +2136,285 @@ async fn affected_paths<A: GovernanceAdapter>(
     base: &str,
     candidate: &str,
     status: &StatusSnapshot,
-    base_tree: &BTreeMap<String, String>,
-    candidate_tree: &BTreeMap<String, String>,
-) -> Result<Vec<String>, ()> {
-    let diff = adapter
+    base_files: &[FileIdentity],
+    candidate_files: &[FileIdentity],
+    current_files: &[FileIdentity],
+) -> Result<AffectedFacts, AffectedFailure> {
+    let mut upstream_diff = adapter
         .revision_diff(base, candidate)
         .await
         .map_err(|_| ())?;
-    let mut paths = BTreeSet::new();
-    for file in diff {
-        if let Some(source) = file.source_path.filter(|path| !path.is_empty()) {
-            paths.insert(source);
-        }
-        if let Some(target) = file.target_path.filter(|path| !path.is_empty()) {
-            paths.insert(target);
+    upstream_diff.sort();
+    if upstream_diff
+        .iter()
+        .any(|raw| raw.action == GovernancePathAction::Copy)
+    {
+        return Err(AffectedFailure::CopySemanticsUnavailable);
+    }
+    let mut base_by_context = BTreeMap::new();
+    let mut current_by_context = BTreeMap::new();
+    let mut base_by_path = BTreeMap::new();
+    let mut candidate_by_path = BTreeMap::new();
+    let mut current_by_path = BTreeMap::new();
+    for file in base_files {
+        if !canonical_lower_hex(&file.hash, 64)
+            || !canonical_lower_hex(&file.context, 32)
+            || file.context.bytes().all(|byte| byte == b'0')
+            || base_by_context
+                .insert(file.context.as_str(), file.path.as_str())
+                .is_some()
+            || base_by_path
+                .insert(file.path.as_str(), file.canonical_id())
+                .is_some()
+        {
+            return Err(AffectedFailure::Unavailable);
         }
     }
-    paths.extend(
-        status
-            .staged_paths
+    for file in candidate_files {
+        if !canonical_lower_hex(&file.hash, 64)
+            || !canonical_lower_hex(&file.context, 32)
+            || file.context.bytes().all(|byte| byte == b'0')
+            || candidate_by_path.insert(file.path.as_str(), file).is_some()
+        {
+            return Err(AffectedFailure::Unavailable);
+        }
+    }
+    for file in current_files {
+        if current_by_context
+            .insert(file.context.as_str(), file.path.as_str())
+            .is_some()
+            || current_by_path
+                .insert(file.path.as_str(), file.canonical_id())
+                .is_some()
+        {
+            return Err(AffectedFailure::Unavailable);
+        }
+    }
+
+    let mut consumed_base = BTreeSet::new();
+    let mut consumed_current = BTreeSet::new();
+    let mut diff = Vec::new();
+    for (context, source) in &base_by_context {
+        if let Some(target) = current_by_context.get(context) {
+            consumed_base.insert(*source);
+            consumed_current.insert(*target);
+            if source != target {
+                diff.push(AffectedPath {
+                    source_path: Some((*source).to_string()),
+                    target_path: Some((*target).to_string()),
+                });
+            } else if base_by_path.get(source) != current_by_path.get(target) {
+                diff.push(AffectedPath::modified(*source));
+            }
+        }
+    }
+    for (path, base_identity) in &base_by_path {
+        if consumed_base.contains(path) {
+            continue;
+        }
+        if let Some(current_identity) = current_by_path.get(path) {
+            if !consumed_current.contains(path) && current_identity != base_identity {
+                consumed_base.insert(*path);
+                consumed_current.insert(*path);
+                diff.push(AffectedPath::modified(*path));
+            }
+        }
+    }
+    for path in base_by_path.keys() {
+        if !consumed_base.contains(path) {
+            diff.push(AffectedPath {
+                source_path: Some((*path).to_string()),
+                target_path: None,
+            });
+        }
+    }
+    for path in current_by_path.keys() {
+        if !consumed_current.contains(path) {
+            diff.push(AffectedPath {
+                source_path: None,
+                target_path: Some((*path).to_string()),
+            });
+        }
+    }
+
+    diff.sort_by(|left, right| {
+        (&left.source_path, &left.target_path).cmp(&(&right.source_path, &right.target_path))
+    });
+    if diff.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(AffectedFailure::Unavailable);
+    }
+
+    let expected_status: BTreeSet<_> = status
+        .staged_changes
+        .iter()
+        .map(|change| match change.action {
+            GovernancePathAction::Modify => (Some(change.path.clone()), Some(change.path.clone())),
+            GovernancePathAction::Add => (None, Some(change.path.clone())),
+            GovernancePathAction::Delete => (Some(change.path.clone()), None),
+            GovernancePathAction::Move | GovernancePathAction::Copy => {
+                (change.from_path.clone(), Some(change.path.clone()))
+            }
+        })
+        .collect();
+    let exact_diff: BTreeSet<_> = diff
+        .iter()
+        .map(|entry| (entry.source_path.clone(), entry.target_path.clone()))
+        .collect();
+    if expected_status.len() != status.staged_changes.len() || expected_status != exact_diff {
+        return Err(AffectedFailure::Unavailable);
+    }
+    let status_paths: BTreeSet<_> = status
+        .staged_changes
+        .iter()
+        .flat_map(|change| {
+            std::iter::once(change.path.as_str()).chain(change.from_path.iter().map(String::as_str))
+        })
+        .collect();
+    if status_paths.len() != status.staged_paths.len()
+        || status_paths != status.staged_paths.iter().map(String::as_str).collect()
+    {
+        return Err(AffectedFailure::Unavailable);
+    }
+
+    let zero_address = format!("{}-{}", "0".repeat(64), "0".repeat(32));
+    let address = |file: &FileIdentity| format!("{}-{}", file.hash, file.context);
+    let canonical_address = |value: &str| {
+        value.len() == 97
+            && value.as_bytes()[64] == b'-'
+            && value.bytes().enumerate().all(|(index, byte)| {
+                index == 64 || byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')
+            })
+    };
+    let base_file_by_path: BTreeMap<_, _> = base_files
+        .iter()
+        .map(|file| (file.path.as_str(), file))
+        .collect();
+    let mut raw_paths = BTreeSet::new();
+    for raw in &upstream_diff {
+        if raw.path.is_empty()
+            || !raw_paths.insert(raw.path.as_str())
+            || !canonical_address(&raw.old_address)
+            || !canonical_address(&raw.new_address)
+        {
+            return Err(AffectedFailure::Unavailable);
+        }
+    }
+
+    let mut consumed_raw = vec![false; upstream_diff.len()];
+    let mut consume = |path: &str,
+                       action: GovernancePathAction,
+                       old_is_file: bool,
+                       new_is_file: bool,
+                       old_address: &str,
+                       new_address: &str|
+     -> Result<(), ()> {
+        let matches: Vec<_> = upstream_diff
             .iter()
-            .filter(|path| !path.is_empty())
-            .cloned(),
-    );
-    for path in base_tree.keys().chain(candidate_tree.keys()) {
-        if base_tree.get(path) != candidate_tree.get(path) {
-            paths.insert(path.clone());
+            .enumerate()
+            .filter(|(index, raw)| {
+                !consumed_raw[*index]
+                    && raw.path == path
+                    && raw.action == action
+                    && raw.old_is_file == old_is_file
+                    && raw.new_is_file == new_is_file
+                    && raw.old_address == old_address
+                    && raw.new_address == new_address
+            })
+            .map(|(index, _)| index)
+            .collect();
+        if let [index] = matches.as_slice() {
+            consumed_raw[*index] = true;
+            Ok(())
+        } else {
+            Err(())
+        }
+    };
+    for change in &status.staged_changes {
+        match change.action {
+            GovernancePathAction::Modify => {
+                let old = base_file_by_path.get(change.path.as_str()).ok_or(())?;
+                let new = candidate_by_path.get(change.path.as_str()).ok_or(())?;
+                consume(
+                    &change.path,
+                    GovernancePathAction::Modify,
+                    true,
+                    true,
+                    &address(old),
+                    &address(new),
+                )?;
+            }
+            GovernancePathAction::Add => {
+                if base_file_by_path.contains_key(change.path.as_str()) {
+                    return Err(AffectedFailure::Unavailable);
+                }
+                let new = candidate_by_path.get(change.path.as_str()).ok_or(())?;
+                consume(
+                    &change.path,
+                    GovernancePathAction::Add,
+                    false,
+                    true,
+                    &zero_address,
+                    &address(new),
+                )?;
+            }
+            GovernancePathAction::Delete => {
+                let old = base_file_by_path.get(change.path.as_str()).ok_or(())?;
+                if candidate_by_path.contains_key(change.path.as_str()) {
+                    return Err(AffectedFailure::Unavailable);
+                }
+                consume(
+                    &change.path,
+                    GovernancePathAction::Delete,
+                    true,
+                    false,
+                    &address(old),
+                    &zero_address,
+                )?;
+            }
+            GovernancePathAction::Move => {
+                let source = change.from_path.as_ref().ok_or(())?;
+                let old = base_file_by_path.get(source.as_str()).ok_or(())?;
+                let new = candidate_by_path.get(change.path.as_str()).ok_or(())?;
+                let old_address = address(old);
+                let new_address = address(new);
+                if old_address != new_address {
+                    return Err(AffectedFailure::Unavailable);
+                }
+                consume(
+                    source,
+                    GovernancePathAction::Delete,
+                    true,
+                    false,
+                    &old_address,
+                    &zero_address,
+                )?;
+                consume(
+                    &change.path,
+                    GovernancePathAction::Add,
+                    false,
+                    true,
+                    &zero_address,
+                    &new_address,
+                )?;
+            }
+            GovernancePathAction::Copy => {
+                return Err(AffectedFailure::CopySemanticsUnavailable);
+            }
         }
     }
-    Ok(paths.into_iter().collect())
+    if consumed_raw.iter().any(|consumed| !consumed) {
+        return Err(AffectedFailure::Unavailable);
+    }
+    let derived_paths: BTreeSet<_> = diff
+        .iter()
+        .flat_map(|entry| entry.source_path.iter().chain(entry.target_path.iter()))
+        .cloned()
+        .collect();
+    Ok(AffectedFacts {
+        upstream_diff,
+        diff,
+        paths: derived_paths.into_iter().collect(),
+    })
 }
 
 enum LockFailure {
@@ -1124,59 +2422,122 @@ enum LockFailure {
     Locked,
 }
 
+#[derive(Default)]
+struct LockFacts {
+    queries: Vec<LockQuery>,
+    status: Option<LockStatusResponse>,
+}
+
 async fn validate_locks<A: GovernanceAdapter>(
     adapter: &A,
+    branch: &str,
     paths: &[String],
-) -> Result<(), LockFailure> {
+) -> Result<LockFacts, (LockFailure, LockFacts)> {
+    let mut facts = LockFacts::default();
     let requested: BTreeSet<String> = paths.iter().cloned().collect();
-    if requested.len() != paths.len() || requested.is_empty() {
-        return Err(LockFailure::Dependency);
+    if branch.is_empty() || requested.len() != paths.len() || requested.is_empty() {
+        return Err((LockFailure::Dependency, facts));
     }
+    let mut locked = false;
     for path in paths {
-        let query = adapter
-            .lock_file_query(path)
-            .await
-            .map_err(|_| LockFailure::Dependency)?;
+        let mut query = match adapter.lock_file_query(branch, path).await {
+            Ok(query) => query,
+            Err(_) => return Err((LockFailure::Dependency, facts)),
+        };
+        query.owners.sort();
+        query.ignored_paths.sort();
         if query.path != *path {
-            return Err(LockFailure::Dependency);
+            facts.queries.push(query);
+            return Err((LockFailure::Dependency, facts));
         }
         if query.begin_events != 1
             || !query.completed
             || !query.ignored_paths.is_empty()
             || query.expected_count != query.owners.len()
         {
-            return Err(LockFailure::Dependency);
+            facts.queries.push(query);
+            return Err((LockFailure::Dependency, facts));
         }
         if !query.owners.is_empty() {
-            return Err(LockFailure::Locked);
+            locked = true;
         }
+        facts.queries.push(query);
     }
-    let status = adapter
-        .lock_file_status(paths)
-        .await
-        .map_err(|_| LockFailure::Dependency)?;
+    let mut status = match adapter.lock_file_status(branch, paths).await {
+        Ok(status) => status,
+        Err(_) => return Err((LockFailure::Dependency, facts)),
+    };
+    status.ignored_paths.sort();
+    status
+        .statuses
+        .sort_by(|left, right| (&left.path, &left.owner).cmp(&(&right.path, &right.owner)));
+    facts.status = Some(status.clone());
     if status.begin_events != 1
         || !status.completed
         || !status.ignored_paths.is_empty()
         || status.expected_count != status.statuses.len()
     {
-        return Err(LockFailure::Dependency);
+        return Err((LockFailure::Dependency, facts));
     }
     let mut observed = BTreeSet::new();
-    for record in status.statuses {
-        if !requested.contains(&record.path) || !observed.insert(record.path) {
-            return Err(LockFailure::Dependency);
+    for record in &status.statuses {
+        if !requested.contains(&record.path) || !observed.insert(record.path.clone()) {
+            return Err((LockFailure::Dependency, facts));
         }
         if record.owner.is_some() {
-            return Err(LockFailure::Locked);
+            locked = true;
         }
     }
-    Ok(())
+    if locked {
+        Err((LockFailure::Locked, facts))
+    } else {
+        Ok(facts)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{revision_only_status_args, scanned_status_args};
+    use super::MetadataKind;
+    use super::{
+        finished_raw_metadata, finished_raw_stream, raw_event_collector, raw_metadata_collector,
+        revision_only_status_args, scanned_status_args,
+    };
+    use lore::interface::{
+        LoreCompleteEventData, LoreErrorEventData, LoreEvent, LoreMetadata, LoreMetadataEventData,
+        LoreString,
+    };
+
+    fn complete(status: i32) -> LoreEvent {
+        LoreEvent::Complete(LoreCompleteEventData {
+            status,
+            error: Default::default(),
+        })
+    }
+
+    fn end() -> LoreEvent {
+        LoreEvent::End(Default::default())
+    }
+
+    fn collect(events: Vec<LoreEvent>, returned: i32) -> bool {
+        let (callback, observed) = raw_event_collector();
+        let callback = callback.expect("collector callback");
+        for event in events {
+            callback(&event);
+        }
+        finished_raw_stream(observed, returned).is_ok()
+    }
+
+    fn collect_metadata(
+        events: Vec<LoreEvent>,
+        returned: i32,
+    ) -> Result<Vec<super::MetadataEntry>, super::AdapterError> {
+        let (callback, observed) = raw_metadata_collector();
+        let callback = callback.expect("metadata collector callback");
+        for event in events {
+            callback(&event);
+        }
+        finished_raw_metadata(observed, returned)
+    }
 
     #[test]
     fn production_status_arguments_pin_exact_reads_and_full_scan() {
@@ -1209,5 +2570,72 @@ mod tests {
             (1, 1, 0, 0, 0, 0, 0)
         );
         assert!(scan.paths.is_empty());
+    }
+
+    #[test]
+    fn raw_collector_rejects_every_inexact_terminal_shape_after_api_return() {
+        assert!(collect(vec![complete(0), end()], 0));
+        assert!(!collect(vec![complete(0), end(), end()], 0));
+        assert!(!collect(vec![end(), complete(0)], 0));
+        assert!(!collect(vec![complete(0)], 0));
+        assert!(!collect(vec![end()], 0));
+        assert!(!collect(
+            vec![
+                LoreEvent::Error(LoreErrorEventData {
+                    error_type: 3,
+                    error_inner: LoreString::from_str("injected"),
+                }),
+                complete(0),
+                end(),
+            ],
+            0,
+        ));
+        assert!(!collect(vec![complete(1), end()], 0));
+        assert!(!collect(vec![complete(0), end()], 1));
+    }
+
+    #[test]
+    fn raw_metadata_retains_kind_value_and_multiplicity_without_binary_fiction() {
+        let string = LoreEvent::Metadata(LoreMetadataEventData {
+            key: LoreString::from_str("typed"),
+            value: LoreMetadata::String(LoreString::from_str("1")),
+        });
+        let numeric = LoreEvent::Metadata(LoreMetadataEventData {
+            key: LoreString::from_str("typed"),
+            value: LoreMetadata::Numeric(1),
+        });
+        let entries =
+            collect_metadata(vec![string.clone(), numeric.clone(), complete(0), end()], 0)
+                .expect_err("duplicate metadata keys are an over-counted raw stream");
+        assert!(entries.message.contains("duplicate"));
+
+        let string = LoreEvent::Metadata(LoreMetadataEventData {
+            key: LoreString::from_str("as_string"),
+            value: LoreMetadata::String(LoreString::from_str("1")),
+        });
+        let numeric = LoreEvent::Metadata(LoreMetadataEventData {
+            key: LoreString::from_str("as_numeric"),
+            value: LoreMetadata::Numeric(1),
+        });
+        let entries =
+            collect_metadata(vec![string.clone(), numeric.clone(), complete(0), end()], 0)
+                .expect("distinct exact metadata events");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].kind, MetadataKind::String);
+        assert_eq!(entries[1].kind, MetadataKind::Numeric);
+        assert_ne!(entries[0], entries[1]);
+
+        assert!(
+            collect_metadata(vec![string.clone(), string, numeric, complete(0), end()], 0,)
+                .is_err()
+        );
+
+        let (_, missing_end) = raw_metadata_collector();
+        *missing_end.lock().unwrap() = super::RawMetadataStream {
+            complete_events: 1,
+            complete_status: Some(0),
+            ..Default::default()
+        };
+        assert!(finished_raw_metadata(missing_end, 0).is_err());
     }
 }

--- a/crates/lore-vm/src/ops/governance/evidence_preserve.rs
+++ b/crates/lore-vm/src/ops/governance/evidence_preserve.rs
@@ -1,0 +1,1332 @@
+//! Actor-produced, non-authoritative canonical evidence preservation.
+//!
+//! The stored bytes are a claim, never a gate verdict. The operation proves an
+//! exact immutable put/get round trip and the sole metadata-pointer delta, then
+//! re-evaluates the resulting staged subject. `storage_close` only releases the
+//! handle and starts upstream's fire-and-forget flush; this module makes no
+//! independent cross-process durability claim.
+
+use super::contract::{
+    AdapterError, CanonicalDcoMetadataObservationV1, CanonicalDcoObservationV1,
+    CanonicalEvidenceSnapshotV1, CanonicalFileIdentityV1, CanonicalRevisionInfoV1,
+    CanonicalRevisionRefV1, CanonicalStatusObservationV1,
+    CanonicalSupersessionMetadataQueryObservationV1, CanonicalSupersessionObservationV1,
+    CanonicalWorktreeFileObservationV1, EvaluationResult, EvidenceCloseEffectV1,
+    EvidencePointerDeltaV1, EvidencePointerV1, EvidencePreserveOutcomeV1, EvidencePreserveRequest,
+    EvidencePublicationAttemptV1, GovernanceRole, ImmutableGetItem, ImmutablePutItem, LockQuery,
+    LockStatusResponse, MetadataEntry, MutationObservation, NoPublicationV1,
+    PendingEvidencePreserveOutcomeV1, PredispatchEvidenceAttemptV1, ReadObservation,
+    ResolvedAuthor, EVIDENCE_POINTER_KEY,
+};
+use super::evaluator::{
+    evaluate, raw_event_collector, raw_stream_completed_exactly, take_raw_stream,
+    GovernanceAdapter, ProductionLoreAdapter,
+};
+use super::GovernanceIo;
+use crate::api::LoreApi;
+use crate::error::{LoreError, Result};
+use lore::interface::{LoreArray, LoreEvent, LoreEventCallback, LoreMetadataType, LoreString};
+use lore::revision::LoreRevisionMetadataSetArgs;
+use lore::storage::close::LoreStorageCloseArgs;
+use lore::storage::get::{LoreStorageGetArgs, LoreStorageGetItem};
+use lore::storage::handle::LoreStore;
+use lore::storage::open::{LoreStorageOpenArgs, LoreStorageRemoteConfig};
+use lore::storage::put::{LoreStoragePutArgs, LoreStoragePutItem};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const EVIDENCE_VERSION: &str = "v1";
+const EVIDENCE_ITEM_ID: u64 = 5934;
+const EVIDENCE_PARTITION: &str = "00000000000000000000000000005934";
+static EVIDENCE_ATTEMPT_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+    let mut message = bytes.to_vec();
+    let bit_len = (message.len() as u64).wrapping_mul(8);
+    message.push(0x80);
+    while message.len() % 64 != 56 {
+        message.push(0);
+    }
+    message.extend_from_slice(&bit_len.to_be_bytes());
+
+    let mut hash = [
+        0x6a09e667u32,
+        0xbb67ae85,
+        0x3c6ef372,
+        0xa54ff53a,
+        0x510e527f,
+        0x9b05688c,
+        0x1f83d9ab,
+        0x5be0cd19,
+    ];
+    for chunk in message.chunks_exact(64) {
+        let mut words = [0u32; 64];
+        for (index, word) in words[..16].iter_mut().enumerate() {
+            *word = u32::from_be_bytes(
+                chunk[index * 4..index * 4 + 4]
+                    .try_into()
+                    .expect("SHA-256 chunk word"),
+            );
+        }
+        for index in 16..64 {
+            let s0 = words[index - 15].rotate_right(7)
+                ^ words[index - 15].rotate_right(18)
+                ^ (words[index - 15] >> 3);
+            let s1 = words[index - 2].rotate_right(17)
+                ^ words[index - 2].rotate_right(19)
+                ^ (words[index - 2] >> 10);
+            words[index] = words[index - 16]
+                .wrapping_add(s0)
+                .wrapping_add(words[index - 7])
+                .wrapping_add(s1);
+        }
+
+        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = hash;
+        for index in 0..64 {
+            let sum1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let choose = (e & f) ^ ((!e) & g);
+            let temp1 = h
+                .wrapping_add(sum1)
+                .wrapping_add(choose)
+                .wrapping_add(K[index])
+                .wrapping_add(words[index]);
+            let sum0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let majority = (a & b) ^ (a & c) ^ (b & c);
+            let temp2 = sum0.wrapping_add(majority);
+            h = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(temp1);
+            d = c;
+            c = b;
+            b = a;
+            a = temp1.wrapping_add(temp2);
+        }
+        for (slot, value) in hash.iter_mut().zip([a, b, c, d, e, f, g, h]) {
+            *slot = slot.wrapping_add(value);
+        }
+    }
+    hash.iter().map(|word| format!("{word:08x}")).collect()
+}
+
+fn new_attempt_id(request: &EvidencePreserveRequest) -> String {
+    let counter = EVIDENCE_ATTEMPT_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    sha256_hex(
+        format!(
+            "studiobrain-governance-evidence-v1\0{}\0{}\0{}\0{}\0{}",
+            std::process::id(),
+            counter,
+            nanos,
+            request.expected_staged_revision,
+            request.target_base_revision
+        )
+        .as_bytes(),
+    )
+}
+
+fn command_failed(context: &str, error: impl std::fmt::Display) -> LoreError {
+    LoreError::CommandFailed(format!("governance evidence {context}: {error}"))
+}
+
+fn canonical_revision(revision: &str, staged: &str) -> CanonicalRevisionRefV1 {
+    if revision == staged {
+        CanonicalRevisionRefV1::StagedSubject
+    } else {
+        CanonicalRevisionRefV1::Exact(revision.to_string())
+    }
+}
+
+fn canonical_status_revisions(revisions: &[String], staged: &str) -> Vec<CanonicalRevisionRefV1> {
+    revisions
+        .iter()
+        .map(|revision| canonical_revision(revision, staged))
+        .collect()
+}
+
+fn sort_resolved_authors(authors: &mut [ResolvedAuthor]) {
+    authors.sort_by(|left, right| {
+        (&left.identity, &left.display_name).cmp(&(&right.identity, &right.display_name))
+    });
+}
+
+fn canonical_files(
+    files: &[super::contract::FileIdentity],
+    staged: &str,
+) -> Vec<CanonicalFileIdentityV1> {
+    let mut canonical: Vec<_> = files
+        .iter()
+        .map(|file| CanonicalFileIdentityV1 {
+            path: file.path.clone(),
+            revision: canonical_revision(&file.revision, staged),
+            hash: file.hash.clone(),
+            context: file.context.clone(),
+        })
+        .collect();
+    canonical.sort_by(|left, right| {
+        (&left.path, &left.revision, &left.hash, &left.context).cmp(&(
+            &right.path,
+            &right.revision,
+            &right.hash,
+            &right.context,
+        ))
+    });
+    canonical
+}
+
+/// Convert a successful evaluator run into the sole canonical v1 evidence
+/// representation. Normalization is limited to the typed staged-subject token
+/// and omission of that subject's self-referential evidence-pointer entry;
+/// all other strings and scalar observations remain exact.
+pub(crate) fn canonical_snapshot(
+    evaluation: &EvaluationResult,
+) -> Result<CanonicalEvidenceSnapshotV1> {
+    if !evaluation.open {
+        return Err(command_failed(
+            "snapshot rejected closed evaluation",
+            evaluation.failure_codes.join(","),
+        ));
+    }
+    let observed = &evaluation.observations;
+    let staged = observed.expected_staged_revision.as_str();
+    let status = observed
+        .status
+        .as_ref()
+        .ok_or_else(|| command_failed("snapshot missing status", "status_unavailable"))?;
+    let base_revision_info = observed
+        .base_revision_info
+        .as_ref()
+        .ok_or_else(|| command_failed("snapshot missing base ancestry", "history_incomplete"))?;
+    if observed.target_base_revision.is_empty()
+        || staged.is_empty()
+        || base_revision_info.revision != observed.target_base_revision
+        || !observed.dependency_observations.is_empty()
+        || !observed.base_tree_observed
+        || !observed.candidate_tree_observed
+        || !observed.revision_diff_observed
+        || !observed.supersession_metadata_observed
+        || [
+            &status.staged_revisions,
+            &status.scanned_staged_revisions,
+            &status.post_scan_staged_revisions,
+        ]
+        .into_iter()
+        .any(|revisions| revisions.as_slice() != [staged])
+    {
+        return Err(command_failed(
+            "snapshot contained incomplete raw observations",
+            "canonicalization_failed",
+        ));
+    }
+
+    let mut revision_graph: Vec<_> = observed
+        .revision_graph
+        .iter()
+        .map(|info| CanonicalRevisionInfoV1 {
+            revision: canonical_revision(&info.revision, staged),
+            // Parent ordering is an exact first-parent input and must not be sorted.
+            parents: info
+                .parents
+                .iter()
+                .map(|parent| canonical_revision(parent, staged))
+                .collect(),
+        })
+        .collect();
+    revision_graph.sort_by(|left, right| left.revision.cmp(&right.revision));
+    let mut supersession_ancestry: Vec<_> = observed
+        .supersession_ancestry
+        .iter()
+        .map(|info| CanonicalRevisionInfoV1 {
+            revision: canonical_revision(&info.revision, staged),
+            parents: info
+                .parents
+                .iter()
+                .map(|parent| canonical_revision(parent, staged))
+                .collect(),
+        })
+        .collect();
+    supersession_ancestry.sort_by(|left, right| left.revision.cmp(&right.revision));
+    let base_revision_info = CanonicalRevisionInfoV1 {
+        revision: canonical_revision(&base_revision_info.revision, staged),
+        parents: base_revision_info
+            .parents
+            .iter()
+            .map(|parent| canonical_revision(parent, staged))
+            .collect(),
+    };
+
+    let mut supersession_markers: Vec<_> = observed
+        .supersession_markers
+        .iter()
+        .map(|entry| CanonicalSupersessionObservationV1 {
+            revision: canonical_revision(&entry.revision, staged),
+            key: entry.key.clone(),
+            value: entry.value.clone(),
+            identity: entry.identity.clone(),
+        })
+        .collect();
+    supersession_markers.sort_by(|left, right| {
+        (&left.revision, &left.key, &left.value, &left.identity).cmp(&(
+            &right.revision,
+            &right.key,
+            &right.value,
+            &right.identity,
+        ))
+    });
+
+    let mut ancestry_revisions: Vec<_> = observed
+        .supersession_ancestry
+        .iter()
+        .map(|info| info.revision.as_str())
+        .collect();
+    ancestry_revisions.sort_unstable();
+    let mut query_revisions: Vec<_> = observed
+        .supersession_metadata_queries
+        .iter()
+        .map(|query| query.revision.as_str())
+        .collect();
+    query_revisions.sort_unstable();
+    if query_revisions != ancestry_revisions {
+        return Err(command_failed(
+            "snapshot metadata-query coverage mismatch",
+            "metadata_unavailable",
+        ));
+    }
+    let mut supersession_metadata_queries: Vec<_> = observed
+        .supersession_metadata_queries
+        .iter()
+        .map(|query| {
+            // The evidence pointer is the one typed metadata delta produced by
+            // this operation. It cannot be included in the bytes that its own
+            // address identifies, so omit only that exact key from the staged
+            // subject's raw-query projection. The actor validates the complete
+            // source/result metadata delta before this comparison, and the
+            // witness separately validates the exact pointer before accepting
+            // the stored snapshot. Every other metadata entry remains bound.
+            let mut metadata: Vec<_> = query
+                .metadata
+                .iter()
+                .filter(|entry| query.revision != staged || entry.key != EVIDENCE_POINTER_KEY)
+                .cloned()
+                .collect();
+            metadata.sort_by(|left, right| {
+                (&left.key, left.kind, &left.value).cmp(&(&right.key, right.kind, &right.value))
+            });
+            CanonicalSupersessionMetadataQueryObservationV1 {
+                revision: canonical_revision(&query.revision, staged),
+                metadata,
+            }
+        })
+        .collect();
+    supersession_metadata_queries.sort_by(|left, right| left.revision.cmp(&right.revision));
+
+    let mut dco: Vec<_> = observed
+        .dco
+        .iter()
+        .map(|entry| {
+            let mut resolved_authors = entry.resolved_authors.clone();
+            sort_resolved_authors(&mut resolved_authors);
+            CanonicalDcoObservationV1 {
+                revision: canonical_revision(&entry.revision, staged),
+                message: entry.message.clone(),
+                trailer: entry.trailer.clone(),
+                signer_name: entry.signer_name.clone(),
+                signer_email: entry.signer_email.clone(),
+                created_by: entry.created_by.clone(),
+                committed_by: entry.committed_by.clone(),
+                resolved_authors,
+            }
+        })
+        .collect();
+    dco.sort_by(|left, right| left.revision.cmp(&right.revision));
+    let mut dco_metadata: Vec<_> = observed
+        .dco_metadata
+        .iter()
+        .map(|entry| {
+            let mut messages = entry.messages.clone();
+            messages.sort();
+            let mut created_by = entry.created_by.clone();
+            created_by.sort();
+            let mut committed_by = entry.committed_by.clone();
+            committed_by.sort();
+            CanonicalDcoMetadataObservationV1 {
+                revision: canonical_revision(&entry.revision, staged),
+                messages,
+                created_by,
+                committed_by,
+            }
+        })
+        .collect();
+    dco_metadata.sort_by(|left, right| left.revision.cmp(&right.revision));
+    let mut author_resolution = observed
+        .author_resolution
+        .clone()
+        .ok_or_else(|| command_failed("snapshot missing author resolution", "auth_unavailable"))?;
+    author_resolution.requested.sort();
+    sort_resolved_authors(&mut author_resolution.replies);
+
+    let mut lock_queries: Vec<LockQuery> = observed.lock_queries.clone();
+    for query in &mut lock_queries {
+        query.ignored_paths.sort();
+        query.owners.sort();
+    }
+    lock_queries.sort_by(|left, right| left.path.cmp(&right.path));
+    let mut lock_status: LockStatusResponse = observed
+        .lock_status
+        .clone()
+        .ok_or_else(|| command_failed("snapshot missing lock status", "locks_unavailable"))?;
+    lock_status.ignored_paths.sort();
+    lock_status
+        .statuses
+        .sort_by(|left, right| (&left.path, &left.owner).cmp(&(&right.path, &right.owner)));
+
+    let mut affected_paths = observed.affected_paths.clone();
+    affected_paths.sort();
+    affected_paths.dedup();
+    let mut dependency_observations = observed.dependency_observations.clone();
+    dependency_observations.sort();
+    dependency_observations.dedup();
+    let mut revision_diff = observed.revision_diff.clone();
+    revision_diff.sort_by(|left, right| {
+        (&left.source_path, &left.target_path).cmp(&(&right.source_path, &right.target_path))
+    });
+    let mut worktree_files: Vec<_> = status
+        .worktree_files
+        .iter()
+        .map(|file| CanonicalWorktreeFileObservationV1 {
+            path: file.path.clone(),
+            revision: canonical_revision(&file.revision, staged),
+            revision_hash: file.revision_hash.clone(),
+            revision_context: file.revision_context.clone(),
+            revision_size: file.revision_size,
+            local_hash: file.local_hash.clone(),
+            local_size: file.local_size,
+            filtered_revision_size: file.filtered_revision_size,
+            flag_modified: file.flag_modified,
+            flag_deleted: file.flag_deleted,
+            flag_added: file.flag_added,
+            flag_conflict: file.flag_conflict,
+        })
+        .collect();
+    worktree_files.sort_by(|left, right| left.path.cmp(&right.path));
+
+    Ok(CanonicalEvidenceSnapshotV1 {
+        version: EVIDENCE_VERSION.into(),
+        target_base_revision: observed.target_base_revision.clone(),
+        status: CanonicalStatusObservationV1 {
+            branch: status.branch.clone(),
+            staged_revisions: canonical_status_revisions(&status.staged_revisions, staged),
+            scanned_staged_revisions: canonical_status_revisions(
+                &status.scanned_staged_revisions,
+                staged,
+            ),
+            post_scan_staged_revisions: canonical_status_revisions(
+                &status.post_scan_staged_revisions,
+                staged,
+            ),
+            staged_paths: {
+                let mut paths = status.staged_paths.clone();
+                paths.sort();
+                paths.dedup();
+                paths
+            },
+            staged_changes: {
+                let mut changes = status.staged_changes.clone();
+                changes.sort();
+                changes
+            },
+            worktree_files,
+            worktree_clean: status.worktree_clean,
+            scan_performed: status.scan_performed,
+        },
+        base_revision_info,
+        supersession_ancestry,
+        supersession_ancestry_observed: observed.supersession_ancestry_observed,
+        revision_graph,
+        // First-parent order is semantic and remains byte-exact.
+        first_parent_history: observed
+            .first_parent_history
+            .iter()
+            .map(|revision| canonical_revision(revision, staged))
+            .collect(),
+        base_files: canonical_files(&observed.base_files, staged),
+        base_tree_observed: observed.base_tree_observed,
+        candidate_files: canonical_files(&observed.candidate_files, staged),
+        candidate_tree_observed: observed.candidate_tree_observed,
+        current_files: canonical_files(&observed.current_files, staged),
+        upstream_revision_diff: {
+            let mut diff = observed.upstream_revision_diff.clone();
+            diff.sort();
+            diff
+        },
+        revision_diff,
+        revision_diff_observed: observed.revision_diff_observed,
+        affected_paths,
+        supersession_markers,
+        supersession_metadata_queries,
+        supersession_metadata_observed: observed.supersession_metadata_observed,
+        dco_metadata,
+        author_resolution,
+        dco,
+        lock_queries,
+        lock_status,
+        dependency_observations,
+    })
+}
+
+fn exact_metadata(mut metadata: Vec<MetadataEntry>) -> Vec<MetadataEntry> {
+    metadata.sort_by(|left, right| {
+        (&left.key, left.kind, &left.value).cmp(&(&right.key, right.kind, &right.value))
+    });
+    metadata
+}
+
+fn exact_address(address: &str) -> bool {
+    let lowercase_hex = |byte: &u8| byte.is_ascii_digit() || matches!(*byte, b'a'..=b'f');
+    let bytes = address.as_bytes();
+    bytes.len() == 97
+        && bytes[64] == b'-'
+        && bytes[..64].iter().all(lowercase_hex)
+        && bytes[65..].iter().all(lowercase_hex)
+}
+
+fn one_put(items: &[ImmutablePutItem]) -> std::result::Result<String, String> {
+    if items.len() != 1 {
+        return Err(format!("put cardinality {}", items.len()));
+    }
+    let item = items.first().expect("length checked");
+    if item.id != EVIDENCE_ITEM_ID || !item.ok || !exact_address(&item.address) {
+        return Err("put item validation failed".into());
+    }
+    Ok(item.address.clone())
+}
+
+enum GetValidation {
+    Exact,
+    Malformed(String),
+    BytesMismatch,
+}
+
+fn one_get(items: &[ImmutableGetItem], address: &str, expected: &[u8]) -> GetValidation {
+    if items.len() != 1 {
+        return GetValidation::Malformed(format!("get cardinality {}", items.len()));
+    }
+    let item = items.first().expect("length checked");
+    if item.id != EVIDENCE_ITEM_ID
+        || !item.ok
+        || item.address != address
+        || item.size != expected.len() as u64
+    {
+        return GetValidation::Malformed("get item validation failed".into());
+    }
+    if item.data != expected {
+        return GetValidation::BytesMismatch;
+    }
+    GetValidation::Exact
+}
+
+fn observed_candidate_addresses(items: &[ImmutablePutItem]) -> Vec<String> {
+    items.iter().map(|item| item.address.clone()).collect()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CapturedStorageGetEvent {
+    Header {
+        id: u64,
+        address: String,
+        size: u64,
+    },
+    Data {
+        id: u64,
+        address: String,
+        offset: u64,
+        bytes: Vec<u8>,
+    },
+    ItemComplete {
+        id: u64,
+        address: String,
+        ok: bool,
+    },
+    Error,
+    Complete {
+        status: i32,
+    },
+    End,
+    Other,
+}
+
+fn raw_storage_get_collector() -> (LoreEventCallback, Arc<Mutex<Vec<CapturedStorageGetEvent>>>) {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let observed = Arc::clone(&events);
+    let callback = Box::new(move |event: &LoreEvent| {
+        let captured = match event {
+            LoreEvent::StorageGetHeader(data) => CapturedStorageGetEvent::Header {
+                id: data.id,
+                address: format!("{}", data.address),
+                size: data.size_content,
+            },
+            LoreEvent::StorageGetData(data) => CapturedStorageGetEvent::Data {
+                id: data.id,
+                address: format!("{}", data.address),
+                offset: data.offset,
+                // SAFETY: the upstream buffer is callback-scoped. Copy it
+                // before returning from this invocation.
+                bytes: unsafe { data.bytes.as_slice() }.to_vec(),
+            },
+            LoreEvent::StorageGetItemComplete(data) => CapturedStorageGetEvent::ItemComplete {
+                id: data.id,
+                address: format!("{}", data.address),
+                ok: data.error_code as i32 == 0,
+            },
+            LoreEvent::Error(_) => CapturedStorageGetEvent::Error,
+            LoreEvent::Complete(data) => CapturedStorageGetEvent::Complete {
+                status: data.status,
+            },
+            LoreEvent::End(_) => CapturedStorageGetEvent::End,
+            _ => CapturedStorageGetEvent::Other,
+        };
+        observed
+            .lock()
+            .expect("raw storage get collector mutex poisoned")
+            .push(captured);
+    });
+    (Some(callback), events)
+}
+
+fn finish_captured_storage_get(
+    events: Vec<CapturedStorageGetEvent>,
+    returned: i32,
+) -> std::result::Result<Vec<ImmutableGetItem>, AdapterError> {
+    let complete_positions: Vec<_> = events
+        .iter()
+        .enumerate()
+        .filter_map(|(index, event)| match event {
+            CapturedStorageGetEvent::Complete { status } => Some((index, *status)),
+            _ => None,
+        })
+        .collect();
+    let end_positions: Vec<_> = events
+        .iter()
+        .enumerate()
+        .filter_map(|(index, event)| matches!(event, CapturedStorageGetEvent::End).then_some(index))
+        .collect();
+    if returned != 0
+        || complete_positions.as_slice() != [(events.len().saturating_sub(2), 0)]
+        || end_positions.as_slice() != [events.len().saturating_sub(1)]
+        || events
+            .iter()
+            .any(|event| matches!(event, CapturedStorageGetEvent::Error))
+    {
+        return Err(AdapterError::new(
+            "raw storage get stream failed terminal validation",
+        ));
+    }
+
+    let headers: Vec<_> = events
+        .iter()
+        .enumerate()
+        .filter_map(|(index, event)| match event {
+            CapturedStorageGetEvent::Header { id, address, size } => {
+                Some((index, *id, address.as_str(), *size))
+            }
+            _ => None,
+        })
+        .collect();
+    let completions: Vec<_> = events
+        .iter()
+        .enumerate()
+        .filter_map(|(index, event)| match event {
+            CapturedStorageGetEvent::ItemComplete { id, address, ok } => {
+                Some((index, *id, address.as_str(), *ok))
+            }
+            _ => None,
+        })
+        .collect();
+    let (header_index, id, address, size) = match headers.as_slice() {
+        [header] => *header,
+        _ => return Err(AdapterError::new("raw storage get header cardinality")),
+    };
+    let (completion_index, completion_id, completion_address, ok) = match completions.as_slice() {
+        [completion] => *completion,
+        _ => return Err(AdapterError::new("raw storage get completion cardinality")),
+    };
+    if !ok
+        || id != completion_id
+        || address != completion_address
+        || header_index >= completion_index
+        || completion_index >= complete_positions[0].0
+    {
+        return Err(AdapterError::new(
+            "raw storage get item sequence was invalid",
+        ));
+    }
+
+    let mut data = Vec::new();
+    let mut next_offset = 0u64;
+    for (index, event) in events.iter().enumerate() {
+        let CapturedStorageGetEvent::Data {
+            id: data_id,
+            address: data_address,
+            offset,
+            bytes,
+        } = event
+        else {
+            continue;
+        };
+        if index <= header_index
+            || index >= completion_index
+            || *data_id != id
+            || data_address != address
+            || *offset != next_offset
+        {
+            return Err(AdapterError::new(
+                "raw storage get data sequence was invalid",
+            ));
+        }
+        next_offset = next_offset
+            .checked_add(bytes.len() as u64)
+            .ok_or_else(|| AdapterError::new("raw storage get size overflow"))?;
+        data.extend_from_slice(bytes);
+    }
+    if next_offset != size || data.len() as u64 != size {
+        return Err(AdapterError::new("raw storage get payload was incomplete"));
+    }
+    Ok(vec![ImmutableGetItem {
+        id,
+        address: address.into(),
+        size,
+        data,
+        ok,
+    }])
+}
+
+fn exact_staged_subject(status: &super::contract::StatusSnapshot) -> Result<String> {
+    let Some(staged) = status.staged_revisions.first() else {
+        return Err(command_failed("metadata result", "missing staged revision"));
+    };
+    if staged.is_empty()
+        || status.staged_revisions.len() != 1
+        || status.scanned_staged_revisions.len() != 1
+        || status.scanned_staged_revisions.first() != Some(staged)
+        || status.post_scan_staged_revisions.len() != 1
+        || status.post_scan_staged_revisions.first() != Some(staged)
+    {
+        return Err(command_failed(
+            "metadata result",
+            "ambiguous staged revision",
+        ));
+    }
+    Ok(staged.clone())
+}
+
+struct PreserveOnOpenInputs<'a> {
+    request: &'a EvidencePreserveRequest,
+    snapshot: CanonicalEvidenceSnapshotV1,
+    bytes: Vec<u8>,
+    source_metadata: Vec<MetadataEntry>,
+}
+
+async fn preserve_on_open<A: GovernanceAdapter, I: GovernanceIo>(
+    adapter: &A,
+    io: &I,
+    handle: u64,
+    attempt: EvidencePublicationAttemptV1<NoPublicationV1>,
+    inputs: PreserveOnOpenInputs<'_>,
+) -> PendingEvidencePreserveOutcomeV1 {
+    let PreserveOnOpenInputs {
+        request,
+        snapshot,
+        bytes,
+        source_metadata,
+    } = inputs;
+    let source = request.expected_staged_revision.as_str();
+
+    if io.role() != GovernanceRole::Actor {
+        return attempt.actor_role_before_put("role changed before immutable put");
+    }
+    let (attempt, address) = match io.storage_put(handle, &bytes).await {
+        MutationObservation::NotDispatched { code } => {
+            return attempt.storage_put_not_dispatched(code)
+        }
+        MutationObservation::OutcomeUnknown { code, observed } => {
+            return attempt
+                .put_observed(observed_candidate_addresses(&observed))
+                .storage_put_outcome_unknown(code)
+        }
+        MutationObservation::Completed(items) => {
+            let candidate_addresses = observed_candidate_addresses(&items);
+            let attempt = attempt.put_observed(candidate_addresses);
+            match one_put(&items) {
+                Ok(address) => (attempt.blob_published(address.clone()), address),
+                Err(code) => return attempt.storage_put_response_malformed(code),
+            }
+        }
+    };
+
+    // Re-read every live dependency after storage I/O and before the mutation.
+    let preattach = evaluate(adapter, request).await;
+    match canonical_snapshot(&preattach) {
+        Ok(observed) if observed == snapshot => {}
+        Ok(_) => {
+            return attempt
+                .preattach_evaluation_incomplete("live observations changed before pointer attach")
+        }
+        Err(error) => return attempt.preattach_evaluation_incomplete(error.to_string()),
+    }
+    let live_source_metadata = match adapter.revision_metadata(source).await {
+        Ok(metadata) => exact_metadata(metadata),
+        Err(error) => return attempt.preattach_evaluation_incomplete(error.message),
+    };
+    if live_source_metadata != source_metadata {
+        return attempt
+            .preattach_evaluation_incomplete("source metadata changed before pointer attach");
+    }
+    if io.role() != GovernanceRole::Actor {
+        return attempt.actor_role_before_attach("role changed before pointer attach");
+    }
+
+    let pointer = EvidencePointerV1 {
+        version: EVIDENCE_VERSION.into(),
+        address: address.clone(),
+    };
+    let pointer_json = match serde_json::to_string(&pointer) {
+        Ok(pointer_json) => pointer_json,
+        Err(error) => return attempt.pointer_serialization_incomplete(error.to_string()),
+    };
+    let attempt = match io
+        .revision_metadata_set(EVIDENCE_POINTER_KEY, &pointer_json)
+        .await
+    {
+        MutationObservation::NotDispatched { code } => {
+            return attempt.pointer_attach_not_dispatched(code)
+        }
+        MutationObservation::OutcomeUnknown { code, observed: () } => {
+            return attempt.pointer_attach_outcome_unknown(code)
+        }
+        MutationObservation::Completed(()) => attempt.pointer_attach_acknowledged(pointer.clone()),
+    };
+
+    // The pointer has been acknowledged. Bind it immediately to one exact
+    // immutable reread before observing a result subject or metadata delta.
+    let attempt = match io.storage_get(handle, &address).await {
+        ReadObservation::NotDispatched { code } | ReadObservation::Unavailable { code } => {
+            return attempt.postattach_get_unavailable(code)
+        }
+        ReadObservation::Completed(items) => match one_get(&items, &address, &bytes) {
+            GetValidation::Exact => attempt.blob_readback_verified(),
+            GetValidation::Malformed(code) => return attempt.postattach_get_malformed(code),
+            GetValidation::BytesMismatch => {
+                return attempt.postattach_bytes_mismatch(
+                    "same-size immutable bytes differed from the canonical snapshot",
+                )
+            }
+        },
+    };
+
+    let result_status = match adapter.status().await {
+        Ok(status) => status,
+        Err(error) => return attempt.result_status_unavailable(error.message),
+    };
+    let result_revision = match exact_staged_subject(&result_status) {
+        Ok(revision) if revision != source => revision,
+        Ok(_) => {
+            return attempt
+                .result_status_invalid("pointer attach did not produce a new staged revision")
+        }
+        Err(error) => return attempt.result_status_invalid(error.to_string()),
+    };
+    let attempt = attempt.result_subject_observed(result_revision.clone());
+
+    let result_metadata = match adapter.revision_metadata(&result_revision).await {
+        Ok(metadata) => exact_metadata(metadata),
+        Err(error) => return attempt.result_metadata_unavailable(error.message),
+    };
+    let pointer_entries: Vec<_> = result_metadata
+        .iter()
+        .filter(|entry| entry.key == EVIDENCE_POINTER_KEY)
+        .collect();
+    if pointer_entries.len() != 1
+        || pointer_entries[0].string_value() != Some(pointer_json.as_str())
+    {
+        return attempt
+            .pointer_delta_invalid("result did not contain exactly the attached string pointer");
+    }
+    let mut expected_metadata = source_metadata.clone();
+    expected_metadata.push(MetadataEntry::new(EVIDENCE_POINTER_KEY, &pointer_json));
+    if exact_metadata(expected_metadata) != result_metadata {
+        return attempt.pointer_delta_invalid("metadata changed outside the sole evidence key");
+    }
+    let Some(pointer_value) = pointer_entries[0].string_value() else {
+        return attempt.pointer_schema_invalid("pointer value was not a string");
+    };
+    let parsed_pointer: EvidencePointerV1 = match serde_json::from_str(pointer_value) {
+        Ok(pointer) => pointer,
+        Err(error) => return attempt.pointer_schema_invalid(error.to_string()),
+    };
+    if parsed_pointer != pointer {
+        return attempt.pointer_schema_invalid("pointer schema round-trip mismatch");
+    }
+
+    let delta = EvidencePointerDeltaV1 {
+        version: EVIDENCE_VERSION.into(),
+        key: EVIDENCE_POINTER_KEY.into(),
+        source_staged_revision: source.into(),
+        result_staged_revision: result_revision.clone(),
+        pointer: pointer.clone(),
+    };
+    let delta_bytes = match serde_json::to_vec(&delta) {
+        Ok(bytes) => bytes,
+        Err(error) => return attempt.pointer_schema_invalid(error.to_string()),
+    };
+    match serde_json::from_slice::<EvidencePointerDeltaV1>(&delta_bytes) {
+        Ok(roundtrip) if roundtrip == delta => {}
+        Ok(_) => return attempt.pointer_schema_invalid("pointer delta round-trip mismatch"),
+        Err(error) => return attempt.pointer_schema_invalid(error.to_string()),
+    }
+    let attempt = attempt.pointer_delta_observed();
+
+    let result_request = EvidencePreserveRequest {
+        expected_staged_revision: result_revision.clone(),
+        target_base_revision: request.target_base_revision.clone(),
+    };
+    let postattach = evaluate(adapter, &result_request).await;
+    match canonical_snapshot(&postattach) {
+        Ok(observed) if observed == snapshot => attempt.postattach_equivalent().ready_to_close(),
+        Ok(_) => {
+            attempt.postattach_drift("live observations changed outside the typed pointer delta")
+        }
+        Err(error) => attempt.postattach_evaluation_incomplete(error.to_string()),
+    }
+}
+
+pub async fn evidence_preserve_with_adapters<A: GovernanceAdapter, I: GovernanceIo>(
+    adapter: &A,
+    io: &I,
+    request: &EvidencePreserveRequest,
+) -> Result<EvidencePreserveOutcomeV1> {
+    let validated = request
+        .validated()
+        .map_err(|error| LoreError::Parse(error.into()))?;
+    let predispatch = PredispatchEvidenceAttemptV1::new(new_attempt_id(request), validated);
+    // This check precedes evaluation and every storage/repository side effect.
+    if io.role() != GovernanceRole::Actor {
+        return predispatch
+            .actor_role_rejected("only an actor may preserve a non-authoritative claim")
+            .map_err(LoreError::Parse);
+    }
+    let initial = evaluate(adapter, request).await;
+    if !initial.open {
+        let code = initial.failure_codes.join(",");
+        return if complete_policy_rejection(&initial) {
+            predispatch
+                .initial_governance_rejected(code)
+                .map_err(LoreError::Parse)
+        } else {
+            predispatch
+                .initial_evaluation_incomplete(code)
+                .map_err(LoreError::Parse)
+        };
+    }
+    let snapshot = match canonical_snapshot(&initial) {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            return predispatch
+                .initial_evaluation_incomplete(error.to_string())
+                .map_err(LoreError::Parse)
+        }
+    };
+    let source_metadata = match adapter
+        .revision_metadata(&request.expected_staged_revision)
+        .await
+    {
+        Ok(metadata) => exact_metadata(metadata),
+        Err(error) => {
+            return predispatch
+                .source_metadata_incomplete(error.message)
+                .map_err(LoreError::Parse)
+        }
+    };
+    if source_metadata
+        .iter()
+        .any(|entry| entry.key == EVIDENCE_POINTER_KEY)
+    {
+        return predispatch
+            .pointer_already_present_rejected("evidence pointer already present")
+            .map_err(LoreError::Parse);
+    }
+    let bytes = match serde_json::to_vec(&snapshot) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            return predispatch
+                .snapshot_serialization_incomplete(error.to_string())
+                .map_err(LoreError::Parse)
+        }
+    };
+    let attempt = predispatch
+        .with_snapshot_sha256(sha256_hex(&bytes))
+        .enter_effect_boundary();
+    let handle = match io.storage_open().await {
+        MutationObservation::NotDispatched { code } => {
+            return attempt
+                .storage_open_not_dispatched(code)
+                .map_err(LoreError::Parse)
+        }
+        MutationObservation::OutcomeUnknown { code, observed: _ } => {
+            return attempt
+                .storage_open_outcome_unknown(code)
+                .map_err(LoreError::Parse)
+        }
+        MutationObservation::Completed(handles) => match handles.as_slice() {
+            [handle] if *handle != 0 => *handle,
+            _ => {
+                return attempt
+                    .storage_open_outcome_unknown("storage open returned an unusable handle set")
+                    .map_err(LoreError::Parse)
+            }
+        },
+    };
+    let operation = preserve_on_open(
+        adapter,
+        io,
+        handle,
+        attempt,
+        PreserveOnOpenInputs {
+            request,
+            snapshot,
+            bytes,
+            source_metadata,
+        },
+    )
+    .await;
+    let close = match io.storage_close(handle).await {
+        MutationObservation::Completed(()) => EvidenceCloseEffectV1::Closed,
+        MutationObservation::NotDispatched { code } => {
+            EvidenceCloseEffectV1::NotDispatched { code }
+        }
+        MutationObservation::OutcomeUnknown { code, observed: () } => {
+            EvidenceCloseEffectV1::OutcomeUnknown { code }
+        }
+    };
+    operation.finalize(close).map_err(LoreError::Parse)
+}
+
+fn complete_policy_rejection(evaluation: &EvaluationResult) -> bool {
+    if evaluation.open || evaluation.failure_codes.len() != 1 {
+        return false;
+    }
+    match evaluation.failure_codes[0].as_str() {
+        "dco_invalid"
+        | "not_superseded_failed"
+        | "worktree_dirty"
+        | "empty_submission"
+        | "locks_clear_failed" => true,
+        "exact_subject_failed" => evaluation.observations.status.is_some(),
+        _ => false,
+    }
+}
+
+/// Production I/O binding. Its role is operation-scoped, not an authorization
+/// assertion; actor claims remain non-authoritative until a witness re-derives
+/// every live fact.
+pub struct ProductionGovernanceIo<'a> {
+    api: &'a LoreApi,
+    role: GovernanceRole,
+}
+
+impl<'a> ProductionGovernanceIo<'a> {
+    pub fn new(api: &'a LoreApi, role: GovernanceRole) -> Self {
+        Self { api, role }
+    }
+}
+
+#[async_trait::async_trait]
+impl GovernanceIo for ProductionGovernanceIo<'_> {
+    fn role(&self) -> GovernanceRole {
+        self.role
+    }
+
+    async fn revision_metadata_set(&self, key: &str, value: &str) -> MutationObservation<()> {
+        let (callback, stream) = raw_event_collector();
+        let returned = lore::revision::metadata_set(
+            self.api.globals().build(),
+            LoreRevisionMetadataSetArgs {
+                keys: LoreArray::from_vec(vec![LoreString::from_str(key)]),
+                values: LoreArray::from_vec(vec![LoreString::from_str(value)]),
+                formats: LoreArray::from_vec(vec![LoreMetadataType::String]),
+            },
+            callback,
+        )
+        .await;
+        let stream = take_raw_stream(stream);
+        if raw_stream_completed_exactly(&stream, returned) {
+            MutationObservation::Completed(())
+        } else {
+            MutationObservation::OutcomeUnknown {
+                code: "raw metadata-set terminal outcome was unknown".into(),
+                observed: (),
+            }
+        }
+    }
+
+    async fn storage_open(&self) -> MutationObservation<Vec<u64>> {
+        let in_memory = self.api.global().in_memory;
+        let repository_path = if in_memory {
+            String::new()
+        } else {
+            self.api
+                .global()
+                .repository_path
+                .to_string_lossy()
+                .into_owned()
+        };
+        let (callback, stream) = raw_event_collector();
+        let returned = lore::storage::open::open(
+            self.api.globals().build(),
+            LoreStorageOpenArgs {
+                repository_path: LoreString::from_str(&repository_path),
+                in_memory: u8::from(in_memory),
+                remote_config: LoreStorageRemoteConfig {
+                    remote_url: LoreString::default(),
+                },
+                has_remote_config: 0,
+                cache_target_bytes: 0,
+                cache_target_fragments: 0,
+            },
+            callback,
+        )
+        .await;
+        let stream = take_raw_stream(stream);
+        let handles: Vec<_> = stream
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                LoreEvent::StorageOpened(opened) => Some(opened.handle_id),
+                _ => None,
+            })
+            .collect();
+        if raw_stream_completed_exactly(&stream, returned) {
+            MutationObservation::Completed(handles)
+        } else {
+            MutationObservation::OutcomeUnknown {
+                code: "raw storage-open terminal outcome was unknown".into(),
+                observed: handles,
+            }
+        }
+    }
+
+    async fn storage_put(
+        &self,
+        handle: u64,
+        bytes: &[u8],
+    ) -> MutationObservation<Vec<ImmutablePutItem>> {
+        let partition =
+            match serde_json::from_value(serde_json::Value::String(EVIDENCE_PARTITION.into())) {
+                Ok(partition) => partition,
+                Err(error) => {
+                    return MutationObservation::NotDispatched {
+                        code: format!("evidence partition: {error}"),
+                    }
+                }
+            };
+        let context = match serde_json::from_value(serde_json::Value::String("0".repeat(32))) {
+            Ok(context) => context,
+            Err(error) => {
+                return MutationObservation::NotDispatched {
+                    code: format!("evidence context: {error}"),
+                }
+            }
+        };
+        let mut item = LoreStoragePutItem {
+            id: EVIDENCE_ITEM_ID,
+            partition,
+            context,
+            // SAFETY: LoreBytes is a pointer/length POD. The borrowed `bytes`
+            // slice remains alive until the awaited put call returns.
+            data: unsafe { std::mem::zeroed() },
+            remote_write: 0,
+            local_cache: 1,
+            fixed_size_chunk: 0,
+        };
+        item.data.ptr = bytes.as_ptr().cast();
+        item.data.len = bytes.len();
+        let (callback, stream) = raw_event_collector();
+        let returned = lore::storage::put::put(
+            self.api.globals().build(),
+            LoreStoragePutArgs {
+                handle: LoreStore { handle_id: handle },
+                items: LoreArray::from_vec(vec![item]),
+            },
+            callback,
+        )
+        .await;
+        let stream = take_raw_stream(stream);
+        let observed: Vec<_> = stream
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                LoreEvent::StoragePutItemComplete(item) => {
+                    let ok = item.error_code as i32 == 0;
+                    Some(ImmutablePutItem {
+                        id: item.id,
+                        address: format!("{}", item.address),
+                        ok,
+                    })
+                }
+                _ => None,
+            })
+            .collect();
+        if raw_stream_completed_exactly(&stream, returned) {
+            MutationObservation::Completed(observed)
+        } else {
+            MutationObservation::OutcomeUnknown {
+                code: "raw storage-put terminal outcome was unknown".into(),
+                observed,
+            }
+        }
+    }
+
+    async fn storage_get(
+        &self,
+        handle: u64,
+        address: &str,
+    ) -> ReadObservation<Vec<ImmutableGetItem>> {
+        let item: LoreStorageGetItem = match serde_json::from_value(serde_json::json!({
+            "id": EVIDENCE_ITEM_ID,
+            "partition": EVIDENCE_PARTITION,
+            "address": address,
+            "streaming": 0,
+            "local_cache": 1,
+        })) {
+            Ok(item) => item,
+            Err(error) => {
+                return ReadObservation::NotDispatched {
+                    code: format!("evidence get item: {error}"),
+                }
+            }
+        };
+        let (callback, events) = raw_storage_get_collector();
+        let returned = lore::storage::get::get(
+            self.api.globals().build(),
+            LoreStorageGetArgs {
+                handle: LoreStore { handle_id: handle },
+                items: LoreArray::from_vec(vec![item]),
+            },
+            callback,
+        )
+        .await;
+        let events = std::mem::take(
+            &mut *events
+                .lock()
+                .expect("raw storage get collector mutex poisoned"),
+        );
+        match finish_captured_storage_get(events, returned) {
+            Ok(items) => ReadObservation::Completed(items),
+            Err(error) => ReadObservation::Unavailable {
+                code: error.message,
+            },
+        }
+    }
+
+    async fn storage_close(&self, handle: u64) -> MutationObservation<()> {
+        let (callback, stream) = raw_event_collector();
+        let returned = lore::storage::close::close(
+            self.api.globals().build(),
+            LoreStorageCloseArgs {
+                handle: LoreStore { handle_id: handle },
+            },
+            callback,
+        )
+        .await;
+        let stream = take_raw_stream(stream);
+        if raw_stream_completed_exactly(&stream, returned) {
+            MutationObservation::Completed(())
+        } else {
+            MutationObservation::OutcomeUnknown {
+                code: "raw storage-close terminal outcome was unknown".into(),
+                observed: (),
+            }
+        }
+    }
+}
+
+pub async fn evidence_preserve(
+    api: &LoreApi,
+    request: EvidencePreserveRequest,
+) -> Result<EvidencePreserveOutcomeV1> {
+    let adapter = ProductionLoreAdapter::new(api, "");
+    let io = ProductionGovernanceIo::new(api, GovernanceRole::Actor);
+    evidence_preserve_with_adapters(&adapter, &io, &request).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{finish_captured_storage_get, CapturedStorageGetEvent};
+
+    const ADDRESS: &str =
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-00000000000000000000000000000000";
+
+    fn exact_events() -> Vec<CapturedStorageGetEvent> {
+        vec![
+            CapturedStorageGetEvent::Header {
+                id: 5934,
+                address: ADDRESS.into(),
+                size: 3,
+            },
+            CapturedStorageGetEvent::Data {
+                id: 5934,
+                address: ADDRESS.into(),
+                offset: 0,
+                bytes: b"raw".to_vec(),
+            },
+            CapturedStorageGetEvent::ItemComplete {
+                id: 5934,
+                address: ADDRESS.into(),
+                ok: true,
+            },
+            CapturedStorageGetEvent::Complete { status: 0 },
+            CapturedStorageGetEvent::End,
+        ]
+    }
+
+    #[test]
+    fn raw_storage_get_retains_duplicate_item_events_and_exact_terminal_shape() {
+        let exact = finish_captured_storage_get(exact_events(), 0).expect("exact raw stream");
+        assert_eq!(exact.len(), 1);
+        assert_eq!(exact[0].data, b"raw");
+
+        let mut duplicate_header = exact_events();
+        duplicate_header.insert(1, duplicate_header[0].clone());
+        assert!(finish_captured_storage_get(duplicate_header, 0).is_err());
+
+        let mut duplicate_item_complete = exact_events();
+        duplicate_item_complete.insert(3, duplicate_item_complete[2].clone());
+        assert!(finish_captured_storage_get(duplicate_item_complete, 0).is_err());
+
+        let mut missing_end = exact_events();
+        missing_end.pop();
+        assert!(finish_captured_storage_get(missing_end, 0).is_err());
+
+        let mut duplicate_end = exact_events();
+        duplicate_end.push(CapturedStorageGetEvent::End);
+        assert!(finish_captured_storage_get(duplicate_end, 0).is_err());
+
+        let mut post_end = exact_events();
+        post_end.push(CapturedStorageGetEvent::Complete { status: 0 });
+        assert!(finish_captured_storage_get(post_end, 0).is_err());
+    }
+}

--- a/crates/lore-vm/src/ops/governance/mod.rs
+++ b/crates/lore-vm/src/ops/governance/mod.rs
@@ -5,4 +5,37 @@
 //! operation is permitted to create a weaker private variant.
 
 pub mod contract;
+pub mod dco_validate;
 pub mod evaluator;
+pub mod evidence_preserve;
+pub mod submission_gate_check;
+
+use contract::{
+    GovernanceRole, ImmutableGetItem, ImmutablePutItem, MutationObservation, ReadObservation,
+};
+
+/// Narrow, injectable boundary for the one governed metadata write and the
+/// immutable-store proof round trip. Implementations retain raw per-item
+/// results so operation code can reject missing, duplicate, or foreign events.
+#[async_trait::async_trait]
+pub trait GovernanceIo {
+    fn role(&self) -> GovernanceRole;
+
+    async fn revision_metadata_set(&self, key: &str, value: &str) -> MutationObservation<()>;
+
+    async fn storage_open(&self) -> MutationObservation<Vec<u64>>;
+
+    async fn storage_put(
+        &self,
+        handle: u64,
+        bytes: &[u8],
+    ) -> MutationObservation<Vec<ImmutablePutItem>>;
+
+    async fn storage_get(
+        &self,
+        handle: u64,
+        address: &str,
+    ) -> ReadObservation<Vec<ImmutableGetItem>>;
+
+    async fn storage_close(&self, handle: u64) -> MutationObservation<()>;
+}

--- a/crates/lore-vm/src/ops/governance/mod.rs
+++ b/crates/lore-vm/src/ops/governance/mod.rs
@@ -1,0 +1,8 @@
+//! Shared strict Option-A governance contract and evaluator.
+//!
+//! Operation-specific implementations live beside this module.  They must use
+//! the schemas in [`contract`] and the injected evaluator in [`evaluator`]; no
+//! operation is permitted to create a weaker private variant.
+
+pub mod contract;
+pub mod evaluator;

--- a/crates/lore-vm/src/ops/governance/submission_gate_check.rs
+++ b/crates/lore-vm/src/ops/governance/submission_gate_check.rs
@@ -1,0 +1,2205 @@
+//! Witness-side submission gate re-evaluation.
+
+use super::contract::{
+    AffectedPath, AuthorResolutionObservation, CanonicalDcoMetadataObservationV1,
+    CanonicalEvidenceSnapshotV1, CanonicalFileIdentityV1, CanonicalRevisionInfoV1,
+    CanonicalRevisionRefV1, CanonicalStatusObservationV1,
+    CanonicalSupersessionMetadataQueryObservationV1, CanonicalWorktreeFileObservationV1,
+    CriterionResult, DcoMetadataObservation, EvaluationResult, EvidencePointerV1, FileIdentity,
+    GovernanceCriterion, GovernancePathAction, GovernanceRemediation, GovernanceRemediationCode,
+    GovernanceRole, HistoryOverflowScope, ImmutableGetItem, LockQuery, LockStatusResponse,
+    MutationObservation, ReadObservation, ResolvedAuthor, RevisionDiffObservation, RevisionInfo,
+    StatusSnapshot, SubmissionGateCheckRequest, SubmissionGateCheckResult, SupersessionMarkerV1,
+    SupersessionMetadataQueryObservation, EVIDENCE_POINTER_KEY, MAX_GOVERNANCE_HISTORY_REVISIONS,
+    SUPERSESSION_MARKER_PREFIX,
+};
+use super::evaluator::{evaluate, GovernanceAdapter, ProductionLoreAdapter};
+use super::evidence_preserve::ProductionGovernanceIo;
+use super::GovernanceIo;
+use crate::api::LoreApi;
+use std::collections::{BTreeMap, BTreeSet};
+
+const EVIDENCE_ITEM_ID: u64 = 5934;
+
+const CRITERIA: [GovernanceCriterion; 7] = [
+    GovernanceCriterion::ExactSubject,
+    GovernanceCriterion::HistoryComplete,
+    GovernanceCriterion::DcoValid,
+    GovernanceCriterion::NotSuperseded,
+    GovernanceCriterion::LocksClear,
+    GovernanceCriterion::WorktreeClean,
+    GovernanceCriterion::EvidenceValid,
+];
+
+fn exact_address(address: &str) -> bool {
+    let lowercase_hex = |byte: &u8| byte.is_ascii_digit() || matches!(*byte, b'a'..=b'f');
+    let bytes = address.as_bytes();
+    bytes.len() == 97
+        && bytes[64] == b'-'
+        && bytes[..64].iter().all(lowercase_hex)
+        && bytes[65..].iter().all(lowercase_hex)
+}
+
+fn passed(criterion: GovernanceCriterion) -> CriterionResult {
+    CriterionResult {
+        criterion,
+        passed: true,
+        failure_code: None,
+        remediation: None,
+    }
+}
+
+fn failed(criterion: GovernanceCriterion, code: &str) -> CriterionResult {
+    CriterionResult {
+        criterion,
+        passed: false,
+        failure_code: Some(code.into()),
+        remediation: None,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum FactError {
+    Dependency,
+    Invalid,
+}
+
+/// Private witness-only decision inputs. The evaluator result is converted at
+/// the boundary and then discarded; no evaluator verdict, summary, derived
+/// path/file/DCO/marker list, failure label, or actor evidence bytes can be
+/// named by a live witness criterion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WitnessRawFacts {
+    expected_staged_revision: String,
+    target_base_revision: String,
+    status: Option<StatusSnapshot>,
+    base_revision_info: Option<RevisionInfo>,
+    supersession_ancestry: Vec<RevisionInfo>,
+    revision_graph: Vec<RevisionInfo>,
+    first_parent_history: Vec<String>,
+    base_files: Vec<FileIdentity>,
+    base_tree_observed: bool,
+    candidate_files: Vec<FileIdentity>,
+    candidate_tree_observed: bool,
+    upstream_revision_diff: Vec<RevisionDiffObservation>,
+    supersession_metadata_queries: Vec<SupersessionMetadataQueryObservation>,
+    dco_metadata: Vec<DcoMetadataObservation>,
+    author_resolution: Option<AuthorResolutionObservation>,
+    lock_queries: Vec<LockQuery>,
+    lock_status: Option<LockStatusResponse>,
+}
+
+impl WitnessRawFacts {
+    fn from_evaluation(evaluation: &EvaluationResult) -> Self {
+        let observed = &evaluation.observations;
+        Self {
+            expected_staged_revision: observed.expected_staged_revision.clone(),
+            target_base_revision: observed.target_base_revision.clone(),
+            status: observed.status.clone(),
+            base_revision_info: observed.base_revision_info.clone(),
+            supersession_ancestry: observed.supersession_ancestry.clone(),
+            revision_graph: observed.revision_graph.clone(),
+            first_parent_history: observed.first_parent_history.clone(),
+            base_files: observed.base_files.clone(),
+            base_tree_observed: observed.base_tree_observed,
+            candidate_files: observed.candidate_files.clone(),
+            candidate_tree_observed: observed.candidate_tree_observed,
+            upstream_revision_diff: observed.upstream_revision_diff.clone(),
+            supersession_metadata_queries: observed.supersession_metadata_queries.clone(),
+            dco_metadata: observed.dco_metadata.clone(),
+            author_resolution: observed.author_resolution.clone(),
+            lock_queries: observed.lock_queries.clone(),
+            lock_status: observed.lock_status.clone(),
+        }
+    }
+}
+
+/// The only actor-evidence fields visible at the witness decision boundary.
+///
+/// `CanonicalEvidenceSnapshotV1` intentionally retains evaluator diagnostics
+/// for review, but those summaries are neither witness facts nor authority.
+/// Convert both the stored claim and the live re-evaluation immediately into
+/// this private raw projection; no decision criterion can name the discarded
+/// `open`, current-file, affected-path, marker, DCO, failure, or remediation
+/// summaries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WitnessEvidenceProjection {
+    version: String,
+    target_base_revision: String,
+    status: CanonicalStatusObservationV1,
+    base_revision_info: CanonicalRevisionInfoV1,
+    supersession_ancestry: Vec<CanonicalRevisionInfoV1>,
+    revision_graph: Vec<CanonicalRevisionInfoV1>,
+    first_parent_history: Vec<CanonicalRevisionRefV1>,
+    base_files: Vec<CanonicalFileIdentityV1>,
+    base_tree_observed: bool,
+    candidate_files: Vec<CanonicalFileIdentityV1>,
+    candidate_tree_observed: bool,
+    upstream_revision_diff: Vec<RevisionDiffObservation>,
+    supersession_metadata_queries: Vec<CanonicalSupersessionMetadataQueryObservationV1>,
+    dco_metadata: Vec<CanonicalDcoMetadataObservationV1>,
+    author_resolution: AuthorResolutionObservation,
+    lock_queries: Vec<LockQuery>,
+    lock_status: LockStatusResponse,
+}
+
+fn witness_canonical_revision(revision: &str, staged: &str) -> CanonicalRevisionRefV1 {
+    if revision == staged {
+        CanonicalRevisionRefV1::StagedSubject
+    } else {
+        CanonicalRevisionRefV1::Exact(revision.to_string())
+    }
+}
+
+fn witness_canonical_revisions(revisions: &[String], staged: &str) -> Vec<CanonicalRevisionRefV1> {
+    revisions
+        .iter()
+        .map(|revision| witness_canonical_revision(revision, staged))
+        .collect()
+}
+
+fn witness_sort_resolved_authors(authors: &mut [ResolvedAuthor]) {
+    authors.sort_by(|left, right| {
+        (&left.identity, &left.display_name).cmp(&(&right.identity, &right.display_name))
+    });
+}
+
+fn witness_canonical_files(files: &[FileIdentity], staged: &str) -> Vec<CanonicalFileIdentityV1> {
+    let mut canonical: Vec<_> = files
+        .iter()
+        .map(|file| CanonicalFileIdentityV1 {
+            path: file.path.clone(),
+            revision: witness_canonical_revision(&file.revision, staged),
+            hash: file.hash.clone(),
+            context: file.context.clone(),
+        })
+        .collect();
+    canonical.sort_by(|left, right| {
+        (&left.path, &left.revision, &left.hash, &left.context).cmp(&(
+            &right.path,
+            &right.revision,
+            &right.hash,
+            &right.context,
+        ))
+    });
+    canonical
+}
+
+impl WitnessEvidenceProjection {
+    fn from_raw(observed: &WitnessRawFacts) -> Result<Self, ()> {
+        let staged = observed.expected_staged_revision.as_str();
+        let status = observed.status.as_ref().ok_or(())?;
+        let base_revision_info = observed.base_revision_info.as_ref().ok_or(())?;
+        let mut author_resolution = observed.author_resolution.clone().ok_or(())?;
+        let mut lock_status = observed.lock_status.clone().ok_or(())?;
+        if staged.is_empty() || observed.target_base_revision.is_empty() {
+            return Err(());
+        }
+
+        let canonical_info = |info: &RevisionInfo| CanonicalRevisionInfoV1 {
+            revision: witness_canonical_revision(&info.revision, staged),
+            // First-parent order is semantic and must remain exact.
+            parents: info
+                .parents
+                .iter()
+                .map(|parent| witness_canonical_revision(parent, staged))
+                .collect(),
+        };
+        let mut supersession_ancestry: Vec<_> = observed
+            .supersession_ancestry
+            .iter()
+            .map(canonical_info)
+            .collect();
+        supersession_ancestry.sort_by(|left, right| left.revision.cmp(&right.revision));
+        let mut revision_graph: Vec<_> =
+            observed.revision_graph.iter().map(canonical_info).collect();
+        revision_graph.sort_by(|left, right| left.revision.cmp(&right.revision));
+
+        let mut worktree_files: Vec<_> = status
+            .worktree_files
+            .iter()
+            .map(|file| CanonicalWorktreeFileObservationV1 {
+                path: file.path.clone(),
+                revision: witness_canonical_revision(&file.revision, staged),
+                revision_hash: file.revision_hash.clone(),
+                revision_context: file.revision_context.clone(),
+                revision_size: file.revision_size,
+                local_hash: file.local_hash.clone(),
+                local_size: file.local_size,
+                filtered_revision_size: file.filtered_revision_size,
+                flag_modified: file.flag_modified,
+                flag_deleted: file.flag_deleted,
+                flag_added: file.flag_added,
+                flag_conflict: file.flag_conflict,
+            })
+            .collect();
+        worktree_files.sort_by(|left, right| left.path.cmp(&right.path));
+
+        let mut supersession_metadata_queries: Vec<_> = observed
+            .supersession_metadata_queries
+            .iter()
+            .map(|query| {
+                let mut metadata: Vec<_> = query
+                    .metadata
+                    .iter()
+                    .filter(|entry| query.revision != staged || entry.key != EVIDENCE_POINTER_KEY)
+                    .cloned()
+                    .collect();
+                metadata.sort_by(|left, right| {
+                    (&left.key, left.kind, &left.value).cmp(&(&right.key, right.kind, &right.value))
+                });
+                CanonicalSupersessionMetadataQueryObservationV1 {
+                    revision: witness_canonical_revision(&query.revision, staged),
+                    metadata,
+                }
+            })
+            .collect();
+        supersession_metadata_queries.sort_by(|left, right| left.revision.cmp(&right.revision));
+
+        let mut dco_metadata: Vec<_> = observed
+            .dco_metadata
+            .iter()
+            .map(|entry| {
+                let mut messages = entry.messages.clone();
+                messages.sort();
+                let mut created_by = entry.created_by.clone();
+                created_by.sort();
+                let mut committed_by = entry.committed_by.clone();
+                committed_by.sort();
+                CanonicalDcoMetadataObservationV1 {
+                    revision: witness_canonical_revision(&entry.revision, staged),
+                    messages,
+                    created_by,
+                    committed_by,
+                }
+            })
+            .collect();
+        dco_metadata.sort_by(|left, right| left.revision.cmp(&right.revision));
+
+        author_resolution.requested.sort();
+        witness_sort_resolved_authors(&mut author_resolution.replies);
+        let mut lock_queries = observed.lock_queries.clone();
+        for query in &mut lock_queries {
+            query.ignored_paths.sort();
+            query.owners.sort();
+        }
+        lock_queries.sort_by(|left, right| left.path.cmp(&right.path));
+        lock_status.ignored_paths.sort();
+        lock_status
+            .statuses
+            .sort_by(|left, right| (&left.path, &left.owner).cmp(&(&right.path, &right.owner)));
+        let mut upstream_revision_diff = observed.upstream_revision_diff.clone();
+        upstream_revision_diff.sort();
+
+        Ok(Self {
+            version: "v1".into(),
+            target_base_revision: observed.target_base_revision.clone(),
+            status: CanonicalStatusObservationV1 {
+                branch: status.branch.clone(),
+                staged_revisions: witness_canonical_revisions(&status.staged_revisions, staged),
+                scanned_staged_revisions: witness_canonical_revisions(
+                    &status.scanned_staged_revisions,
+                    staged,
+                ),
+                post_scan_staged_revisions: witness_canonical_revisions(
+                    &status.post_scan_staged_revisions,
+                    staged,
+                ),
+                staged_paths: {
+                    let mut paths = status.staged_paths.clone();
+                    paths.sort();
+                    paths.dedup();
+                    paths
+                },
+                staged_changes: {
+                    let mut changes = status.staged_changes.clone();
+                    changes.sort();
+                    changes
+                },
+                worktree_files,
+                worktree_clean: status.worktree_clean,
+                scan_performed: status.scan_performed,
+            },
+            base_revision_info: canonical_info(base_revision_info),
+            supersession_ancestry,
+            revision_graph,
+            first_parent_history: witness_canonical_revisions(
+                &observed.first_parent_history,
+                staged,
+            ),
+            base_files: witness_canonical_files(&observed.base_files, staged),
+            base_tree_observed: observed.base_tree_observed,
+            candidate_files: witness_canonical_files(&observed.candidate_files, staged),
+            candidate_tree_observed: observed.candidate_tree_observed,
+            upstream_revision_diff,
+            supersession_metadata_queries,
+            dco_metadata,
+            author_resolution,
+            lock_queries,
+            lock_status,
+        })
+    }
+
+    fn from_stored(stored: &CanonicalEvidenceSnapshotV1) -> Self {
+        Self {
+            version: stored.version.clone(),
+            target_base_revision: stored.target_base_revision.clone(),
+            status: stored.status.clone(),
+            base_revision_info: stored.base_revision_info.clone(),
+            supersession_ancestry: stored.supersession_ancestry.clone(),
+            revision_graph: stored.revision_graph.clone(),
+            first_parent_history: stored.first_parent_history.clone(),
+            base_files: stored.base_files.clone(),
+            base_tree_observed: stored.base_tree_observed,
+            candidate_files: stored.candidate_files.clone(),
+            candidate_tree_observed: stored.candidate_tree_observed,
+            upstream_revision_diff: stored.upstream_revision_diff.clone(),
+            supersession_metadata_queries: stored.supersession_metadata_queries.clone(),
+            dco_metadata: stored.dco_metadata.clone(),
+            author_resolution: stored.author_resolution.clone(),
+            lock_queries: stored.lock_queries.clone(),
+            lock_status: stored.lock_status.clone(),
+        }
+    }
+}
+
+fn canonical_lower_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+fn witness_artifact_identity(identity: &str) -> bool {
+    let Some((hash, context)) = identity.split_once(':') else {
+        return false;
+    };
+    canonical_lower_hex(hash, 64)
+        && canonical_lower_hex(context, 32)
+        && !context.bytes().all(|byte| byte == b'0')
+}
+
+fn witness_worktree_clean(
+    status: &StatusSnapshot,
+    candidate_files: &[FileIdentity],
+    expected_revision: &str,
+) -> bool {
+    if !status.scan_performed || !status.worktree_clean {
+        return false;
+    }
+    let expected: BTreeMap<_, _> = candidate_files
+        .iter()
+        .map(|file| (file.path.as_str(), file))
+        .collect();
+    if expected.len() != candidate_files.len() || status.worktree_files.len() != expected.len() {
+        return false;
+    }
+    let mut observed = BTreeSet::new();
+    let staged_paths: BTreeSet<_> = status.staged_paths.iter().map(String::as_str).collect();
+    if staged_paths.len() != status.staged_paths.len()
+        || staged_paths.iter().any(|path| path.is_empty())
+    {
+        return false;
+    }
+    status.worktree_files.iter().all(|file| {
+        let Some(candidate) = expected.get(file.path.as_str()) else {
+            return false;
+        };
+        let is_staged_path = staged_paths.contains(file.path.as_str());
+        !file.path.is_empty()
+            && observed.insert(file.path.as_str())
+            && file.revision == expected_revision
+            && file.revision_hash == candidate.hash
+            && file.revision_context == candidate.context
+            && !file.revision_hash.is_empty()
+            && !file.revision_context.is_empty()
+            && !file.local_hash.is_empty()
+            && (is_staged_path
+                || (file.local_hash == file.revision_hash
+                    && !file.flag_modified
+                    && !file.flag_added))
+            && !file.flag_deleted
+            && !file.flag_conflict
+    })
+}
+
+fn witness_current_files(
+    status: &StatusSnapshot,
+    candidate_files: &[FileIdentity],
+    expected_revision: &str,
+) -> Result<Vec<FileIdentity>, ()> {
+    if !witness_worktree_clean(status, candidate_files, expected_revision) {
+        return Err(());
+    }
+    let staged_paths: BTreeSet<_> = status.staged_paths.iter().map(String::as_str).collect();
+    let worktree: BTreeMap<_, _> = status
+        .worktree_files
+        .iter()
+        .map(|file| (file.path.as_str(), file))
+        .collect();
+    let mut identities = BTreeSet::new();
+    let mut current = Vec::with_capacity(candidate_files.len());
+    for file in candidate_files {
+        let observed = worktree.get(file.path.as_str()).ok_or(())?;
+        let hash = if staged_paths.contains(file.path.as_str()) {
+            observed.local_hash.clone()
+        } else {
+            file.hash.clone()
+        };
+        if !canonical_lower_hex(&hash, 64)
+            || !canonical_lower_hex(&file.context, 32)
+            || file.context.bytes().all(|byte| byte == b'0')
+        {
+            return Err(());
+        }
+        if !identities.insert(format!("{hash}:{}", file.context)) {
+            return Err(());
+        }
+        current.push(FileIdentity::new(
+            &file.path,
+            expected_revision,
+            hash,
+            &file.context,
+        ));
+    }
+    current.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(current)
+}
+
+/// Reconstruct the affected path set from raw status, trees, capture-time
+/// bytes, and the upstream terminal diff. This is deliberately independent of
+/// the evaluator's affected-path implementation and never accepts its
+/// `revision_diff` or `affected_paths` summaries.
+fn witness_affected_paths(observed: &WitnessRawFacts) -> Result<Vec<String>, ()> {
+    if !observed.base_tree_observed || !observed.candidate_tree_observed {
+        return Err(());
+    }
+    let status = observed.status.as_ref().ok_or(())?;
+    let current_files = witness_current_files(
+        status,
+        &observed.candidate_files,
+        &observed.expected_staged_revision,
+    )?;
+    let mut upstream_diff = observed.upstream_revision_diff.clone();
+    upstream_diff.sort();
+    if upstream_diff
+        .iter()
+        .any(|raw| raw.action == GovernancePathAction::Copy)
+    {
+        return Err(());
+    }
+
+    let mut base_by_context = BTreeMap::new();
+    let mut current_by_context = BTreeMap::new();
+    let mut base_by_path = BTreeMap::new();
+    let mut candidate_by_path = BTreeMap::new();
+    let mut current_by_path = BTreeMap::new();
+    for file in &observed.base_files {
+        if !canonical_lower_hex(&file.hash, 64)
+            || !canonical_lower_hex(&file.context, 32)
+            || file.context.bytes().all(|byte| byte == b'0')
+            || base_by_context
+                .insert(file.context.as_str(), file.path.as_str())
+                .is_some()
+            || base_by_path
+                .insert(file.path.as_str(), file.canonical_id())
+                .is_some()
+        {
+            return Err(());
+        }
+    }
+    for file in &observed.candidate_files {
+        if !canonical_lower_hex(&file.hash, 64)
+            || !canonical_lower_hex(&file.context, 32)
+            || file.context.bytes().all(|byte| byte == b'0')
+            || candidate_by_path.insert(file.path.as_str(), file).is_some()
+        {
+            return Err(());
+        }
+    }
+    for file in &current_files {
+        if current_by_context
+            .insert(file.context.as_str(), file.path.as_str())
+            .is_some()
+            || current_by_path
+                .insert(file.path.as_str(), file.canonical_id())
+                .is_some()
+        {
+            return Err(());
+        }
+    }
+
+    let mut consumed_base = BTreeSet::new();
+    let mut consumed_current = BTreeSet::new();
+    let mut diff = Vec::<AffectedPath>::new();
+    for (context, source) in &base_by_context {
+        if let Some(target) = current_by_context.get(context) {
+            consumed_base.insert(*source);
+            consumed_current.insert(*target);
+            if source != target {
+                diff.push(AffectedPath {
+                    source_path: Some((*source).to_string()),
+                    target_path: Some((*target).to_string()),
+                });
+            } else if base_by_path.get(source) != current_by_path.get(target) {
+                diff.push(AffectedPath::modified(*source));
+            }
+        }
+    }
+    for (path, base_identity) in &base_by_path {
+        if consumed_base.contains(path) {
+            continue;
+        }
+        if let Some(current_identity) = current_by_path.get(path) {
+            if !consumed_current.contains(path) && current_identity != base_identity {
+                consumed_base.insert(*path);
+                consumed_current.insert(*path);
+                diff.push(AffectedPath::modified(*path));
+            }
+        }
+    }
+    for path in base_by_path.keys() {
+        if !consumed_base.contains(path) {
+            diff.push(AffectedPath {
+                source_path: Some((*path).to_string()),
+                target_path: None,
+            });
+        }
+    }
+    for path in current_by_path.keys() {
+        if !consumed_current.contains(path) {
+            diff.push(AffectedPath {
+                source_path: None,
+                target_path: Some((*path).to_string()),
+            });
+        }
+    }
+    diff.sort_by(|left, right| {
+        (&left.source_path, &left.target_path).cmp(&(&right.source_path, &right.target_path))
+    });
+    if diff.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(());
+    }
+
+    let expected_status: BTreeSet<_> = status
+        .staged_changes
+        .iter()
+        .map(|change| match change.action {
+            GovernancePathAction::Modify => (Some(change.path.clone()), Some(change.path.clone())),
+            GovernancePathAction::Add => (None, Some(change.path.clone())),
+            GovernancePathAction::Delete => (Some(change.path.clone()), None),
+            GovernancePathAction::Move | GovernancePathAction::Copy => {
+                (change.from_path.clone(), Some(change.path.clone()))
+            }
+        })
+        .collect();
+    let exact_diff: BTreeSet<_> = diff
+        .iter()
+        .map(|entry| (entry.source_path.clone(), entry.target_path.clone()))
+        .collect();
+    if expected_status.len() != status.staged_changes.len() || expected_status != exact_diff {
+        return Err(());
+    }
+    let status_paths: BTreeSet<_> = status
+        .staged_changes
+        .iter()
+        .flat_map(|change| {
+            std::iter::once(change.path.as_str()).chain(change.from_path.iter().map(String::as_str))
+        })
+        .collect();
+    if status_paths.len() != status.staged_paths.len()
+        || status_paths != status.staged_paths.iter().map(String::as_str).collect()
+    {
+        return Err(());
+    }
+
+    let zero_address = format!("{}-{}", "0".repeat(64), "0".repeat(32));
+    let address = |file: &FileIdentity| format!("{}-{}", file.hash, file.context);
+    let canonical_address = |value: &str| {
+        value.len() == 97
+            && value.as_bytes()[64] == b'-'
+            && value.bytes().enumerate().all(|(index, byte)| {
+                index == 64 || byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')
+            })
+    };
+    let base_file_by_path: BTreeMap<_, _> = observed
+        .base_files
+        .iter()
+        .map(|file| (file.path.as_str(), file))
+        .collect();
+    let mut raw_paths = BTreeSet::new();
+    for raw in &upstream_diff {
+        if raw.path.is_empty()
+            || !raw_paths.insert(raw.path.as_str())
+            || !canonical_address(&raw.old_address)
+            || !canonical_address(&raw.new_address)
+        {
+            return Err(());
+        }
+    }
+
+    let mut consumed_raw = vec![false; upstream_diff.len()];
+    let mut consume = |path: &str,
+                       action: GovernancePathAction,
+                       old_is_file: bool,
+                       new_is_file: bool,
+                       old_address: &str,
+                       new_address: &str|
+     -> Result<(), ()> {
+        let matches: Vec<_> = upstream_diff
+            .iter()
+            .enumerate()
+            .filter(|(index, raw)| {
+                !consumed_raw[*index]
+                    && raw.path == path
+                    && raw.action == action
+                    && raw.old_is_file == old_is_file
+                    && raw.new_is_file == new_is_file
+                    && raw.old_address == old_address
+                    && raw.new_address == new_address
+            })
+            .map(|(index, _)| index)
+            .collect();
+        if let [index] = matches.as_slice() {
+            consumed_raw[*index] = true;
+            Ok(())
+        } else {
+            Err(())
+        }
+    };
+    for change in &status.staged_changes {
+        match change.action {
+            GovernancePathAction::Modify => {
+                let old = base_file_by_path.get(change.path.as_str()).ok_or(())?;
+                let new = candidate_by_path.get(change.path.as_str()).ok_or(())?;
+                consume(
+                    &change.path,
+                    GovernancePathAction::Modify,
+                    true,
+                    true,
+                    &address(old),
+                    &address(new),
+                )?;
+            }
+            GovernancePathAction::Add => {
+                if base_file_by_path.contains_key(change.path.as_str()) {
+                    return Err(());
+                }
+                let new = candidate_by_path.get(change.path.as_str()).ok_or(())?;
+                consume(
+                    &change.path,
+                    GovernancePathAction::Add,
+                    false,
+                    true,
+                    &zero_address,
+                    &address(new),
+                )?;
+            }
+            GovernancePathAction::Delete => {
+                let old = base_file_by_path.get(change.path.as_str()).ok_or(())?;
+                if candidate_by_path.contains_key(change.path.as_str()) {
+                    return Err(());
+                }
+                consume(
+                    &change.path,
+                    GovernancePathAction::Delete,
+                    true,
+                    false,
+                    &address(old),
+                    &zero_address,
+                )?;
+            }
+            GovernancePathAction::Move => {
+                let source = change.from_path.as_ref().ok_or(())?;
+                let old = base_file_by_path.get(source.as_str()).ok_or(())?;
+                let new = candidate_by_path.get(change.path.as_str()).ok_or(())?;
+                let old_address = address(old);
+                let new_address = address(new);
+                if old_address != new_address {
+                    return Err(());
+                }
+                consume(
+                    source,
+                    GovernancePathAction::Delete,
+                    true,
+                    false,
+                    &old_address,
+                    &zero_address,
+                )?;
+                consume(
+                    &change.path,
+                    GovernancePathAction::Add,
+                    false,
+                    true,
+                    &zero_address,
+                    &new_address,
+                )?;
+            }
+            GovernancePathAction::Copy => return Err(()),
+        }
+    }
+    if consumed_raw.iter().any(|consumed| !consumed) {
+        return Err(());
+    }
+    let paths: BTreeSet<_> = diff
+        .iter()
+        .flat_map(|entry| entry.source_path.iter().chain(entry.target_path.iter()))
+        .cloned()
+        .collect();
+    if paths.is_empty() {
+        return Err(());
+    }
+    Ok(paths.into_iter().collect())
+}
+
+fn witness_remediation_for_overflow(scope: HistoryOverflowScope) -> GovernanceRemediation {
+    match scope {
+        HistoryOverflowScope::PendingDco => GovernanceRemediation {
+            code: GovernanceRemediationCode::SplitSubmissionOrAdvanceTargetBase,
+            ticket: None,
+        },
+        HistoryOverflowScope::SupersessionAncestry => GovernanceRemediation {
+            code: GovernanceRemediationCode::MigrateSupersessionIndex,
+            ticket: Some("SBAI-6010".into()),
+        },
+    }
+}
+
+fn exact_subject(observed: &WitnessRawFacts) -> CriterionResult {
+    let criterion = GovernanceCriterion::ExactSubject;
+    let Some(status) = observed.status.as_ref() else {
+        return failed(criterion, "exact_subject_dependency_failed");
+    };
+    let expected = observed.expected_staged_revision.as_str();
+    if expected.is_empty()
+        || observed.target_base_revision.is_empty()
+        || [
+            &status.staged_revisions,
+            &status.scanned_staged_revisions,
+            &status.post_scan_staged_revisions,
+        ]
+        .into_iter()
+        .any(|revisions| revisions.as_slice() != [expected])
+    {
+        failed(criterion, "exact_subject_failed")
+    } else {
+        passed(criterion)
+    }
+}
+
+fn exact_history(observed: &WitnessRawFacts) -> Result<BTreeSet<String>, FactError> {
+    let Some(base_info) = observed.base_revision_info.as_ref() else {
+        return Err(FactError::Dependency);
+    };
+    if observed.revision_graph.is_empty() {
+        return Err(FactError::Dependency);
+    }
+    let candidate = observed.expected_staged_revision.as_str();
+    let base = observed.target_base_revision.as_str();
+    if candidate.is_empty()
+        || base.is_empty()
+        || candidate == base
+        || base_info.revision != base
+        || observed.revision_graph.len() > MAX_GOVERNANCE_HISTORY_REVISIONS
+        || observed.first_parent_history.len() > MAX_GOVERNANCE_HISTORY_REVISIONS
+    {
+        return Err(FactError::Invalid);
+    }
+
+    let mut graph = BTreeMap::new();
+    for info in &observed.revision_graph {
+        let unique_parents: BTreeSet<_> = info.parents.iter().collect();
+        if info.revision.is_empty()
+            || info.revision == base
+            || info.parents.is_empty()
+            || info.parents.len() > 2
+            || unique_parents.len() != info.parents.len()
+            || info
+                .parents
+                .iter()
+                .any(|parent| parent.is_empty() || parent == &info.revision)
+            || graph.insert(info.revision.as_str(), info).is_some()
+        {
+            return Err(FactError::Invalid);
+        }
+    }
+
+    let mut states = BTreeMap::<&str, u8>::new();
+    let mut stack = vec![(candidate, false)];
+    while let Some((revision, leaving)) = stack.pop() {
+        if revision == base {
+            continue;
+        }
+        if leaving {
+            states.insert(revision, 2);
+            continue;
+        }
+        match states.get(revision) {
+            Some(1) => return Err(FactError::Invalid),
+            Some(2) => continue,
+            _ => {}
+        }
+        let Some(info) = graph.get(revision) else {
+            return Err(FactError::Invalid);
+        };
+        states.insert(revision, 1);
+        stack.push((revision, true));
+        for parent in info.parents.iter().rev() {
+            stack.push((parent.as_str(), false));
+        }
+    }
+    if states.len() != graph.len() || states.values().any(|state| *state != 2) {
+        return Err(FactError::Invalid);
+    }
+    if observed.first_parent_history.is_empty() {
+        return Err(FactError::Dependency);
+    }
+
+    let mut reconstructed = Vec::new();
+    let mut seen = BTreeSet::new();
+    let mut revision = candidate;
+    while revision != base {
+        if !seen.insert(revision) || reconstructed.len() == MAX_GOVERNANCE_HISTORY_REVISIONS {
+            return Err(FactError::Invalid);
+        }
+        let Some(info) = graph.get(revision) else {
+            return Err(FactError::Invalid);
+        };
+        reconstructed.push(revision.to_string());
+        revision = info.parents[0].as_str();
+    }
+    if reconstructed != observed.first_parent_history {
+        return Err(FactError::Invalid);
+    }
+    Ok(graph
+        .keys()
+        .map(|revision| (*revision).to_string())
+        .collect())
+}
+
+fn exact_revision_shape(info: &RevisionInfo, allow_root: bool) -> bool {
+    let parents: BTreeSet<_> = info.parents.iter().map(String::as_str).collect();
+    !info.revision.is_empty()
+        && (allow_root || !info.parents.is_empty())
+        && info.parents.len() <= 2
+        && parents.len() == info.parents.len()
+        && info
+            .parents
+            .iter()
+            .all(|parent| !parent.is_empty() && parent != &info.revision)
+}
+
+/// Validate a retained N+1 traversal prefix without assuming its frontier is
+/// complete. Every retained node must be exact, structurally valid, acyclic,
+/// and reachable from the candidate through retained edges. Parent references
+/// outside the prefix are the unvisited frontier after the sentinel.
+fn exact_overflow_prefix(
+    infos: &[RevisionInfo],
+    candidate: &str,
+    base: &str,
+    pending: bool,
+) -> Result<(), FactError> {
+    if infos.len() != MAX_GOVERNANCE_HISTORY_REVISIONS + 1 {
+        return Err(FactError::Invalid);
+    }
+    let mut graph = BTreeMap::new();
+    for info in infos {
+        if !exact_revision_shape(info, !pending)
+            || (pending && info.revision == base)
+            || graph.insert(info.revision.as_str(), info).is_some()
+        {
+            return Err(FactError::Invalid);
+        }
+    }
+    if !graph.contains_key(candidate) {
+        return Err(FactError::Invalid);
+    }
+
+    let mut states = BTreeMap::<&str, u8>::new();
+    let mut stack = vec![(candidate, false)];
+    while let Some((revision, leaving)) = stack.pop() {
+        if leaving {
+            states.insert(revision, 2);
+            continue;
+        }
+        match states.get(revision) {
+            Some(1) => return Err(FactError::Invalid),
+            Some(2) => continue,
+            _ => {}
+        }
+        let Some(info) = graph.get(revision) else {
+            continue;
+        };
+        states.insert(revision, 1);
+        stack.push((revision, true));
+        for parent in info.parents.iter().rev() {
+            if graph.contains_key(parent.as_str()) {
+                stack.push((parent.as_str(), false));
+            }
+        }
+    }
+    if states.len() != graph.len() || states.values().any(|state| *state != 2) {
+        return Err(FactError::Invalid);
+    }
+    Ok(())
+}
+
+/// Derive overflow scope solely from the exact N+1 raw graph. The evaluator's
+/// scope label is deliberately inert and can never select or alter witness
+/// reason/remediation.
+fn raw_overflow_scope(
+    observed: &WitnessRawFacts,
+) -> Result<Option<HistoryOverflowScope>, FactError> {
+    let pending_overflow = observed.revision_graph.len() == MAX_GOVERNANCE_HISTORY_REVISIONS + 1;
+    let ancestry_overflow =
+        observed.supersession_ancestry.len() == MAX_GOVERNANCE_HISTORY_REVISIONS + 1;
+    if observed.revision_graph.len() > MAX_GOVERNANCE_HISTORY_REVISIONS + 1
+        || observed.supersession_ancestry.len() > MAX_GOVERNANCE_HISTORY_REVISIONS + 1
+        || (pending_overflow && ancestry_overflow)
+    {
+        return Err(FactError::Invalid);
+    }
+    let candidate = observed.expected_staged_revision.as_str();
+    let base = observed.target_base_revision.as_str();
+    let Some(base_info) = observed.base_revision_info.as_ref() else {
+        return Err(FactError::Dependency);
+    };
+    if base_info.revision != base || !exact_revision_shape(base_info, true) {
+        return Err(FactError::Invalid);
+    }
+
+    if pending_overflow {
+        if !observed.supersession_ancestry.is_empty() || !observed.first_parent_history.is_empty() {
+            return Err(FactError::Invalid);
+        }
+        exact_overflow_prefix(&observed.revision_graph, candidate, base, true)?;
+        return Ok(Some(HistoryOverflowScope::PendingDco));
+    }
+    if ancestry_overflow {
+        let pending_graph: BTreeMap<_, _> = observed
+            .revision_graph
+            .iter()
+            .map(|info| (info.revision.as_str(), info))
+            .collect();
+        if exact_history(observed).is_err()
+            || observed
+                .supersession_ancestry
+                .iter()
+                .find(|info| info.revision == base)
+                != Some(base_info)
+            || observed.supersession_ancestry.iter().any(|info| {
+                pending_graph
+                    .get(info.revision.as_str())
+                    .is_some_and(|pending| *pending != info)
+            })
+        {
+            return Err(FactError::Invalid);
+        }
+        exact_overflow_prefix(&observed.supersession_ancestry, candidate, base, false)?;
+        return Ok(Some(HistoryOverflowScope::SupersessionAncestry));
+    }
+    Ok(None)
+}
+
+fn history_criterion(observed: &WitnessRawFacts) -> CriterionResult {
+    let raw_scope = match raw_overflow_scope(observed) {
+        Ok(scope) => scope,
+        Err(FactError::Dependency) => {
+            return failed(
+                GovernanceCriterion::HistoryComplete,
+                "history_dependency_failed",
+            )
+        }
+        Err(FactError::Invalid) => {
+            return failed(GovernanceCriterion::HistoryComplete, "history_incomplete")
+        }
+    };
+    if let Some(scope) = raw_scope {
+        return CriterionResult {
+            criterion: GovernanceCriterion::HistoryComplete,
+            passed: false,
+            failure_code: Some("history_depth_exceeded".into()),
+            remediation: Some(witness_remediation_for_overflow(scope)),
+        };
+    }
+    match (
+        exact_history(observed),
+        exact_supersession_ancestry(observed),
+    ) {
+        (Ok(_), Ok(_)) => passed(GovernanceCriterion::HistoryComplete),
+        (Err(FactError::Invalid), _) | (_, Err(FactError::Invalid)) => {
+            failed(GovernanceCriterion::HistoryComplete, "history_incomplete")
+        }
+        (Err(FactError::Dependency), _) | (_, Err(FactError::Dependency)) => failed(
+            GovernanceCriterion::HistoryComplete,
+            "history_dependency_failed",
+        ),
+    }
+}
+
+fn exact_supersession_ancestry(observed: &WitnessRawFacts) -> Result<BTreeSet<String>, FactError> {
+    if observed.supersession_ancestry.is_empty() {
+        return Err(FactError::Dependency);
+    }
+    if observed.supersession_ancestry.len() > MAX_GOVERNANCE_HISTORY_REVISIONS {
+        return Err(FactError::Invalid);
+    }
+    let mut pending_graph = BTreeMap::new();
+    for info in &observed.revision_graph {
+        if pending_graph.insert(info.revision.as_str(), info).is_some() {
+            return Err(FactError::Invalid);
+        }
+    }
+    let mut graph = BTreeMap::new();
+    for info in &observed.supersession_ancestry {
+        let parents: BTreeSet<_> = info.parents.iter().map(String::as_str).collect();
+        if info.revision.is_empty()
+            || info.parents.len() > 2
+            || parents.len() != info.parents.len()
+            || info
+                .parents
+                .iter()
+                .any(|parent| parent.is_empty() || parent == &info.revision)
+            || pending_graph
+                .get(info.revision.as_str())
+                .is_some_and(|pending| *pending != info)
+            || graph.insert(info.revision.as_str(), info).is_some()
+        {
+            return Err(FactError::Invalid);
+        }
+    }
+    let candidate = observed.expected_staged_revision.as_str();
+    let base = observed.target_base_revision.as_str();
+    let Some(base_info) = observed.base_revision_info.as_ref() else {
+        return Err(FactError::Dependency);
+    };
+    if graph.get(base).copied() != Some(base_info) || !graph.contains_key(candidate) {
+        return Err(FactError::Invalid);
+    }
+
+    let mut states = BTreeMap::<&str, u8>::new();
+    let mut stack = vec![(candidate, false)];
+    while let Some((revision, leaving)) = stack.pop() {
+        if leaving {
+            states.insert(revision, 2);
+            continue;
+        }
+        match states.get(revision) {
+            Some(1) => return Err(FactError::Invalid),
+            Some(2) => continue,
+            _ => {}
+        }
+        let Some(info) = graph.get(revision) else {
+            return Err(FactError::Invalid);
+        };
+        states.insert(revision, 1);
+        stack.push((revision, true));
+        for parent in info.parents.iter().rev() {
+            stack.push((parent.as_str(), false));
+        }
+    }
+    if states.len() != graph.len() || states.values().any(|state| *state != 2) {
+        return Err(FactError::Invalid);
+    }
+    Ok(graph
+        .keys()
+        .map(|revision| (*revision).to_string())
+        .collect())
+}
+
+struct WitnessDcoSigner {
+    name: String,
+}
+
+fn witness_parse_trailer(line: &str) -> Option<(&str, &str)> {
+    let (key, value) = line.split_once(": ")?;
+    if key.is_empty()
+        || !key.as_bytes()[0].is_ascii_alphanumeric()
+        || !key
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        || value.is_empty()
+        || value.trim() != value
+    {
+        return None;
+    }
+    Some((key, value))
+}
+
+fn witness_canonical_dco_email(email: &str) -> bool {
+    if email.is_empty()
+        || email.chars().any(|character| {
+            character.is_whitespace() || character.is_control() || matches!(character, '<' | '>')
+        })
+    {
+        return false;
+    }
+    let mut parts = email.split('@');
+    let (Some(local), Some(domain)) = (parts.next(), parts.next()) else {
+        return false;
+    };
+    !local.is_empty()
+        && !domain.is_empty()
+        && parts.next().is_none()
+        && domain.split('.').all(|label| {
+            let (Some(first), Some(last)) = (label.as_bytes().first(), label.as_bytes().last())
+            else {
+                return false;
+            };
+            first.is_ascii_alphanumeric()
+                && last.is_ascii_alphanumeric()
+                && label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        })
+}
+
+fn witness_parse_dco_signer(message: &str) -> Option<WitnessDcoSigner> {
+    let mut lines: Vec<&str> = message.lines().collect();
+    while lines.last().is_some_and(|line| line.is_empty()) {
+        lines.pop();
+    }
+    let end = lines.len();
+    let mut start = end;
+    while start > 0 && witness_parse_trailer(lines[start - 1]).is_some() {
+        start -= 1;
+    }
+    if start == end
+        || start == 0
+        || !lines[start - 1].is_empty()
+        || !lines[..start - 1].iter().any(|line| !line.is_empty())
+        || lines[..start]
+            .iter()
+            .any(|line| line.starts_with("Signed-off-by:"))
+    {
+        return None;
+    }
+    let signers: Vec<&str> = lines[start..end]
+        .iter()
+        .filter_map(|line| {
+            let (key, value) = witness_parse_trailer(line)?;
+            (key == "Signed-off-by").then_some(value)
+        })
+        .collect();
+    let [signer] = signers.as_slice() else {
+        return None;
+    };
+    let identity = signer.strip_suffix('>')?;
+    let (name, email) = identity.split_once(" <")?;
+    let first = name.chars().next()?;
+    let last = name.chars().last()?;
+    if first.is_whitespace()
+        || last.is_whitespace()
+        || name
+            .chars()
+            .any(|character| character.is_control() || matches!(character, '<' | '>'))
+        || !witness_canonical_dco_email(email)
+    {
+        return None;
+    }
+    Some(WitnessDcoSigner { name: name.into() })
+}
+
+fn dco_criterion(observed: &WitnessRawFacts) -> CriterionResult {
+    let criterion = GovernanceCriterion::DcoValid;
+    let pending = match exact_history(observed) {
+        Ok(pending) => pending,
+        Err(_) => return failed(criterion, "dco_dependency_failed"),
+    };
+    if observed.dco_metadata.is_empty() || observed.dco_metadata.len() != pending.len() {
+        return failed(criterion, "dco_dependency_failed");
+    }
+    let mut revisions = BTreeSet::new();
+    let mut identities = BTreeSet::new();
+    let mut identity_signer_names = Vec::new();
+    for raw in &observed.dco_metadata {
+        if !pending.contains(&raw.revision)
+            || !revisions.insert(raw.revision.as_str())
+            || raw.messages.len() != 1
+            || raw.created_by.len() != 1
+            || raw.committed_by.len() > 1
+            || raw.messages[0].is_empty()
+            || raw.created_by[0].is_empty()
+            || raw.committed_by.iter().any(String::is_empty)
+        {
+            return failed(criterion, "dco_invalid");
+        }
+        let Some(signer) = witness_parse_dco_signer(&raw.messages[0]) else {
+            return failed(criterion, "dco_invalid");
+        };
+        identities.insert(raw.created_by[0].clone());
+        identities.extend(raw.committed_by.iter().cloned());
+        identity_signer_names.push((raw.created_by[0].clone(), signer.name.clone()));
+        identity_signer_names.extend(
+            raw.committed_by
+                .iter()
+                .cloned()
+                .map(|identity| (identity, signer.name.clone())),
+        );
+    }
+    let Some(auth) = observed.author_resolution.as_ref() else {
+        return failed(criterion, "dco_dependency_failed");
+    };
+    let requested: BTreeSet<_> = auth.requested.iter().cloned().collect();
+    if requested != identities || requested.len() != auth.requested.len() {
+        return failed(criterion, "dco_invalid");
+    }
+    let mut replies = BTreeMap::new();
+    if auth.replies.len() != requested.len()
+        || auth.replies.iter().any(|reply| {
+            reply.identity.is_empty()
+                || reply.display_name.is_empty()
+                || !requested.contains(&reply.identity)
+                || replies
+                    .insert(reply.identity.as_str(), reply.display_name.as_str())
+                    .is_some()
+        })
+        || identity_signer_names.iter().any(|(identity, signer_name)| {
+            replies.get(identity.as_str()).copied() != Some(signer_name.as_str())
+        })
+    {
+        return failed(criterion, "dco_invalid");
+    }
+    passed(criterion)
+}
+
+fn not_superseded_criterion(observed: &WitnessRawFacts) -> CriterionResult {
+    let criterion = GovernanceCriterion::NotSuperseded;
+    if !observed.candidate_tree_observed {
+        return failed(criterion, "not_superseded_dependency_failed");
+    }
+    let Some(status) = observed.status.as_ref() else {
+        return failed(criterion, "not_superseded_dependency_failed");
+    };
+    let current_files = match witness_current_files(
+        status,
+        &observed.candidate_files,
+        &observed.expected_staged_revision,
+    ) {
+        Ok(files) => files,
+        _ => return failed(criterion, "not_superseded_dependency_failed"),
+    };
+    let ancestry = match exact_supersession_ancestry(observed) {
+        Ok(ancestry) => ancestry,
+        Err(_) => return failed(criterion, "not_superseded_dependency_failed"),
+    };
+    let mut candidate_paths = BTreeSet::new();
+    let mut candidate_identities = BTreeSet::new();
+    for file in &current_files {
+        if file.path.is_empty()
+            || file.revision != observed.expected_staged_revision
+            || file.hash.is_empty()
+            || file.context.is_empty()
+            || !candidate_paths.insert(file.path.as_str())
+            || !candidate_identities.insert(file.canonical_id())
+        {
+            return failed(criterion, "not_superseded_failed");
+        }
+    }
+    let mut queries = BTreeMap::new();
+    for query in &observed.supersession_metadata_queries {
+        if query.revision.is_empty()
+            || !ancestry.contains(&query.revision)
+            || queries
+                .insert(query.revision.as_str(), query.metadata.as_slice())
+                .is_some()
+        {
+            return failed(criterion, "not_superseded_failed");
+        }
+    }
+    if queries.len() != ancestry.len()
+        || ancestry
+            .iter()
+            .any(|revision| !queries.contains_key(revision.as_str()))
+    {
+        return failed(criterion, "not_superseded_dependency_failed");
+    }
+
+    let mut records = BTreeMap::<String, String>::new();
+    for metadata in queries.values() {
+        let mut keys = BTreeSet::new();
+        for entry in *metadata {
+            if entry.key.is_empty() || !keys.insert(entry.key.as_str()) {
+                return failed(criterion, "not_superseded_failed");
+            }
+            if !entry.key.starts_with(SUPERSESSION_MARKER_PREFIX) {
+                continue;
+            }
+            let identity = entry.key[SUPERSESSION_MARKER_PREFIX.len()..].to_string();
+            let Some(value) = entry.string_value() else {
+                return failed(criterion, "not_superseded_failed");
+            };
+            let marker: SupersessionMarkerV1 = match serde_json::from_str(value) {
+                Ok(marker) => marker,
+                Err(_) => return failed(criterion, "not_superseded_failed"),
+            };
+            if !witness_artifact_identity(&identity)
+                || marker.version != "v1"
+                || marker.identity != identity
+                || records
+                    .insert(identity, value.to_string())
+                    .is_some_and(|existing| existing != value)
+            {
+                return failed(criterion, "not_superseded_failed");
+            }
+        }
+    }
+    if records
+        .keys()
+        .any(|identity| candidate_identities.contains(identity))
+    {
+        failed(criterion, "not_superseded_failed")
+    } else {
+        passed(criterion)
+    }
+}
+
+fn locks_criterion(observed: &WitnessRawFacts) -> CriterionResult {
+    let criterion = GovernanceCriterion::LocksClear;
+    let affected_paths = match witness_affected_paths(observed) {
+        Ok(paths) => paths,
+        Err(()) => return failed(criterion, "locks_dependency_failed"),
+    };
+    let paths: BTreeSet<_> = affected_paths.iter().map(String::as_str).collect();
+    let Some(status) = observed.lock_status.as_ref() else {
+        return failed(criterion, "locks_dependency_failed");
+    };
+    if paths.is_empty()
+        || observed
+            .status
+            .as_ref()
+            .map(|status| status.branch.is_empty())
+            .unwrap_or(true)
+        || paths.len() != affected_paths.len()
+        || observed.lock_queries.len() != paths.len()
+    {
+        return failed(criterion, "locks_dependency_failed");
+    }
+    let mut queried = BTreeSet::new();
+    for query in &observed.lock_queries {
+        if query.path.is_empty()
+            || !paths.contains(query.path.as_str())
+            || !queried.insert(query.path.as_str())
+            || query.begin_events != 1
+            || !query.completed
+            || !query.ignored_paths.is_empty()
+            || query.expected_count != query.owners.len()
+        {
+            return failed(criterion, "locks_dependency_failed");
+        }
+        if !query.owners.is_empty() {
+            return failed(criterion, "locks_clear_failed");
+        }
+    }
+    if status.begin_events != 1
+        || !status.completed
+        || !status.ignored_paths.is_empty()
+        || status.expected_count != status.statuses.len()
+    {
+        return failed(criterion, "locks_dependency_failed");
+    }
+    let mut status_paths = BTreeSet::new();
+    for entry in &status.statuses {
+        if !paths.contains(entry.path.as_str()) || !status_paths.insert(entry.path.as_str()) {
+            return failed(criterion, "locks_dependency_failed");
+        }
+        if entry.owner.is_some() {
+            return failed(criterion, "locks_clear_failed");
+        }
+    }
+    passed(criterion)
+}
+
+fn worktree_criterion(observed: &WitnessRawFacts) -> CriterionResult {
+    let criterion = GovernanceCriterion::WorktreeClean;
+    let Some(status) = observed.status.as_ref() else {
+        return failed(criterion, "worktree_dependency_failed");
+    };
+    if !observed.candidate_tree_observed || !status.scan_performed {
+        return failed(criterion, "worktree_dependency_failed");
+    }
+    if witness_worktree_clean(
+        status,
+        &observed.candidate_files,
+        &observed.expected_staged_revision,
+    ) {
+        passed(criterion)
+    } else {
+        failed(criterion, "worktree_dirty")
+    }
+}
+
+fn live_criteria(observed: &WitnessRawFacts) -> Vec<CriterionResult> {
+    vec![
+        exact_subject(observed),
+        history_criterion(observed),
+        dco_criterion(observed),
+        not_superseded_criterion(observed),
+        locks_criterion(observed),
+        worktree_criterion(observed),
+    ]
+}
+
+fn witness_role_rejection() -> SubmissionGateCheckResult {
+    SubmissionGateCheckResult {
+        gate_open: false,
+        criteria: CRITERIA
+            .into_iter()
+            .map(|criterion| failed(criterion, "witness_role_required"))
+            .collect(),
+    }
+}
+
+fn validate_get(items: Vec<ImmutableGetItem>, address: &str) -> Result<Vec<u8>, String> {
+    if items.len() != 1 {
+        return Err("evidence_get_cardinality".into());
+    }
+    let item = items.into_iter().next().expect("length checked");
+    if item.id != EVIDENCE_ITEM_ID
+        || !item.ok
+        || item.address != address
+        || item.size != item.data.len() as u64
+    {
+        return Err("evidence_get_invalid".into());
+    }
+    Ok(item.data)
+}
+
+async fn evidence_criterion<A: GovernanceAdapter, I: GovernanceIo>(
+    adapter: &A,
+    io: &I,
+    request: &SubmissionGateCheckRequest,
+    observed: &WitnessRawFacts,
+    live: &[CriterionResult],
+) -> CriterionResult {
+    let failure = |code: &str| CriterionResult {
+        criterion: GovernanceCriterion::EvidenceValid,
+        passed: false,
+        failure_code: Some(code.into()),
+        remediation: None,
+    };
+    if live.iter().any(|criterion| !criterion.passed) {
+        return failure("dependency_failed");
+    }
+    let expected = match WitnessEvidenceProjection::from_raw(observed) {
+        Ok(projection) => projection,
+        Err(_) => return failure("evidence_live_snapshot_invalid"),
+    };
+
+    let metadata = match adapter
+        .revision_metadata(&request.expected_staged_revision)
+        .await
+    {
+        Ok(metadata) => metadata,
+        Err(_) => return failure("evidence_pointer_unavailable"),
+    };
+    let pointers: Vec<_> = metadata
+        .iter()
+        .filter(|entry| entry.key == EVIDENCE_POINTER_KEY)
+        .collect();
+    if pointers.is_empty() {
+        return failure("evidence_pointer_missing");
+    }
+    if pointers.len() != 1 {
+        return failure("evidence_pointer_invalid");
+    }
+    let Some(pointer_value) = pointers[0].string_value() else {
+        return failure("evidence_pointer_invalid");
+    };
+    let pointer: EvidencePointerV1 = match serde_json::from_str(pointer_value) {
+        Ok(pointer) => pointer,
+        Err(_) => return failure("evidence_pointer_invalid"),
+    };
+    if pointer.version != "v1" || !exact_address(&pointer.address) {
+        return failure("evidence_pointer_invalid");
+    }
+
+    let handle = match io.storage_open().await {
+        MutationObservation::Completed(handles) => match handles.as_slice() {
+            [handle] if *handle != 0 => *handle,
+            _ => return failure("evidence_storage_open_failed"),
+        },
+        MutationObservation::NotDispatched { .. } | MutationObservation::OutcomeUnknown { .. } => {
+            return failure("evidence_storage_open_failed")
+        }
+    };
+    let read = match io.storage_get(handle, &pointer.address).await {
+        ReadObservation::Completed(items) => validate_get(items, &pointer.address),
+        ReadObservation::NotDispatched { .. } | ReadObservation::Unavailable { .. } => {
+            Err("evidence_get_failed".into())
+        }
+    };
+    if !matches!(
+        io.storage_close(handle).await,
+        MutationObservation::Completed(())
+    ) {
+        return failure("evidence_storage_close_failed");
+    }
+    let bytes = match read {
+        Ok(bytes) => bytes,
+        Err(code) => return failure(&code),
+    };
+    let stored_snapshot: CanonicalEvidenceSnapshotV1 = match serde_json::from_slice(&bytes) {
+        Ok(snapshot) => snapshot,
+        Err(_) => return failure("evidence_schema_invalid"),
+    };
+    let stored = WitnessEvidenceProjection::from_stored(&stored_snapshot);
+    if stored != expected {
+        return failure("evidence_mismatch");
+    }
+    // The actor claim proves only schema/raw-fact equality/binding. Discard
+    // the complete summary-bearing claim and its bytes before the post-claim
+    // live witness pass; no decision criterion can recover either.
+    drop(stored);
+    drop(stored_snapshot);
+    drop(bytes);
+
+    CriterionResult {
+        criterion: GovernanceCriterion::EvidenceValid,
+        passed: true,
+        failure_code: None,
+        remediation: None,
+    }
+}
+
+pub async fn submission_gate_check_with_adapters<A: GovernanceAdapter, I: GovernanceIo>(
+    adapter: &A,
+    io: &I,
+    request: &SubmissionGateCheckRequest,
+) -> SubmissionGateCheckResult {
+    if io.role() != GovernanceRole::Witness {
+        return witness_role_rejection();
+    }
+    let initial = evaluate(adapter, request).await;
+    let initial_facts = WitnessRawFacts::from_evaluation(&initial);
+    // The summary-bearing evaluator result is deliberately unavailable to
+    // every evidence and terminal decision below this boundary.
+    drop(initial);
+    let initial_live = live_criteria(&initial_facts);
+    let mut evidence =
+        evidence_criterion(adapter, io, request, &initial_facts, &initial_live).await;
+
+    // Evidence retrieval is not atomic with repository state. Re-read every
+    // live dependency after the storage handle has closed and require both the
+    // independently derived criteria and canonical raw snapshot to be stable.
+    let final_evaluation = evaluate(adapter, request).await;
+    let final_facts = WitnessRawFacts::from_evaluation(&final_evaluation);
+    drop(final_evaluation);
+    let criteria = live_criteria(&final_facts);
+    // Stability is a property of the retained raw inputs, not merely of the
+    // verdicts they happen to derive. Two different fact sets that produce the
+    // same criteria are still live drift and must close the gate.
+    let live_stable = final_facts == initial_facts;
+    let projections_stable = match (
+        WitnessEvidenceProjection::from_raw(&initial_facts),
+        WitnessEvidenceProjection::from_raw(&final_facts),
+    ) {
+        (Ok(initial), Ok(final_projection)) => initial == final_projection,
+        _ => false,
+    };
+    if !live_stable || !projections_stable {
+        evidence = failed(GovernanceCriterion::EvidenceValid, "evidence_live_drift");
+    }
+    if io.role() != GovernanceRole::Witness {
+        evidence = failed(GovernanceCriterion::EvidenceValid, "witness_role_required");
+    }
+    let mut criteria = criteria;
+    criteria.push(evidence);
+    debug_assert_eq!(criteria.len(), CRITERIA.len());
+    let gate_open = criteria.len() == CRITERIA.len()
+        && criteria
+            .iter()
+            .zip(CRITERIA)
+            .all(|(result, expected)| result.criterion == expected && result.passed);
+    SubmissionGateCheckResult {
+        gate_open,
+        criteria,
+    }
+}
+
+pub async fn submission_gate_check(
+    api: &LoreApi,
+    request: SubmissionGateCheckRequest,
+) -> crate::error::Result<SubmissionGateCheckResult> {
+    let adapter = ProductionLoreAdapter::new(api, "");
+    let io = ProductionGovernanceIo::new(api, GovernanceRole::Witness);
+    Ok(submission_gate_check_with_adapters(&adapter, &io, &request).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        dco_criterion, exact_history, history_criterion, live_criteria, not_superseded_criterion,
+        raw_overflow_scope, WitnessRawFacts,
+    };
+    use crate::ops::governance::contract::{
+        AffectedPath, AuthorResolutionObservation, DcoMetadataObservation, DcoObservation,
+        EvaluationResult, FileIdentity, GovernanceCriterion, GovernanceObservations,
+        GovernancePathAction, GovernanceRemediation, GovernanceRemediationCode,
+        HistoryOverflowScope, LockQuery, LockStatusResponse, MetadataEntry, ResolvedAuthor,
+        RevisionDiffObservation, RevisionInfo, StagedPathObservation, StatusSnapshot,
+        SupersessionMarkerV1, SupersessionMetadataQueryObservation, WorktreeFileObservation,
+        MAX_GOVERNANCE_HISTORY_REVISIONS,
+    };
+
+    fn pending_chain(count: usize) -> (Vec<RevisionInfo>, Vec<String>) {
+        assert!(count > 0);
+        let revisions: Vec<_> = (0..count)
+            .map(|index| {
+                if index == 0 {
+                    "candidate".into()
+                } else {
+                    format!("pending-{index}")
+                }
+            })
+            .collect();
+        let graph = revisions
+            .iter()
+            .enumerate()
+            .map(|(index, revision)| RevisionInfo {
+                revision: revision.clone(),
+                parents: vec![revisions
+                    .get(index + 1)
+                    .cloned()
+                    .unwrap_or_else(|| "base".into())],
+            })
+            .collect();
+        (graph, revisions)
+    }
+
+    fn raw(evaluation: &EvaluationResult) -> WitnessRawFacts {
+        WitnessRawFacts::from_evaluation(evaluation)
+    }
+
+    fn ancestry_chain(count: usize) -> Vec<RevisionInfo> {
+        assert!(count >= 2);
+        let revisions: Vec<_> = (0..count)
+            .map(|index| match index {
+                0 => "candidate".into(),
+                1 => "base".into(),
+                _ => format!("ancestor-{}", index - 1),
+            })
+            .collect();
+        revisions
+            .iter()
+            .enumerate()
+            .map(|(index, revision)| RevisionInfo {
+                revision: revision.clone(),
+                parents: revisions.get(index + 1).cloned().into_iter().collect(),
+            })
+            .collect()
+    }
+
+    fn complete_evaluation(failure_codes: Vec<String>) -> EvaluationResult {
+        let mut observations = GovernanceObservations::new("candidate", "base");
+        observations.status = Some(StatusSnapshot {
+            branch: "branch".into(),
+            staged_revisions: vec!["candidate".into()],
+            scanned_staged_revisions: vec!["candidate".into()],
+            post_scan_staged_revisions: vec!["candidate".into()],
+            staged_paths: vec!["asset.txt".into()],
+            staged_changes: vec![StagedPathObservation {
+                path: "asset.txt".into(),
+                from_path: None,
+                action: GovernancePathAction::Modify,
+                dirty: true,
+                conflict: false,
+            }],
+            worktree_files: vec![WorktreeFileObservation {
+                path: "asset.txt".into(),
+                revision: "candidate".into(),
+                revision_hash: "1111111111111111111111111111111111111111111111111111111111111111"
+                    .into(),
+                revision_context: "22222222222222222222222222222222".into(),
+                revision_size: 5,
+                local_hash: "1111111111111111111111111111111111111111111111111111111111111111"
+                    .into(),
+                local_size: 5,
+                filtered_revision_size: 5,
+                flag_modified: false,
+                flag_deleted: false,
+                flag_added: false,
+                flag_conflict: false,
+            }],
+            worktree_clean: true,
+            scan_performed: true,
+        });
+        observations.base_revision_info = Some(RevisionInfo {
+            revision: "base".into(),
+            parents: Vec::new(),
+        });
+        observations.supersession_ancestry = vec![
+            RevisionInfo {
+                revision: "base".into(),
+                parents: Vec::new(),
+            },
+            RevisionInfo {
+                revision: "candidate".into(),
+                parents: vec!["base".into()],
+            },
+        ];
+        observations.supersession_ancestry_observed = true;
+        observations.revision_graph = vec![RevisionInfo {
+            revision: "candidate".into(),
+            parents: vec!["base".into()],
+        }];
+        observations.first_parent_history = vec!["candidate".into()];
+        observations.candidate_files = vec![FileIdentity::new(
+            "asset.txt",
+            "candidate",
+            "1111111111111111111111111111111111111111111111111111111111111111",
+            "22222222222222222222222222222222",
+        )];
+        observations.base_files = vec![FileIdentity::new(
+            "asset.txt",
+            "base",
+            "3333333333333333333333333333333333333333333333333333333333333333",
+            "22222222222222222222222222222222",
+        )];
+        observations.candidate_tree_observed = true;
+        observations.current_files = observations.candidate_files.clone();
+        observations.base_tree_observed = true;
+        observations.upstream_revision_diff = vec![RevisionDiffObservation {
+            path: "asset.txt".into(),
+            action: GovernancePathAction::Modify,
+            old_is_file: true,
+            new_is_file: true,
+            old_address: format!("{}-{}", "3".repeat(64), "2".repeat(32)),
+            new_address: format!("{}-{}", "1".repeat(64), "2".repeat(32)),
+        }];
+        observations.revision_diff = vec![AffectedPath::modified("asset.txt")];
+        observations.revision_diff_observed = true;
+        observations.affected_paths = vec!["asset.txt".into()];
+        observations.supersession_metadata_queries = vec![
+            SupersessionMetadataQueryObservation {
+                revision: "base".into(),
+                metadata: vec![],
+            },
+            SupersessionMetadataQueryObservation {
+                revision: "candidate".into(),
+                metadata: vec![],
+            },
+        ];
+        observations.supersession_metadata_observed = true;
+        observations.dco_metadata = vec![DcoMetadataObservation {
+            revision: "candidate".into(),
+            messages: vec!["change\n\nSigned-off-by: Alice <alice@example.test>".into()],
+            created_by: vec!["alice".into()],
+            committed_by: vec![],
+        }];
+        observations.author_resolution = Some(AuthorResolutionObservation {
+            requested: vec!["alice".into()],
+            replies: vec![ResolvedAuthor::new("alice", "Alice")],
+        });
+        observations.dco = vec![DcoObservation {
+            revision: "candidate".into(),
+            message: "change\n\nSigned-off-by: Alice <alice@example.test>".into(),
+            trailer: "Signed-off-by: Alice <alice@example.test>".into(),
+            signer_name: "Alice".into(),
+            signer_email: "alice@example.test".into(),
+            created_by: "alice".into(),
+            committed_by: None,
+            resolved_authors: vec![ResolvedAuthor::new("alice", "Alice")],
+        }];
+        observations.lock_queries = vec![LockQuery::unlocked("asset.txt")];
+        observations.lock_status = Some(LockStatusResponse::unlocked());
+        EvaluationResult {
+            open: false,
+            pending_revisions: Vec::new(),
+            affected_paths: Vec::new(),
+            identities: Vec::new(),
+            superseded_identities: Vec::new(),
+            failure_codes,
+            remediation: None,
+            observations,
+        }
+    }
+
+    #[test]
+    fn shuffled_failure_codes_cannot_change_complete_raw_criteria() {
+        let left = complete_evaluation(vec!["dco_invalid".into(), "worktree_dirty".into()]);
+        let right = complete_evaluation(vec![
+            "unknown_future_code".into(),
+            "worktree_dirty".into(),
+            "dco_invalid".into(),
+        ]);
+        let left_criteria = live_criteria(&super::WitnessRawFacts::from_evaluation(&left));
+        let right_criteria = live_criteria(&super::WitnessRawFacts::from_evaluation(&right));
+        assert_eq!(left_criteria, right_criteria);
+        assert!(left_criteria.iter().all(|criterion| criterion.passed));
+    }
+
+    #[test]
+    fn evaluator_summaries_are_inert_at_the_witness_decision_boundary() {
+        let baseline = complete_evaluation(Vec::new());
+        let expected = live_criteria(&super::WitnessRawFacts::from_evaluation(&baseline));
+        assert!(expected.iter().all(|criterion| criterion.passed));
+
+        let mut changed = baseline.clone();
+        changed.open = true;
+        changed.pending_revisions = vec!["forged-pending-summary".into()];
+        changed.affected_paths = vec!["forged-top-level-summary.txt".into()];
+        changed.identities = vec!["forged-identity-summary".into()];
+        changed.superseded_identities = vec!["forged-superseded-summary".into()];
+        changed.failure_codes = vec!["forged-failure-summary".into()];
+        changed.remediation = Some(GovernanceRemediation {
+            code: GovernanceRemediationCode::MigrateSupersessionIndex,
+            ticket: Some("forged-ticket".into()),
+        });
+        changed.observations.affected_paths = vec!["forged-summary.txt".into()];
+        changed.observations.dco[0].signer_name = "Mallory".into();
+        changed.observations.supersession_markers.push(
+            crate::ops::governance::contract::SupersessionObservation {
+                revision: "candidate".into(),
+                key: format!(
+                    "{}{}:{}",
+                    crate::ops::governance::contract::SUPERSESSION_MARKER_PREFIX,
+                    "1".repeat(64),
+                    "2".repeat(32)
+                ),
+                value: serde_json::to_string(
+                    &crate::ops::governance::contract::SupersessionMarkerV1 {
+                        version: "v1".into(),
+                        identity: format!("{}:{}", "1".repeat(64), "2".repeat(32)),
+                    },
+                )
+                .unwrap(),
+                identity: format!("{}:{}", "1".repeat(64), "2".repeat(32)),
+            },
+        );
+        changed.observations.supersession_metadata_observed = false;
+        changed.observations.history_overflow_scope =
+            Some(crate::ops::governance::contract::HistoryOverflowScope::PendingDco);
+
+        assert_eq!(
+            live_criteria(&super::WitnessRawFacts::from_evaluation(&changed)),
+            expected,
+            "witness criteria must derive only from retained raw facts, never evaluator summaries",
+        );
+        assert_eq!(
+            super::WitnessEvidenceProjection::from_raw(&super::WitnessRawFacts::from_evaluation(
+                &changed
+            )),
+            super::WitnessEvidenceProjection::from_raw(&super::WitnessRawFacts::from_evaluation(
+                &baseline
+            )),
+            "evidence equality and stability must use the private raw projection, not summaries",
+        );
+    }
+
+    #[test]
+    fn witness_requires_exact_supersession_metadata_query_coverage() {
+        let baseline = complete_evaluation(Vec::new());
+
+        let mut missing = baseline.clone();
+        missing.observations.supersession_metadata_queries.pop();
+        let result = not_superseded_criterion(&WitnessRawFacts::from_evaluation(&missing));
+        assert!(!result.passed);
+        assert_eq!(
+            result.failure_code.as_deref(),
+            Some("not_superseded_dependency_failed")
+        );
+
+        let mut duplicate = baseline.clone();
+        duplicate
+            .observations
+            .supersession_metadata_queries
+            .push(duplicate.observations.supersession_metadata_queries[0].clone());
+        let result = not_superseded_criterion(&WitnessRawFacts::from_evaluation(&duplicate));
+        assert!(!result.passed);
+        assert_eq!(
+            result.failure_code.as_deref(),
+            Some("not_superseded_failed")
+        );
+
+        let mut foreign = baseline;
+        foreign.observations.supersession_metadata_queries[0].revision = "foreign".into();
+        let result = not_superseded_criterion(&WitnessRawFacts::from_evaluation(&foreign));
+        assert!(!result.passed);
+        assert_eq!(
+            result.failure_code.as_deref(),
+            Some("not_superseded_failed")
+        );
+    }
+
+    #[test]
+    fn witness_rederives_supersession_from_an_ancestor_raw_query() {
+        let mut evaluation = complete_evaluation(Vec::new());
+        let identity = format!("{}:{}", "1".repeat(64), "2".repeat(32));
+        evaluation.observations.supersession_metadata_queries[0]
+            .metadata
+            .push(MetadataEntry::new(
+                format!("{}{}", super::SUPERSESSION_MARKER_PREFIX, identity),
+                serde_json::to_string(&SupersessionMarkerV1 {
+                    version: "v1".into(),
+                    identity,
+                })
+                .unwrap(),
+            ));
+        let result = not_superseded_criterion(&WitnessRawFacts::from_evaluation(&evaluation));
+        assert!(!result.passed);
+        assert_eq!(
+            result.failure_code.as_deref(),
+            Some("not_superseded_failed")
+        );
+    }
+
+    #[test]
+    fn witness_rejects_dco_row_and_reply_multiplicity_without_normalizing() {
+        let baseline = complete_evaluation(Vec::new());
+
+        let mut foreign = baseline.clone();
+        foreign.observations.dco_metadata[0].revision = "foreign".into();
+        let result = dco_criterion(&WitnessRawFacts::from_evaluation(&foreign));
+        assert!(!result.passed);
+        assert_eq!(result.failure_code.as_deref(), Some("dco_invalid"));
+
+        let mut duplicate_row = baseline.clone();
+        duplicate_row
+            .observations
+            .dco_metadata
+            .push(duplicate_row.observations.dco_metadata[0].clone());
+        let result = dco_criterion(&WitnessRawFacts::from_evaluation(&duplicate_row));
+        assert!(!result.passed);
+        assert_eq!(
+            result.failure_code.as_deref(),
+            Some("dco_dependency_failed")
+        );
+
+        let mut duplicate_reply = baseline;
+        let reply = duplicate_reply
+            .observations
+            .author_resolution
+            .as_ref()
+            .unwrap()
+            .replies[0]
+            .clone();
+        duplicate_reply
+            .observations
+            .author_resolution
+            .as_mut()
+            .unwrap()
+            .replies
+            .push(reply);
+        let result = dco_criterion(&WitnessRawFacts::from_evaluation(&duplicate_reply));
+        assert!(!result.passed);
+        assert_eq!(result.failure_code.as_deref(), Some("dco_invalid"));
+    }
+
+    #[test]
+    fn multiple_raw_failures_are_criterion_local_regardless_of_code_order() {
+        let mut left = complete_evaluation(vec!["worktree_dirty".into(), "dco_invalid".into()]);
+        left.observations.dco_metadata[0].messages[0] = "malformed raw message".into();
+        left.observations.lock_queries[0].owners = vec!["foreign".into()];
+        left.observations.lock_queries[0].expected_count = 1;
+        let mut right = left.clone();
+        right.failure_codes.reverse();
+
+        let left_criteria = live_criteria(&super::WitnessRawFacts::from_evaluation(&left));
+        assert_eq!(
+            left_criteria,
+            live_criteria(&super::WitnessRawFacts::from_evaluation(&right))
+        );
+        for result in left_criteria {
+            let expected = matches!(
+                result.criterion,
+                GovernanceCriterion::DcoValid | GovernanceCriterion::LocksClear
+            );
+            assert_eq!(!result.passed, expected, "{result:?}");
+        }
+    }
+
+    #[test]
+    fn witness_accepts_exact_1000_pending_nodes_and_derives_1001_remediation() {
+        let mut evaluation = complete_evaluation(Vec::new());
+        let (graph, history) = pending_chain(MAX_GOVERNANCE_HISTORY_REVISIONS);
+        evaluation.observations.revision_graph = graph;
+        evaluation.observations.first_parent_history = history;
+        assert!(exact_history(&raw(&evaluation)).is_ok());
+
+        let (graph, _) = pending_chain(MAX_GOVERNANCE_HISTORY_REVISIONS + 1);
+        evaluation.observations.revision_graph = graph;
+        evaluation.observations.first_parent_history.clear();
+        evaluation.observations.supersession_ancestry.clear();
+        evaluation.observations.supersession_ancestry_observed = false;
+        evaluation.observations.history_overflow_scope = Some(HistoryOverflowScope::PendingDco);
+        assert_eq!(
+            raw_overflow_scope(&raw(&evaluation)).unwrap(),
+            Some(HistoryOverflowScope::PendingDco)
+        );
+        let result = history_criterion(&raw(&evaluation));
+        assert_eq!(
+            result.failure_code.as_deref(),
+            Some("history_depth_exceeded")
+        );
+        assert_eq!(
+            result.remediation,
+            Some(GovernanceRemediation {
+                code: GovernanceRemediationCode::SplitSubmissionOrAdvanceTargetBase,
+                ticket: None,
+            })
+        );
+    }
+
+    #[test]
+    fn witness_ignores_lied_pending_scope_but_rejects_missing_and_malformed_sentinel() {
+        let mut evaluation = complete_evaluation(Vec::new());
+        let (graph, _) = pending_chain(MAX_GOVERNANCE_HISTORY_REVISIONS + 1);
+        evaluation.observations.revision_graph = graph;
+        evaluation.observations.first_parent_history.clear();
+        evaluation.observations.supersession_ancestry.clear();
+        evaluation.observations.supersession_ancestry_observed = false;
+        evaluation.observations.history_overflow_scope =
+            Some(HistoryOverflowScope::SupersessionAncestry);
+        let lied = history_criterion(&raw(&evaluation));
+        assert_eq!(lied.failure_code.as_deref(), Some("history_depth_exceeded"));
+        assert_eq!(
+            lied.remediation,
+            Some(GovernanceRemediation {
+                code: GovernanceRemediationCode::SplitSubmissionOrAdvanceTargetBase,
+                ticket: None,
+            })
+        );
+
+        evaluation.observations.history_overflow_scope = Some(HistoryOverflowScope::PendingDco);
+        evaluation.observations.revision_graph.pop();
+        let missing = history_criterion(&raw(&evaluation));
+        assert_eq!(missing.failure_code.as_deref(), Some("history_incomplete"));
+        assert!(missing.remediation.is_none());
+
+        let (mut graph, _) = pending_chain(MAX_GOVERNANCE_HISTORY_REVISIONS + 1);
+        graph.last_mut().unwrap().parents.clear();
+        evaluation.observations.revision_graph = graph;
+        let malformed = history_criterion(&raw(&evaluation));
+        assert_eq!(
+            malformed.failure_code.as_deref(),
+            Some("history_incomplete")
+        );
+        assert!(malformed.remediation.is_none());
+
+        let (mut cycle, _) = pending_chain(MAX_GOVERNANCE_HISTORY_REVISIONS + 1);
+        cycle.last_mut().unwrap().parents = vec!["candidate".into()];
+        evaluation.observations.revision_graph = cycle;
+        evaluation.observations.history_overflow_scope =
+            Some(HistoryOverflowScope::SupersessionAncestry);
+        let cycle = history_criterion(&raw(&evaluation));
+        assert_eq!(cycle.failure_code.as_deref(), Some("history_incomplete"));
+        assert!(cycle.remediation.is_none());
+
+        let (mut duplicate, _) = pending_chain(MAX_GOVERNANCE_HISTORY_REVISIONS + 1);
+        duplicate.last_mut().unwrap().revision = "pending-1".into();
+        evaluation.observations.revision_graph = duplicate;
+        let duplicate = history_criterion(&raw(&evaluation));
+        assert_eq!(
+            duplicate.failure_code.as_deref(),
+            Some("history_incomplete")
+        );
+        assert!(duplicate.remediation.is_none());
+    }
+
+    #[test]
+    fn witness_accepts_exact_1000_ancestry_nodes_and_derives_1001_remediation() {
+        let mut evaluation = complete_evaluation(Vec::new());
+        let graph = ancestry_chain(MAX_GOVERNANCE_HISTORY_REVISIONS);
+        evaluation.observations.base_revision_info = Some(graph[1].clone());
+        evaluation.observations.supersession_ancestry = graph;
+        evaluation.observations.supersession_ancestry_observed = true;
+        assert!(history_criterion(&raw(&evaluation)).passed);
+
+        let graph = ancestry_chain(MAX_GOVERNANCE_HISTORY_REVISIONS + 1);
+        evaluation.observations.base_revision_info = Some(graph[1].clone());
+        evaluation.observations.supersession_ancestry = graph;
+        evaluation.observations.history_overflow_scope =
+            Some(HistoryOverflowScope::SupersessionAncestry);
+        assert_eq!(
+            raw_overflow_scope(&raw(&evaluation)).unwrap(),
+            Some(HistoryOverflowScope::SupersessionAncestry)
+        );
+        let result = history_criterion(&raw(&evaluation));
+        assert_eq!(
+            result.failure_code.as_deref(),
+            Some("history_depth_exceeded")
+        );
+        assert_eq!(
+            result.remediation,
+            Some(GovernanceRemediation {
+                code: GovernanceRemediationCode::MigrateSupersessionIndex,
+                ticket: Some("SBAI-6010".into()),
+            })
+        );
+    }
+
+    #[test]
+    fn witness_ignores_lied_ancestry_scope_but_rejects_missing_and_malformed_sentinel() {
+        let mut evaluation = complete_evaluation(Vec::new());
+        let graph = ancestry_chain(MAX_GOVERNANCE_HISTORY_REVISIONS + 1);
+        evaluation.observations.base_revision_info = Some(graph[1].clone());
+        evaluation.observations.supersession_ancestry = graph;
+        evaluation.observations.supersession_ancestry_observed = true;
+        evaluation.observations.history_overflow_scope = Some(HistoryOverflowScope::PendingDco);
+        let lied = history_criterion(&raw(&evaluation));
+        assert_eq!(lied.failure_code.as_deref(), Some("history_depth_exceeded"));
+        assert_eq!(
+            lied.remediation,
+            Some(GovernanceRemediation {
+                code: GovernanceRemediationCode::MigrateSupersessionIndex,
+                ticket: Some("SBAI-6010".into()),
+            })
+        );
+
+        evaluation.observations.history_overflow_scope =
+            Some(HistoryOverflowScope::SupersessionAncestry);
+        evaluation.observations.supersession_ancestry.pop();
+        let missing = history_criterion(&raw(&evaluation));
+        assert_eq!(missing.failure_code.as_deref(), Some("history_incomplete"));
+        assert!(missing.remediation.is_none());
+
+        let mut graph = ancestry_chain(MAX_GOVERNANCE_HISTORY_REVISIONS + 1);
+        graph.last_mut().unwrap().parents = vec!["duplicate".into(), "duplicate".into()];
+        evaluation.observations.supersession_ancestry = graph;
+        let malformed = history_criterion(&raw(&evaluation));
+        assert_eq!(
+            malformed.failure_code.as_deref(),
+            Some("history_incomplete")
+        );
+        assert!(malformed.remediation.is_none());
+
+        let mut cycle = ancestry_chain(MAX_GOVERNANCE_HISTORY_REVISIONS + 1);
+        cycle.last_mut().unwrap().parents = vec!["candidate".into()];
+        evaluation.observations.supersession_ancestry = cycle;
+        evaluation.observations.history_overflow_scope = Some(HistoryOverflowScope::PendingDco);
+        let cycle = history_criterion(&raw(&evaluation));
+        assert_eq!(cycle.failure_code.as_deref(), Some("history_incomplete"));
+        assert!(cycle.remediation.is_none());
+
+        let mut duplicate = ancestry_chain(MAX_GOVERNANCE_HISTORY_REVISIONS + 1);
+        duplicate.last_mut().unwrap().revision = "ancestor-1".into();
+        evaluation.observations.supersession_ancestry = duplicate;
+        let duplicate = history_criterion(&raw(&evaluation));
+        assert_eq!(
+            duplicate.failure_code.as_deref(),
+            Some("history_incomplete")
+        );
+        assert!(duplicate.remediation.is_none());
+    }
+
+    #[test]
+    fn witness_rejects_ancestry_overflow_fact_that_disagrees_with_pending_graph() {
+        let mut evaluation = complete_evaluation(Vec::new());
+        let mut graph = ancestry_chain(MAX_GOVERNANCE_HISTORY_REVISIONS);
+        graph[0].parents.push("side-root".into());
+        graph.push(RevisionInfo {
+            revision: "side-root".into(),
+            parents: vec![],
+        });
+        evaluation.observations.base_revision_info = Some(graph[1].clone());
+        evaluation.observations.supersession_ancestry = graph;
+        evaluation.observations.supersession_ancestry_observed = true;
+        evaluation.observations.history_overflow_scope =
+            Some(HistoryOverflowScope::SupersessionAncestry);
+
+        let result = history_criterion(&raw(&evaluation));
+        assert_eq!(result.failure_code.as_deref(), Some("history_incomplete"));
+        assert!(result.remediation.is_none());
+    }
+}

--- a/crates/lore-vm/src/ops/mod.rs
+++ b/crates/lore-vm/src/ops/mod.rs
@@ -7,6 +7,7 @@ pub mod auth;
 pub mod branch;
 pub mod dependency;
 pub mod file;
+pub mod governance;
 pub mod layer;
 pub mod link;
 pub mod lock;

--- a/crates/lore-vm/tests/governance_option_a.rs
+++ b/crates/lore-vm/tests/governance_option_a.rs
@@ -1,20 +1,19 @@
 //! Behavioral contract and fail-closed evaluator matrix for SBAI-5934 Option A.
 
 use lore_vm::ops::governance::contract::{
-    ArtifactMarkSupersededRequest, DcoValidateRequest, EvidencePreserveRequest,
-    GovernanceCriterion, SubmissionGateCheckRequest, EVIDENCE_POINTER_KEY,
+    AdapterError, AffectedPath, ArtifactMarkSupersededRequest, DcoValidateRequest,
+    EvidencePreserveRequest, FileIdentity, GovernanceCriterion, LockQuery, LockStatus,
+    LockStatusResponse, MetadataEntry, ResolvedAuthor, RevisionInfo, RevisionInfoResponse,
+    StatusSnapshot, SubmissionGateCheckRequest, EVIDENCE_POINTER_KEY,
     MAX_GOVERNANCE_HISTORY_REVISIONS, SUPERSESSION_MARKER_PREFIX,
 };
-use lore_vm::ops::governance::evaluator::{
-    evaluate, AdapterError, AffectedPath, FileIdentity, GovernanceAdapter, LockQuery, LockStatus,
-    LockStatusResponse, MetadataEntry, ResolvedAuthor, RevisionInfo, StatusSnapshot,
-};
+use lore_vm::ops::governance::evaluator::{evaluate, GovernanceAdapter};
 use std::collections::BTreeMap;
 
 #[derive(Clone)]
 struct FakeLore {
     status: Result<StatusSnapshot, AdapterError>,
-    infos: BTreeMap<String, Result<RevisionInfo, AdapterError>>,
+    infos: BTreeMap<String, Result<RevisionInfoResponse, AdapterError>>,
     metadata: BTreeMap<String, Result<Vec<MetadataEntry>, AdapterError>>,
     history: Result<Vec<String>, AdapterError>,
     dumps: BTreeMap<String, Result<Vec<String>, AdapterError>>,
@@ -24,6 +23,7 @@ struct FakeLore {
     lock_queries: BTreeMap<String, Result<LockQuery, AdapterError>>,
     lock_status: Result<LockStatusResponse, AdapterError>,
     history_limits: std::sync::Arc<std::sync::Mutex<Vec<usize>>>,
+    info_queries: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
 }
 
 impl FakeLore {
@@ -31,17 +31,17 @@ impl FakeLore {
         let mut infos = BTreeMap::new();
         infos.insert(
             "candidate".into(),
-            Ok(RevisionInfo {
+            Ok(RevisionInfoResponse::exact(RevisionInfo {
                 revision: "candidate".into(),
                 parents: vec!["base".into()],
-            }),
+            })),
         );
         infos.insert(
             "base".into(),
-            Ok(RevisionInfo {
+            Ok(RevisionInfoResponse::exact(RevisionInfo {
                 revision: "base".into(),
                 parents: vec![],
-            }),
+            })),
         );
 
         let mut metadata = BTreeMap::new();
@@ -80,8 +80,11 @@ impl FakeLore {
         Self {
             status: Ok(StatusSnapshot {
                 staged_revisions: vec!["candidate".into()],
+                scanned_staged_revisions: vec!["candidate".into()],
+                post_scan_staged_revisions: vec!["candidate".into()],
                 staged_paths: vec!["asset.txt".into()],
                 worktree_clean: true,
+                scan_performed: true,
             }),
             infos,
             metadata,
@@ -93,6 +96,7 @@ impl FakeLore {
             lock_queries,
             lock_status: Ok(LockStatusResponse::unlocked()),
             history_limits: Default::default(),
+            info_queries: Default::default(),
         }
     }
 
@@ -110,10 +114,10 @@ impl FakeLore {
             let revision = format!("pending-{index}");
             fake.infos.insert(
                 revision.clone(),
-                Ok(RevisionInfo {
+                Ok(RevisionInfoResponse::exact(RevisionInfo {
                     revision: revision.clone(),
                     parents: vec![parent],
-                }),
+                })),
             );
             fake.metadata.insert(
                 revision.clone(),
@@ -130,13 +134,51 @@ impl FakeLore {
 
         fake.infos.insert(
             "candidate".into(),
-            Ok(RevisionInfo {
+            Ok(RevisionInfoResponse::exact(RevisionInfo {
                 revision: "candidate".into(),
                 parents: vec![parent],
-            }),
+            })),
         );
         history.extend((1..count).map(|index| format!("pending-{index}")));
         fake.history = Ok(history);
+        fake
+    }
+
+    fn with_second_parent_pending_count(count: usize) -> Self {
+        assert!(count > 1);
+        let mut fake = Self::clean();
+        let mut parent = "base".to_string();
+
+        for index in (1..count).rev() {
+            let revision = format!("side-{index}");
+            fake.infos.insert(
+                revision.clone(),
+                Ok(RevisionInfoResponse::exact(RevisionInfo {
+                    revision: revision.clone(),
+                    parents: vec![parent],
+                })),
+            );
+            fake.metadata.insert(
+                revision.clone(),
+                Ok(vec![
+                    MetadataEntry::new(
+                        "message",
+                        "change\n\nSigned-off-by: Alice <alice@example.test>",
+                    ),
+                    MetadataEntry::new("created-by", "alice"),
+                ]),
+            );
+            parent = revision;
+        }
+
+        fake.infos.insert(
+            "candidate".into(),
+            Ok(RevisionInfoResponse::exact(RevisionInfo {
+                revision: "candidate".into(),
+                parents: vec!["base".into(), parent],
+            })),
+        );
+        fake.history = Ok(vec!["candidate".into()]);
         fake
     }
 }
@@ -147,7 +189,8 @@ impl GovernanceAdapter for FakeLore {
         self.status.clone()
     }
 
-    async fn revision_info(&self, revision: &str) -> Result<RevisionInfo, AdapterError> {
+    async fn revision_info(&self, revision: &str) -> Result<RevisionInfoResponse, AdapterError> {
+        self.info_queries.lock().unwrap().push(revision.into());
         self.infos
             .get(revision)
             .cloned()
@@ -308,18 +351,18 @@ fn traverses_both_merge_parents_and_rejects_depth_overflow() {
     let mut merge = FakeLore::clean();
     merge.infos.insert(
         "candidate".into(),
-        Ok(RevisionInfo {
+        Ok(RevisionInfoResponse::exact(RevisionInfo {
             revision: "candidate".into(),
             parents: vec!["left".into(), "right".into()],
-        }),
+        })),
     );
     for revision in ["left", "right"] {
         merge.infos.insert(
             revision.into(),
-            Ok(RevisionInfo {
+            Ok(RevisionInfoResponse::exact(RevisionInfo {
                 revision: revision.into(),
                 parents: vec!["base".into()],
-            }),
+            })),
         );
         merge.metadata.insert(
             revision.into(),
@@ -359,6 +402,22 @@ fn accepts_500_999_and_1000_clean_pending_nodes() {
 }
 
 #[test]
+fn enforces_1000_unique_pending_limit_across_second_parent_dag() {
+    let exact_limit = FakeLore::with_second_parent_pending_count(1000);
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(evaluate(&exact_limit, &request()));
+    assert!(result.open, "exactly 1000 unique pending nodes: {result:?}");
+
+    let overflow = FakeLore::with_second_parent_pending_count(1002);
+    let queries = overflow.info_queries.clone();
+    assert_closed_for(overflow, |_| {}, "history_depth_exceeded");
+    let queries = queries.lock().unwrap();
+    assert!(queries.iter().any(|revision| revision == "side-1000"));
+    assert!(!queries.iter().any(|revision| revision == "side-1001"));
+}
+
+#[test]
 fn closes_for_status_and_history_graph_failures() {
     assert_closed_for(
         FakeLore::clean(),
@@ -368,11 +427,7 @@ fn closes_for_status_and_history_graph_failures() {
     assert_closed_for(
         FakeLore::clean(),
         |fake| {
-            fake.status = Ok(StatusSnapshot {
-                staged_revisions: vec![],
-                staged_paths: vec![],
-                worktree_clean: true,
-            })
+            fake.status.as_mut().unwrap().staged_revisions.clear();
         },
         "exact_subject_failed",
     );
@@ -384,22 +439,18 @@ fn closes_for_status_and_history_graph_failures() {
     assert_closed_for(
         FakeLore::clean(),
         |fake| {
-            fake.status = Ok(StatusSnapshot {
-                staged_revisions: vec!["candidate".into(), "extra".into()],
-                staged_paths: vec![],
-                worktree_clean: true,
-            })
+            fake.status
+                .as_mut()
+                .unwrap()
+                .staged_revisions
+                .push("extra".into());
         },
         "exact_subject_failed",
     );
     assert_closed_for(
         FakeLore::clean(),
         |fake| {
-            fake.status = Ok(StatusSnapshot {
-                staged_revisions: vec!["other".into()],
-                staged_paths: vec![],
-                worktree_clean: true,
-            })
+            fake.status.as_mut().unwrap().staged_revisions = vec!["other".into()];
         },
         "exact_subject_failed",
     );
@@ -416,10 +467,10 @@ fn closes_for_status_and_history_graph_failures() {
         |fake| {
             fake.infos.insert(
                 "base".into(),
-                Ok(RevisionInfo {
+                Ok(RevisionInfoResponse::exact(RevisionInfo {
                     revision: "fallback".into(),
                     parents: vec![],
-                }),
+                })),
             );
         },
         "history_incomplete",
@@ -429,10 +480,10 @@ fn closes_for_status_and_history_graph_failures() {
         |fake| {
             fake.infos.insert(
                 "candidate".into(),
-                Ok(RevisionInfo {
+                Ok(RevisionInfoResponse::exact(RevisionInfo {
                     revision: "wrong".into(),
                     parents: vec!["base".into()],
-                }),
+                })),
             );
         },
         "history_incomplete",
@@ -442,10 +493,10 @@ fn closes_for_status_and_history_graph_failures() {
         |fake| {
             fake.infos.insert(
                 "candidate".into(),
-                Ok(RevisionInfo {
+                Ok(RevisionInfoResponse::exact(RevisionInfo {
                     revision: "candidate".into(),
                     parents: vec!["candidate".into()],
-                }),
+                })),
             );
         },
         "history_incomplete",
@@ -455,10 +506,10 @@ fn closes_for_status_and_history_graph_failures() {
         |fake| {
             fake.infos.insert(
                 "candidate".into(),
-                Ok(RevisionInfo {
+                Ok(RevisionInfoResponse::exact(RevisionInfo {
                     revision: "candidate".into(),
                     parents: vec![],
-                }),
+                })),
             );
         },
         "history_incomplete",
@@ -468,10 +519,10 @@ fn closes_for_status_and_history_graph_failures() {
         |fake| {
             fake.infos.insert(
                 "candidate".into(),
-                Ok(RevisionInfo {
+                Ok(RevisionInfoResponse::exact(RevisionInfo {
                     revision: "candidate".into(),
                     parents: vec!["unreadable-parent".into()],
-                }),
+                })),
             );
         },
         "history_incomplete",
@@ -489,6 +540,76 @@ fn closes_for_status_and_history_graph_failures() {
     assert_closed_for(
         FakeLore::clean(),
         |fake| fake.history = Ok(vec!["candidate".into(), "candidate".into()]),
+        "history_incomplete",
+    );
+}
+
+#[test]
+fn closes_when_status_cannot_prove_a_full_scan_or_stable_exact_subject() {
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| fake.status.as_mut().unwrap().scan_performed = false,
+        "worktree_unverified",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| fake.status.as_mut().unwrap().scanned_staged_revisions = vec!["other".into()],
+        "exact_subject_failed",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| fake.status.as_mut().unwrap().post_scan_staged_revisions = vec!["other".into()],
+        "exact_subject_failed",
+    );
+}
+
+#[test]
+fn raw_revision_info_boundary_rejects_zero_duplicate_and_over_counted_responses() {
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.infos.insert(
+                "candidate".into(),
+                Ok(RevisionInfoResponse { revisions: vec![] }),
+            );
+        },
+        "history_incomplete",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            let info = RevisionInfo {
+                revision: "candidate".into(),
+                parents: vec!["base".into()],
+            };
+            fake.infos.insert(
+                "candidate".into(),
+                Ok(RevisionInfoResponse {
+                    revisions: vec![info.clone(), info],
+                }),
+            );
+        },
+        "history_incomplete",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.infos.insert(
+                "candidate".into(),
+                Ok(RevisionInfoResponse {
+                    revisions: vec![
+                        RevisionInfo {
+                            revision: "candidate".into(),
+                            parents: vec!["base".into()],
+                        },
+                        RevisionInfo {
+                            revision: "unexpected".into(),
+                            parents: vec![],
+                        },
+                    ],
+                }),
+            );
+        },
         "history_incomplete",
     );
 }
@@ -597,6 +718,79 @@ fn closes_for_metadata_supersession_and_dco_dependency_failures() {
         },
         "supersession_invalid",
     );
+}
+
+#[test]
+fn scans_supersession_metadata_on_the_verified_base_revision() {
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.metadata.insert(
+                "base".into(),
+                Ok(vec![MetadataEntry::new(
+                    "studiobrain.governance.v1.superseded.hash-1:context-1",
+                    r#"{"version":"v1","identity":"hash-1:context-1"}"#,
+                )]),
+            );
+        },
+        "not_superseded_failed",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.metadata.insert(
+                "base".into(),
+                Ok(vec![MetadataEntry::new(
+                    "studiobrain.governance.v1.superseded.hash-1:context-1",
+                    r#"{"version":"v2","identity":"hash-1:context-1"}"#,
+                )]),
+            );
+        },
+        "supersession_invalid",
+    );
+}
+
+#[test]
+fn dco_requires_exactly_one_signoff_in_the_terminal_trailer_block() {
+    let mut valid = FakeLore::clean();
+    valid.metadata.insert(
+        "candidate".into(),
+        Ok(vec![
+            MetadataEntry::new(
+                "message",
+                "change\n\nSigned-off-by: Alice <alice@example.test>\nReviewed-by: Bob <bob@example.test>",
+            ),
+            MetadataEntry::new("created-by", "alice"),
+        ]),
+    );
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(evaluate(&valid, &request()));
+    assert!(
+        result.open,
+        "other well-formed terminal trailers: {result:?}"
+    );
+
+    for message in [
+        "Signed-off-by: Alice <alice@example.test>\n\nchange",
+        "change\n\nSigned-off-by: Alice <alice@example.test>\ntrailing prose",
+        "change\nSigned-off-by: Alice <alice@example.test>\n\nReviewed-by: Bob <bob@example.test>",
+        "change\n\nSigned-off-by: Alice <alice@example.test>\nSigned-off-by: Alice <alice@example.test>",
+    ] {
+        assert_closed_for(
+            FakeLore::clean(),
+            |fake| {
+                fake.metadata.insert(
+                    "candidate".into(),
+                    Ok(vec![
+                        MetadataEntry::new("message", message),
+                        MetadataEntry::new("created-by", "alice"),
+                    ]),
+                );
+            },
+            "dco_invalid",
+        );
+    }
 }
 
 #[test]

--- a/crates/lore-vm/tests/governance_option_a.rs
+++ b/crates/lore-vm/tests/governance_option_a.rs
@@ -1,14 +1,68 @@
 //! Behavioral contract and fail-closed evaluator matrix for SBAI-5934 Option A.
 
 use lore_vm::ops::governance::contract::{
-    AdapterError, AffectedPath, ArtifactMarkSupersededRequest, DcoValidateRequest,
-    EvidencePreserveRequest, FileIdentity, GovernanceCriterion, LockQuery, LockStatus,
-    LockStatusResponse, MetadataEntry, ResolvedAuthor, RevisionInfo, RevisionInfoResponse,
-    StatusSnapshot, SubmissionGateCheckRequest, EVIDENCE_POINTER_KEY,
+    AdapterError, AffectedPath, ArtifactMarkSupersededRequest, AuthorResolutionObservation,
+    CanonicalDcoMetadataObservationV1, CanonicalDcoObservationV1, CanonicalEvidenceSnapshotV1,
+    CanonicalFileIdentityV1, CanonicalRevisionInfoV1, CanonicalRevisionRefV1,
+    CanonicalStatusObservationV1, CanonicalSupersessionMetadataQueryObservationV1, CriterionResult,
+    DcoMetadataObservation, DcoValidateRequest, EvidenceCloseStateV1, EvidencePointerDeltaV1,
+    EvidencePointerV1, EvidencePreserveDispositionV1, EvidencePreserveOutcomeV1,
+    EvidencePreserveRequest, EvidencePreserveStopCodeV1, EvidencePublicationStateV1,
+    EvidenceRejectionCodeV1, FileIdentity, GovernanceCriterion, GovernancePathAction,
+    GovernanceRemediation, GovernanceRemediationCode, GovernanceRole, HistoryOverflowScope,
+    ImmutableGetItem, ImmutablePutItem, LockQuery, LockStatus, LockStatusResponse, MetadataEntry,
+    MetadataKind, MutationObservation, ReadObservation, ResolvedAuthor, RevisionDiffObservation,
+    RevisionInfo, RevisionInfoResponse, StagedPathObservation, StatusSnapshot,
+    SubmissionGateCheckRequest, WorktreeFileObservation, EVIDENCE_POINTER_KEY,
     MAX_GOVERNANCE_HISTORY_REVISIONS, SUPERSESSION_MARKER_PREFIX,
 };
+use lore_vm::ops::governance::dco_validate::dco_validate_with_adapter;
+#[cfg(feature = "integration-tests")]
+use lore_vm::ops::governance::evaluator::ProductionLoreAdapter;
 use lore_vm::ops::governance::evaluator::{evaluate, GovernanceAdapter};
-use std::collections::BTreeMap;
+use lore_vm::ops::governance::evidence_preserve::evidence_preserve_with_adapters;
+#[cfg(feature = "integration-tests")]
+use lore_vm::ops::governance::evidence_preserve::ProductionGovernanceIo;
+use lore_vm::ops::governance::submission_gate_check::submission_gate_check_with_adapters;
+use lore_vm::ops::governance::GovernanceIo;
+use lore_vm::{dispatch, is_mutating_op, supported_ops, LoreApi};
+#[cfg(feature = "integration-tests")]
+use lore_vm::{global::LoreGlobal, ops};
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Mutex};
+
+fn raw_modified(path: &str) -> RevisionDiffObservation {
+    RevisionDiffObservation {
+        path: path.into(),
+        action: GovernancePathAction::Modify,
+        old_is_file: true,
+        new_is_file: true,
+        old_address: format!("{}-{}", "4".repeat(64), "2".repeat(32)),
+        new_address: format!("{}-{}", "4".repeat(64), "2".repeat(32)),
+    }
+}
+
+fn raw_deleted(path: &str) -> RevisionDiffObservation {
+    RevisionDiffObservation {
+        path: path.into(),
+        action: GovernancePathAction::Delete,
+        old_is_file: true,
+        new_is_file: false,
+        old_address: format!("{}-{}", "4".repeat(64), "2".repeat(32)),
+        new_address: format!("{}-{}", "0".repeat(64), "0".repeat(32)),
+    }
+}
+
+fn raw_added(path: &str) -> RevisionDiffObservation {
+    RevisionDiffObservation {
+        path: path.into(),
+        action: GovernancePathAction::Add,
+        old_is_file: false,
+        new_is_file: true,
+        old_address: format!("{}-{}", "0".repeat(64), "0".repeat(32)),
+        new_address: format!("{}-{}", "4".repeat(64), "2".repeat(32)),
+    }
+}
 
 #[derive(Clone)]
 struct FakeLore {
@@ -18,12 +72,13 @@ struct FakeLore {
     history: Result<Vec<String>, AdapterError>,
     dumps: BTreeMap<String, Result<Vec<String>, AdapterError>>,
     file_info: BTreeMap<String, Result<Vec<FileIdentity>, AdapterError>>,
-    diff: Result<Vec<AffectedPath>, AdapterError>,
+    diff: Result<Vec<RevisionDiffObservation>, AdapterError>,
     authors: Result<Vec<ResolvedAuthor>, AdapterError>,
     lock_queries: BTreeMap<String, Result<LockQuery, AdapterError>>,
     lock_status: Result<LockStatusResponse, AdapterError>,
     history_limits: std::sync::Arc<std::sync::Mutex<Vec<usize>>>,
     info_queries: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    lock_branches: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
 }
 
 impl FakeLore {
@@ -60,7 +115,7 @@ impl FakeLore {
 
         let mut dumps = BTreeMap::new();
         dumps.insert("candidate".into(), Ok(vec!["asset.txt".into()]));
-        dumps.insert("base".into(), Ok(vec![]));
+        dumps.insert("base".into(), Ok(vec!["asset.txt".into()]));
 
         let mut file_info = BTreeMap::new();
         file_info.insert(
@@ -68,21 +123,53 @@ impl FakeLore {
             Ok(vec![FileIdentity::new(
                 "asset.txt",
                 "candidate",
-                "hash-1",
-                "context-1",
+                "4444444444444444444444444444444444444444444444444444444444444444",
+                "22222222222222222222222222222222",
             )]),
         );
-        file_info.insert("base".into(), Ok(vec![]));
+        file_info.insert(
+            "base".into(),
+            Ok(vec![FileIdentity::new(
+                "asset.txt",
+                "base",
+                "4444444444444444444444444444444444444444444444444444444444444444",
+                "22222222222222222222222222222222",
+            )]),
+        );
 
         let mut lock_queries = BTreeMap::new();
         lock_queries.insert("asset.txt".into(), Ok(LockQuery::unlocked("asset.txt")));
 
         Self {
             status: Ok(StatusSnapshot {
+                branch: "branch".into(),
                 staged_revisions: vec!["candidate".into()],
                 scanned_staged_revisions: vec!["candidate".into()],
                 post_scan_staged_revisions: vec!["candidate".into()],
                 staged_paths: vec!["asset.txt".into()],
+                staged_changes: vec![StagedPathObservation {
+                    path: "asset.txt".into(),
+                    from_path: None,
+                    action: GovernancePathAction::Modify,
+                    dirty: true,
+                    conflict: false,
+                }],
+                worktree_files: vec![WorktreeFileObservation {
+                    path: "asset.txt".into(),
+                    revision: "candidate".into(),
+                    revision_hash:
+                        "4444444444444444444444444444444444444444444444444444444444444444".into(),
+                    revision_context: "22222222222222222222222222222222".into(),
+                    revision_size: 5,
+                    local_hash: "1111111111111111111111111111111111111111111111111111111111111111"
+                        .into(),
+                    local_size: 5,
+                    filtered_revision_size: 5,
+                    flag_modified: true,
+                    flag_deleted: false,
+                    flag_added: false,
+                    flag_conflict: false,
+                }],
                 worktree_clean: true,
                 scan_performed: true,
             }),
@@ -91,13 +178,43 @@ impl FakeLore {
             history: Ok(vec!["candidate".into()]),
             dumps,
             file_info,
-            diff: Ok(vec![AffectedPath::modified("asset.txt")]),
+            diff: Ok(vec![raw_modified("asset.txt")]),
             authors: Ok(vec![ResolvedAuthor::new("alice", "Alice")]),
             lock_queries,
             lock_status: Ok(LockStatusResponse::unlocked()),
             history_limits: Default::default(),
             info_queries: Default::default(),
+            lock_branches: Default::default(),
         }
+    }
+
+    fn clean_rename() -> Self {
+        let mut fake = Self::clean();
+        fake.dumps
+            .insert("candidate".into(), Ok(vec!["renamed.txt".into()]));
+        fake.file_info.insert(
+            "candidate".into(),
+            Ok(vec![FileIdentity::new(
+                "renamed.txt",
+                "candidate",
+                "4444444444444444444444444444444444444444444444444444444444444444",
+                "22222222222222222222222222222222",
+            )]),
+        );
+        let status = fake.status.as_mut().unwrap();
+        status.staged_paths = vec!["asset.txt".into(), "renamed.txt".into()];
+        status.staged_changes = vec![StagedPathObservation {
+            path: "renamed.txt".into(),
+            from_path: Some("asset.txt".into()),
+            action: GovernancePathAction::Move,
+            dirty: true,
+            conflict: false,
+        }];
+        status.worktree_files[0].path = "renamed.txt".into();
+        fake.lock_queries
+            .insert("renamed.txt".into(), Ok(LockQuery::unlocked("renamed.txt")));
+        fake.diff = Ok(vec![raw_deleted("asset.txt"), raw_added("renamed.txt")]);
+        fake
     }
 
     fn error(name: &str) -> AdapterError {
@@ -236,7 +353,7 @@ impl GovernanceAdapter for FakeLore {
         &self,
         _base: &str,
         _candidate: &str,
-    ) -> Result<Vec<AffectedPath>, AdapterError> {
+    ) -> Result<Vec<RevisionDiffObservation>, AdapterError> {
         self.diff.clone()
     }
 
@@ -247,7 +364,14 @@ impl GovernanceAdapter for FakeLore {
         self.authors.clone()
     }
 
-    async fn lock_file_query(&self, path: &str) -> Result<LockQuery, AdapterError> {
+    async fn lock_file_query(&self, branch: &str, path: &str) -> Result<LockQuery, AdapterError> {
+        self.lock_branches
+            .lock()
+            .unwrap()
+            .push(format!("query:{branch}"));
+        if branch != "branch" {
+            return Err(Self::error("wrong lock query branch"));
+        }
         self.lock_queries
             .get(path)
             .cloned()
@@ -256,8 +380,16 @@ impl GovernanceAdapter for FakeLore {
 
     async fn lock_file_status(
         &self,
+        branch: &str,
         _paths: &[String],
     ) -> Result<LockStatusResponse, AdapterError> {
+        self.lock_branches
+            .lock()
+            .unwrap()
+            .push(format!("status:{branch}"));
+        if branch != "branch" {
+            return Err(Self::error("wrong lock status branch"));
+        }
         self.lock_status.clone()
     }
 }
@@ -293,6 +425,92 @@ fn clean_exact_subject_is_open_and_uses_1001_overflow_sentinel() {
     assert_eq!(result.pending_revisions, vec!["candidate"]);
     assert_eq!(result.affected_paths, vec!["asset.txt"]);
     assert_eq!(*fake.history_limits.lock().unwrap(), vec![1001]);
+    assert_eq!(
+        *fake.lock_branches.lock().unwrap(),
+        vec!["query:branch", "status:branch"]
+    );
+}
+
+#[test]
+fn evaluator_exposes_complete_sorted_raw_observations_without_replacing_them_with_a_verdict() {
+    let fake = FakeLore::clean();
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(evaluate(&fake, &request()));
+    let observed = result.observations;
+
+    assert_eq!(observed.expected_staged_revision, "candidate");
+    assert_eq!(observed.target_base_revision, "base");
+    assert_eq!(observed.status.unwrap().staged_paths, vec!["asset.txt"]);
+    assert_eq!(
+        observed.base_revision_info,
+        Some(RevisionInfo {
+            revision: "base".into(),
+            parents: vec![],
+        })
+    );
+    assert_eq!(
+        observed.revision_graph,
+        vec![RevisionInfo {
+            revision: "candidate".into(),
+            parents: vec!["base".into()],
+        }]
+    );
+    assert_eq!(observed.first_parent_history, vec!["candidate"]);
+    assert_eq!(observed.base_files.len(), 1);
+    assert_eq!(
+        observed.base_files[0].canonical_id(),
+        "4444444444444444444444444444444444444444444444444444444444444444:22222222222222222222222222222222"
+    );
+    assert_eq!(observed.candidate_files.len(), 1);
+    assert_eq!(
+        observed.candidate_files[0].canonical_id(),
+        "4444444444444444444444444444444444444444444444444444444444444444:22222222222222222222222222222222"
+    );
+    assert_eq!(
+        observed.current_files[0].canonical_id(),
+        "1111111111111111111111111111111111111111111111111111111111111111:22222222222222222222222222222222"
+    );
+    assert_eq!(
+        observed.revision_diff,
+        vec![AffectedPath::modified("asset.txt")]
+    );
+    assert_eq!(observed.affected_paths, vec!["asset.txt"]);
+    assert!(observed.supersession_markers.is_empty());
+    assert_eq!(
+        observed.dco_metadata,
+        vec![DcoMetadataObservation {
+            revision: "candidate".into(),
+            messages: vec!["change\n\nSigned-off-by: Alice <alice@example.test>".into()],
+            created_by: vec!["alice".into()],
+            committed_by: vec![],
+        }]
+    );
+    assert_eq!(
+        observed.author_resolution,
+        Some(AuthorResolutionObservation {
+            requested: vec!["alice".into()],
+            replies: vec![ResolvedAuthor::new("alice", "Alice")],
+        })
+    );
+    assert_eq!(observed.dco.len(), 1);
+    assert_eq!(observed.dco[0].revision, "candidate");
+    assert_eq!(
+        observed.dco[0].trailer,
+        "Signed-off-by: Alice <alice@example.test>"
+    );
+    assert_eq!(observed.dco[0].signer_name, "Alice");
+    assert_eq!(observed.dco[0].signer_email, "alice@example.test");
+    assert_eq!(
+        observed.dco[0].resolved_authors,
+        vec![ResolvedAuthor::new("alice", "Alice")]
+    );
+    assert_eq!(
+        observed.lock_queries,
+        vec![LockQuery::unlocked("asset.txt")]
+    );
+    assert_eq!(observed.lock_status, Some(LockStatusResponse::unlocked()));
+    assert!(observed.dependency_observations.is_empty());
 }
 
 #[test]
@@ -344,6 +562,2225 @@ fn strict_v1_requests_reject_every_legacy_control_and_pin_ratified_namespaces() 
         assert!(serde_json::from_str::<EvidencePreserveRequest>(&value).is_err());
         assert!(serde_json::from_str::<SubmissionGateCheckRequest>(&value).is_err());
     }
+
+    for value in [
+        serde_json::json!({
+            "expected_staged_revision": "",
+            "target_base_revision": "base"
+        }),
+        serde_json::json!({
+            "expected_staged_revision": "candidate",
+            "target_base_revision": ""
+        }),
+        serde_json::json!({
+            "expected_staged_revision": "",
+            "target_base_revision": ""
+        }),
+    ] {
+        assert!(
+            serde_json::from_value::<EvidencePreserveRequest>(value).is_err(),
+            "serde must reject an empty evidence subject before attempt creation"
+        );
+    }
+
+    for request in [
+        EvidencePreserveRequest {
+            expected_staged_revision: String::new(),
+            target_base_revision: "base".into(),
+        },
+        EvidencePreserveRequest {
+            expected_staged_revision: "candidate".into(),
+            target_base_revision: String::new(),
+        },
+    ] {
+        assert!(
+            request.validate().is_err(),
+            "direct construction must share the strict serde validator"
+        );
+    }
+}
+
+#[test]
+fn remediation_schema_is_a_strict_fixed_enum_and_nonoverflow_failures_have_none() {
+    let remediation = GovernanceRemediation {
+        code: GovernanceRemediationCode::MigrateSupersessionIndex,
+        ticket: Some("SBAI-6010".into()),
+    };
+    assert_eq!(
+        serde_json::to_value(&remediation).unwrap(),
+        serde_json::json!({
+            "code": "migrate_supersession_index",
+            "ticket": "SBAI-6010"
+        })
+    );
+    assert!(
+        serde_json::from_value::<GovernanceRemediation>(serde_json::json!({
+            "code": "raise_history_limit",
+            "ticket": null
+        }))
+        .is_err()
+    );
+    assert!(
+        serde_json::from_value::<GovernanceRemediation>(serde_json::json!({
+            "code": "migrate_supersession_index",
+            "ticket": "SBAI-6010",
+            "automatic": true
+        }))
+        .is_err()
+    );
+    assert!(
+        serde_json::from_value::<CriterionResult>(serde_json::json!({
+            "criterion": "history_complete",
+            "passed": false,
+            "failure_code": "history_depth_exceeded",
+            "remediation": {
+                "code": "split_submission_or_advance_target_base",
+                "ticket": null,
+                "unknown": true
+            }
+        }))
+        .is_err()
+    );
+
+    let mut dependency = FakeLore::clean();
+    dependency.status = Err(FakeLore::error("status"));
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(evaluate(&dependency, &request()));
+    assert_eq!(result.failure_codes, ["status_unavailable"]);
+    assert!(result.remediation.is_none());
+}
+
+#[test]
+fn deferred_supersession_contract_requires_a_target_path_selector() {
+    let missing_selector = serde_json::json!({
+        "expected_staged_revision": "candidate",
+        "target_base_revision": "base"
+    });
+    assert!(
+        serde_json::from_value::<ArtifactMarkSupersededRequest>(missing_selector).is_err(),
+        "the deferred v2 writer contract must never select an arbitrary tree identity"
+    );
+
+    let request: ArtifactMarkSupersededRequest = serde_json::from_value(serde_json::json!({
+        "expected_staged_revision": "candidate",
+        "target_base_revision": "base",
+        "target_path": "asset.txt"
+    }))
+    .expect("the strict future contract accepts one mandatory path selector");
+    assert_eq!(request.target_path, "asset.txt");
+}
+
+#[test]
+fn canonical_evidence_and_pointer_delta_are_strict_typed_boundaries() {
+    assert_ne!(
+        MetadataEntry::new("typed", "1"),
+        MetadataEntry::with_kind("typed", MetadataKind::Numeric, "1"),
+        "metadata kind is part of exact sole-delta equivalence"
+    );
+
+    let snapshot = CanonicalEvidenceSnapshotV1 {
+        version: "v1".into(),
+        target_base_revision: "base".into(),
+        status: CanonicalStatusObservationV1 {
+            branch: "branch".into(),
+            staged_revisions: vec![CanonicalRevisionRefV1::StagedSubject],
+            scanned_staged_revisions: vec![CanonicalRevisionRefV1::StagedSubject],
+            post_scan_staged_revisions: vec![CanonicalRevisionRefV1::StagedSubject],
+            staged_paths: vec!["asset.txt".into()],
+            staged_changes: vec![StagedPathObservation {
+                path: "asset.txt".into(),
+                from_path: None,
+                action: GovernancePathAction::Modify,
+                dirty: true,
+                conflict: false,
+            }],
+            worktree_files: vec![
+                lore_vm::ops::governance::contract::CanonicalWorktreeFileObservationV1 {
+                    path: "asset.txt".into(),
+                    revision: CanonicalRevisionRefV1::StagedSubject,
+                    revision_hash:
+                        "4444444444444444444444444444444444444444444444444444444444444444".into(),
+                    revision_context: "22222222222222222222222222222222".into(),
+                    revision_size: 5,
+                    local_hash: "1111111111111111111111111111111111111111111111111111111111111111"
+                        .into(),
+                    local_size: 5,
+                    filtered_revision_size: 5,
+                    flag_modified: true,
+                    flag_deleted: false,
+                    flag_added: false,
+                    flag_conflict: false,
+                },
+            ],
+            worktree_clean: true,
+            scan_performed: true,
+        },
+        base_revision_info: CanonicalRevisionInfoV1 {
+            revision: CanonicalRevisionRefV1::Exact("base".into()),
+            parents: vec![],
+        },
+        supersession_ancestry: vec![
+            CanonicalRevisionInfoV1 {
+                revision: CanonicalRevisionRefV1::Exact("base".into()),
+                parents: vec![],
+            },
+            CanonicalRevisionInfoV1 {
+                revision: CanonicalRevisionRefV1::StagedSubject,
+                parents: vec![CanonicalRevisionRefV1::Exact("base".into())],
+            },
+        ],
+        supersession_ancestry_observed: true,
+        revision_graph: vec![CanonicalRevisionInfoV1 {
+            revision: CanonicalRevisionRefV1::StagedSubject,
+            parents: vec![CanonicalRevisionRefV1::Exact("base".into())],
+        }],
+        first_parent_history: vec![CanonicalRevisionRefV1::StagedSubject],
+        base_files: vec![CanonicalFileIdentityV1 {
+            path: "asset.txt".into(),
+            revision: CanonicalRevisionRefV1::Exact("base".into()),
+            hash: "4444444444444444444444444444444444444444444444444444444444444444".into(),
+            context: "22222222222222222222222222222222".into(),
+        }],
+        base_tree_observed: true,
+        candidate_files: vec![CanonicalFileIdentityV1 {
+            path: "asset.txt".into(),
+            revision: CanonicalRevisionRefV1::StagedSubject,
+            hash: "4444444444444444444444444444444444444444444444444444444444444444".into(),
+            context: "22222222222222222222222222222222".into(),
+        }],
+        candidate_tree_observed: true,
+        current_files: vec![CanonicalFileIdentityV1 {
+            path: "asset.txt".into(),
+            revision: CanonicalRevisionRefV1::StagedSubject,
+            hash: "1111111111111111111111111111111111111111111111111111111111111111".into(),
+            context: "22222222222222222222222222222222".into(),
+        }],
+        upstream_revision_diff: vec![raw_modified("asset.txt")],
+        revision_diff: vec![AffectedPath::modified("asset.txt")],
+        revision_diff_observed: true,
+        affected_paths: vec!["asset.txt".into()],
+        supersession_markers: vec![],
+        supersession_metadata_queries: vec![
+            CanonicalSupersessionMetadataQueryObservationV1 {
+                revision: CanonicalRevisionRefV1::Exact("base".into()),
+                metadata: vec![],
+            },
+            CanonicalSupersessionMetadataQueryObservationV1 {
+                revision: CanonicalRevisionRefV1::StagedSubject,
+                metadata: vec![],
+            },
+        ],
+        supersession_metadata_observed: true,
+        dco_metadata: vec![CanonicalDcoMetadataObservationV1 {
+            revision: CanonicalRevisionRefV1::StagedSubject,
+            messages: vec!["change\n\nSigned-off-by: Alice <alice@example.test>".into()],
+            created_by: vec!["alice".into()],
+            committed_by: vec![],
+        }],
+        author_resolution: AuthorResolutionObservation {
+            requested: vec!["alice".into()],
+            replies: vec![ResolvedAuthor::new("alice", "Alice")],
+        },
+        dco: vec![CanonicalDcoObservationV1 {
+            revision: CanonicalRevisionRefV1::StagedSubject,
+            message: "change\n\nSigned-off-by: Alice <alice@example.test>".into(),
+            trailer: "Signed-off-by: Alice <alice@example.test>".into(),
+            signer_name: "Alice".into(),
+            signer_email: "alice@example.test".into(),
+            created_by: "alice".into(),
+            committed_by: None,
+            resolved_authors: vec![ResolvedAuthor::new("alice", "Alice")],
+        }],
+        lock_queries: vec![LockQuery::unlocked("asset.txt")],
+        lock_status: LockStatusResponse::unlocked(),
+        dependency_observations: vec![],
+    };
+    let bytes = serde_json::to_vec(&snapshot).expect("canonical snapshot serializes");
+    assert_eq!(
+        serde_json::from_slice::<CanonicalEvidenceSnapshotV1>(&bytes).unwrap(),
+        snapshot
+    );
+
+    let mut with_unknown = serde_json::to_value(&snapshot).unwrap();
+    with_unknown["gate_open"] = serde_json::json!(true);
+    assert!(serde_json::from_value::<CanonicalEvidenceSnapshotV1>(with_unknown).is_err());
+
+    for path in ["/status/staged_revisions/0", "/revision_graph/0/parents/0"] {
+        let mut nested_unknown = serde_json::to_value(&snapshot).unwrap();
+        nested_unknown
+            .pointer_mut(path)
+            .expect("canonical revision reference exists")["unknown"] = serde_json::json!(true);
+        assert!(
+            serde_json::from_value::<CanonicalEvidenceSnapshotV1>(nested_unknown).is_err(),
+            "nested canonical revision reference accepted an unknown field at {path}"
+        );
+    }
+
+    let delta = EvidencePointerDeltaV1 {
+        version: "v1".into(),
+        key: EVIDENCE_POINTER_KEY.into(),
+        source_staged_revision: "candidate".into(),
+        result_staged_revision: "candidate-with-pointer".into(),
+        pointer: EvidencePointerV1 {
+            version: "v1".into(),
+            address: format!("{}-{}", "a".repeat(64), "0".repeat(32)),
+        },
+    };
+    let mut encoded = serde_json::to_value(&delta).unwrap();
+    encoded["passed"] = serde_json::json!(true);
+    assert!(serde_json::from_value::<EvidencePointerDeltaV1>(encoded).is_err());
+}
+
+#[test]
+fn evidence_outcomes_are_strict_checked_residual_state_not_actor_verdicts() {
+    let address = format!("{}-{}", "a".repeat(64), "0".repeat(32));
+    let pointer = serde_json::json!({
+        "version": "v1",
+        "address": address,
+    });
+    let verified = serde_json::json!({
+        "version": "v1",
+        "outcome": "verified",
+        "attempt_id": "1".repeat(64),
+        "source_staged_revision": "candidate",
+        "target_base_revision": "base",
+        "snapshot_sha256": "2".repeat(64),
+        "observed_candidate_addresses": [address],
+        "result_staged_revision": "candidate-with-pointer",
+        "evidence_address": address,
+        "pointer": pointer,
+        "last_confirmed_publication": {
+            "state": "postattach_equivalent",
+            "evidence_address": address,
+            "pointer": pointer,
+            "result_staged_revision": "candidate-with-pointer"
+        },
+        "close": { "state": "closed" }
+    });
+    let parsed: EvidencePreserveOutcomeV1 =
+        serde_json::from_value(verified.clone()).expect("the full closed chain is verified");
+    assert_eq!(serde_json::to_value(parsed).unwrap(), verified);
+    for forbidden in ["gate_open", "passed", "valid", "verdict"] {
+        assert!(
+            !verified.to_string().contains(forbidden),
+            "actor residual outcomes must not contain authority field {forbidden}"
+        );
+    }
+
+    let mut not_closed = verified.clone();
+    not_closed["close"] = serde_json::json!({
+        "state": "close_not_dispatched",
+        "code": "fixture"
+    });
+    assert!(serde_json::from_value::<EvidencePreserveOutcomeV1>(not_closed).is_err());
+
+    let mut skipped_stage = verified.clone();
+    skipped_stage["last_confirmed_publication"]["state"] =
+        serde_json::json!("pointer_delta_observed");
+    assert!(serde_json::from_value::<EvidencePreserveOutcomeV1>(skipped_stage).is_err());
+
+    let mut mismatched_address = verified.clone();
+    mismatched_address["last_confirmed_publication"]["evidence_address"] =
+        serde_json::json!(format!("{}-{}", "b".repeat(64), "0".repeat(32)));
+    assert!(serde_json::from_value::<EvidencePreserveOutcomeV1>(mismatched_address).is_err());
+
+    let mut unknown = verified.clone();
+    unknown["authoritative"] = serde_json::json!(false);
+    assert!(serde_json::from_value::<EvidencePreserveOutcomeV1>(unknown).is_err());
+
+    let impossible_incomplete = serde_json::json!({
+        "version": "v1",
+        "outcome": "verification_incomplete",
+        "attempt_id": "1".repeat(64),
+        "source_staged_revision": "candidate",
+        "target_base_revision": "base",
+        "snapshot_sha256": null,
+        "observed_candidate_addresses": [],
+        "stopped_at": { "stage": "initial_evaluation", "code": "fixture" },
+        "last_confirmed_publication": {
+            "state": "blob_published",
+            "evidence_address": address
+        },
+        "close": { "state": "not_opened" }
+    });
+    assert!(serde_json::from_value::<EvidencePreserveOutcomeV1>(impossible_incomplete).is_err());
+}
+
+#[tokio::test]
+async fn ruled_governance_dispatch_surface_routes_three_ops_and_defers_writer() {
+    let expected = [
+        "governance.dco_validate",
+        "governance.evidence_preserve",
+        "governance.submission_gate_check",
+    ];
+    for op in expected {
+        assert!(supported_ops().contains(&op), "missing canonical op {op}");
+        let api = LoreApi::new(std::path::PathBuf::from("/nonexistent-governance-dispatch"));
+        let error = dispatch(&api, op, serde_json::Value::Null)
+            .await
+            .expect_err("null args must fail before touching Lore");
+        assert!(
+            !error.to_string().contains("unknown op"),
+            "{op} is listed but not canonically routed: {error}"
+        );
+    }
+
+    assert!(!supported_ops().contains(&"governance.artifact_mark_superseded"));
+    let api = LoreApi::new(std::path::PathBuf::from("."));
+    let error = dispatch(
+        &api,
+        "governance.artifact_mark_superseded",
+        serde_json::json!({
+            "expected_staged_revision": "candidate",
+            "target_base_revision": "base",
+            "target_path": "asset.txt"
+        }),
+    )
+    .await
+    .expect_err("the authoritative writer is deferred to v2");
+    assert!(error.to_string().contains("unknown op"));
+
+    assert!(!is_mutating_op("governance.dco_validate"));
+    assert!(is_mutating_op("governance.evidence_preserve"));
+    assert!(!is_mutating_op("governance.submission_gate_check"));
+    assert!(!is_mutating_op("governance.artifact_mark_superseded"));
+}
+
+#[derive(Clone)]
+struct SharedFakeLore(Arc<Mutex<FakeLore>>);
+
+impl SharedFakeLore {
+    fn clean() -> Self {
+        Self(Arc::new(Mutex::new(FakeLore::clean())))
+    }
+
+    fn snapshot(&self) -> FakeLore {
+        self.0.lock().unwrap().clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl GovernanceAdapter for SharedFakeLore {
+    async fn status(&self) -> Result<StatusSnapshot, AdapterError> {
+        GovernanceAdapter::status(&self.snapshot()).await
+    }
+
+    async fn revision_info(&self, revision: &str) -> Result<RevisionInfoResponse, AdapterError> {
+        GovernanceAdapter::revision_info(&self.snapshot(), revision).await
+    }
+
+    async fn revision_metadata(&self, revision: &str) -> Result<Vec<MetadataEntry>, AdapterError> {
+        GovernanceAdapter::revision_metadata(&self.snapshot(), revision).await
+    }
+
+    async fn first_parent_history(
+        &self,
+        candidate: &str,
+        target_base: &str,
+        max_revisions: usize,
+    ) -> Result<Vec<String>, AdapterError> {
+        GovernanceAdapter::first_parent_history(
+            &self.snapshot(),
+            candidate,
+            target_base,
+            max_revisions,
+        )
+        .await
+    }
+
+    async fn repository_dump(&self, revision: &str) -> Result<Vec<String>, AdapterError> {
+        GovernanceAdapter::repository_dump(&self.snapshot(), revision).await
+    }
+
+    async fn file_info(
+        &self,
+        revision: &str,
+        paths: &[String],
+    ) -> Result<Vec<FileIdentity>, AdapterError> {
+        GovernanceAdapter::file_info(&self.snapshot(), revision, paths).await
+    }
+
+    async fn revision_diff(
+        &self,
+        base: &str,
+        candidate: &str,
+    ) -> Result<Vec<RevisionDiffObservation>, AdapterError> {
+        GovernanceAdapter::revision_diff(&self.snapshot(), base, candidate).await
+    }
+
+    async fn resolve_authors(
+        &self,
+        identities: &[String],
+    ) -> Result<Vec<ResolvedAuthor>, AdapterError> {
+        GovernanceAdapter::resolve_authors(&self.snapshot(), identities).await
+    }
+
+    async fn lock_file_query(&self, branch: &str, path: &str) -> Result<LockQuery, AdapterError> {
+        GovernanceAdapter::lock_file_query(&self.snapshot(), branch, path).await
+    }
+
+    async fn lock_file_status(
+        &self,
+        branch: &str,
+        paths: &[String],
+    ) -> Result<LockStatusResponse, AdapterError> {
+        GovernanceAdapter::lock_file_status(&self.snapshot(), branch, paths).await
+    }
+}
+
+#[derive(Clone, Default)]
+struct FakeIoState {
+    failures: BTreeSet<String>,
+    mutation_modes: BTreeMap<String, FakeMutationMode>,
+    applied_effects: BTreeSet<String>,
+    calls: Vec<String>,
+    opens: usize,
+    puts: usize,
+    gets: usize,
+    closes: usize,
+    metadata_writes: Vec<(String, String)>,
+    stored: BTreeMap<String, Vec<u8>>,
+    corrupt_get_bytes: bool,
+    metadata_type_drift_on_set: bool,
+    open_override: Option<MutationObservation<Vec<u64>>>,
+    put_override: Option<MutationObservation<Vec<ImmutablePutItem>>>,
+    get_override: Option<ReadObservation<Vec<ImmutableGetItem>>>,
+    get_mutation: Option<GetMutation>,
+    put_metadata_mutation: Option<MetadataEntry>,
+}
+
+#[derive(Clone, Copy)]
+enum GetMutation {
+    Fingerprint,
+    Lock,
+    Subject,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum FakeMutationMode {
+    #[default]
+    Completed,
+    NotDispatched,
+    OutcomeUnknownAbsent,
+    OutcomeUnknownApplied,
+}
+
+#[derive(Clone)]
+struct FakeIo {
+    lore: SharedFakeLore,
+    role: GovernanceRole,
+    state: Arc<Mutex<FakeIoState>>,
+}
+
+impl FakeIo {
+    fn new(lore: SharedFakeLore, role: GovernanceRole) -> Self {
+        Self {
+            lore,
+            role,
+            state: Arc::new(Mutex::new(FakeIoState::default())),
+        }
+    }
+
+    fn with_role(&self, role: GovernanceRole) -> Self {
+        Self {
+            lore: self.lore.clone(),
+            role,
+            state: self.state.clone(),
+        }
+    }
+
+    fn fail(&self, dependency: &str) {
+        self.state
+            .lock()
+            .unwrap()
+            .failures
+            .insert(dependency.into());
+    }
+
+    fn set_mutation_mode(&self, dependency: &str, mode: FakeMutationMode) {
+        self.state
+            .lock()
+            .unwrap()
+            .mutation_modes
+            .insert(dependency.into(), mode);
+    }
+
+    fn state(&self) -> FakeIoState {
+        self.state.lock().unwrap().clone()
+    }
+
+    fn set_put_override(&self, result: Result<Vec<ImmutablePutItem>, AdapterError>) {
+        self.state.lock().unwrap().put_override = Some(match result {
+            Ok(items) => MutationObservation::Completed(items),
+            Err(error) => MutationObservation::NotDispatched {
+                code: error.message,
+            },
+        });
+    }
+
+    fn set_open_override(&self, observation: MutationObservation<Vec<u64>>) {
+        self.state.lock().unwrap().open_override = Some(observation);
+    }
+
+    fn set_get_override(&self, result: Result<Vec<ImmutableGetItem>, AdapterError>) {
+        self.state.lock().unwrap().get_override = Some(match result {
+            Ok(items) => ReadObservation::Completed(items),
+            Err(error) => ReadObservation::Unavailable {
+                code: error.message,
+            },
+        });
+    }
+
+    fn replace_stored_bytes(&self, address: &str, bytes: Vec<u8>) {
+        self.state
+            .lock()
+            .unwrap()
+            .stored
+            .insert(address.into(), bytes);
+    }
+
+    fn corrupt_get_bytes(&self) {
+        self.state.lock().unwrap().corrupt_get_bytes = true;
+    }
+
+    fn drift_metadata_type_on_set(&self) {
+        self.state.lock().unwrap().metadata_type_drift_on_set = true;
+    }
+
+    fn mutate_on_get(&self, mutation: GetMutation) {
+        self.state.lock().unwrap().get_mutation = Some(mutation);
+    }
+
+    fn mutate_metadata_on_put(&self, entry: MetadataEntry) {
+        self.state.lock().unwrap().put_metadata_mutation = Some(entry);
+    }
+
+    fn has_failure(&self, dependency: &str) -> bool {
+        self.state.lock().unwrap().failures.contains(dependency)
+    }
+
+    fn mutation_mode(&self, dependency: &str) -> FakeMutationMode {
+        self.state
+            .lock()
+            .unwrap()
+            .mutation_modes
+            .get(dependency)
+            .copied()
+            .unwrap_or_default()
+    }
+}
+
+const FAKE_EVIDENCE_ADDRESS: &str =
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-00000000000000000000000000000000";
+
+#[async_trait::async_trait]
+impl GovernanceIo for FakeIo {
+    fn role(&self) -> GovernanceRole {
+        self.role
+    }
+
+    async fn revision_metadata_set(&self, key: &str, value: &str) -> MutationObservation<()> {
+        self.state.lock().unwrap().calls.push("metadata_set".into());
+        if self.has_failure("metadata_set") {
+            return MutationObservation::NotDispatched {
+                code: "metadata_set".into(),
+            };
+        }
+        let mode = self.mutation_mode("metadata_set");
+        if mode == FakeMutationMode::NotDispatched {
+            return MutationObservation::NotDispatched {
+                code: "metadata_set not dispatched".into(),
+            };
+        }
+        if mode == FakeMutationMode::OutcomeUnknownAbsent {
+            return MutationObservation::OutcomeUnknown {
+                code: "metadata_set outcome unknown".into(),
+                observed: (),
+            };
+        }
+
+        let applied = (|| -> Result<(), AdapterError> {
+            let mut state = self.state.lock().unwrap();
+            state.metadata_writes.push((key.into(), value.into()));
+            let ordinal = state.metadata_writes.len();
+            let metadata_type_drift_on_set = state.metadata_type_drift_on_set;
+            drop(state);
+
+            let mut fake = self.lore.0.lock().unwrap();
+            let source = fake
+                .status
+                .as_ref()
+                .map_err(Clone::clone)?
+                .staged_revisions
+                .first()
+                .cloned()
+                .ok_or_else(|| AdapterError::new("no staged source"))?;
+            let result = format!("{source}-metadata-{ordinal}");
+
+            let source_info = fake
+                .infos
+                .get(&source)
+                .cloned()
+                .ok_or_else(|| AdapterError::new("missing source info"))??;
+            let exact = source_info
+                .revisions
+                .first()
+                .cloned()
+                .ok_or_else(|| AdapterError::new("missing exact source info"))?;
+            fake.infos.insert(
+                result.clone(),
+                Ok(RevisionInfoResponse::exact(RevisionInfo {
+                    revision: result.clone(),
+                    parents: exact.parents,
+                })),
+            );
+
+            let mut metadata = fake
+                .metadata
+                .get(&source)
+                .cloned()
+                .ok_or_else(|| AdapterError::new("missing source metadata"))??;
+            if metadata_type_drift_on_set {
+                let typed = metadata
+                    .iter_mut()
+                    .find(|entry| entry.key == "typed")
+                    .ok_or_else(|| AdapterError::new("missing typed metadata fixture"))?;
+                typed.kind = MetadataKind::Numeric;
+            }
+            metadata.push(MetadataEntry::new(key, value));
+            fake.metadata.insert(result.clone(), Ok(metadata));
+
+            let dump = fake
+                .dumps
+                .get(&source)
+                .cloned()
+                .ok_or_else(|| AdapterError::new("missing source dump"))?;
+            fake.dumps.insert(result.clone(), dump);
+            let mut identities = fake
+                .file_info
+                .get(&source)
+                .cloned()
+                .ok_or_else(|| AdapterError::new("missing source identities"))??;
+            for identity in &mut identities {
+                identity.revision.clone_from(&result);
+            }
+            fake.file_info.insert(result.clone(), Ok(identities));
+
+            if let Ok(history) = &mut fake.history {
+                if let Some(first) = history.first_mut() {
+                    *first = result.clone();
+                }
+            }
+            let status = fake.status.as_mut().map_err(|error| error.clone())?;
+            status.staged_revisions = vec![result.clone()];
+            status.scanned_staged_revisions = vec![result.clone()];
+            status.post_scan_staged_revisions = vec![result.clone()];
+            for file in &mut status.worktree_files {
+                file.revision.clone_from(&result);
+            }
+            Ok(())
+        })();
+        match applied {
+            Ok(()) => {
+                self.state
+                    .lock()
+                    .unwrap()
+                    .applied_effects
+                    .insert("metadata_set".into());
+                if mode == FakeMutationMode::OutcomeUnknownApplied {
+                    MutationObservation::OutcomeUnknown {
+                        code: "metadata_set outcome unknown".into(),
+                        observed: (),
+                    }
+                } else {
+                    MutationObservation::Completed(())
+                }
+            }
+            Err(error) => MutationObservation::OutcomeUnknown {
+                code: error.message,
+                observed: (),
+            },
+        }
+    }
+
+    async fn storage_open(&self) -> MutationObservation<Vec<u64>> {
+        let mut state = self.state.lock().unwrap();
+        state.calls.push("open".into());
+        state.opens += 1;
+        if state.failures.contains("open") {
+            return MutationObservation::NotDispatched {
+                code: "open".into(),
+            };
+        }
+        if let Some(observation) = state.open_override.clone() {
+            return observation;
+        }
+        let mode = state
+            .mutation_modes
+            .get("open")
+            .copied()
+            .unwrap_or_default();
+        match mode {
+            FakeMutationMode::NotDispatched => MutationObservation::NotDispatched {
+                code: "open not dispatched".into(),
+            },
+            FakeMutationMode::OutcomeUnknownAbsent => MutationObservation::OutcomeUnknown {
+                code: "open outcome unknown".into(),
+                observed: vec![],
+            },
+            FakeMutationMode::OutcomeUnknownApplied => {
+                state.applied_effects.insert("open".into());
+                MutationObservation::OutcomeUnknown {
+                    code: "open outcome unknown".into(),
+                    observed: vec![],
+                }
+            }
+            FakeMutationMode::Completed => {
+                state.applied_effects.insert("open".into());
+                MutationObservation::Completed(vec![5934])
+            }
+        }
+    }
+
+    async fn storage_put(
+        &self,
+        _handle: u64,
+        bytes: &[u8],
+    ) -> MutationObservation<Vec<ImmutablePutItem>> {
+        let mut state = self.state.lock().unwrap();
+        state.calls.push("put".into());
+        state.puts += 1;
+        if state.failures.contains("put") {
+            return MutationObservation::NotDispatched { code: "put".into() };
+        }
+        if let Some(result) = state.put_override.clone() {
+            return result;
+        }
+        let observed = vec![ImmutablePutItem {
+            id: 5934,
+            address: FAKE_EVIDENCE_ADDRESS.into(),
+            ok: true,
+        }];
+        let mode = state.mutation_modes.get("put").copied().unwrap_or_default();
+        let observation = match mode {
+            FakeMutationMode::NotDispatched => MutationObservation::NotDispatched {
+                code: "put not dispatched".into(),
+            },
+            FakeMutationMode::OutcomeUnknownAbsent => MutationObservation::OutcomeUnknown {
+                code: "put outcome unknown".into(),
+                observed,
+            },
+            FakeMutationMode::OutcomeUnknownApplied => {
+                state
+                    .stored
+                    .insert(FAKE_EVIDENCE_ADDRESS.into(), bytes.to_vec());
+                state.applied_effects.insert("put".into());
+                MutationObservation::OutcomeUnknown {
+                    code: "put outcome unknown".into(),
+                    observed,
+                }
+            }
+            FakeMutationMode::Completed => {
+                state
+                    .stored
+                    .insert(FAKE_EVIDENCE_ADDRESS.into(), bytes.to_vec());
+                state.applied_effects.insert("put".into());
+                MutationObservation::Completed(observed)
+            }
+        };
+        let metadata_mutation = if matches!(&observation, MutationObservation::Completed(_)) {
+            state.put_metadata_mutation.take()
+        } else {
+            None
+        };
+        drop(state);
+        if let Some(entry) = metadata_mutation {
+            let mut lore = self.lore.0.lock().unwrap();
+            let subject = lore
+                .status
+                .as_ref()
+                .expect("put-time metadata mutation requires status")
+                .staged_revisions[0]
+                .clone();
+            lore.metadata
+                .get_mut(&subject)
+                .expect("put-time metadata mutation requires subject")
+                .as_mut()
+                .expect("put-time metadata mutation requires metadata")
+                .push(entry);
+        }
+        observation
+    }
+
+    async fn storage_get(
+        &self,
+        _handle: u64,
+        address: &str,
+    ) -> ReadObservation<Vec<ImmutableGetItem>> {
+        let mut state = self.state.lock().unwrap();
+        state.calls.push("get".into());
+        state.gets += 1;
+        if state.failures.contains("get") {
+            return ReadObservation::Unavailable { code: "get".into() };
+        }
+        if let Some(result) = state.get_override.clone() {
+            return result;
+        }
+        let mut data = state.stored.get(address).cloned().unwrap_or_default();
+        if data.is_empty() && !state.stored.contains_key(address) {
+            return ReadObservation::Unavailable {
+                code: "missing immutable address".into(),
+            };
+        }
+        if state.corrupt_get_bytes && !data.is_empty() {
+            data[0] ^= 1;
+        }
+        let result = vec![ImmutableGetItem {
+            id: 5934,
+            address: address.into(),
+            size: data.len() as u64,
+            data,
+            ok: true,
+        }];
+        let mutation = state.get_mutation.take();
+        drop(state);
+        if let Some(mutation) = mutation {
+            let mut lore = self.lore.0.lock().unwrap();
+            match mutation {
+                GetMutation::Fingerprint => {
+                    lore.status.as_mut().unwrap().worktree_files[0].local_hash =
+                        "3333333333333333333333333333333333333333333333333333333333333333".into();
+                }
+                GetMutation::Lock => {
+                    lore.lock_queries.insert(
+                        "asset.txt".into(),
+                        Ok(LockQuery::with_owners(
+                            "asset.txt",
+                            1,
+                            vec!["foreign".into()],
+                        )),
+                    );
+                }
+                GetMutation::Subject => {
+                    let status = lore.status.as_mut().unwrap();
+                    status.staged_revisions = vec!["other".into()];
+                    status.scanned_staged_revisions = vec!["other".into()];
+                    status.post_scan_staged_revisions = vec!["other".into()];
+                }
+            }
+        }
+        ReadObservation::Completed(result)
+    }
+
+    async fn storage_close(&self, _handle: u64) -> MutationObservation<()> {
+        let mut state = self.state.lock().unwrap();
+        state.calls.push("close".into());
+        state.closes += 1;
+        if state.failures.contains("close") {
+            return MutationObservation::NotDispatched {
+                code: "close".into(),
+            };
+        }
+        let mode = state
+            .mutation_modes
+            .get("close")
+            .copied()
+            .unwrap_or_default();
+        match mode {
+            FakeMutationMode::NotDispatched => MutationObservation::NotDispatched {
+                code: "close not dispatched".into(),
+            },
+            FakeMutationMode::OutcomeUnknownAbsent => MutationObservation::OutcomeUnknown {
+                code: "close outcome unknown".into(),
+                observed: (),
+            },
+            FakeMutationMode::OutcomeUnknownApplied => {
+                state.applied_effects.insert("close".into());
+                MutationObservation::OutcomeUnknown {
+                    code: "close outcome unknown".into(),
+                    observed: (),
+                }
+            }
+            FakeMutationMode::Completed => {
+                state.applied_effects.insert("close".into());
+                MutationObservation::Completed(())
+            }
+        }
+    }
+}
+
+fn evidence_request(expected: impl Into<String>) -> EvidencePreserveRequest {
+    EvidencePreserveRequest {
+        expected_staged_revision: expected.into(),
+        target_base_revision: "base".into(),
+    }
+}
+
+fn expect_rejected(
+    outcome: &EvidencePreserveOutcomeV1,
+    reason: EvidenceRejectionCodeV1,
+) -> &lore_vm::ops::governance::contract::EvidencePreserveRejectedV1 {
+    let rejected = outcome
+        .rejected()
+        .unwrap_or_else(|| panic!("expected rejected_before_publication, got {outcome:?}"));
+    assert_eq!(rejected.stopped_at.reason, reason, "{outcome:?}");
+    rejected
+}
+
+fn expect_residual(
+    outcome: &EvidencePreserveOutcomeV1,
+    unknown: bool,
+    stage: EvidencePreserveStopCodeV1,
+) -> &lore_vm::ops::governance::contract::EvidencePreserveResidualV1 {
+    match (unknown, outcome.disposition()) {
+        (true, EvidencePreserveDispositionV1::Unknown(residual))
+        | (false, EvidencePreserveDispositionV1::VerificationIncomplete(residual)) => {
+            assert_eq!(residual.stopped_at.stage, stage, "{outcome:?}");
+            residual
+        }
+        _ => panic!("unexpected evidence residual class: {outcome:?}"),
+    }
+}
+
+fn normalized_outcome_json(outcome: &EvidencePreserveOutcomeV1) -> serde_json::Value {
+    let mut value = serde_json::to_value(outcome).expect("outcome remains serializable");
+    value["attempt_id"] = serde_json::json!("normalized-attempt-id");
+    value
+}
+
+fn gate_request(expected: impl Into<String>) -> SubmissionGateCheckRequest {
+    SubmissionGateCheckRequest {
+        expected_staged_revision: expected.into(),
+        target_base_revision: "base".into(),
+    }
+}
+
+#[tokio::test]
+async fn dco_operation_reuses_exact_evaluation_and_closes_on_every_identity_failure() {
+    let clean = FakeLore::clean();
+    let result = dco_validate_with_adapter(
+        &clean,
+        &DcoValidateRequest {
+            expected_staged_revision: "candidate".into(),
+            target_base_revision: "base".into(),
+        },
+    )
+    .await;
+    assert!(result.valid, "{result:?}");
+    assert_eq!(result.pending_revisions, vec!["candidate"]);
+
+    let cases: [(&str, fn(&mut FakeLore)); 4] = [
+        ("mismatch", |fake: &mut FakeLore| {
+            fake.authors = Ok(vec![ResolvedAuthor::new("alice", "Mallory")]);
+        }),
+        ("malformed", |fake: &mut FakeLore| {
+            fake.metadata.insert(
+                "candidate".into(),
+                Ok(vec![
+                    MetadataEntry::new("message", "change\n\nSigned-off-by: malformed"),
+                    MetadataEntry::new("created-by", "alice"),
+                ]),
+            );
+        }),
+        ("duplicate", |fake: &mut FakeLore| {
+            fake.authors = Ok(vec![
+                ResolvedAuthor::new("alice", "Alice"),
+                ResolvedAuthor::new("alice", "Alice"),
+            ]);
+        }),
+        ("unresolved", |fake: &mut FakeLore| {
+            fake.authors = Ok(vec![]);
+        }),
+    ];
+    for (name, mutate) in cases {
+        let mut fake = FakeLore::clean();
+        mutate(&mut fake);
+        let result = dco_validate_with_adapter(
+            &fake,
+            &DcoValidateRequest {
+                expected_staged_revision: "candidate".into(),
+                target_base_revision: "base".into(),
+            },
+        )
+        .await;
+        assert!(!result.valid, "{name}: {result:?}");
+        assert_eq!(result.failure_codes, vec!["dco_invalid"], "{name}");
+    }
+
+    let mut auth_unavailable = FakeLore::clean();
+    auth_unavailable.authors = Err(FakeLore::error("auth dependency"));
+    let result = dco_validate_with_adapter(
+        &auth_unavailable,
+        &DcoValidateRequest {
+            expected_staged_revision: "candidate".into(),
+            target_base_revision: "base".into(),
+        },
+    )
+    .await;
+    assert!(
+        !result.valid,
+        "unavailable author resolution must close DCO"
+    );
+    assert_eq!(result.failure_codes, vec!["auth_unavailable"]);
+
+    let mut history_unavailable = FakeLore::clean();
+    history_unavailable.history = Err(FakeLore::error("history dependency"));
+    let result = dco_validate_with_adapter(
+        &history_unavailable,
+        &DcoValidateRequest {
+            expected_staged_revision: "candidate".into(),
+            target_base_revision: "base".into(),
+        },
+    )
+    .await;
+    assert!(!result.valid, "unavailable history must close DCO");
+    assert_eq!(result.failure_codes, vec!["history_incomplete"]);
+}
+
+#[tokio::test]
+async fn dco_result_does_not_conflate_later_supersession_lock_or_worktree_policy() {
+    let cases: [(&str, fn(&mut FakeLore)); 9] = [
+        ("superseded", |fake| {
+            let identity = "1111111111111111111111111111111111111111111111111111111111111111:22222222222222222222222222222222";
+            fake.metadata
+                .get_mut("base")
+                .unwrap()
+                .as_mut()
+                .unwrap()
+                .push(MetadataEntry::new(
+                    format!("{SUPERSESSION_MARKER_PREFIX}{identity}"),
+                    serde_json::to_string(&serde_json::json!({
+                        "version": "v1",
+                        "identity": identity,
+                    }))
+                    .unwrap(),
+                ));
+        }),
+        ("locked", |fake| {
+            fake.lock_queries.insert(
+                "asset.txt".into(),
+                Ok(LockQuery::with_owners(
+                    "asset.txt",
+                    1,
+                    vec!["foreign".into()],
+                )),
+            );
+        }),
+        ("dirty", |fake| {
+            fake.status.as_mut().unwrap().worktree_clean = false;
+        }),
+        ("malformed supersession", |fake| {
+            fake.metadata
+                .get_mut("base")
+                .unwrap()
+                .as_mut()
+                .unwrap()
+                .push(MetadataEntry::new(
+                    format!("{SUPERSESSION_MARKER_PREFIX}1111111111111111111111111111111111111111111111111111111111111111:22222222222222222222222222222222"),
+                    r#"{"version":"v1","identity":"wrong"}"#,
+                ));
+        }),
+        ("marker metadata unavailable", |fake| {
+            fake.metadata
+                .insert("base".into(), Err(FakeLore::error("base marker metadata")));
+        }),
+        ("worktree scan unverified", |fake| {
+            fake.status.as_mut().unwrap().scan_performed = false;
+        }),
+        ("candidate tree unavailable", |fake| {
+            fake.dumps
+                .insert("candidate".into(), Err(FakeLore::error("tree")));
+        }),
+        ("revision diff unavailable", |fake| {
+            fake.diff = Err(FakeLore::error("diff"));
+        }),
+        ("lock dependency unavailable", |fake| {
+            fake.lock_queries
+                .insert("asset.txt".into(), Err(FakeLore::error("lock")));
+        }),
+    ];
+
+    for (name, mutate) in cases {
+        let mut fake = FakeLore::clean();
+        mutate(&mut fake);
+        let result = dco_validate_with_adapter(
+            &fake,
+            &DcoValidateRequest {
+                expected_staged_revision: "candidate".into(),
+                target_base_revision: "base".into(),
+            },
+        )
+        .await;
+        assert!(result.valid, "{name} is not a DCO failure: {result:?}");
+        assert_eq!(result.pending_revisions, vec!["candidate"]);
+        assert!(result.failure_codes.is_empty(), "{name}: {result:?}");
+    }
+}
+
+#[tokio::test]
+async fn wrong_role_evidence_call_rejects_before_any_repository_or_storage_state() {
+    let lore = SharedFakeLore::clean();
+    let io = FakeIo::new(lore.clone(), GovernanceRole::Witness);
+    let outcome = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+        .await
+        .expect("wrong-role rejection is an exact no-effect outcome");
+    let rejected = expect_rejected(&outcome, EvidenceRejectionCodeV1::ActorRoleRequired);
+    assert!(matches!(rejected.close, EvidenceCloseStateV1::NotOpened));
+    assert!(rejected.snapshot_sha256.is_none());
+
+    let state = io.state();
+    assert_eq!(
+        (state.opens, state.puts, state.gets, state.closes),
+        (0, 0, 0, 0)
+    );
+    assert!(state.metadata_writes.is_empty());
+    assert!(state.stored.is_empty());
+    let fake = lore.snapshot();
+    assert_eq!(
+        fake.status.unwrap().staged_revisions,
+        vec!["candidate"],
+        "wrong-role rejection must leave the exact staged subject untouched"
+    );
+}
+
+#[tokio::test]
+async fn dirty_only_unselected_path_rejects_before_evidence_state() {
+    let lore = SharedFakeLore::clean();
+    {
+        let mut fake = lore.0.lock().unwrap();
+        let status = fake.status.as_mut().unwrap();
+        status.worktree_clean = false;
+        status.worktree_files.push(WorktreeFileObservation {
+            path: "unselected.txt".into(),
+            revision: "candidate".into(),
+            revision_hash: "base-hash".into(),
+            revision_context: "other-context".into(),
+            revision_size: 4,
+            local_hash: "dirty-hash".into(),
+            local_size: 5,
+            filtered_revision_size: 4,
+            flag_modified: true,
+            flag_deleted: false,
+            flag_added: false,
+            flag_conflict: false,
+        });
+        assert_eq!(status.staged_paths, ["asset.txt"]);
+    }
+    let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+    let outcome = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+        .await
+        .expect("a complete dirty fact is a deterministic policy rejection");
+    let rejected = expect_rejected(&outcome, EvidenceRejectionCodeV1::InitialGovernanceClosed);
+    assert_eq!(rejected.stopped_at.code, "worktree_dirty");
+    let state = io.state();
+    assert_eq!(
+        (state.opens, state.puts, state.gets, state.closes),
+        (0, 0, 0, 0)
+    );
+    assert!(state.metadata_writes.is_empty());
+    assert!(state.stored.is_empty());
+}
+
+#[tokio::test]
+async fn evidence_rereads_the_exact_blob_only_after_pointer_attachment() {
+    let lore = SharedFakeLore::clean();
+    let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+
+    evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+        .await
+        .expect("clean actor evidence should preserve");
+
+    assert_eq!(
+        io.state().calls,
+        ["open", "put", "metadata_set", "get", "close"],
+        "the immutable reread must bind the pointer after attachment, not merely preflight the put"
+    );
+}
+
+#[tokio::test]
+async fn preattach_reread_rejects_a_concurrent_pointer_before_actor_attach() {
+    let lore = SharedFakeLore::clean();
+    let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+    io.mutate_metadata_on_put(MetadataEntry::new(
+        EVIDENCE_POINTER_KEY,
+        serde_json::to_string(&EvidencePointerV1 {
+            version: "v1".into(),
+            address: FAKE_EVIDENCE_ADDRESS.into(),
+        })
+        .unwrap(),
+    ));
+
+    let outcome = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+        .await
+        .expect("a preattach metadata race remains an exact residual");
+    expect_residual(
+        &outcome,
+        false,
+        EvidencePreserveStopCodeV1::PreattachEvaluation,
+    );
+    let state = io.state();
+    assert_eq!(state.metadata_writes.len(), 0, "the actor must not attach");
+    assert_eq!(state.gets, 0, "no postattach read may start");
+    assert_eq!(state.closes, 1, "the usable handle must still close");
+}
+
+#[tokio::test]
+async fn actor_evidence_is_canonical_non_authoritative_and_witness_rederives_it() {
+    let lore = SharedFakeLore::clean();
+    let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+    let preserved = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+        .await
+        .expect("clean actor evidence should preserve");
+    let preserved = preserved.verified().expect("full actor chain closed");
+
+    assert_eq!(preserved.source_staged_revision, "candidate");
+    assert_eq!(preserved.evidence_address, FAKE_EVIDENCE_ADDRESS);
+    assert_ne!(preserved.result_staged_revision, "candidate");
+    let state = io.state();
+    assert_eq!(
+        (state.opens, state.puts, state.gets, state.closes),
+        (1, 1, 1, 1)
+    );
+    assert_eq!(state.metadata_writes.len(), 1);
+    assert_eq!(state.metadata_writes[0].0, EVIDENCE_POINTER_KEY);
+
+    let stored = state.stored.get(FAKE_EVIDENCE_ADDRESS).unwrap();
+    let snapshot: CanonicalEvidenceSnapshotV1 =
+        serde_json::from_slice(stored).expect("stored bytes use the strict snapshot schema");
+    assert_eq!(snapshot.version, "v1");
+    assert_eq!(snapshot.target_base_revision, "base");
+    assert_eq!(
+        snapshot.first_parent_history,
+        vec![CanonicalRevisionRefV1::StagedSubject]
+    );
+    assert_eq!(snapshot.affected_paths, vec!["asset.txt"]);
+    assert_eq!(snapshot.candidate_files.len(), 1);
+    let staged_metadata = snapshot
+        .supersession_metadata_queries
+        .iter()
+        .find(|query| query.revision == CanonicalRevisionRefV1::StagedSubject)
+        .expect("the exact staged metadata query remains retained");
+    assert!(
+        staged_metadata
+            .metadata
+            .iter()
+            .all(|entry| entry.key != EVIDENCE_POINTER_KEY),
+        "the self-referential pointer is represented only by EvidencePointerDeltaV1"
+    );
+    assert_eq!(
+        staged_metadata
+            .metadata
+            .iter()
+            .map(|entry| entry.key.as_str())
+            .collect::<Vec<_>>(),
+        ["created-by", "message"],
+        "all non-pointer raw metadata remains byte-bound"
+    );
+    assert_eq!(
+        snapshot.candidate_files[0].hash,
+        "4444444444444444444444444444444444444444444444444444444444444444"
+    );
+    assert_eq!(
+        snapshot.candidate_files[0].context,
+        "22222222222222222222222222222222"
+    );
+    let json = serde_json::to_value(&snapshot).unwrap();
+    for forbidden in ["gate_open", "passed", "valid", "verdict"] {
+        assert!(
+            json.get(forbidden).is_none(),
+            "actor claim contained {forbidden}"
+        );
+    }
+
+    let before_actor_gate = io.state();
+    let actor_gate = submission_gate_check_with_adapters(
+        &lore,
+        &io,
+        &gate_request(&preserved.result_staged_revision),
+    )
+    .await;
+    assert!(
+        !actor_gate.gate_open,
+        "an Actor must never open the witness gate"
+    );
+    assert_eq!(
+        before_actor_gate.metadata_writes,
+        io.state().metadata_writes
+    );
+    assert_eq!(before_actor_gate.stored, io.state().stored);
+
+    let witness = io.with_role(GovernanceRole::Witness);
+    let gate = submission_gate_check_with_adapters(
+        &lore,
+        &witness,
+        &gate_request(&preserved.result_staged_revision),
+    )
+    .await;
+    assert!(gate.gate_open, "{gate:?}");
+    assert_eq!(gate.criteria.len(), 7);
+    assert!(gate.criteria.iter().all(|criterion| criterion.passed));
+    assert_eq!(
+        gate.criteria
+            .iter()
+            .map(|criterion| criterion.criterion)
+            .collect::<Vec<_>>(),
+        vec![
+            GovernanceCriterion::ExactSubject,
+            GovernanceCriterion::HistoryComplete,
+            GovernanceCriterion::DcoValid,
+            GovernanceCriterion::NotSuperseded,
+            GovernanceCriterion::LocksClear,
+            GovernanceCriterion::WorktreeClean,
+            GovernanceCriterion::EvidenceValid,
+        ]
+    );
+}
+
+#[tokio::test]
+async fn canonical_pointer_omission_is_limited_to_the_current_staged_subject() {
+    let lore = SharedFakeLore::clean();
+    lore.0
+        .lock()
+        .unwrap()
+        .metadata
+        .get_mut("base")
+        .unwrap()
+        .as_mut()
+        .unwrap()
+        .push(MetadataEntry::new(
+            EVIDENCE_POINTER_KEY,
+            "ancestor-pointer-remains-raw",
+        ));
+    let io = FakeIo::new(lore, GovernanceRole::Actor);
+    let preserved = evidence_preserve_with_adapters(&io.lore, &io, &evidence_request("candidate"))
+        .await
+        .expect("ancestor pointer metadata is not the active evidence pointer");
+    preserved.verified().expect("full actor chain closed");
+    let state = io.state();
+    let snapshot: CanonicalEvidenceSnapshotV1 =
+        serde_json::from_slice(state.stored.get(FAKE_EVIDENCE_ADDRESS).unwrap()).unwrap();
+    let base_metadata = snapshot
+        .supersession_metadata_queries
+        .iter()
+        .find(|query| query.revision == CanonicalRevisionRefV1::Exact("base".into()))
+        .expect("base metadata query remains retained");
+    assert!(base_metadata.metadata.iter().any(|entry| {
+        entry.key == EVIDENCE_POINTER_KEY && entry.value == "ancestor-pointer-remains-raw"
+    }));
+}
+
+#[tokio::test]
+async fn witness_rejects_a_well_formed_but_forged_actor_snapshot() {
+    let lore = SharedFakeLore::clean();
+    let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+    let preserved = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+        .await
+        .unwrap();
+    let preserved = preserved.verified().expect("full actor chain closed");
+    let mut forged: CanonicalEvidenceSnapshotV1 =
+        serde_json::from_slice(io.state().stored.get(FAKE_EVIDENCE_ADDRESS).unwrap()).unwrap();
+    forged.candidate_files[0].hash = "forged".into();
+    io.replace_stored_bytes(FAKE_EVIDENCE_ADDRESS, serde_json::to_vec(&forged).unwrap());
+
+    let witness = io.with_role(GovernanceRole::Witness);
+    let gate = submission_gate_check_with_adapters(
+        &lore,
+        &witness,
+        &gate_request(&preserved.result_staged_revision),
+    )
+    .await;
+    assert!(
+        !gate.gate_open,
+        "stored actor bytes must never be authority"
+    );
+    let evidence = gate
+        .criteria
+        .iter()
+        .find(|criterion| criterion.criterion == GovernanceCriterion::EvidenceValid)
+        .unwrap();
+    assert!(!evidence.passed);
+    assert_eq!(evidence.failure_code.as_deref(), Some("evidence_mismatch"));
+    assert!(
+        gate.criteria[..6].iter().all(|criterion| criterion.passed),
+        "the witness must distinguish a forged claim from live governance failures"
+    );
+}
+
+#[tokio::test]
+async fn witness_full_gate_is_inert_to_poisoned_evaluator_summaries() {
+    let lore = SharedFakeLore::clean();
+    let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+    let preserved = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+        .await
+        .expect("seed exact actor evidence");
+    let preserved = preserved.verified().expect("full actor chain closed");
+
+    let mut poisoned: CanonicalEvidenceSnapshotV1 =
+        serde_json::from_slice(io.state().stored.get(FAKE_EVIDENCE_ADDRESS).unwrap()).unwrap();
+    poisoned.current_files[0].hash = "9".repeat(64);
+    poisoned.revision_diff = vec![AffectedPath::modified("forged-summary.txt")];
+    poisoned.affected_paths = vec!["forged-summary.txt".into()];
+    poisoned.supersession_markers.push(
+        lore_vm::ops::governance::contract::CanonicalSupersessionObservationV1 {
+            revision: CanonicalRevisionRefV1::StagedSubject,
+            key: format!(
+                "{SUPERSESSION_MARKER_PREFIX}{}:{}",
+                "9".repeat(64),
+                "8".repeat(32)
+            ),
+            value: "forged-summary".into(),
+            identity: format!("{}:{}", "9".repeat(64), "8".repeat(32)),
+        },
+    );
+    poisoned.dco[0].signer_name = "Mallory".into();
+    poisoned.dependency_observations = vec!["forged-summary-label".into()];
+    io.replace_stored_bytes(
+        FAKE_EVIDENCE_ADDRESS,
+        serde_json::to_vec(&poisoned).unwrap(),
+    );
+
+    let witness = io.with_role(GovernanceRole::Witness);
+    let gate = submission_gate_check_with_adapters(
+        &lore,
+        &witness,
+        &gate_request(&preserved.result_staged_revision),
+    )
+    .await;
+
+    assert!(
+        gate.gate_open,
+        "derived evaluator summaries in actor evidence must be diagnostic-only: {gate:?}"
+    );
+    assert!(gate.criteria.iter().all(|criterion| criterion.passed));
+}
+
+#[tokio::test]
+async fn witness_final_reread_closes_storage_get_fingerprint_lock_and_subject_races() {
+    for mutation in [
+        GetMutation::Fingerprint,
+        GetMutation::Lock,
+        GetMutation::Subject,
+    ] {
+        let lore = SharedFakeLore::clean();
+        let actor = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+        let preserved =
+            evidence_preserve_with_adapters(&lore, &actor, &evidence_request("candidate"))
+                .await
+                .expect("seed exact actor evidence");
+        let preserved = preserved.verified().expect("full actor chain closed");
+        let witness = actor.with_role(GovernanceRole::Witness);
+        let before = witness.state();
+        witness.mutate_on_get(mutation);
+        let gate = submission_gate_check_with_adapters(
+            &lore,
+            &witness,
+            &gate_request(&preserved.result_staged_revision),
+        )
+        .await;
+        assert!(!gate.gate_open, "a get-time live race opened: {gate:?}");
+        assert!(
+            gate.criteria.iter().any(|criterion| !criterion.passed),
+            "the final reread must expose the drift"
+        );
+        let after = witness.state();
+        assert_eq!(before.metadata_writes, after.metadata_writes);
+        assert_eq!(before.stored, after.stored, "the witness must never write");
+    }
+}
+
+#[tokio::test]
+async fn witness_rejects_an_uppercase_hex_evidence_address_alias() {
+    let lore = SharedFakeLore::clean();
+    let actor = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+    let preserved = evidence_preserve_with_adapters(&lore, &actor, &evidence_request("candidate"))
+        .await
+        .unwrap();
+    let preserved = preserved.verified().expect("full actor chain closed");
+    {
+        let mut fake = lore.0.lock().unwrap();
+        let metadata = fake
+            .metadata
+            .get_mut(&preserved.result_staged_revision)
+            .unwrap()
+            .as_mut()
+            .unwrap();
+        let pointer = metadata
+            .iter_mut()
+            .find(|entry| entry.key == EVIDENCE_POINTER_KEY)
+            .unwrap();
+        pointer.value = serde_json::to_string(&EvidencePointerV1 {
+            version: "v1".into(),
+            address: format!("{}-{}", "A".repeat(64), "0".repeat(32)),
+        })
+        .unwrap();
+    }
+    let witness = actor.with_role(GovernanceRole::Witness);
+    let gate = submission_gate_check_with_adapters(
+        &lore,
+        &witness,
+        &gate_request(&preserved.result_staged_revision),
+    )
+    .await;
+    assert!(!gate.gate_open);
+    assert_eq!(
+        gate.criteria.last().unwrap().failure_code.as_deref(),
+        Some("evidence_pointer_invalid")
+    );
+}
+
+#[tokio::test]
+async fn witness_compares_exact_stored_dco_lock_and_worktree_observations() {
+    let mutations: [(&str, fn(&mut CanonicalEvidenceSnapshotV1)); 3] = [
+        ("dco", |snapshot| {
+            snapshot.dco_metadata[0].messages[0].push_str("\nforged")
+        }),
+        ("lock", |snapshot| {
+            snapshot.lock_queries[0].owners.push("forged".into())
+        }),
+        ("worktree", |snapshot| {
+            snapshot.status.worktree_clean = false
+        }),
+    ];
+    for (name, mutate) in mutations {
+        let lore = SharedFakeLore::clean();
+        let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+        let preserved = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+            .await
+            .unwrap();
+        let preserved = preserved.verified().expect("full actor chain closed");
+        let mut forged: CanonicalEvidenceSnapshotV1 =
+            serde_json::from_slice(io.state().stored.get(FAKE_EVIDENCE_ADDRESS).unwrap()).unwrap();
+        mutate(&mut forged);
+        io.replace_stored_bytes(FAKE_EVIDENCE_ADDRESS, serde_json::to_vec(&forged).unwrap());
+
+        let witness = io.with_role(GovernanceRole::Witness);
+        let gate = submission_gate_check_with_adapters(
+            &lore,
+            &witness,
+            &gate_request(&preserved.result_staged_revision),
+        )
+        .await;
+        assert!(!gate.gate_open, "{name}: {gate:?}");
+        assert_eq!(
+            gate.criteria.last().unwrap().failure_code.as_deref(),
+            Some("evidence_mismatch"),
+            "{name}: every raw stored fact must compare exactly"
+        );
+    }
+}
+
+#[tokio::test]
+async fn post_attach_dco_lock_and_worktree_changes_each_falsify_equivalence() {
+    let cases: [(&str, GovernanceCriterion, &str, fn(&mut FakeLore, &str)); 3] = [
+        (
+            "dco",
+            GovernanceCriterion::DcoValid,
+            "dco_invalid",
+            |fake: &mut FakeLore, current: &str| {
+                fake.metadata.insert(
+                    current.into(),
+                    Ok(vec![
+                        MetadataEntry::new("message", "change\n\nSigned-off-by: malformed"),
+                        MetadataEntry::new("created-by", "alice"),
+                    ]),
+                );
+            },
+        ),
+        (
+            "lock",
+            GovernanceCriterion::LocksClear,
+            "locks_clear_failed",
+            |fake: &mut FakeLore, _current: &str| {
+                fake.lock_queries.insert(
+                    "asset.txt".into(),
+                    Ok(LockQuery::with_owners(
+                        "asset.txt",
+                        1,
+                        vec!["foreign".into()],
+                    )),
+                );
+            },
+        ),
+        (
+            "worktree",
+            GovernanceCriterion::WorktreeClean,
+            "worktree_dirty",
+            |fake: &mut FakeLore, _current: &str| {
+                fake.status.as_mut().unwrap().worktree_clean = false;
+            },
+        ),
+    ];
+    for (name, criterion, failure_code, mutate) in cases {
+        let lore = SharedFakeLore::clean();
+        let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+        let preserved = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+            .await
+            .unwrap();
+        let preserved = preserved.verified().expect("full actor chain closed");
+        mutate(
+            &mut lore.0.lock().unwrap(),
+            &preserved.result_staged_revision,
+        );
+
+        let witness = io.with_role(GovernanceRole::Witness);
+        let gate = submission_gate_check_with_adapters(
+            &lore,
+            &witness,
+            &gate_request(&preserved.result_staged_revision),
+        )
+        .await;
+        assert!(!gate.gate_open, "{name}: {gate:?}");
+        let observed = gate
+            .criteria
+            .iter()
+            .find(|item| item.criterion == criterion)
+            .unwrap();
+        assert!(!observed.passed, "{name}: {gate:?}");
+        assert_eq!(
+            observed.failure_code.as_deref(),
+            Some(failure_code),
+            "{name}"
+        );
+        assert!(
+            !gate
+                .criteria
+                .iter()
+                .find(|item| item.criterion == GovernanceCriterion::EvidenceValid)
+                .unwrap()
+                .passed,
+            "{name}: a mandatory live-fact change must invalidate equivalence"
+        );
+    }
+}
+
+#[tokio::test]
+async fn pointer_delta_rejects_same_text_with_a_different_metadata_kind() {
+    let lore = SharedFakeLore::clean();
+    lore.0
+        .lock()
+        .unwrap()
+        .metadata
+        .get_mut("candidate")
+        .unwrap()
+        .as_mut()
+        .unwrap()
+        .push(MetadataEntry::new("typed", "1"));
+    let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+    io.drift_metadata_type_on_set();
+
+    let outcome = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+        .await
+        .expect("metadata drift is an exact residual state");
+    let residual = expect_residual(
+        &outcome,
+        false,
+        EvidencePreserveStopCodeV1::PointerDeltaInvalid,
+    );
+    assert!(matches!(
+        residual.last_confirmed_publication,
+        EvidencePublicationStateV1::ResultSubjectObserved { .. }
+    ));
+    assert!(matches!(residual.close, EvidenceCloseStateV1::Closed));
+    assert_eq!(io.state().closes, 1);
+}
+
+#[tokio::test]
+async fn evidence_failures_report_exact_residuals_and_always_close_a_usable_handle() {
+    let cases = [
+        (
+            "put",
+            EvidencePreserveStopCodeV1::StoragePutNotDispatched,
+            "none",
+        ),
+        (
+            "metadata_set",
+            EvidencePreserveStopCodeV1::PointerAttachNotDispatched,
+            "blob_published",
+        ),
+        (
+            "get",
+            EvidencePreserveStopCodeV1::PostattachGetUnavailable,
+            "pointer_attach_acknowledged",
+        ),
+        (
+            "close",
+            EvidencePreserveStopCodeV1::StorageCloseNotDispatched,
+            "postattach_equivalent",
+        ),
+    ];
+    for (dependency, expected_stop, expected_publication) in cases {
+        let lore = SharedFakeLore::clean();
+        let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+        io.fail(dependency);
+        let outcome = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+            .await
+            .expect("released failure is represented in-band");
+        let residual = expect_residual(&outcome, false, expected_stop);
+        assert!(
+            serde_json::to_value(&residual.last_confirmed_publication).unwrap()["state"]
+                .as_str()
+                .is_some_and(|state| state == expected_publication),
+            "{dependency}: {outcome:?}"
+        );
+        if dependency == "close" {
+            assert!(matches!(
+                residual.close,
+                EvidenceCloseStateV1::CloseNotDispatched { .. }
+            ));
+        } else {
+            assert!(matches!(residual.close, EvidenceCloseStateV1::Closed));
+        }
+        let state = io.state();
+        assert_eq!(state.opens, 1, "{dependency}");
+        assert_eq!(state.closes, 1, "{dependency}: every opened handle closes");
+    }
+
+    let lore = SharedFakeLore::clean();
+    let io = FakeIo::new(lore, GovernanceRole::Actor);
+    io.fail("open");
+    let outcome = evidence_preserve_with_adapters(&io.lore, &io, &evidence_request("candidate"))
+        .await
+        .expect("open predispatch failure is representable");
+    let residual = expect_residual(
+        &outcome,
+        false,
+        EvidencePreserveStopCodeV1::StorageOpenNotDispatched,
+    );
+    assert!(matches!(residual.close, EvidenceCloseStateV1::NotOpened));
+    assert_eq!(io.state().closes, 0, "no handle existed to close");
+}
+
+#[tokio::test]
+async fn empty_public_adapter_diagnostic_is_a_typed_stop_not_a_panic() {
+    let lore = SharedFakeLore::clean();
+    let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+    io.set_open_override(MutationObservation::NotDispatched {
+        code: String::new(),
+    });
+
+    let outcome = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+        .await
+        .expect("malformed adapter diagnostics remain an in-band residual state");
+    let residual = expect_residual(
+        &outcome,
+        false,
+        EvidencePreserveStopCodeV1::StorageOpenNotDispatched,
+    );
+    assert_eq!(
+        residual.stopped_at.code,
+        "storage_open_not_dispatched_without_code"
+    );
+    assert!(matches!(
+        residual.last_confirmed_publication,
+        EvidencePublicationStateV1::None
+    ));
+    assert!(matches!(residual.close, EvidenceCloseStateV1::NotOpened));
+    assert_eq!(io.state().closes, 0);
+}
+
+#[tokio::test]
+async fn completed_open_without_exactly_one_usable_handle_is_open_outcome_unknown() {
+    for handles in [vec![], vec![0], vec![5934, 5935]] {
+        let lore = SharedFakeLore::clean();
+        let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+        io.set_open_override(MutationObservation::Completed(handles));
+        let outcome = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+            .await
+            .expect("unusable completed-open data remains an in-band unknown");
+        let residual = expect_residual(
+            &outcome,
+            true,
+            EvidencePreserveStopCodeV1::StorageOpenOutcome,
+        );
+        assert!(matches!(
+            residual.last_confirmed_publication,
+            EvidencePublicationStateV1::None
+        ));
+        assert!(matches!(
+            residual.close,
+            EvidenceCloseStateV1::OpenOutcomeUnknown { .. }
+        ));
+        assert_eq!(io.state().closes, 0);
+    }
+}
+
+#[tokio::test]
+async fn direct_empty_evidence_request_cannot_create_an_attempt_or_touch_io() {
+    for request in [
+        EvidencePreserveRequest {
+            expected_staged_revision: String::new(),
+            target_base_revision: "base".into(),
+        },
+        EvidencePreserveRequest {
+            expected_staged_revision: "candidate".into(),
+            target_base_revision: String::new(),
+        },
+    ] {
+        let lore = SharedFakeLore::clean();
+        let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+        let error = evidence_preserve_with_adapters(&lore, &io, &request)
+            .await
+            .expect_err("empty exact revisions are pre-attempt contract errors");
+        assert!(error.to_string().contains("nonempty exact revisions"));
+        let state = io.state();
+        assert!(state.calls.is_empty());
+        assert!(state.metadata_writes.is_empty());
+        assert!(state.stored.is_empty());
+    }
+}
+
+#[tokio::test]
+async fn unknown_mutation_effects_serialize_identically_whether_hidden_effect_applied_or_absent() {
+    let cases = [
+        (
+            "open",
+            EvidencePreserveStopCodeV1::StorageOpenOutcome,
+            "none",
+        ),
+        ("put", EvidencePreserveStopCodeV1::StoragePutOutcome, "none"),
+        (
+            "metadata_set",
+            EvidencePreserveStopCodeV1::PointerAttachOutcome,
+            "blob_published",
+        ),
+        (
+            "close",
+            EvidencePreserveStopCodeV1::StorageCloseOutcome,
+            "postattach_equivalent",
+        ),
+    ];
+
+    for (dependency, expected_stop, expected_publication) in cases {
+        let mut public_outcomes = Vec::new();
+        for (mode, hidden_applied) in [
+            (FakeMutationMode::OutcomeUnknownAbsent, false),
+            (FakeMutationMode::OutcomeUnknownApplied, true),
+        ] {
+            let lore = SharedFakeLore::clean();
+            let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+            io.set_mutation_mode(dependency, mode);
+
+            let outcome =
+                evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+                    .await
+                    .expect("unknown effects remain an in-band lower bound");
+            let residual = expect_residual(&outcome, true, expected_stop);
+            assert_eq!(
+                serde_json::to_value(&residual.last_confirmed_publication).unwrap()["state"],
+                expected_publication,
+                "{dependency}: wrong lower-bound publication state"
+            );
+            assert_eq!(
+                io.state().applied_effects.contains(dependency),
+                hidden_applied,
+                "{dependency}: fake did not establish the hidden-world distinction"
+            );
+            match dependency {
+                "open" => assert!(matches!(
+                    residual.close,
+                    EvidenceCloseStateV1::OpenOutcomeUnknown { .. }
+                )),
+                "close" => assert!(matches!(
+                    residual.close,
+                    EvidenceCloseStateV1::CloseOutcomeUnknown { .. }
+                )),
+                "put" | "metadata_set" => {
+                    assert!(matches!(residual.close, EvidenceCloseStateV1::Closed))
+                }
+                _ => unreachable!("fixed effect-matrix dependency"),
+            }
+            public_outcomes.push(normalized_outcome_json(&outcome));
+        }
+        assert_eq!(
+            public_outcomes[0], public_outcomes[1],
+            "{dependency}: public residual reconstructed an unknowable hidden effect"
+        );
+    }
+}
+
+#[tokio::test]
+async fn close_cross_product_preserves_primary_stop_and_only_full_closed_chain_verifies() {
+    for stage in ["ready", "incomplete", "unknown"] {
+        for close_mode in [
+            FakeMutationMode::Completed,
+            FakeMutationMode::NotDispatched,
+            FakeMutationMode::OutcomeUnknownAbsent,
+        ] {
+            let lore = SharedFakeLore::clean();
+            let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+            match stage {
+                "ready" => {}
+                "incomplete" => io.fail("get"),
+                "unknown" => io.set_mutation_mode("put", FakeMutationMode::OutcomeUnknownAbsent),
+                _ => unreachable!("fixed close-matrix stage"),
+            }
+            io.set_mutation_mode("close", close_mode);
+
+            let outcome =
+                evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+                    .await
+                    .expect("every close observation has an exact in-band result");
+            if stage == "ready" && close_mode == FakeMutationMode::Completed {
+                let verified = outcome
+                    .verified()
+                    .expect("only the full chain plus Closed is Verified");
+                assert!(matches!(verified.close, EvidenceCloseStateV1::Closed));
+                continue;
+            }
+
+            let expected_unknown =
+                stage == "unknown" || close_mode == FakeMutationMode::OutcomeUnknownAbsent;
+            let expected_stop = match stage {
+                "ready" if close_mode == FakeMutationMode::NotDispatched => {
+                    EvidencePreserveStopCodeV1::StorageCloseNotDispatched
+                }
+                "ready" => EvidencePreserveStopCodeV1::StorageCloseOutcome,
+                "incomplete" => EvidencePreserveStopCodeV1::PostattachGetUnavailable,
+                "unknown" => EvidencePreserveStopCodeV1::StoragePutOutcome,
+                _ => unreachable!("full ready case continued above"),
+            };
+            let residual = expect_residual(&outcome, expected_unknown, expected_stop);
+            match close_mode {
+                FakeMutationMode::Completed => {
+                    assert!(matches!(residual.close, EvidenceCloseStateV1::Closed))
+                }
+                FakeMutationMode::NotDispatched => assert!(matches!(
+                    residual.close,
+                    EvidenceCloseStateV1::CloseNotDispatched { .. }
+                )),
+                FakeMutationMode::OutcomeUnknownAbsent => assert!(matches!(
+                    residual.close,
+                    EvidenceCloseStateV1::CloseOutcomeUnknown { .. }
+                )),
+                FakeMutationMode::OutcomeUnknownApplied => {
+                    unreachable!("applied/absent close uncertainty is covered separately")
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn retry_after_unknown_applied_pointer_attach_rejects_existing_pointer_without_resume() {
+    let lore = SharedFakeLore::clean();
+    let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+    io.set_mutation_mode("metadata_set", FakeMutationMode::OutcomeUnknownApplied);
+    let first = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+        .await
+        .expect("unknown applied pointer attach remains in-band");
+    expect_residual(
+        &first,
+        true,
+        EvidencePreserveStopCodeV1::PointerAttachOutcome,
+    );
+    let result_subject = lore
+        .snapshot()
+        .status
+        .unwrap()
+        .staged_revisions
+        .into_iter()
+        .next()
+        .expect("the hidden applied branch advanced the staged subject");
+    let before_retry = io.state();
+
+    let retry = evidence_preserve_with_adapters(
+        &lore,
+        &io,
+        &EvidencePreserveRequest {
+            expected_staged_revision: result_subject,
+            target_base_revision: "base".into(),
+        },
+    )
+    .await
+    .expect("retry returns an exact deterministic rejection");
+    let rejected = expect_rejected(&retry, EvidenceRejectionCodeV1::PointerAlreadyPresent);
+    assert_eq!(rejected.stopped_at.code, "evidence pointer already present");
+    let after_retry = io.state();
+    assert_eq!(
+        after_retry.opens, before_retry.opens,
+        "retry must not resume"
+    );
+    assert_eq!(
+        after_retry.puts, before_retry.puts,
+        "retry must not republish"
+    );
+    assert_eq!(
+        after_retry.metadata_writes, before_retry.metadata_writes,
+        "retry must not attach another pointer"
+    );
+}
+
+#[tokio::test]
+async fn evidence_rejects_ambiguous_put_and_get_streams_and_wrong_bytes() {
+    let valid_put = ImmutablePutItem {
+        id: 5934,
+        address: FAKE_EVIDENCE_ADDRESS.into(),
+        ok: true,
+    };
+    for items in [vec![], vec![valid_put.clone(), valid_put.clone()]] {
+        let lore = SharedFakeLore::clean();
+        let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+        let addresses: Vec<_> = items.iter().map(|item| item.address.clone()).collect();
+        io.set_put_override(Ok(items));
+        let outcome = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+            .await
+            .unwrap();
+        let residual = expect_residual(
+            &outcome,
+            true,
+            EvidencePreserveStopCodeV1::StoragePutResponseMalformed,
+        );
+        assert_eq!(residual.observed_candidate_addresses, addresses);
+        assert!(matches!(
+            residual.last_confirmed_publication,
+            EvidencePublicationStateV1::None
+        ));
+        assert_eq!(io.state().closes, 1);
+        assert!(io.state().metadata_writes.is_empty());
+    }
+
+    for invalid in [
+        ImmutablePutItem {
+            id: 9,
+            ..valid_put.clone()
+        },
+        ImmutablePutItem {
+            address: "not-an-address".into(),
+            ..valid_put.clone()
+        },
+        ImmutablePutItem {
+            address: format!("{}-{}", "A".repeat(64), "0".repeat(32)),
+            ..valid_put.clone()
+        },
+        ImmutablePutItem {
+            ok: false,
+            ..valid_put.clone()
+        },
+    ] {
+        let lore = SharedFakeLore::clean();
+        let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+        let address = invalid.address.clone();
+        io.set_put_override(Ok(vec![invalid]));
+        let outcome = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+            .await
+            .unwrap();
+        let residual = expect_residual(
+            &outcome,
+            true,
+            EvidencePreserveStopCodeV1::StoragePutResponseMalformed,
+        );
+        assert_eq!(residual.observed_candidate_addresses, [address]);
+        assert_eq!(io.state().closes, 1);
+        assert!(io.state().metadata_writes.is_empty());
+    }
+
+    for get in [
+        vec![],
+        vec![
+            ImmutableGetItem {
+                id: 5934,
+                address: FAKE_EVIDENCE_ADDRESS.into(),
+                size: 1,
+                data: vec![1],
+                ok: true,
+            },
+            ImmutableGetItem {
+                id: 5934,
+                address: FAKE_EVIDENCE_ADDRESS.into(),
+                size: 1,
+                data: vec![1],
+                ok: true,
+            },
+        ],
+        vec![ImmutableGetItem {
+            id: 7,
+            address: FAKE_EVIDENCE_ADDRESS.into(),
+            size: 1,
+            data: vec![1],
+            ok: true,
+        }],
+        vec![ImmutableGetItem {
+            id: 5934,
+            address: format!("{}-{}", "b".repeat(64), "0".repeat(32)),
+            size: 1,
+            data: vec![1],
+            ok: true,
+        }],
+        vec![ImmutableGetItem {
+            id: 5934,
+            address: FAKE_EVIDENCE_ADDRESS.into(),
+            size: 99,
+            data: vec![1],
+            ok: true,
+        }],
+        vec![ImmutableGetItem {
+            id: 5934,
+            address: FAKE_EVIDENCE_ADDRESS.into(),
+            size: 1,
+            data: vec![1],
+            ok: false,
+        }],
+    ] {
+        let lore = SharedFakeLore::clean();
+        let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+        io.set_get_override(Ok(get));
+        let outcome = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+            .await
+            .unwrap();
+        let residual = expect_residual(
+            &outcome,
+            false,
+            EvidencePreserveStopCodeV1::PostattachGetMalformed,
+        );
+        assert!(matches!(
+            residual.last_confirmed_publication,
+            EvidencePublicationStateV1::PointerAttachAcknowledged { .. }
+        ));
+        assert_eq!(io.state().closes, 1);
+        assert_eq!(io.state().metadata_writes.len(), 1);
+    }
+
+    let lore = SharedFakeLore::clean();
+    let io = FakeIo::new(lore.clone(), GovernanceRole::Actor);
+    io.corrupt_get_bytes();
+    let outcome = evidence_preserve_with_adapters(&lore, &io, &evidence_request("candidate"))
+        .await
+        .unwrap();
+    let residual = expect_residual(
+        &outcome,
+        false,
+        EvidencePreserveStopCodeV1::PostattachBytesMismatch,
+    );
+    assert!(matches!(
+        residual.last_confirmed_publication,
+        EvidencePublicationStateV1::PointerAttachAcknowledged { .. }
+    ));
+    assert_eq!(io.state().closes, 1, "same-size wrong bytes are fatal");
+    assert_eq!(
+        io.state().metadata_writes.len(),
+        1,
+        "the exact pointer attach precedes the required postattach readback"
+    );
+}
+
+#[tokio::test]
+async fn gate_always_returns_the_exact_inventory_and_closes_missing_evidence() {
+    let lore = SharedFakeLore::clean();
+    let io = FakeIo::new(lore.clone(), GovernanceRole::Witness);
+    let gate = submission_gate_check_with_adapters(&lore, &io, &gate_request("candidate")).await;
+    assert!(!gate.gate_open);
+    assert_eq!(gate.criteria.len(), 7);
+    let mut unique = BTreeSet::new();
+    for criterion in &gate.criteria {
+        assert!(unique.insert(criterion.criterion));
+    }
+    assert_eq!(
+        gate.criteria
+            .last()
+            .map(|criterion| criterion.failure_code.as_deref()),
+        Some(Some("evidence_pointer_missing"))
+    );
 }
 
 #[test]
@@ -386,19 +2823,61 @@ fn traverses_both_merge_parents_and_rejects_depth_overflow() {
     assert_closed_for(
         FakeLore::clean(),
         |fake| fake.history = Ok(vec!["x".to_string(); 1001]),
-        "history_depth_exceeded",
+        "history_incomplete",
     );
 }
 
 #[test]
-fn accepts_500_999_and_1000_clean_pending_nodes() {
-    for count in [500_usize, 999, 1000] {
+fn separate_pending_and_whole_ancestry_ceilings_map_exact_remediation() {
+    for count in [500_usize, 999] {
         let fake = FakeLore::with_linear_pending_count(count);
         let result = tokio::runtime::Runtime::new()
             .unwrap()
             .block_on(evaluate(&fake, &request()));
         assert!(result.open, "count {count}: {result:?}");
+        assert!(result.remediation.is_none());
+        if count == 999 {
+            assert_eq!(
+                result.observations.supersession_ancestry.len(),
+                MAX_GOVERNANCE_HISTORY_REVISIONS,
+                "whole ancestry accepts exactly 1000 unique revisions"
+            );
+        }
     }
+
+    let exact_pending = FakeLore::with_linear_pending_count(1000);
+    let dco = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(dco_validate_with_adapter(
+            &exact_pending,
+            &DcoValidateRequest {
+                expected_staged_revision: "candidate".into(),
+                target_base_revision: "base".into(),
+            },
+        ));
+    assert!(dco.valid, "exact pending ceiling: {dco:?}");
+    assert!(dco.remediation.is_none());
+
+    let ancestry_overflow = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(evaluate(&exact_pending, &request()));
+    assert!(!ancestry_overflow.open, "{ancestry_overflow:?}");
+    assert_eq!(
+        ancestry_overflow.observations.supersession_ancestry.len(),
+        MAX_GOVERNANCE_HISTORY_REVISIONS + 1,
+        "whole ancestry retains its exact N+1 sentinel graph"
+    );
+    assert_eq!(
+        ancestry_overflow.observations.history_overflow_scope,
+        Some(HistoryOverflowScope::SupersessionAncestry)
+    );
+    assert_eq!(
+        ancestry_overflow.remediation,
+        Some(GovernanceRemediation {
+            code: GovernanceRemediationCode::MigrateSupersessionIndex,
+            ticket: Some("SBAI-6010".into()),
+        })
+    );
 }
 
 #[test]
@@ -406,15 +2885,152 @@ fn enforces_1000_unique_pending_limit_across_second_parent_dag() {
     let exact_limit = FakeLore::with_second_parent_pending_count(1000);
     let result = tokio::runtime::Runtime::new()
         .unwrap()
-        .block_on(evaluate(&exact_limit, &request()));
-    assert!(result.open, "exactly 1000 unique pending nodes: {result:?}");
+        .block_on(dco_validate_with_adapter(
+            &exact_limit,
+            &DcoValidateRequest {
+                expected_staged_revision: "candidate".into(),
+                target_base_revision: "base".into(),
+            },
+        ));
+    assert!(
+        result.valid,
+        "exactly 1000 unique pending nodes: {result:?}"
+    );
 
-    let overflow = FakeLore::with_second_parent_pending_count(1002);
+    let overflow = FakeLore::with_second_parent_pending_count(1001);
     let queries = overflow.info_queries.clone();
-    assert_closed_for(overflow, |_| {}, "history_depth_exceeded");
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(dco_validate_with_adapter(
+            &overflow,
+            &DcoValidateRequest {
+                expected_staged_revision: "candidate".into(),
+                target_base_revision: "base".into(),
+            },
+        ));
+    assert!(!result.valid, "{result:?}");
+    assert_eq!(result.failure_codes, ["history_depth_exceeded"]);
+    assert_eq!(result.pending_revisions.len(), 1001);
+    assert_eq!(
+        result.remediation,
+        Some(GovernanceRemediation {
+            code: GovernanceRemediationCode::SplitSubmissionOrAdvanceTargetBase,
+            ticket: None,
+        })
+    );
+    let evaluation = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(evaluate(&overflow, &request()));
+    assert_eq!(evaluation.failure_codes, ["history_depth_exceeded"]);
+    assert_eq!(
+        evaluation.observations.history_overflow_scope,
+        Some(HistoryOverflowScope::PendingDco)
+    );
+    assert_eq!(
+        evaluation.observations.revision_graph.len(),
+        MAX_GOVERNANCE_HISTORY_REVISIONS + 1
+    );
+    assert!(evaluation.observations.supersession_ancestry.is_empty());
+    assert_eq!(evaluation.remediation, result.remediation);
     let queries = queries.lock().unwrap();
     assert!(queries.iter().any(|revision| revision == "side-1000"));
     assert!(!queries.iter().any(|revision| revision == "side-1001"));
+}
+
+#[test]
+fn malformed_base_never_inherits_pending_overflow_remediation() {
+    let malformed_parents = [
+        vec!["older".into(), "older".into()],
+        vec!["one".into(), "two".into(), "three".into()],
+        vec!["base".into()],
+    ];
+    for parents in malformed_parents {
+        let mut fake = FakeLore::with_second_parent_pending_count(1001);
+        fake.infos.insert(
+            "base".into(),
+            Ok(RevisionInfoResponse::exact(RevisionInfo {
+                revision: "base".into(),
+                parents,
+            })),
+        );
+
+        let evaluation = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(evaluate(&fake, &request()));
+        assert_eq!(evaluation.failure_codes, ["history_incomplete"]);
+        assert!(evaluation.remediation.is_none());
+        assert!(evaluation.observations.revision_graph.is_empty());
+
+        let dco = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(dco_validate_with_adapter(
+                &fake,
+                &DcoValidateRequest {
+                    expected_staged_revision: "candidate".into(),
+                    target_base_revision: "base".into(),
+                },
+            ));
+        assert_eq!(dco.failure_codes, ["history_incomplete"]);
+        assert!(dco.remediation.is_none());
+        assert!(dco.pending_revisions.is_empty());
+    }
+}
+
+#[test]
+fn genuine_pending_and_whole_ancestry_cycles_fail_before_any_remediation() {
+    let mut pending_cycle = FakeLore::clean();
+    pending_cycle.infos.insert(
+        "candidate".into(),
+        Ok(RevisionInfoResponse::exact(RevisionInfo {
+            revision: "candidate".into(),
+            parents: vec!["loop".into()],
+        })),
+    );
+    pending_cycle.infos.insert(
+        "loop".into(),
+        Ok(RevisionInfoResponse::exact(RevisionInfo {
+            revision: "loop".into(),
+            parents: vec!["candidate".into()],
+        })),
+    );
+    let evaluation = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(evaluate(&pending_cycle, &request()));
+    assert_eq!(evaluation.failure_codes, ["history_incomplete"]);
+    assert!(evaluation.remediation.is_none());
+    let dco = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(dco_validate_with_adapter(
+            &pending_cycle,
+            &DcoValidateRequest {
+                expected_staged_revision: "candidate".into(),
+                target_base_revision: "base".into(),
+            },
+        ));
+    assert_eq!(dco.failure_codes, ["history_incomplete"]);
+    assert!(dco.remediation.is_none());
+
+    let mut ancestry_cycle = FakeLore::clean();
+    ancestry_cycle.infos.insert(
+        "base".into(),
+        Ok(RevisionInfoResponse::exact(RevisionInfo {
+            revision: "base".into(),
+            parents: vec!["older".into()],
+        })),
+    );
+    ancestry_cycle.infos.insert(
+        "older".into(),
+        Ok(RevisionInfoResponse::exact(RevisionInfo {
+            revision: "older".into(),
+            parents: vec!["base".into()],
+        })),
+    );
+    let evaluation = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(evaluate(&ancestry_cycle, &request()));
+    assert_eq!(evaluation.failure_codes, ["history_incomplete"]);
+    assert!(evaluation.remediation.is_none());
+    assert_eq!(evaluation.observations.first_parent_history, ["candidate"]);
 }
 
 #[test]
@@ -459,6 +3075,58 @@ fn closes_for_status_and_history_graph_failures() {
         |fake| {
             fake.infos
                 .insert("base".into(), Err(FakeLore::error("base")));
+        },
+        "history_incomplete",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.infos.insert(
+                "candidate".into(),
+                Ok(RevisionInfoResponse::exact(RevisionInfo {
+                    revision: "candidate".into(),
+                    parents: vec!["base".into(), "base".into()],
+                })),
+            );
+        },
+        "history_incomplete",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.infos.insert(
+                "candidate".into(),
+                Ok(RevisionInfoResponse::exact(RevisionInfo {
+                    revision: "candidate".into(),
+                    parents: vec!["base".into(), "left".into(), "right".into()],
+                })),
+            );
+        },
+        "history_incomplete",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.infos.insert(
+                "base".into(),
+                Ok(RevisionInfoResponse::exact(RevisionInfo {
+                    revision: "base".into(),
+                    parents: vec!["older".into(), "older".into()],
+                })),
+            );
+        },
+        "history_incomplete",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.infos.insert(
+                "base".into(),
+                Ok(RevisionInfoResponse::exact(RevisionInfo {
+                    revision: "base".into(),
+                    parents: vec!["one".into(), "two".into(), "three".into()],
+                })),
+            );
         },
         "history_incomplete",
     );
@@ -560,6 +3228,112 @@ fn closes_when_status_cannot_prove_a_full_scan_or_stable_exact_subject() {
         FakeLore::clean(),
         |fake| fake.status.as_mut().unwrap().post_scan_staged_revisions = vec!["other".into()],
         "exact_subject_failed",
+    );
+}
+
+#[test]
+fn missing_deleted_conflicting_duplicate_or_incomplete_fingerprints_close() {
+    let cases: [fn(&mut FakeLore); 5] = [
+        |fake| fake.status.as_mut().unwrap().worktree_files.clear(),
+        |fake| fake.status.as_mut().unwrap().worktree_files[0].flag_deleted = true,
+        |fake| fake.status.as_mut().unwrap().worktree_files[0].flag_conflict = true,
+        |fake| {
+            let duplicate = fake.status.as_ref().unwrap().worktree_files[0].clone();
+            fake.status.as_mut().unwrap().worktree_files.push(duplicate);
+        },
+        |fake| {
+            fake.status.as_mut().unwrap().worktree_files[0]
+                .local_hash
+                .clear()
+        },
+    ];
+    for mutate in cases {
+        assert_closed_for(FakeLore::clean(), mutate, "worktree_dirty");
+    }
+}
+
+#[test]
+fn ambiguous_repeated_staged_status_endpoint_closes_instead_of_deduplicating() {
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.status
+                .as_mut()
+                .unwrap()
+                .staged_changes
+                .push(StagedPathObservation {
+                    path: "asset.txt".into(),
+                    from_path: None,
+                    action: GovernancePathAction::Add,
+                    dirty: true,
+                    conflict: false,
+                });
+        },
+        "affected_paths_unavailable",
+    );
+}
+
+#[test]
+fn fake_status_cannot_exceed_pinned_production_endpoint_shapes() {
+    for action in [
+        GovernancePathAction::Modify,
+        GovernancePathAction::Add,
+        GovernancePathAction::Delete,
+    ] {
+        assert_closed_for(
+            FakeLore::clean(),
+            |fake| {
+                let status = fake.status.as_mut().unwrap();
+                status.staged_paths = vec!["asset.txt".into(), "fabricated-source.txt".into()];
+                status.staged_changes[0].action = action;
+                status.staged_changes[0].from_path = Some("fabricated-source.txt".into());
+            },
+            "affected_paths_unavailable",
+        );
+    }
+
+    for from_path in [None, Some(String::new()), Some("asset.txt".into())] {
+        assert_closed_for(
+            FakeLore::clean(),
+            |fake| {
+                let status = fake.status.as_mut().unwrap();
+                status.staged_paths = vec!["asset.txt".into()];
+                status.staged_changes[0].action = GovernancePathAction::Move;
+                status.staged_changes[0].from_path = from_path;
+            },
+            "affected_paths_unavailable",
+        );
+    }
+}
+
+#[test]
+fn delete_readd_cannot_reuse_the_old_context_as_an_aba_identity() {
+    let mut fake = FakeLore::clean();
+    fake.dumps
+        .insert("base".into(), Ok(vec!["asset.txt".into()]));
+    fake.file_info.insert(
+        "base".into(),
+        Ok(vec![FileIdentity::new(
+            "asset.txt",
+            "base",
+            "1111111111111111111111111111111111111111111111111111111111111111",
+            "22222222222222222222222222222222",
+        )]),
+    );
+    fake.status.as_mut().unwrap().staged_changes = vec![StagedPathObservation {
+        path: "asset.txt".into(),
+        from_path: None,
+        action: GovernancePathAction::Add,
+        dirty: true,
+        conflict: false,
+    }];
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(evaluate(&fake, &request()));
+    assert_eq!(
+        result.failure_codes,
+        ["affected_paths_unavailable"],
+        "an add event that reuses the old file ID must never collapse into the old identity"
     );
 }
 
@@ -697,8 +3471,8 @@ fn closes_for_metadata_supersession_and_dco_dependency_failures() {
                 .as_mut()
                 .unwrap()
                 .push(MetadataEntry::new(
-                    "studiobrain.governance.v1.superseded.hash-1:context-1",
-                    r#"{"version":"v2","identity":"hash-1:context-1"}"#,
+                    "studiobrain.governance.v1.superseded.1111111111111111111111111111111111111111111111111111111111111111:22222222222222222222222222222222",
+                    r#"{"version":"v2","identity":"1111111111111111111111111111111111111111111111111111111111111111:22222222222222222222222222222222"}"#,
                 ));
         },
         "supersession_invalid",
@@ -712,7 +3486,7 @@ fn closes_for_metadata_supersession_and_dco_dependency_failures() {
                 .as_mut()
                 .unwrap()
                 .push(MetadataEntry::new(
-                    "studiobrain.governance.v1.superseded.hash-1:context-1",
+                    "studiobrain.governance.v1.superseded.1111111111111111111111111111111111111111111111111111111111111111:22222222222222222222222222222222",
                     r#"{"version":"v1","identity":"different"}"#,
                 ));
         },
@@ -728,8 +3502,8 @@ fn scans_supersession_metadata_on_the_verified_base_revision() {
             fake.metadata.insert(
                 "base".into(),
                 Ok(vec![MetadataEntry::new(
-                    "studiobrain.governance.v1.superseded.hash-1:context-1",
-                    r#"{"version":"v1","identity":"hash-1:context-1"}"#,
+                    "studiobrain.governance.v1.superseded.1111111111111111111111111111111111111111111111111111111111111111:22222222222222222222222222222222",
+                    r#"{"version":"v1","identity":"1111111111111111111111111111111111111111111111111111111111111111:22222222222222222222222222222222"}"#,
                 )]),
             );
         },
@@ -741,13 +3515,140 @@ fn scans_supersession_metadata_on_the_verified_base_revision() {
             fake.metadata.insert(
                 "base".into(),
                 Ok(vec![MetadataEntry::new(
-                    "studiobrain.governance.v1.superseded.hash-1:context-1",
-                    r#"{"version":"v2","identity":"hash-1:context-1"}"#,
+                    "studiobrain.governance.v1.superseded.1111111111111111111111111111111111111111111111111111111111111111:22222222222222222222222222222222",
+                    r#"{"version":"v2","identity":"1111111111111111111111111111111111111111111111111111111111111111:22222222222222222222222222222222"}"#,
                 )]),
             );
         },
         "supersession_invalid",
     );
+}
+
+#[test]
+fn ancestor_marker_survives_cleared_tip_and_base_metadata() {
+    let identity = format!("{}:{}", "1".repeat(64), "2".repeat(32));
+    let mut fake = FakeLore::clean();
+    fake.infos.insert(
+        "base".into(),
+        Ok(RevisionInfoResponse::exact(RevisionInfo {
+            revision: "base".into(),
+            parents: vec!["older".into()],
+        })),
+    );
+    fake.infos.insert(
+        "older".into(),
+        Ok(RevisionInfoResponse::exact(RevisionInfo {
+            revision: "older".into(),
+            parents: vec![],
+        })),
+    );
+    for revision in ["candidate", "base"] {
+        assert!(fake.metadata[revision]
+            .as_ref()
+            .unwrap()
+            .iter()
+            .all(|entry| !entry.key.starts_with(SUPERSESSION_MARKER_PREFIX)));
+    }
+    fake.metadata.insert(
+        "older".into(),
+        Ok(vec![MetadataEntry::new(
+            format!("{SUPERSESSION_MARKER_PREFIX}{identity}"),
+            serde_json::to_string(&lore_vm::ops::governance::contract::SupersessionMarkerV1 {
+                version: "v1".into(),
+                identity,
+            })
+            .unwrap(),
+        )]),
+    );
+
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(evaluate(&fake, &request()));
+    assert_eq!(result.failure_codes, ["not_superseded_failed"]);
+    assert!(result.remediation.is_none());
+    assert_eq!(
+        result
+            .observations
+            .supersession_ancestry
+            .iter()
+            .map(|info| info.revision.as_str())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["base", "candidate", "older"])
+    );
+}
+
+#[test]
+fn marker_on_older_second_parent_of_base_blocks_revival() {
+    let identity = format!("{}:{}", "1".repeat(64), "2".repeat(32));
+    let mut fake = FakeLore::clean();
+    fake.infos.insert(
+        "base".into(),
+        Ok(RevisionInfoResponse::exact(RevisionInfo {
+            revision: "base".into(),
+            parents: vec!["left-root".into(), "right-root".into()],
+        })),
+    );
+    for revision in ["left-root", "right-root"] {
+        fake.infos.insert(
+            revision.into(),
+            Ok(RevisionInfoResponse::exact(RevisionInfo {
+                revision: revision.into(),
+                parents: vec![],
+            })),
+        );
+        fake.metadata.insert(revision.into(), Ok(vec![]));
+    }
+    fake.metadata.insert(
+        "right-root".into(),
+        Ok(vec![MetadataEntry::new(
+            format!("{SUPERSESSION_MARKER_PREFIX}{identity}"),
+            serde_json::to_string(&lore_vm::ops::governance::contract::SupersessionMarkerV1 {
+                version: "v1".into(),
+                identity,
+            })
+            .unwrap(),
+        )]),
+    );
+
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(evaluate(&fake, &request()));
+    assert_eq!(result.failure_codes, ["not_superseded_failed"]);
+    assert!(result.remediation.is_none());
+    assert!(result
+        .observations
+        .supersession_markers
+        .iter()
+        .any(|marker| marker.revision == "right-root"));
+}
+
+#[test]
+fn supersession_markers_reject_short_uppercase_and_zero_context_identities() {
+    for identity in [
+        "short:identity".to_string(),
+        format!("{}:{}", "A".repeat(64), "2".repeat(32)),
+        format!("{}:{}", "1".repeat(64), "0".repeat(32)),
+    ] {
+        assert_closed_for(
+            FakeLore::clean(),
+            |fake| {
+                fake.metadata
+                    .get_mut("base")
+                    .unwrap()
+                    .as_mut()
+                    .unwrap()
+                    .push(MetadataEntry::new(
+                        format!("{SUPERSESSION_MARKER_PREFIX}{identity}"),
+                        serde_json::to_string(&serde_json::json!({
+                            "version": "v1",
+                            "identity": identity,
+                        }))
+                        .unwrap(),
+                    ));
+            },
+            "supersession_invalid",
+        );
+    }
 }
 
 #[test]
@@ -864,7 +3765,12 @@ fn closes_for_tree_file_info_diff_and_lock_dependency_failures() {
             fake.file_info.insert(
                 "candidate".into(),
                 Ok(vec![
-                    FileIdentity::new("asset.txt", "candidate", "hash-1", "context-1"),
+                    FileIdentity::new(
+                        "asset.txt",
+                        "candidate",
+                        "1111111111111111111111111111111111111111111111111111111111111111",
+                        "22222222222222222222222222222222",
+                    ),
                     FileIdentity::new("asset.txt", "candidate", "hash-2", "context-2"),
                 ]),
             );
@@ -894,8 +3800,8 @@ fn closes_for_tree_file_info_diff_and_lock_dependency_failures() {
                 Ok(vec![FileIdentity::new(
                     "asset.txt",
                     "fallback",
-                    "hash-1",
-                    "context-1",
+                    "1111111111111111111111111111111111111111111111111111111111111111",
+                    "22222222222222222222222222222222",
                 )]),
             );
         },
@@ -910,7 +3816,7 @@ fn closes_for_tree_file_info_diff_and_lock_dependency_failures() {
                     "asset.txt",
                     "candidate",
                     "",
-                    "context-1",
+                    "22222222222222222222222222222222",
                 )]),
             );
         },
@@ -926,17 +3832,10 @@ fn closes_for_tree_file_info_diff_and_lock_dependency_failures() {
         |fake| {
             fake.diff = Ok(vec![]);
             fake.status.as_mut().unwrap().staged_paths.clear();
-            fake.dumps
-                .insert("base".into(), Ok(vec!["asset.txt".into()]));
-            fake.file_info.insert(
-                "base".into(),
-                Ok(vec![FileIdentity::new(
-                    "asset.txt",
-                    "base",
-                    "hash-1",
-                    "context-1",
-                )]),
-            );
+            fake.status.as_mut().unwrap().staged_changes.clear();
+            let worktree = &mut fake.status.as_mut().unwrap().worktree_files[0];
+            worktree.local_hash = worktree.revision_hash.clone();
+            worktree.flag_modified = false;
         },
         "empty_submission",
     );
@@ -989,6 +3888,182 @@ fn closes_for_tree_file_info_diff_and_lock_dependency_failures() {
         },
         "locks_clear_failed",
     );
+}
+
+#[test]
+fn raw_revision_diff_rejects_wrong_action_direction_duplicate_and_incomplete_facts() {
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.diff = Err(FakeLore::error("raw diff ended before End"));
+        },
+        "affected_paths_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            let mut wrong = raw_modified("asset.txt");
+            wrong.action = GovernancePathAction::Add;
+            wrong.old_is_file = false;
+            wrong.old_address = format!("{}-{}", "0".repeat(64), "0".repeat(32));
+            fake.diff = Ok(vec![wrong]);
+        },
+        "affected_paths_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            let mut wrong = raw_modified("asset.txt");
+            wrong.action = GovernancePathAction::Delete;
+            wrong.new_is_file = false;
+            wrong.new_address = format!("{}-{}", "0".repeat(64), "0".repeat(32));
+            fake.diff = Ok(vec![wrong]);
+        },
+        "affected_paths_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.diff = Ok(vec![raw_modified("asset.txt"), raw_modified("asset.txt")]);
+        },
+        "affected_paths_unavailable",
+    );
+}
+
+#[test]
+fn raw_move_pair_is_exact_and_rejects_orphan_reused_extra_reversed_or_mismatched_facts() {
+    let clean = FakeLore::clean_rename();
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(evaluate(&clean, &request()));
+    assert!(result.open, "exact raw move pair: {result:?}");
+    assert_eq!(
+        result.observations.revision_diff,
+        vec![AffectedPath {
+            source_path: Some("asset.txt".into()),
+            target_path: Some("renamed.txt".into()),
+        }]
+    );
+    assert_eq!(result.affected_paths, ["asset.txt", "renamed.txt"]);
+    assert_eq!(result.observations.lock_queries.len(), 2);
+
+    let cases: [(&str, fn(&mut FakeLore)); 8] = [
+        ("orphan", |fake| {
+            fake.diff.as_mut().unwrap().pop();
+        }),
+        ("raw_move_instead_of_exact_pair", |fake| {
+            fake.diff = Ok(vec![RevisionDiffObservation {
+                path: "renamed.txt".into(),
+                action: GovernancePathAction::Move,
+                old_is_file: true,
+                new_is_file: true,
+                old_address: format!("{}-{}", "4".repeat(64), "2".repeat(32)),
+                new_address: format!("{}-{}", "4".repeat(64), "2".repeat(32)),
+            }]);
+        }),
+        ("extra", |fake| {
+            fake.diff.as_mut().unwrap().push(raw_added("orphan.txt"));
+        }),
+        ("reversed_endpoints", |fake| {
+            fake.diff = Ok(vec![raw_deleted("renamed.txt"), raw_added("asset.txt")]);
+        }),
+        ("wrong_flags", |fake| {
+            fake.diff.as_mut().unwrap()[0].new_is_file = true;
+        }),
+        ("wrong_hash", |fake| {
+            fake.diff.as_mut().unwrap()[1].new_address =
+                format!("{}-{}", "9".repeat(64), "2".repeat(32));
+        }),
+        ("context_mismatch", |fake| {
+            fake.diff.as_mut().unwrap()[1].new_address =
+                format!("{}-{}", "4".repeat(64), "3".repeat(32));
+        }),
+        ("reused_duplicate_event", |fake| {
+            fake.diff.as_mut().unwrap().push(raw_added("renamed.txt"));
+        }),
+    ];
+    for (name, mutate) in cases {
+        let mut fake = FakeLore::clean_rename();
+        mutate(&mut fake);
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(evaluate(&fake, &request()));
+        assert!(!result.open, "{name}: {result:?}");
+        assert_eq!(
+            result.failure_codes,
+            ["affected_paths_unavailable"],
+            "{name}: {result:?}"
+        );
+    }
+}
+
+#[test]
+fn synthetic_status_or_raw_copy_is_explicitly_unsupported_at_pinned_lore() {
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            let status = fake.status.as_mut().unwrap();
+            status.staged_paths = vec!["asset.txt".into(), "copied.txt".into()];
+            status.staged_changes = vec![StagedPathObservation {
+                path: "copied.txt".into(),
+                from_path: Some("asset.txt".into()),
+                action: GovernancePathAction::Copy,
+                dirty: true,
+                conflict: false,
+            }];
+        },
+        "copy_semantics_unavailable",
+    );
+
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| fake.diff.as_mut().unwrap()[0].action = GovernancePathAction::Copy,
+        "copy_semantics_unavailable",
+    );
+}
+
+#[test]
+fn exact_tree_rejects_noncanonical_base_and_selected_candidate_identities() {
+    for (revision, field, value) in [
+        ("base", "hash", "A".repeat(64)),
+        ("base", "hash", "abcd".into()),
+        ("base", "context", "0".repeat(32)),
+        ("candidate", "hash", "A".repeat(64)),
+        ("candidate", "hash", "abcd".into()),
+        ("candidate", "context", "0".repeat(32)),
+    ] {
+        let mut fake = FakeLore::clean();
+        if revision == "base" {
+            fake.dumps
+                .insert("base".into(), Ok(vec!["base.txt".into()]));
+            fake.file_info.insert(
+                "base".into(),
+                Ok(vec![FileIdentity::new(
+                    "base.txt",
+                    "base",
+                    "4444444444444444444444444444444444444444444444444444444444444444",
+                    "55555555555555555555555555555555",
+                )]),
+            );
+        }
+        let identity = fake
+            .file_info
+            .get_mut(revision)
+            .unwrap()
+            .as_mut()
+            .unwrap()
+            .first_mut()
+            .unwrap();
+        if field == "hash" {
+            identity.hash = value;
+        } else {
+            identity.context = value;
+        }
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(evaluate(&fake, &request()));
+        assert_eq!(result.failure_codes, ["tree_invalid"], "{revision} {field}");
+    }
 }
 
 #[test]
@@ -1045,4 +4120,1079 @@ fn raw_lock_boundaries_reject_missing_duplicate_over_counted_and_ignored_streams
         },
         "locks_unavailable",
     );
+}
+
+#[cfg(feature = "integration-tests")]
+#[derive(Clone, Copy)]
+enum InjectedLockDependency {
+    Clear,
+    QueryUnavailable,
+    StatusUnavailable,
+}
+
+#[cfg(feature = "integration-tests")]
+#[derive(Clone, Copy)]
+enum InjectedAuthorDependency {
+    Match,
+    Mismatch,
+    Duplicate,
+    Unresolved,
+    Unavailable,
+}
+
+/// Truthful hybrid: repository/status/history/tree/diff/metadata are the real
+/// in-process Lore engine; only remote auth and lock replies are deterministic
+/// injected dependencies. SBAI-6001 tracks authenticated remote corroboration.
+#[cfg(feature = "integration-tests")]
+struct HybridGovernanceAdapter<'a> {
+    real: ProductionLoreAdapter<'a>,
+    lock: InjectedLockDependency,
+    authors: InjectedAuthorDependency,
+}
+
+#[cfg(feature = "integration-tests")]
+impl<'a> HybridGovernanceAdapter<'a> {
+    fn new(api: &'a LoreApi, branch: &str, lock: InjectedLockDependency) -> Self {
+        Self {
+            real: ProductionLoreAdapter::new(api, branch),
+            lock,
+            authors: InjectedAuthorDependency::Match,
+        }
+    }
+
+    fn with_authors(mut self, authors: InjectedAuthorDependency) -> Self {
+        self.authors = authors;
+        self
+    }
+}
+
+#[cfg(feature = "integration-tests")]
+#[async_trait::async_trait]
+impl GovernanceAdapter for HybridGovernanceAdapter<'_> {
+    async fn exact_staged_revisions(&self) -> Result<Vec<String>, AdapterError> {
+        self.real.exact_staged_revisions().await
+    }
+
+    async fn status(&self) -> Result<StatusSnapshot, AdapterError> {
+        self.real.status().await
+    }
+
+    async fn revision_info(&self, revision: &str) -> Result<RevisionInfoResponse, AdapterError> {
+        self.real.revision_info(revision).await
+    }
+
+    async fn revision_metadata(&self, revision: &str) -> Result<Vec<MetadataEntry>, AdapterError> {
+        self.real.revision_metadata(revision).await
+    }
+
+    async fn first_parent_history(
+        &self,
+        candidate: &str,
+        target_base: &str,
+        max_revisions: usize,
+    ) -> Result<Vec<String>, AdapterError> {
+        self.real
+            .first_parent_history(candidate, target_base, max_revisions)
+            .await
+    }
+
+    async fn repository_dump(&self, revision: &str) -> Result<Vec<String>, AdapterError> {
+        self.real.repository_dump(revision).await
+    }
+
+    async fn file_info(
+        &self,
+        revision: &str,
+        paths: &[String],
+    ) -> Result<Vec<FileIdentity>, AdapterError> {
+        self.real.file_info(revision, paths).await
+    }
+
+    async fn revision_diff(
+        &self,
+        base: &str,
+        candidate: &str,
+    ) -> Result<Vec<RevisionDiffObservation>, AdapterError> {
+        self.real.revision_diff(base, candidate).await
+    }
+
+    async fn resolve_authors(
+        &self,
+        identities: &[String],
+    ) -> Result<Vec<ResolvedAuthor>, AdapterError> {
+        match self.authors {
+            InjectedAuthorDependency::Match => Ok(identities
+                .iter()
+                .map(|identity| ResolvedAuthor::new(identity, "Alice"))
+                .collect()),
+            InjectedAuthorDependency::Mismatch => Ok(identities
+                .iter()
+                .map(|identity| ResolvedAuthor::new(identity, "Mallory"))
+                .collect()),
+            InjectedAuthorDependency::Duplicate => {
+                let Some(identity) = identities.first() else {
+                    return Ok(Vec::new());
+                };
+                Ok(vec![
+                    ResolvedAuthor::new(identity, "Alice"),
+                    ResolvedAuthor::new(identity, "Alice"),
+                ])
+            }
+            InjectedAuthorDependency::Unresolved => Ok(Vec::new()),
+            InjectedAuthorDependency::Unavailable => {
+                Err(AdapterError::new("injected author resolution unavailable"))
+            }
+        }
+    }
+
+    async fn lock_file_query(&self, _branch: &str, path: &str) -> Result<LockQuery, AdapterError> {
+        match self.lock {
+            InjectedLockDependency::QueryUnavailable => {
+                Err(AdapterError::new("injected lock query unavailable"))
+            }
+            _ => Ok(LockQuery::unlocked(path)),
+        }
+    }
+
+    async fn lock_file_status(
+        &self,
+        _branch: &str,
+        _paths: &[String],
+    ) -> Result<LockStatusResponse, AdapterError> {
+        match self.lock {
+            InjectedLockDependency::StatusUnavailable => {
+                Err(AdapterError::new("injected lock status unavailable"))
+            }
+            _ => Ok(LockStatusResponse::unlocked()),
+        }
+    }
+}
+
+#[cfg(feature = "integration-tests")]
+struct RealGovernanceFixture {
+    _tempdir: tempfile::TempDir,
+    _store: tempfile::TempDir,
+    api: LoreApi,
+    base: String,
+    candidate: String,
+    branch: String,
+}
+
+#[cfg(feature = "integration-tests")]
+async fn real_governance_fixture() -> RealGovernanceFixture {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT_REPOSITORY: AtomicU64 = AtomicU64::new(1);
+
+    let tempdir = tempfile::tempdir().expect("create governance real-engine tempdir");
+    let store = tempfile::tempdir().expect("create governance shared-store tempdir");
+    let store_path = store.path().join("shared-store");
+    let api = LoreApi::from_global(
+        LoreGlobal::new(tempdir.path().to_path_buf())
+            .in_memory(false)
+            .offline(true)
+            .identity("alice"),
+    );
+    ops::shared_store::create::create(
+        &api,
+        ops::shared_store::create::SharedStoreCreateArgs {
+            remote_url: String::new(),
+            path: Some(store_path.to_string_lossy().into_owned()),
+            make_default: false,
+        },
+    )
+    .await
+    .expect("create real governance shared store");
+    let suffix = NEXT_REPOSITORY.fetch_add(1, Ordering::Relaxed);
+    ops::repository::create::create(
+        &api,
+        ops::repository::create::CreateArgs {
+            repository_url: format!(
+                "lore://localhost/governance-{}-{suffix}",
+                std::process::id()
+            ),
+            description: "SBAI-5934 real-engine hybrid fixture".into(),
+            id: String::new(),
+            use_shared_store: true,
+            shared_store_path: store_path.to_string_lossy().into_owned(),
+        },
+    )
+    .await
+    .expect("real Lore repository creation must succeed");
+
+    let asset = tempdir.path().join("asset.txt");
+    std::fs::write(&asset, b"base bytes").expect("write base fixture");
+    ops::file::stage::stage(
+        &api,
+        ops::file::stage::FileStageArgs {
+            paths: vec![asset.to_string_lossy().into_owned()],
+            case_change: ops::file::stage::CaseChange::Error,
+            scan: true,
+        },
+    )
+    .await
+    .expect("stage base fixture");
+    let committed = ops::revision::commit::commit(
+        &api,
+        ops::revision::commit::CommitArgs {
+            message: "base\n\nSigned-off-by: Alice <alice@example.test>".into(),
+        },
+    )
+    .await
+    .expect("commit base fixture");
+
+    std::fs::write(&asset, b"candidate bytes").expect("write candidate fixture");
+    ops::file::stage::stage(
+        &api,
+        ops::file::stage::FileStageArgs {
+            paths: vec![asset.to_string_lossy().into_owned()],
+            case_change: ops::file::stage::CaseChange::Error,
+            scan: true,
+        },
+    )
+    .await
+    .expect("stage candidate fixture");
+    ops::revision::metadata_set::metadata_set(
+        &api,
+        ops::revision::metadata_set::MetadataSetArgs {
+            keys: vec!["message".into(), "created-by".into()],
+            values: vec![
+                "candidate\n\nSigned-off-by: Alice <alice@example.test>".into(),
+                "alice".into(),
+            ],
+            formats: vec![
+                ops::revision::metadata_set::MetadataFormat::String,
+                ops::revision::metadata_set::MetadataFormat::String,
+            ],
+        },
+    )
+    .await
+    .expect("attach candidate DCO metadata");
+
+    let real = ProductionLoreAdapter::new(&api, &committed.branch);
+    let status = real
+        .status()
+        .await
+        .expect("real status must resolve the exact staged subject");
+    assert_eq!(status.staged_revisions.len(), 1);
+    let candidate = status.staged_revisions[0].clone();
+    assert_ne!(candidate, committed.revision);
+
+    RealGovernanceFixture {
+        _tempdir: tempdir,
+        _store: store,
+        api,
+        base: committed.revision,
+        candidate,
+        branch: committed.branch,
+    }
+}
+
+#[cfg(feature = "integration-tests")]
+#[derive(Clone, Default)]
+struct NoWriteIo {
+    calls: Arc<Mutex<Vec<String>>>,
+}
+
+#[cfg(feature = "integration-tests")]
+impl NoWriteIo {
+    fn assert_unused(&self, context: &str) {
+        assert!(
+            self.calls.lock().unwrap().is_empty(),
+            "{context}: I/O occurred"
+        );
+    }
+
+    fn called(&self, name: &str) -> AdapterError {
+        self.calls.lock().unwrap().push(name.into());
+        AdapterError::new(format!("unexpected {name}"))
+    }
+}
+
+#[cfg(feature = "integration-tests")]
+#[async_trait::async_trait]
+impl GovernanceIo for NoWriteIo {
+    fn role(&self) -> GovernanceRole {
+        GovernanceRole::Actor
+    }
+
+    async fn revision_metadata_set(&self, _key: &str, _value: &str) -> MutationObservation<()> {
+        MutationObservation::NotDispatched {
+            code: self.called("metadata_set").message,
+        }
+    }
+
+    async fn storage_open(&self) -> MutationObservation<Vec<u64>> {
+        MutationObservation::NotDispatched {
+            code: self.called("storage_open").message,
+        }
+    }
+
+    async fn storage_put(
+        &self,
+        _handle: u64,
+        _bytes: &[u8],
+    ) -> MutationObservation<Vec<ImmutablePutItem>> {
+        MutationObservation::NotDispatched {
+            code: self.called("storage_put").message,
+        }
+    }
+
+    async fn storage_get(
+        &self,
+        _handle: u64,
+        _address: &str,
+    ) -> ReadObservation<Vec<ImmutableGetItem>> {
+        ReadObservation::NotDispatched {
+            code: self.called("storage_get").message,
+        }
+    }
+
+    async fn storage_close(&self, _handle: u64) -> MutationObservation<()> {
+        MutationObservation::NotDispatched {
+            code: self.called("storage_close").message,
+        }
+    }
+}
+
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn hybrid_real_lore_corroborates_repository_tree_metadata_and_storage_flow() {
+    let fixture = real_governance_fixture().await;
+    let adapter =
+        HybridGovernanceAdapter::new(&fixture.api, &fixture.branch, InjectedLockDependency::Clear);
+    let request = EvidencePreserveRequest {
+        expected_staged_revision: fixture.candidate.clone(),
+        target_base_revision: fixture.base.clone(),
+    };
+
+    let direct_history = adapter
+        .first_parent_history(&fixture.candidate, &fixture.base, 1001)
+        .await
+        .expect("real first-parent history dependency");
+    assert_eq!(
+        direct_history,
+        [fixture.candidate.clone()],
+        "production staged history must retain its exact staged head"
+    );
+
+    let evaluated = evaluate(&adapter, &request).await;
+    assert!(
+        evaluated.open,
+        "real Lore facts did not open: {evaluated:?}"
+    );
+    assert_eq!(
+        evaluated
+            .observations
+            .status
+            .as_ref()
+            .unwrap()
+            .staged_revisions,
+        [fixture.candidate.clone()]
+    );
+    assert!(!evaluated.observations.candidate_files.is_empty());
+    assert!(!evaluated.observations.base_files.is_empty());
+
+    let actor_io = ProductionGovernanceIo::new(&fixture.api, GovernanceRole::Actor);
+    let preserved = evidence_preserve_with_adapters(&adapter, &actor_io, &request)
+        .await
+        .expect("hybrid real Lore actor evidence should preserve");
+    let preserved = preserved.verified().expect("full actor chain closed");
+    assert_ne!(preserved.result_staged_revision, fixture.candidate);
+    let result_metadata = adapter
+        .revision_metadata(&preserved.result_staged_revision)
+        .await
+        .expect("real result metadata");
+    assert_eq!(
+        result_metadata
+            .iter()
+            .filter(|entry| entry.key == EVIDENCE_POINTER_KEY)
+            .count(),
+        1
+    );
+
+    let witness_io = ProductionGovernanceIo::new(&fixture.api, GovernanceRole::Witness);
+    let gate = submission_gate_check_with_adapters(
+        &adapter,
+        &witness_io,
+        &SubmissionGateCheckRequest {
+            expected_staged_revision: preserved.result_staged_revision.clone(),
+            target_base_revision: fixture.base.clone(),
+        },
+    )
+    .await;
+    assert!(
+        gate.gate_open,
+        "hybrid real Lore witness did not open: {gate:?}"
+    );
+
+    std::fs::write(
+        fixture._tempdir.path().join("asset.txt"),
+        b"post-evidence edit",
+    )
+    .expect("write a real post-evidence edit");
+    let before_reject = adapter.status().await.expect("pre-reject exact status");
+    let before_metadata = adapter
+        .revision_metadata(&preserved.result_staged_revision)
+        .await
+        .expect("pre-reject exact metadata");
+    let changed = submission_gate_check_with_adapters(
+        &adapter,
+        &witness_io,
+        &SubmissionGateCheckRequest {
+            expected_staged_revision: preserved.result_staged_revision.clone(),
+            target_base_revision: fixture.base,
+        },
+    )
+    .await;
+    assert!(!changed.gate_open, "post-evidence edit opened: {changed:?}");
+    assert_eq!(
+        changed.criteria.last().unwrap().failure_code.as_deref(),
+        Some("evidence_mismatch"),
+        "the witness must compare the exact live filesystem fingerprint"
+    );
+    let after_reject = adapter.status().await.expect("post-reject exact status");
+    let after_metadata = adapter
+        .revision_metadata(&preserved.result_staged_revision)
+        .await
+        .expect("post-reject exact metadata");
+    assert_eq!(
+        before_reject.staged_revisions,
+        after_reject.staged_revisions
+    );
+    assert_eq!(
+        before_metadata, after_metadata,
+        "a closed gate has zero effect"
+    );
+}
+
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn real_lore_dirty_copy_projects_only_zero_identity_add_until_commit() {
+    let fixture = real_governance_fixture().await;
+    let copy_base = ops::revision::commit::commit(
+        &fixture.api,
+        ops::revision::commit::CommitArgs {
+            message: "copy base\n\nSigned-off-by: Alice <alice@example.test>".into(),
+        },
+    )
+    .await
+    .expect("commit the existing candidate before exercising dirty_copy");
+    let source = fixture._tempdir.path().join("asset.txt");
+    let target = fixture._tempdir.path().join("copied.txt");
+    std::fs::copy(&source, &target).expect("materialize the filesystem copy");
+    ops::file::dirty_copy::dirty_copy(
+        &fixture.api,
+        ops::file::dirty_copy::FileDirtyCopyArgs {
+            from_path: source.to_string_lossy().into_owned(),
+            to_path: target.to_string_lossy().into_owned(),
+        },
+    )
+    .await
+    .expect("record the pinned real-Lore dirty_copy state");
+
+    let before_stage = ops::repository::status::status(
+        &fixture.api,
+        ops::repository::status::RepositoryStatusArgs {
+            staged: true,
+            scan: false,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("observe dirty_copy before ordinary stage");
+    let before_target = before_stage
+        .files
+        .iter()
+        .find(|file| file.path == "copied.txt")
+        .expect("dirty_copy target is observable");
+    assert_ne!(
+        before_target.action,
+        ops::repository::status::StatusFileAction::Copy
+    );
+    assert!(before_target.from_path.is_empty());
+
+    let staged = ops::file::stage::stage(
+        &fixture.api,
+        ops::file::stage::FileStageArgs {
+            paths: vec![target.to_string_lossy().into_owned()],
+            case_change: ops::file::stage::CaseChange::Error,
+            scan: true,
+        },
+    )
+    .await
+    .expect("ordinary stage resolves the dirty_copy projection");
+    assert!(staged.files.iter().all(|file| {
+        file.action != ops::file::stage::FileStageAction::Copy && file.from_path.is_empty()
+    }));
+
+    let after_stage = ops::repository::status::status(
+        &fixture.api,
+        ops::repository::status::RepositoryStatusArgs {
+            staged: true,
+            scan: false,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("observe staged dirty_copy target");
+    let revision = after_stage
+        .revision
+        .as_ref()
+        .expect("status revision")
+        .revision_staged
+        .clone();
+    let target_status = after_stage
+        .files
+        .iter()
+        .find(|file| file.path == "copied.txt")
+        .expect("staged target status");
+    assert_eq!(
+        target_status.action,
+        ops::repository::status::StatusFileAction::Add
+    );
+    assert!(target_status.from_path.is_empty());
+    assert!(target_status.staged);
+
+    let diff = ops::revision::diff::diff(
+        &fixture.api,
+        ops::revision::diff::RevisionDiffArgs {
+            revision_source: copy_base.revision.clone(),
+            revision_target: revision.clone(),
+            paths: vec![],
+        },
+    )
+    .await
+    .expect("observe exact base-to-staged revision diff");
+    let target_diff = diff
+        .files
+        .iter()
+        .find(|file| file.path == "copied.txt")
+        .expect("target-only diff");
+    assert_eq!(target_diff.action, ops::revision::diff::DiffFileAction::Add);
+    assert!(!target_diff.old_is_file && target_diff.new_is_file);
+    let zero_address = format!("{}-{}", "0".repeat(64), "0".repeat(32));
+    assert_eq!(target_diff.old_address, zero_address);
+    assert_eq!(target_diff.new_address, zero_address);
+
+    let info = ops::file::info::info(
+        &fixture.api,
+        ops::file::info::FileInfoArgs {
+            paths: vec![target.to_string_lossy().into_owned()],
+            revision: revision.clone(),
+            local: false,
+            filtered: false,
+        },
+    )
+    .await
+    .expect("observe exact staged target identity");
+    assert_eq!(info.entries.len(), 1);
+    assert_eq!(info.entries[0].hash, "0".repeat(64));
+    assert_eq!(info.entries[0].context, "0".repeat(32));
+
+    ops::revision::metadata_set::metadata_set(
+        &fixture.api,
+        ops::revision::metadata_set::MetadataSetArgs {
+            keys: vec!["message".into(), "created-by".into()],
+            values: vec![
+                "copy candidate\n\nSigned-off-by: Alice <alice@example.test>".into(),
+                "alice".into(),
+            ],
+            formats: vec![
+                ops::revision::metadata_set::MetadataFormat::String,
+                ops::revision::metadata_set::MetadataFormat::String,
+            ],
+        },
+    )
+    .await
+    .expect("attach DCO metadata without committing the unresolved target");
+    let adapter = HybridGovernanceAdapter::new(
+        &fixture.api,
+        &copy_base.branch,
+        InjectedLockDependency::Clear,
+    );
+    // Like stage_move at this pin, the first full scan may rewrite the staged
+    // subject. Prime that rewrite, then bind evaluation to the resulting exact
+    // staged hash; this must not manufacture a nonzero Copy identity.
+    let _ = adapter.status().await;
+    let exact_subject = adapter
+        .exact_staged_revisions()
+        .await
+        .expect("read exact staged subject")
+        .pop()
+        .expect("one staged subject");
+    let result = evaluate(
+        &adapter,
+        &EvidencePreserveRequest {
+            expected_staged_revision: exact_subject,
+            target_base_revision: copy_base.revision,
+        },
+    )
+    .await;
+    assert_eq!(
+        result.failure_codes,
+        ["tree_invalid"],
+        "zero-context staged Add must remain fail closed: {result:?}"
+    );
+}
+
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn real_lore_descendant_metadata_clear_cannot_revive_reachable_marked_identity() {
+    let fixture = real_governance_fixture().await;
+    let adapter =
+        HybridGovernanceAdapter::new(&fixture.api, &fixture.branch, InjectedLockDependency::Clear);
+    let initial = evaluate(
+        &adapter,
+        &EvidencePreserveRequest {
+            expected_staged_revision: fixture.candidate.clone(),
+            target_base_revision: fixture.base.clone(),
+        },
+    )
+    .await;
+    assert!(initial.open, "initial real candidate: {initial:?}");
+    let identity = initial.observations.current_files[0].canonical_id();
+    let marker_key = format!("{SUPERSESSION_MARKER_PREFIX}{identity}");
+    ops::revision::metadata_set::metadata_set(
+        &fixture.api,
+        ops::revision::metadata_set::MetadataSetArgs {
+            keys: vec![marker_key.clone()],
+            values: vec![serde_json::to_string(
+                &lore_vm::ops::governance::contract::SupersessionMarkerV1 {
+                    version: "v1".into(),
+                    identity: identity.clone(),
+                },
+            )
+            .unwrap()],
+            formats: vec![ops::revision::metadata_set::MetadataFormat::String],
+        },
+    )
+    .await
+    .expect("seed strict marker on the exact staged subject");
+    let marked = ops::revision::commit::commit(
+        &fixture.api,
+        ops::revision::commit::CommitArgs {
+            message: "marked ancestor\n\nSigned-off-by: Alice <alice@example.test>".into(),
+        },
+    )
+    .await
+    .expect("commit the marked reachable ancestor");
+
+    let lineage = fixture._tempdir.path().join("lineage.txt");
+    std::fs::write(&lineage, b"ordinary descendant change")
+        .expect("write unrelated descendant content");
+    ops::file::stage::stage(
+        &fixture.api,
+        ops::file::stage::FileStageArgs {
+            paths: vec![lineage.to_string_lossy().into_owned()],
+            case_change: ops::file::stage::CaseChange::Error,
+            scan: true,
+        },
+    )
+    .await
+    .expect("stage an ordinary descendant before clearing its metadata");
+    ops::revision::metadata_clear::metadata_clear(
+        &fixture.api,
+        ops::revision::metadata_clear::MetadataClearArgs::default(),
+    )
+    .await
+    .expect("clear metadata only on a descendant staged state");
+    let cleared = ops::revision::commit::commit(
+        &fixture.api,
+        ops::revision::commit::CommitArgs {
+            message: "cleared descendant\n\nSigned-off-by: Alice <alice@example.test>".into(),
+        },
+    )
+    .await
+    .expect("commit the metadata-cleared descendant");
+    assert!(adapter
+        .revision_metadata(&marked.revision)
+        .await
+        .expect("marked ancestor metadata")
+        .iter()
+        .any(|entry| entry.key == marker_key));
+    assert!(adapter
+        .revision_metadata(&cleared.revision)
+        .await
+        .expect("cleared descendant metadata")
+        .iter()
+        .all(|entry| !entry.key.starts_with(SUPERSESSION_MARKER_PREFIX)));
+
+    let source = fixture._tempdir.path().join("asset.txt");
+    let target = fixture._tempdir.path().join("renamed-after-clear.txt");
+    std::fs::rename(&source, &target).expect("rename identical bytes after metadata clear");
+    ops::file::stage_move::stage_move(
+        &fixture.api,
+        ops::file::stage_move::FileStageMoveArgs {
+            from_path: source.to_string_lossy().into_owned(),
+            to_path: target.to_string_lossy().into_owned(),
+        },
+    )
+    .await
+    .expect("stage ordinary same-identity rename on the descendant");
+    ops::revision::metadata_set::metadata_set(
+        &fixture.api,
+        ops::revision::metadata_set::MetadataSetArgs {
+            keys: vec!["message".into(), "created-by".into()],
+            values: vec![
+                "rename after clear\n\nSigned-off-by: Alice <alice@example.test>".into(),
+                "alice".into(),
+            ],
+            formats: vec![
+                ops::revision::metadata_set::MetadataFormat::String,
+                ops::revision::metadata_set::MetadataFormat::String,
+            ],
+        },
+    )
+    .await
+    .expect("attach DCO metadata on the later descendant");
+    let _ = adapter.status().await;
+    let candidate = adapter
+        .exact_staged_revisions()
+        .await
+        .expect("later exact staged subject")
+        .pop()
+        .expect("one later staged subject");
+    let blocked = evaluate(
+        &adapter,
+        &EvidencePreserveRequest {
+            expected_staged_revision: candidate,
+            target_base_revision: cleared.revision.clone(),
+        },
+    )
+    .await;
+    assert_eq!(blocked.failure_codes, ["not_superseded_failed"]);
+    assert!(blocked.remediation.is_none());
+    assert_eq!(
+        blocked
+            .observations
+            .current_files
+            .iter()
+            .find(|file| file.path == "renamed-after-clear.txt")
+            .expect("later renamed artifact identity")
+            .canonical_id(),
+        identity
+    );
+    assert!(blocked
+        .observations
+        .supersession_markers
+        .iter()
+        .any(|marker| marker.revision == marked.revision && marker.key == marker_key));
+    assert!(blocked
+        .observations
+        .supersession_ancestry
+        .iter()
+        .any(|info| info.revision == marked.revision));
+}
+
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn real_lore_rename_plus_modify_keeps_context_types_one_move_and_locks_both_endpoints() {
+    let fixture = real_governance_fixture().await;
+    let source = fixture._tempdir.path().join("asset.txt");
+    let target = fixture._tempdir.path().join("renamed.txt");
+    std::fs::write(&source, b"explicit rename plus modified bytes")
+        .expect("edit the selected bytes before the move");
+    std::fs::rename(&source, &target).expect("rename the selected real-Lore file");
+    ops::file::stage_move::stage_move(
+        &fixture.api,
+        ops::file::stage_move::FileStageMoveArgs {
+            from_path: source.to_string_lossy().into_owned(),
+            to_path: target.to_string_lossy().into_owned(),
+        },
+    )
+    .await
+    .expect("stage the real-Lore move");
+    ops::revision::metadata_set::metadata_set(
+        &fixture.api,
+        ops::revision::metadata_set::MetadataSetArgs {
+            keys: vec!["message".into(), "created-by".into()],
+            values: vec![
+                "rename candidate\n\nSigned-off-by: Alice <alice@example.test>".into(),
+                "alice".into(),
+            ],
+            formats: vec![
+                ops::revision::metadata_set::MetadataFormat::String,
+                ops::revision::metadata_set::MetadataFormat::String,
+            ],
+        },
+    )
+    .await
+    .expect("retain exact DCO metadata after the move");
+
+    let adapter =
+        HybridGovernanceAdapter::new(&fixture.api, &fixture.branch, InjectedLockDependency::Clear);
+    let priming_scan = adapter
+        .status()
+        .await
+        .expect_err("the first scan must expose and reject Lore's post-move staged-state rewrite");
+    assert!(
+        priming_scan
+            .message
+            .contains("full status scan changed the exact staged subject"),
+        "{priming_scan:?}"
+    );
+    let candidate = adapter.status().await.unwrap().staged_revisions[0].clone();
+    let evaluated = evaluate(
+        &adapter,
+        &EvidencePreserveRequest {
+            expected_staged_revision: candidate,
+            target_base_revision: fixture.base.clone(),
+        },
+    )
+    .await;
+    assert!(evaluated.open, "real rename+modify: {evaluated:?}");
+    assert_eq!(
+        evaluated.observations.revision_diff,
+        vec![AffectedPath {
+            source_path: Some("asset.txt".into()),
+            target_path: Some("renamed.txt".into()),
+        }]
+    );
+    assert_eq!(evaluated.observations.upstream_revision_diff.len(), 2);
+
+    let base = &evaluated.observations.base_files[0];
+    let candidate = &evaluated.observations.candidate_files[0];
+    let current = &evaluated.observations.current_files[0];
+    assert_eq!(base.path, "asset.txt");
+    assert_eq!(candidate.path, "renamed.txt");
+    assert_eq!(current.path, "renamed.txt");
+    assert_eq!(base.context, candidate.context);
+    assert_eq!(base.context, current.context);
+    assert_ne!(
+        base.hash, current.hash,
+        "the selected rename also carries changed capture-time bytes"
+    );
+    let raw_delete = &evaluated.observations.upstream_revision_diff[0];
+    let raw_add = &evaluated.observations.upstream_revision_diff[1];
+    assert_eq!(
+        (raw_delete.path.as_str(), raw_delete.action),
+        ("asset.txt", GovernancePathAction::Delete)
+    );
+    assert!(raw_delete.old_is_file && !raw_delete.new_is_file);
+    assert_eq!(
+        raw_delete.old_address,
+        format!("{}-{}", base.hash, base.context)
+    );
+    assert_eq!(
+        (raw_add.path.as_str(), raw_add.action),
+        ("renamed.txt", GovernancePathAction::Add)
+    );
+    assert!(!raw_add.old_is_file && raw_add.new_is_file);
+    assert_eq!(
+        raw_add.new_address,
+        format!("{}-{}", candidate.hash, candidate.context)
+    );
+    assert_eq!(raw_delete.old_address, raw_add.new_address);
+    assert_eq!(
+        evaluated
+            .observations
+            .lock_queries
+            .iter()
+            .map(|query| query.path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["asset.txt", "renamed.txt"],
+        "both exact move endpoints must pass the per-file lock query"
+    );
+
+    let identity = current.canonical_id();
+    ops::revision::metadata_set::metadata_set(
+        &fixture.api,
+        ops::revision::metadata_set::MetadataSetArgs {
+            keys: vec![format!("{SUPERSESSION_MARKER_PREFIX}{identity}")],
+            values: vec![serde_json::to_string(
+                &lore_vm::ops::governance::contract::SupersessionMarkerV1 {
+                    version: "v1".into(),
+                    identity: identity.clone(),
+                },
+            )
+            .unwrap()],
+            formats: vec![ops::revision::metadata_set::MetadataFormat::String],
+        },
+    )
+    .await
+    .expect("seed the strict marker through lower-level real Lore metadata");
+    let marked_candidate = adapter.status().await.unwrap().staged_revisions[0].clone();
+    let blocked = evaluate(
+        &adapter,
+        &EvidencePreserveRequest {
+            expected_staged_revision: marked_candidate,
+            target_base_revision: fixture.base,
+        },
+    )
+    .await;
+    assert!(
+        !blocked.open,
+        "the same moved identity reopened: {blocked:?}"
+    );
+    assert_eq!(blocked.failure_codes, ["not_superseded_failed"]);
+    assert_eq!(
+        blocked.observations.current_files[0].canonical_id(),
+        identity
+    );
+}
+
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn hybrid_real_lore_dco_matrix_uses_real_history_and_revision_metadata() {
+    let fixture = real_governance_fixture().await;
+    let request = DcoValidateRequest {
+        expected_staged_revision: fixture.candidate.clone(),
+        target_base_revision: fixture.base.clone(),
+    };
+    for (name, authors, expected_code) in [
+        ("match", InjectedAuthorDependency::Match, None),
+        (
+            "mismatch",
+            InjectedAuthorDependency::Mismatch,
+            Some("dco_invalid"),
+        ),
+        (
+            "duplicate",
+            InjectedAuthorDependency::Duplicate,
+            Some("dco_invalid"),
+        ),
+        (
+            "unresolved",
+            InjectedAuthorDependency::Unresolved,
+            Some("dco_invalid"),
+        ),
+        (
+            "unavailable",
+            InjectedAuthorDependency::Unavailable,
+            Some("auth_unavailable"),
+        ),
+    ] {
+        let adapter = HybridGovernanceAdapter::new(
+            &fixture.api,
+            &fixture.branch,
+            InjectedLockDependency::Clear,
+        )
+        .with_authors(authors);
+        let result = dco_validate_with_adapter(&adapter, &request).await;
+        assert_eq!(result.valid, expected_code.is_none(), "{name}: {result:?}");
+        assert_eq!(
+            result.failure_codes.first().map(String::as_str),
+            expected_code,
+            "{name}: {result:?}"
+        );
+    }
+
+    ops::revision::metadata_set::metadata_set(
+        &fixture.api,
+        ops::revision::metadata_set::MetadataSetArgs {
+            keys: vec!["message".into()],
+            values: vec!["candidate\n\nSigned-off-by: malformed".into()],
+            formats: vec![ops::revision::metadata_set::MetadataFormat::String],
+        },
+    )
+    .await
+    .expect("write malformed real candidate DCO metadata");
+    let adapter =
+        HybridGovernanceAdapter::new(&fixture.api, &fixture.branch, InjectedLockDependency::Clear);
+    let malformed_candidate = adapter.status().await.unwrap().staged_revisions[0].clone();
+    let malformed = dco_validate_with_adapter(
+        &adapter,
+        &DcoValidateRequest {
+            expected_staged_revision: malformed_candidate,
+            target_base_revision: fixture.base,
+        },
+    )
+    .await;
+    assert!(!malformed.valid, "malformed real DCO: {malformed:?}");
+    assert_eq!(malformed.failure_codes, ["dco_invalid"]);
+}
+
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn production_status_retains_a_post_stage_worktree_fingerprint_change() {
+    let fixture = real_governance_fixture().await;
+    let adapter = ProductionLoreAdapter::new(&fixture.api, &fixture.branch);
+    let before = adapter
+        .status()
+        .await
+        .expect("read exact pre-edit worktree fingerprint");
+    std::fs::write(
+        fixture._tempdir.path().join("asset.txt"),
+        b"unstaged bytes after the exact staged subject",
+    )
+    .expect("write post-stage worktree edit");
+    let after = adapter.status().await.expect("full production status scan");
+    assert_eq!(before.worktree_files.len(), 1);
+    assert_eq!(after.worktree_files.len(), 1);
+    assert_ne!(
+        before.worktree_files[0].local_hash, after.worktree_files[0].local_hash,
+        "the exact raw fingerprint must expose a same-path edit even though Lore's staged tree intentionally retains the base hash"
+    );
+}
+
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn production_auth_unavailable_fails_closed_before_any_evidence_io_or_metadata_write() {
+    let fixture = real_governance_fixture().await;
+    let adapter = ProductionLoreAdapter::new(&fixture.api, &fixture.branch);
+    let before = adapter
+        .revision_metadata(&fixture.candidate)
+        .await
+        .expect("read exact metadata before production negative");
+    let io = NoWriteIo::default();
+    let outcome = evidence_preserve_with_adapters(
+        &adapter,
+        &io,
+        &EvidencePreserveRequest {
+            expected_staged_revision: fixture.candidate.clone(),
+            target_base_revision: fixture.base,
+        },
+    )
+    .await
+    .expect("offline auth unavailability is an exact incomplete outcome");
+    let residual = expect_residual(
+        &outcome,
+        false,
+        EvidencePreserveStopCodeV1::InitialEvaluation,
+    );
+    assert_eq!(residual.stopped_at.code, "auth_unavailable");
+    assert!(matches!(residual.close, EvidenceCloseStateV1::NotOpened));
+    io.assert_unused("auth unavailable");
+    assert_eq!(
+        adapter.revision_metadata(&fixture.candidate).await.unwrap(),
+        before
+    );
+}
+
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn each_unavailable_lock_leg_fails_before_any_evidence_io_or_metadata_write() {
+    for lock in [
+        InjectedLockDependency::QueryUnavailable,
+        InjectedLockDependency::StatusUnavailable,
+    ] {
+        let fixture = real_governance_fixture().await;
+        let adapter = HybridGovernanceAdapter::new(&fixture.api, &fixture.branch, lock);
+        let before = adapter
+            .revision_metadata(&fixture.candidate)
+            .await
+            .expect("read exact metadata before lock negative");
+        let io = NoWriteIo::default();
+        let outcome = evidence_preserve_with_adapters(
+            &adapter,
+            &io,
+            &EvidencePreserveRequest {
+                expected_staged_revision: fixture.candidate.clone(),
+                target_base_revision: fixture.base,
+            },
+        )
+        .await
+        .expect("lock unavailability is an exact incomplete outcome");
+        let residual = expect_residual(
+            &outcome,
+            false,
+            EvidencePreserveStopCodeV1::InitialEvaluation,
+        );
+        assert_eq!(residual.stopped_at.code, "locks_unavailable");
+        io.assert_unused("lock unavailable");
+        assert_eq!(
+            adapter.revision_metadata(&fixture.candidate).await.unwrap(),
+            before
+        );
+    }
 }

--- a/crates/lore-vm/tests/governance_option_a.rs
+++ b/crates/lore-vm/tests/governance_option_a.rs
@@ -1,0 +1,809 @@
+//! Behavioral contract and fail-closed evaluator matrix for SBAI-5934 Option A.
+
+use lore_vm::ops::governance::contract::{
+    ArtifactMarkSupersededRequest, DcoValidateRequest, EvidencePreserveRequest,
+    GovernanceCriterion, SubmissionGateCheckRequest, EVIDENCE_POINTER_KEY,
+    MAX_GOVERNANCE_HISTORY_REVISIONS, SUPERSESSION_MARKER_PREFIX,
+};
+use lore_vm::ops::governance::evaluator::{
+    evaluate, AdapterError, AffectedPath, FileIdentity, GovernanceAdapter, LockQuery, LockStatus,
+    LockStatusResponse, MetadataEntry, ResolvedAuthor, RevisionInfo, StatusSnapshot,
+};
+use std::collections::BTreeMap;
+
+#[derive(Clone)]
+struct FakeLore {
+    status: Result<StatusSnapshot, AdapterError>,
+    infos: BTreeMap<String, Result<RevisionInfo, AdapterError>>,
+    metadata: BTreeMap<String, Result<Vec<MetadataEntry>, AdapterError>>,
+    history: Result<Vec<String>, AdapterError>,
+    dumps: BTreeMap<String, Result<Vec<String>, AdapterError>>,
+    file_info: BTreeMap<String, Result<Vec<FileIdentity>, AdapterError>>,
+    diff: Result<Vec<AffectedPath>, AdapterError>,
+    authors: Result<Vec<ResolvedAuthor>, AdapterError>,
+    lock_queries: BTreeMap<String, Result<LockQuery, AdapterError>>,
+    lock_status: Result<LockStatusResponse, AdapterError>,
+    history_limits: std::sync::Arc<std::sync::Mutex<Vec<usize>>>,
+}
+
+impl FakeLore {
+    fn clean() -> Self {
+        let mut infos = BTreeMap::new();
+        infos.insert(
+            "candidate".into(),
+            Ok(RevisionInfo {
+                revision: "candidate".into(),
+                parents: vec!["base".into()],
+            }),
+        );
+        infos.insert(
+            "base".into(),
+            Ok(RevisionInfo {
+                revision: "base".into(),
+                parents: vec![],
+            }),
+        );
+
+        let mut metadata = BTreeMap::new();
+        for revision in ["candidate", "base"] {
+            metadata.insert(
+                revision.into(),
+                Ok(vec![
+                    MetadataEntry::new(
+                        "message",
+                        "change\n\nSigned-off-by: Alice <alice@example.test>",
+                    ),
+                    MetadataEntry::new("created-by", "alice"),
+                ]),
+            );
+        }
+
+        let mut dumps = BTreeMap::new();
+        dumps.insert("candidate".into(), Ok(vec!["asset.txt".into()]));
+        dumps.insert("base".into(), Ok(vec![]));
+
+        let mut file_info = BTreeMap::new();
+        file_info.insert(
+            "candidate".into(),
+            Ok(vec![FileIdentity::new(
+                "asset.txt",
+                "candidate",
+                "hash-1",
+                "context-1",
+            )]),
+        );
+        file_info.insert("base".into(), Ok(vec![]));
+
+        let mut lock_queries = BTreeMap::new();
+        lock_queries.insert("asset.txt".into(), Ok(LockQuery::unlocked("asset.txt")));
+
+        Self {
+            status: Ok(StatusSnapshot {
+                staged_revisions: vec!["candidate".into()],
+                staged_paths: vec!["asset.txt".into()],
+                worktree_clean: true,
+            }),
+            infos,
+            metadata,
+            history: Ok(vec!["candidate".into()]),
+            dumps,
+            file_info,
+            diff: Ok(vec![AffectedPath::modified("asset.txt")]),
+            authors: Ok(vec![ResolvedAuthor::new("alice", "Alice")]),
+            lock_queries,
+            lock_status: Ok(LockStatusResponse::unlocked()),
+            history_limits: Default::default(),
+        }
+    }
+
+    fn error(name: &str) -> AdapterError {
+        AdapterError::new(name)
+    }
+
+    fn with_linear_pending_count(count: usize) -> Self {
+        assert!(count > 0);
+        let mut fake = Self::clean();
+        let mut history = vec!["candidate".to_string()];
+        let mut parent = "base".to_string();
+
+        for index in (1..count).rev() {
+            let revision = format!("pending-{index}");
+            fake.infos.insert(
+                revision.clone(),
+                Ok(RevisionInfo {
+                    revision: revision.clone(),
+                    parents: vec![parent],
+                }),
+            );
+            fake.metadata.insert(
+                revision.clone(),
+                Ok(vec![
+                    MetadataEntry::new(
+                        "message",
+                        "change\n\nSigned-off-by: Alice <alice@example.test>",
+                    ),
+                    MetadataEntry::new("created-by", "alice"),
+                ]),
+            );
+            parent = revision;
+        }
+
+        fake.infos.insert(
+            "candidate".into(),
+            Ok(RevisionInfo {
+                revision: "candidate".into(),
+                parents: vec![parent],
+            }),
+        );
+        history.extend((1..count).map(|index| format!("pending-{index}")));
+        fake.history = Ok(history);
+        fake
+    }
+}
+
+#[async_trait::async_trait]
+impl GovernanceAdapter for FakeLore {
+    async fn status(&self) -> Result<StatusSnapshot, AdapterError> {
+        self.status.clone()
+    }
+
+    async fn revision_info(&self, revision: &str) -> Result<RevisionInfo, AdapterError> {
+        self.infos
+            .get(revision)
+            .cloned()
+            .unwrap_or_else(|| Err(Self::error("missing revision info")))
+    }
+
+    async fn revision_metadata(&self, revision: &str) -> Result<Vec<MetadataEntry>, AdapterError> {
+        self.metadata
+            .get(revision)
+            .cloned()
+            .unwrap_or_else(|| Err(Self::error("missing revision metadata")))
+    }
+
+    async fn first_parent_history(
+        &self,
+        _candidate: &str,
+        _target_base: &str,
+        max_revisions: usize,
+    ) -> Result<Vec<String>, AdapterError> {
+        self.history_limits.lock().unwrap().push(max_revisions);
+        self.history.clone()
+    }
+
+    async fn repository_dump(&self, revision: &str) -> Result<Vec<String>, AdapterError> {
+        self.dumps
+            .get(revision)
+            .cloned()
+            .unwrap_or_else(|| Err(Self::error("missing dump")))
+    }
+
+    async fn file_info(
+        &self,
+        revision: &str,
+        _paths: &[String],
+    ) -> Result<Vec<FileIdentity>, AdapterError> {
+        self.file_info
+            .get(revision)
+            .cloned()
+            .unwrap_or_else(|| Err(Self::error("missing file info")))
+    }
+
+    async fn revision_diff(
+        &self,
+        _base: &str,
+        _candidate: &str,
+    ) -> Result<Vec<AffectedPath>, AdapterError> {
+        self.diff.clone()
+    }
+
+    async fn resolve_authors(
+        &self,
+        _identities: &[String],
+    ) -> Result<Vec<ResolvedAuthor>, AdapterError> {
+        self.authors.clone()
+    }
+
+    async fn lock_file_query(&self, path: &str) -> Result<LockQuery, AdapterError> {
+        self.lock_queries
+            .get(path)
+            .cloned()
+            .unwrap_or_else(|| Err(Self::error("missing lock query")))
+    }
+
+    async fn lock_file_status(
+        &self,
+        _paths: &[String],
+    ) -> Result<LockStatusResponse, AdapterError> {
+        self.lock_status.clone()
+    }
+}
+
+fn request() -> SubmissionGateCheckRequest {
+    SubmissionGateCheckRequest {
+        expected_staged_revision: "candidate".into(),
+        target_base_revision: "base".into(),
+    }
+}
+
+fn assert_closed_for(mut fake: FakeLore, mutate: impl FnOnce(&mut FakeLore), expected: &str) {
+    mutate(&mut fake);
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(evaluate(&fake, &request()));
+    assert!(!result.open, "{expected}: {result:?}");
+    assert!(
+        result.failure_codes.iter().any(|code| code == expected),
+        "expected {expected}, got {:?}",
+        result.failure_codes
+    );
+}
+
+#[test]
+fn clean_exact_subject_is_open_and_uses_1001_overflow_sentinel() {
+    let fake = FakeLore::clean();
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(evaluate(&fake, &request()));
+
+    assert!(result.open, "{result:?}");
+    assert_eq!(result.pending_revisions, vec!["candidate"]);
+    assert_eq!(result.affected_paths, vec!["asset.txt"]);
+    assert_eq!(*fake.history_limits.lock().unwrap(), vec![1001]);
+}
+
+#[test]
+fn strict_v1_requests_reject_every_legacy_control_and_pin_ratified_namespaces() {
+    assert_eq!(
+        SUPERSESSION_MARKER_PREFIX,
+        "studiobrain.governance.v1.superseded."
+    );
+    assert_eq!(EVIDENCE_POINTER_KEY, "studiobrain.governance.v1.evidence");
+    assert_eq!(MAX_GOVERNANCE_HISTORY_REVISIONS, 1000);
+    assert_eq!(
+        serde_json::to_value([
+            GovernanceCriterion::ExactSubject,
+            GovernanceCriterion::HistoryComplete,
+            GovernanceCriterion::DcoValid,
+            GovernanceCriterion::NotSuperseded,
+            GovernanceCriterion::LocksClear,
+            GovernanceCriterion::WorktreeClean,
+            GovernanceCriterion::EvidenceValid,
+        ])
+        .unwrap(),
+        serde_json::json!([
+            "exact_subject",
+            "history_complete",
+            "dco_valid",
+            "not_superseded",
+            "locks_clear",
+            "worktree_clean",
+            "evidence_valid",
+        ])
+    );
+
+    for field in [
+        "disable_dco",
+        "disable_history",
+        "force",
+        "include",
+        "require_dco",
+        "reject_superseded",
+        "require_clean_workdir",
+        "since",
+        "limit",
+    ] {
+        let value = format!(
+            r#"{{"expected_staged_revision":"candidate","target_base_revision":"base","{field}":true}}"#
+        );
+        assert!(serde_json::from_str::<ArtifactMarkSupersededRequest>(&value).is_err());
+        assert!(serde_json::from_str::<DcoValidateRequest>(&value).is_err());
+        assert!(serde_json::from_str::<EvidencePreserveRequest>(&value).is_err());
+        assert!(serde_json::from_str::<SubmissionGateCheckRequest>(&value).is_err());
+    }
+}
+
+#[test]
+fn traverses_both_merge_parents_and_rejects_depth_overflow() {
+    let mut merge = FakeLore::clean();
+    merge.infos.insert(
+        "candidate".into(),
+        Ok(RevisionInfo {
+            revision: "candidate".into(),
+            parents: vec!["left".into(), "right".into()],
+        }),
+    );
+    for revision in ["left", "right"] {
+        merge.infos.insert(
+            revision.into(),
+            Ok(RevisionInfo {
+                revision: revision.into(),
+                parents: vec!["base".into()],
+            }),
+        );
+        merge.metadata.insert(
+            revision.into(),
+            Ok(vec![
+                MetadataEntry::new(
+                    "message",
+                    "change\n\nSigned-off-by: Alice <alice@example.test>",
+                ),
+                MetadataEntry::new("created-by", "alice"),
+            ]),
+        );
+    }
+    merge.history = Ok(vec!["candidate".into(), "left".into()]);
+
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(evaluate(&merge, &request()));
+    assert!(result.open, "{result:?}");
+    assert_eq!(result.pending_revisions, vec!["candidate", "left", "right"]);
+
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| fake.history = Ok(vec!["x".to_string(); 1001]),
+        "history_depth_exceeded",
+    );
+}
+
+#[test]
+fn accepts_500_999_and_1000_clean_pending_nodes() {
+    for count in [500_usize, 999, 1000] {
+        let fake = FakeLore::with_linear_pending_count(count);
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(evaluate(&fake, &request()));
+        assert!(result.open, "count {count}: {result:?}");
+    }
+}
+
+#[test]
+fn closes_for_status_and_history_graph_failures() {
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| fake.status = Err(FakeLore::error("status")),
+        "status_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.status = Ok(StatusSnapshot {
+                staged_revisions: vec![],
+                staged_paths: vec![],
+                worktree_clean: true,
+            })
+        },
+        "exact_subject_failed",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| fake.status.as_mut().unwrap().worktree_clean = false,
+        "worktree_dirty",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.status = Ok(StatusSnapshot {
+                staged_revisions: vec!["candidate".into(), "extra".into()],
+                staged_paths: vec![],
+                worktree_clean: true,
+            })
+        },
+        "exact_subject_failed",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.status = Ok(StatusSnapshot {
+                staged_revisions: vec!["other".into()],
+                staged_paths: vec![],
+                worktree_clean: true,
+            })
+        },
+        "exact_subject_failed",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.infos
+                .insert("base".into(), Err(FakeLore::error("base")));
+        },
+        "history_incomplete",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.infos.insert(
+                "base".into(),
+                Ok(RevisionInfo {
+                    revision: "fallback".into(),
+                    parents: vec![],
+                }),
+            );
+        },
+        "history_incomplete",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.infos.insert(
+                "candidate".into(),
+                Ok(RevisionInfo {
+                    revision: "wrong".into(),
+                    parents: vec!["base".into()],
+                }),
+            );
+        },
+        "history_incomplete",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.infos.insert(
+                "candidate".into(),
+                Ok(RevisionInfo {
+                    revision: "candidate".into(),
+                    parents: vec!["candidate".into()],
+                }),
+            );
+        },
+        "history_incomplete",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.infos.insert(
+                "candidate".into(),
+                Ok(RevisionInfo {
+                    revision: "candidate".into(),
+                    parents: vec![],
+                }),
+            );
+        },
+        "history_incomplete",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.infos.insert(
+                "candidate".into(),
+                Ok(RevisionInfo {
+                    revision: "candidate".into(),
+                    parents: vec!["unreadable-parent".into()],
+                }),
+            );
+        },
+        "history_incomplete",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| fake.history = Err(FakeLore::error("history")),
+        "history_incomplete",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| fake.history = Ok(vec![]),
+        "history_incomplete",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| fake.history = Ok(vec!["candidate".into(), "candidate".into()]),
+        "history_incomplete",
+    );
+}
+
+#[test]
+fn closes_for_metadata_supersession_and_dco_dependency_failures() {
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.metadata
+                .insert("candidate".into(), Err(FakeLore::error("metadata")));
+        },
+        "metadata_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.metadata.insert(
+                "candidate".into(),
+                Ok(vec![
+                    MetadataEntry::new("message", "x\n\nSigned-off-by: Alice <alice@example.test>"),
+                    MetadataEntry::new("message", "duplicate"),
+                    MetadataEntry::new("created-by", "alice"),
+                ]),
+            );
+        },
+        "dco_invalid",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.metadata.insert(
+                "candidate".into(),
+                Ok(vec![
+                    MetadataEntry::new("message", "x"),
+                    MetadataEntry::new("created-by", "alice"),
+                ]),
+            );
+        },
+        "dco_invalid",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.metadata.insert(
+                "candidate".into(),
+                Ok(vec![
+                    MetadataEntry::new(
+                        "message",
+                        "x\n\nSigned-off-by: Mallory <mallory@example.test>",
+                    ),
+                    MetadataEntry::new("created-by", "alice"),
+                ]),
+            );
+        },
+        "dco_invalid",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| fake.authors = Err(FakeLore::error("auth")),
+        "auth_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| fake.authors = Ok(vec![]),
+        "dco_invalid",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.authors = Ok(vec![
+                ResolvedAuthor::new("alice", "Alice"),
+                ResolvedAuthor::new("alice", "Alice"),
+            ])
+        },
+        "dco_invalid",
+    );
+
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.metadata
+                .get_mut("candidate")
+                .unwrap()
+                .as_mut()
+                .unwrap()
+                .push(MetadataEntry::new(
+                    "studiobrain.governance.v1.superseded.hash-1:context-1",
+                    r#"{"version":"v2","identity":"hash-1:context-1"}"#,
+                ));
+        },
+        "supersession_invalid",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.metadata
+                .get_mut("candidate")
+                .unwrap()
+                .as_mut()
+                .unwrap()
+                .push(MetadataEntry::new(
+                    "studiobrain.governance.v1.superseded.hash-1:context-1",
+                    r#"{"version":"v1","identity":"different"}"#,
+                ));
+        },
+        "supersession_invalid",
+    );
+}
+
+#[test]
+fn closes_for_tree_file_info_diff_and_lock_dependency_failures() {
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.dumps
+                .insert("candidate".into(), Err(FakeLore::error("tree")));
+        },
+        "tree_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.dumps.insert(
+                "candidate".into(),
+                Ok(vec!["asset.txt".into(), "asset.txt".into()]),
+            );
+        },
+        "tree_invalid",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.file_info.insert(
+                "candidate".into(),
+                Ok(vec![
+                    FileIdentity::new("asset.txt", "candidate", "hash-1", "context-1"),
+                    FileIdentity::new("asset.txt", "candidate", "hash-2", "context-2"),
+                ]),
+            );
+        },
+        "tree_invalid",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.file_info
+                .insert("candidate".into(), Err(FakeLore::error("file info")));
+        },
+        "file_info_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.file_info.insert("candidate".into(), Ok(vec![]));
+        },
+        "tree_invalid",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.file_info.insert(
+                "candidate".into(),
+                Ok(vec![FileIdentity::new(
+                    "asset.txt",
+                    "fallback",
+                    "hash-1",
+                    "context-1",
+                )]),
+            );
+        },
+        "tree_invalid",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.file_info.insert(
+                "candidate".into(),
+                Ok(vec![FileIdentity::new(
+                    "asset.txt",
+                    "candidate",
+                    "",
+                    "context-1",
+                )]),
+            );
+        },
+        "tree_invalid",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| fake.diff = Err(FakeLore::error("diff")),
+        "affected_paths_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.diff = Ok(vec![]);
+            fake.status.as_mut().unwrap().staged_paths.clear();
+            fake.dumps
+                .insert("base".into(), Ok(vec!["asset.txt".into()]));
+            fake.file_info.insert(
+                "base".into(),
+                Ok(vec![FileIdentity::new(
+                    "asset.txt",
+                    "base",
+                    "hash-1",
+                    "context-1",
+                )]),
+            );
+        },
+        "empty_submission",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.lock_queries
+                .insert("asset.txt".into(), Err(FakeLore::error("query")));
+        },
+        "locks_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.lock_queries
+                .insert("asset.txt".into(), Ok(LockQuery::unlocked("other.txt")));
+        },
+        "locks_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| fake.lock_status = Err(FakeLore::error("status")),
+        "locks_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| fake.lock_status = Ok(LockStatusResponse::incomplete()),
+        "locks_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.lock_status = Ok(LockStatusResponse::with_locks(
+                2,
+                vec![
+                    LockStatus::unlocked("asset.txt"),
+                    LockStatus::unlocked("extra.txt"),
+                ],
+            ))
+        },
+        "locks_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.lock_status = Ok(LockStatusResponse::with_locks(
+                1,
+                vec![LockStatus::locked("asset.txt", "foreign")],
+            ))
+        },
+        "locks_clear_failed",
+    );
+}
+
+#[test]
+fn raw_lock_boundaries_reject_missing_duplicate_over_counted_and_ignored_streams() {
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.lock_queries
+                .insert("asset.txt".into(), Ok(LockQuery::incomplete("asset.txt")));
+        },
+        "locks_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.lock_queries.insert(
+                "asset.txt".into(),
+                Ok(LockQuery::with_owners(
+                    "asset.txt",
+                    2,
+                    vec!["foreign".into()],
+                )),
+            );
+        },
+        "locks_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.lock_status = Ok(LockStatusResponse::ignored("asset.txt"));
+        },
+        "locks_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.lock_status = Ok(LockStatusResponse::with_locks(
+                2,
+                vec![LockStatus::unlocked("asset.txt")],
+            ));
+        },
+        "locks_unavailable",
+    );
+    assert_closed_for(
+        FakeLore::clean(),
+        |fake| {
+            fake.lock_status = Ok(LockStatusResponse::with_locks(
+                2,
+                vec![
+                    LockStatus::unlocked("asset.txt"),
+                    LockStatus::unlocked("asset.txt"),
+                ],
+            ));
+        },
+        "locks_unavailable",
+    );
+}

--- a/crates/lore-vm/tests/governance_option_a.rs
+++ b/crates/lore-vm/tests/governance_option_a.rs
@@ -753,12 +753,13 @@ fn scans_supersession_metadata_on_the_verified_base_revision() {
 #[test]
 fn dco_requires_exactly_one_signoff_in_the_terminal_trailer_block() {
     let mut valid = FakeLore::clean();
+    valid.authors = Ok(vec![ResolvedAuthor::new("alice", "Alice Example")]);
     valid.metadata.insert(
         "candidate".into(),
         Ok(vec![
             MetadataEntry::new(
                 "message",
-                "change\n\nSigned-off-by: Alice <alice@example.test>\nReviewed-by: Bob <bob@example.test>",
+                "change\n\nSigned-off-by: Alice Example <alice@example.test>\nReviewed-by: Bob <bob@example.test>",
             ),
             MetadataEntry::new("created-by", "alice"),
         ]),
@@ -791,6 +792,50 @@ fn dco_requires_exactly_one_signoff_in_the_terminal_trailer_block() {
             "dco_invalid",
         );
     }
+}
+
+#[test]
+fn dco_rejects_noncanonical_signer_and_email_bytes() {
+    let cases = [
+        ("double separator spacing", "Alice  <alice@example.test>"),
+        ("missing at sign", "Alice <not-an-email>"),
+        ("extra angle brackets", "Alice <<alice@example.test>>"),
+        (
+            "embedded control character",
+            "Alice <alice@exam\u{0007}ple.test>",
+        ),
+        ("empty local part", "Alice <@example.test>"),
+        ("empty domain", "Alice <alice@>"),
+        ("multiple at signs", "Alice <alice@@example.test>"),
+        ("empty domain label", "Alice <alice@example..test>"),
+        ("hyphen-bounded domain label", "Alice <alice@-example.test>"),
+        ("invalid domain label byte", "Alice <alice@example_test>"),
+    ];
+    let mut accepted = Vec::new();
+
+    for (case, signer) in cases {
+        let mut fake = FakeLore::clean();
+        fake.metadata.insert(
+            "candidate".into(),
+            Ok(vec![
+                MetadataEntry::new("message", format!("change\n\nSigned-off-by: {signer}")),
+                MetadataEntry::new("created-by", "alice"),
+            ]),
+        );
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(evaluate(&fake, &request()));
+        if result.open {
+            accepted.push(case);
+        } else {
+            assert_eq!(result.failure_codes, vec!["dco_invalid"], "{case}");
+        }
+    }
+
+    assert!(
+        accepted.is_empty(),
+        "accepted noncanonical DCO identities: {accepted:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

SBAI-5934 adds the strict Option A governance contract, evaluator, durable evidence-preserve flow, DCO validation, and submission gate to lore-vm.

The gate is fail-closed over exact staged-subject facts, full pending and reachable ancestry DAGs, canonical file identities, DCO metadata, locks, worktree state, supersession markers, and durable actor evidence. The witness re-derives every terminal criterion from private raw facts; evaluator summaries remain diagnostic-only.

Three typed machine-only operations are registered in their own governance dispatch section:

- governance.dco_validate
- governance.evidence_preserve
- governance.submission_gate_check

The deferred authoritative supersession writer is intentionally not implemented or registered. Calling governance.artifact_mark_superseded remains an unknown operation until its v2 writer contract exists.

## Related issue / ticket

SBAI-5934

## Type of change

- [x] Bug fix
- [x] New lore op / feature
- [ ] UI / UX
- [ ] Docs only
- [ ] Build / CI / tooling
- [ ] Upstream lore pin bump

## Checklist

- [x] cargo fmt --all --check passes
- [x] cargo clippy -p lore-vm -- -D warnings passes
- [x] cargo test -p lore-vm passes, including the real-Lore hybrid integration
- [x] cargo check -p loregui passes
- [x] npm --prefix frontend run build passes
- [x] node frontend/scripts/palette-parity.mjs passes
- [x] New operations have an intentional machine-only governance surface; auth dispatch remains unchanged
- [x] No files outside the approved governance fence were touched or reformatted
- [x] No user-facing docs change is required; contract and boundary documentation live with the typed operations

## Verification

Exact candidate head: 96a8fcccae6da121be0957aac90a6388c633fbc5
Exact base: 37ad236438206c545d6c7662b85f78a2cc7028da

- cargo +nightly fmt --all -- --check: exit 0
- cargo clippy -p lore-vm --locked -- -D warnings: exit 0
- cargo test -p lore-vm --locked: exit 0; 779 library tests, governance 57/57, default integrations, doctest
- cargo test -p lore-vm --locked --features integration-tests --test governance_option_a hybrid_real_lore: exit 0, 2/2
- cargo check -p loregui --locked: exit 0
- npm --prefix frontend run build: exit 0 after npm ci populated this isolated worktree
- node frontend/scripts/palette-parity.mjs: exit 0; 0 parity errors
- git diff --check: exit 0
- worktree clean

All four commits carry exactly one authorized Signed-off-by trailer. The DCO-only rewrite preserved every per-commit tree ID in order and the final tree is byte-identical to the pre-rewrite rollback ref.

## Notes for reviewers

This is a fresh whole-candidate target. Earlier Task-1 and Task-2 verdicts do not transfer to 96a8fcc.

The Task-1 source audit found six real blockers in the earlier three-commit head: incomplete ancestry, staged-tree identity reuse, caller-selected lock branch, noncanonical identities, erased metadata kinds, and first-End terminal truncation. Task 2 was built to close all six. Its exact-byte QA PASS is recorded in SBAI-5934 Jira comment 159749 with report SHA-256 2244f13b6921eb6d571eeb8308f0b4dfdd5f64acef8bc66551cbcb3ecc00da3b.

Load-bearing review points:

- both-parent DAG traversal to roots with an N+1 overflow sentinel
- capture-time local identity for modified files and stable upstream context IDs
- witness-owned private raw projections for all seven criteria, evidence, and stability
- stored evaluator summaries are inert under full-gate poisoning
- exact DCO row cardinality and raw author-response rebinding
- active staged evidence-pointer omission is the sole typed self-reference delta; ancestor pointers remain visible
- no supersession writer, no actor verdict, no dispatch-selected authority
- auth operation code is unchanged

Known explicit boundaries remain tracked separately: authenticated remote fixture SBAI-6001; ancestry-index migration SBAI-6010; upstream provenance and Binary metadata observability SBAI-6011/SBAI-6012.

This PR is ready for fresh exact-head source review. It is not a merge authorization and the author will not self-merge.
