### PR TITLE
SBAI-6756: document Lore server + S3 backend design constraints

### DIFF
--- a/THIRD-PARTY-LICENSES-RUST.md
+++ b/THIRD-PARTY-LICENSES-RUST.md
@@ -7812,10 +7812,10 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- lore-vm 0.1.4 — https://github.com/BiloxiStudios/loregui
-- lorevm-cli 0.1.4 — https://github.com/BiloxiStudios/loregui
-- lorevm-ffi 0.1.4 — https://github.com/BiloxiStudios/loregui
-- loregui 0.1.4 — https://github.com/BiloxiStudios/loregui
+- lore-vm 0.1.5 — https://github.com/BiloxiStudios/loregui
+- lorevm-cli 0.1.5 — https://github.com/BiloxiStudios/loregui
+- lorevm-ffi 0.1.5 — https://github.com/BiloxiStudios/loregui
+- loregui 0.1.5 — https://github.com/BiloxiStudios/loregui
 - async-stream-impl 0.3.6 — https://github.com/tokio-rs/async-stream
 - async-stream 0.3.6 — https://github.com/tokio-rs/async-stream
 - bitcode_derive 0.6.9 — https://github.com/SoftbearStudios/bitcode/

--- a/crates/lore-vm/src/ops/storage/upload.rs
+++ b/crates/lore-vm/src/ops/storage/upload.rs
@@ -5,6 +5,32 @@
 //! by `(partition, address)` and runs independently; per-item results are
 //! collected from `StorageUploadItemComplete` events emitted by the upstream
 //! crate.
+//!
+//! # Design Constraints for Lore Server + S3 Backend (SBAI-6756)
+//!
+//! When the lore-server/storage-backend track (Wasabi/R2) kicks off, two DB
+//! constraints must be carried into the design:
+//!
+//! 1. **Object keys must be UUID or content-addressed, never sequence-derived.**
+//!    Both sites (Biloxi and Cloudcroft) write concurrently — a counter-derived
+//!    key means the two sites could independently write different content to the
+//!    same key, with one silently winning. This is the same failure class as the
+//!    billing bug tracked in SBAI-6754, but relocated into the storage bucket
+//!    where no DB-level check would catch it. The existing Lore content-addressed
+//!    storage model (partition + hash-based address) already satisfies this
+//!    constraint.
+//!
+//! 2. **`tenant_lore_configs` is the V4249 table** — the original incident where
+//!    an auto-run `CREATE INDEX` at boot against a replicated table hung forever
+//!    and blocked cloud deploys for weeks. Any lore-server migration touching
+//!    this table must go through the human-run remove→DDL→add ceremony, never
+//!    a boot-time auto-runner. This applies to any schema evolution that touches
+//!    the lore configuration tables that the storage backend layer may interact
+//!    with.
+//!
+//! These constraints are captured here because the storage upload path is the
+//! primary code surface that will interact with a future S3-compatible remote
+//! backend (Wasabi/R2).
 
 use crate::api::LoreApi;
 use crate::collect::collect_events;

--- a/frontend/public/licenses/rust.md
+++ b/frontend/public/licenses/rust.md
@@ -7812,10 +7812,10 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- lore-vm 0.1.4 — https://github.com/BiloxiStudios/loregui
-- lorevm-cli 0.1.4 — https://github.com/BiloxiStudios/loregui
-- lorevm-ffi 0.1.4 — https://github.com/BiloxiStudios/loregui
-- loregui 0.1.4 — https://github.com/BiloxiStudios/loregui
+- lore-vm 0.1.5 — https://github.com/BiloxiStudios/loregui
+- lorevm-cli 0.1.5 — https://github.com/BiloxiStudios/loregui
+- lorevm-ffi 0.1.5 — https://github.com/BiloxiStudios/loregui
+- loregui 0.1.5 — https://github.com/BiloxiStudios/loregui
 - async-stream-impl 0.3.6 — https://github.com/tokio-rs/async-stream
 - async-stream 0.3.6 — https://github.com/tokio-rs/async-stream
 - bitcode_derive 0.6.9 — https://github.com/SoftbearStudios/bitcode/


### PR DESCRIPTION
Resolves SBAI-6756

## Summary
Documents two DB constraints for the future Lore server + S3 backend (Wasabi/R2) track inline in the storage upload module, so the future lore-server/storage-backend crew has them immediately visible.

## Constraints Captured
1. **Object keys must be UUID or content-addressed, never sequence-derived** — prevents concurrent Biloxi/Cloudcroft write collisions in the storage bucket where no DB-level check would catch it (same failure class as SBAI-6754 billing bug)
2. **tenant_lore_configs (V4249) requires human-run remove→DDL→add ceremony** — never boot-time auto-runner (prevents replicated-table index hang that blocked cloud deploys for weeks)

## Files Changed
- crates/lore-vm/src/ops/storage/upload.rs — added design constraints doc block

## Testing
- cargo check -p lore-vm: green
- Complexity: 1/5 (design capture, no functional code changes)

## Related
- SBAI-6754 (billing identity bug — same failure class relocated to storage)

Generated with Qwen Code