### PR TITLE
SBAI-6885: bound LoreGUI PR CI and pause auto release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,8 +11,6 @@
 name: auto-release
 
 on:
-  schedule:
-    - cron: "30 4 * * *" # 23:30 CDT / end of day America/Chicago
   workflow_dispatch:
     inputs:
       force:

--- a/.github/workflows/boundary-guard.yml
+++ b/.github/workflows/boundary-guard.yml
@@ -10,7 +10,6 @@ name: boundary-guard
 on:
   push:
     branches: [main]
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-crossplatform.yml
+++ b/.github/workflows/build-crossplatform.yml
@@ -16,8 +16,6 @@ name: build-crossplatform
 # satisfied (same mechanism windows-build.yml relies on). release.yml stages the
 # genuine binary for actual releases.
 on:
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ name: ci
 on:
   push:
     branches: [main]
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -14,10 +14,6 @@ on:
     paths:
       - "frontend/**"
       - ".github/workflows/frontend-test.yml"
-  pull_request:
-    paths:
-      - "frontend/**"
-      - ".github/workflows/frontend-test.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,19 +18,6 @@ name: integration
 on:
   push:
     branches: [main]
-  pull_request:
-    paths:
-      - "crates/lore-vm/**"
-      - "crates/lorevm-cli/**"
-      - "crates/lorevm-ffi/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "scripts/exact-pin-service-cwd-canary.sh"
-      - "scripts/exact-pin-service-cwd-canary.test.sh"
-      - "scripts/exact-pin-authless-contract.mjs"
-      - "scripts/exact-pin-authless-contract.test.mjs"
-      - "scripts/live-server-client.sh"
-      - ".github/workflows/integration.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -15,7 +15,6 @@ name: licenses
 on:
   push:
     branches: [main]
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pr-fast-gate.yml
+++ b/.github/workflows/pr-fast-gate.yml
@@ -1,0 +1,40 @@
+name: PR Fast Gate
+
+# SBAI-6885: the merge backlog needs a bounded structural gate. Heavy runtime,
+# installer, and release workflows remain available by manual dispatch; the
+# scheduled parity and remote-QA jobs retain their schedules.
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: pr-fast-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  patch-integrity:
+    name: patch-integrity
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Reject malformed whitespace and conflict markers
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.sha }}"
+          git diff --check "$base_sha" "$head_sha"
+          if git diff --name-only "$base_sha" "$head_sha" | xargs -r grep -nE '^(<<<<<<<|=======|>>>>>>>)' -- 2>/dev/null; then
+            echo 'merge conflict marker found in changed text'
+            exit 1
+          fi
+      - name: Emit changed-file manifest
+        shell: bash
+        run: git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}"

--- a/.github/workflows/release-supply-chain.yml
+++ b/.github/workflows/release-supply-chain.yml
@@ -11,7 +11,6 @@ name: release-supply-chain
 on:
   push:
     branches: [main]
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/runner-policy-preflight.yml
+++ b/.github/workflows/runner-policy-preflight.yml
@@ -9,7 +9,6 @@
 name: runner-policy-preflight
 
 on:
-  pull_request:
   push:
     branches: [main]
 

--- a/.github/workflows/tauri-e2e.yml
+++ b/.github/workflows/tauri-e2e.yml
@@ -16,13 +16,6 @@ name: tauri-e2e
 on:
   push:
     branches: [main]
-  pull_request:
-    paths:
-      - "src-tauri/**"
-      - "crates/lore-vm/**"
-      - "frontend/e2e/**"
-      - "frontend/src/**"
-      - ".github/workflows/tauri-e2e.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/upstream-parity.yml
+++ b/.github/workflows/upstream-parity.yml
@@ -13,12 +13,6 @@ on:
   schedule:
     - cron: "0 7 * * 1" # Mondays 07:00 UTC
   workflow_dispatch:
-  pull_request:
-    paths:
-      - "scripts/upstream-lore-distance.mjs"
-      - "scripts/upstream-lore-distance.test.mjs"
-      - "scripts/upstream-lore-parity.mjs"
-      - ".github/workflows/upstream-parity.yml"
 
 permissions:
   contents: write

--- a/.github/workflows/vscode-test.yml
+++ b/.github/workflows/vscode-test.yml
@@ -16,12 +16,6 @@ on:
       - "crates/lore-vm/**"
       - "crates/lorevm-cli/**"
       - ".github/workflows/vscode-test.yml"
-  pull_request:
-    paths:
-      - "vscode-extension/**"
-      - "crates/lore-vm/**"
-      - "crates/lorevm-cli/**"
-      - ".github/workflows/vscode-test.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -5,8 +5,6 @@ name: windows-build
 # Windows/Linux/macOS) is handled by release.yml — kept separate so nightly is
 # managed in exactly one place.
 on:
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Implements the owner-approved CI backlog policy for LoreGUI.

- Removes `pull_request` triggers from heavy test, installer, integration, supply-chain, VS Code, Tauri, and parity workflows.
- Adds the shared two-minute `patch-integrity` gate for PRs.
- Leaves manual dispatch available for all deferred workflows.
- Preserves scheduled upstream-parity and remote-QA checks.
- Removes the auto-release schedule so releases are manual until the hold is lifted.

No product/runtime behavior changes; this changes CI triggering only.