### PR TITLE
SBAI-7016: refresh LoreGUI attribution bundles

### DIFF
--- a/THIRD-PARTY-LICENSES-RUST.md
+++ b/THIRD-PARTY-LICENSES-RUST.md
@@ -7812,10 +7812,10 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- lore-vm 0.1.4 — https://github.com/BiloxiStudios/loregui
-- lorevm-cli 0.1.4 — https://github.com/BiloxiStudios/loregui
-- lorevm-ffi 0.1.4 — https://github.com/BiloxiStudios/loregui
-- loregui 0.1.4 — https://github.com/BiloxiStudios/loregui
+- lore-vm 0.1.5 — https://github.com/BiloxiStudios/loregui
+- lorevm-cli 0.1.5 — https://github.com/BiloxiStudios/loregui
+- lorevm-ffi 0.1.5 — https://github.com/BiloxiStudios/loregui
+- loregui 0.1.5 — https://github.com/BiloxiStudios/loregui
 - async-stream-impl 0.3.6 — https://github.com/tokio-rs/async-stream
 - async-stream 0.3.6 — https://github.com/tokio-rs/async-stream
 - bitcode_derive 0.6.9 — https://github.com/SoftbearStudios/bitcode/

--- a/frontend/public/licenses/rust.md
+++ b/frontend/public/licenses/rust.md
@@ -7812,10 +7812,10 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- lore-vm 0.1.4 — https://github.com/BiloxiStudios/loregui
-- lorevm-cli 0.1.4 — https://github.com/BiloxiStudios/loregui
-- lorevm-ffi 0.1.4 — https://github.com/BiloxiStudios/loregui
-- loregui 0.1.4 — https://github.com/BiloxiStudios/loregui
+- lore-vm 0.1.5 — https://github.com/BiloxiStudios/loregui
+- lorevm-cli 0.1.5 — https://github.com/BiloxiStudios/loregui
+- lorevm-ffi 0.1.5 — https://github.com/BiloxiStudios/loregui
+- loregui 0.1.5 — https://github.com/BiloxiStudios/loregui
 - async-stream-impl 0.3.6 — https://github.com/tokio-rs/async-stream
 - async-stream 0.3.6 — https://github.com/tokio-rs/async-stream
 - bitcode_derive 0.6.9 — https://github.com/SoftbearStudios/bitcode/


### PR DESCRIPTION
Resolves SBAI-7016

Summary:
- regenerates the Rust third-party attribution bundle after the v0.1.5 release
- updates the matching in-app public license copy
- leaves frontend dependency attributions unchanged

Verification:
- bash scripts/gen-licenses.sh exits 0
- a second generator run leaves the committed worktree clean
- git diff --check passes
- change scope is two generated files, +8/-8