### PR TITLE
SBAI-5817: fix fresh-runner auto-release ordering

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -76,6 +76,10 @@ jobs:
           set -euo pipefail
           NEXT=${{ steps.decide.outputs.next }}
           V=${NEXT#v}
+          # SBAI-5817: a fresh runner has no cached EpicGames/lore git source.
+          # Populate the exact locked graph before changing either manifest so
+          # the version-stamp update can remain fully offline and drift-free.
+          cargo fetch --locked
           # Single source of truth: [workspace.package] version (src-tauri and
           # tauri.conf.json's explicit copy both track it).
           sed -i -E "0,/^version = \"[0-9.]+\"/s//version = \"$V\"/" Cargo.toml

--- a/scripts/release-supply-chain.test.mjs
+++ b/scripts/release-supply-chain.test.mjs
@@ -14,6 +14,9 @@ function normalizeNewlines(text) {
 const workflow = normalizeNewlines(
   readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8"),
 );
+const autoReleaseWorkflow = normalizeNewlines(
+  readFileSync(new URL("../.github/workflows/auto-release.yml", import.meta.url), "utf8"),
+);
 const guard = normalizeNewlines(
   readFileSync(new URL("../.github/workflows/release-supply-chain.yml", import.meta.url), "utf8"),
 );
@@ -34,6 +37,25 @@ test("release workflow pins reviewed supply-chain actions and keeps OIDC off pul
     workflow,
     /uses: actions\/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1\.4\.4/,
   );
+});
+
+test("auto-release fetches the exact locked graph before offline version stamping", () => {
+  const bumpStep = autoReleaseWorkflow.slice(
+    autoReleaseWorkflow.indexOf("name: Bump workspace version + tag"),
+    autoReleaseWorkflow.indexOf("name: Dispatch release build on the tag"),
+  );
+  const lockedFetch = bumpStep.match(/^\s*cargo fetch --locked\s*$/m);
+  const manifestMutation = bumpStep.indexOf('sed -i -E "0,/^version =');
+  const tauriMutation = bumpStep.indexOf('sed -i -E "s/\\"version\\":');
+  const offlineStamp = bumpStep.indexOf("cargo update -w --offline");
+
+  assert.ok(lockedFetch, "the fresh runner must populate the exact locked graph");
+  const lockedFetchOffset = bumpStep.indexOf(lockedFetch[0]);
+  assert.ok(lockedFetchOffset < manifestMutation, "fetch must run before Cargo.toml changes");
+  assert.ok(lockedFetchOffset < tauriMutation, "fetch must run before tauri.conf.json changes");
+  assert.ok(lockedFetchOffset < offlineStamp, "fetch must run before the offline version stamp");
+  assert.equal(bumpStep.match(/^\s*cargo fetch --locked\s*$/gm)?.length, 1);
+  assert.equal(bumpStep.match(/^\s*cargo update -w --offline\s*$/gm)?.length, 1);
 });
 
 test("release workflow uses one staged raw-sidecar trust boundary", () => {


### PR DESCRIPTION
## Summary

SBAI-5817: hydrate Cargo's exact locked dependency graph before either release manifest is version-stamped.

A genuinely fresh runner has no local checkout for the pinned EpicGames/lore git source, so the existing `cargo update -w --offline` fails before the release build can be dispatched. This keeps the offline stamp and exact pin intact, adds one preceding `cargo fetch --locked`, and adds a regression contract for command presence, uniqueness, and ordering.

## Related issue / ticket

SBAI-5817

This fixes the source workflow ordering defect. It does not close the delivery ticket or authorize a release.

## Type of change

- [x] Bug fix
- [ ] New lore op / feature
- [ ] UI / UX
- [ ] Docs only
- [x] Build / CI / tooling
- [ ] Upstream `lore` pin bump (manager-owned — see CONTRIBUTING.md)

## Checklist

- [ ] `cargo fmt --all --check` passes — not run; no Rust source changed
- [ ] `cargo clippy -p lore-vm -- -D warnings` passes — not run; no Rust source changed
- [ ] `cargo test -p lore-vm` passes — not run; no Rust source changed
- [ ] `cargo check -p loregui` passes — not run; no Rust source changed
- [ ] `npm --prefix frontend run build` passes — not run; no frontend source changed
- [ ] `node frontend/scripts/palette-parity.mjs` passes — not applicable
- [ ] New/changed ops land in the app coherently — not applicable
- [x] No files outside the scope of this change were touched/reformatted
- [x] Docs updated if behavior or workflow changed — the inline invariant and regression contract document the ordering requirement

## Verification

- `node --test scripts/release-supply-chain.test.mjs`: 15 pass, 0 fail, 1 Windows-only skip
- `node --test scripts/exact-pin-authless-contract.test.mjs`: 9 pass, 0 fail
- Exact `origin/main` failure reproduced with an empty `CARGO_HOME`: exit 101 because the pinned Epic checkout was unavailable offline
- A second empty `CARGO_HOME` passed `cargo fetch --locked`; `Cargo.lock` remained byte-identical
- The subsequent offline stamp in a disposable extracted fixture succeeded; its lock diff contained only the four named local workspace package versions, while all 13 Epic lock-source lines remained exact
- YAML parsed successfully; only existing line-length warnings remain
- Independent exact-range review found no Critical, Important, or Minor issues

## Notes for reviewers

Scope is deliberately narrow per sb-fable's ruling: no dependency-management redesign, no pin change, and no changes to the later release/tag/publish path. No release, tag, publication, repository version bump, or merge was performed. Any actual release remains separately gated.
