### PR TITLE
SBAI-7197: refresh LoreGUI 0.1.6 attribution bundles

### DIFF
--- a/THIRD-PARTY-LICENSES-RUST.md
+++ b/THIRD-PARTY-LICENSES-RUST.md
@@ -7812,10 +7812,10 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- lore-vm 0.1.5 — https://github.com/BiloxiStudios/loregui
-- lorevm-cli 0.1.5 — https://github.com/BiloxiStudios/loregui
-- lorevm-ffi 0.1.5 — https://github.com/BiloxiStudios/loregui
-- loregui 0.1.5 — https://github.com/BiloxiStudios/loregui
+- lore-vm 0.1.6 — https://github.com/BiloxiStudios/loregui
+- lorevm-cli 0.1.6 — https://github.com/BiloxiStudios/loregui
+- lorevm-ffi 0.1.6 — https://github.com/BiloxiStudios/loregui
+- loregui 0.1.6 — https://github.com/BiloxiStudios/loregui
 - async-stream-impl 0.3.6 — https://github.com/tokio-rs/async-stream
 - async-stream 0.3.6 — https://github.com/tokio-rs/async-stream
 - bitcode_derive 0.6.9 — https://github.com/SoftbearStudios/bitcode/

--- a/frontend/public/licenses/rust.md
+++ b/frontend/public/licenses/rust.md
@@ -7812,10 +7812,10 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- lore-vm 0.1.5 — https://github.com/BiloxiStudios/loregui
-- lorevm-cli 0.1.5 — https://github.com/BiloxiStudios/loregui
-- lorevm-ffi 0.1.5 — https://github.com/BiloxiStudios/loregui
-- loregui 0.1.5 — https://github.com/BiloxiStudios/loregui
+- lore-vm 0.1.6 — https://github.com/BiloxiStudios/loregui
+- lorevm-cli 0.1.6 — https://github.com/BiloxiStudios/loregui
+- lorevm-ffi 0.1.6 — https://github.com/BiloxiStudios/loregui
+- loregui 0.1.6 — https://github.com/BiloxiStudios/loregui
 - async-stream-impl 0.3.6 — https://github.com/tokio-rs/async-stream
 - async-stream 0.3.6 — https://github.com/tokio-rs/async-stream
 - bitcode_derive 0.6.9 — https://github.com/SoftbearStudios/bitcode/


### PR DESCRIPTION
Fixes current-main attribution drift exposed while updating SBAI-6876. Regenerates only the two Rust attribution bundles from 0.1.5 to 0.1.6. Verification: generator rerun was byte-stable; git diff --check passed. npm audit separately reported nanoid GHSA-2v37-7h3g-55p8 and is tracked as SBAI-7198.