### PR TITLE
SBAI-7201: emit [server.grpc_internal] from Expert host wizard

### DIFF
--- a/docs/domains/storage.md
+++ b/docs/domains/storage.md
@@ -40,7 +40,7 @@ obliterate upload mutable_store mutable_load mutable_list mutable_compare_and_sw
   exposes every lore-server `Settings` option grouped into collapsible sections —
   Network (bind host, QUIC, gRPC, HTTP), Storage (local-store flush/eviction/
   capacity + lock-store mode), Topology & replication (`none`/`fixed`/
-  `rotating_id_fixed` + peers + the opt-in mTLS `quic_internal`/`replication`
+  `rotating_id_fixed` + peers + the opt-in mTLS `quic_internal`/`grpc_internal`
   endpoints), Telemetry, Runtime (Tokio), Notifications, Features, and Shutdown
   timeouts. Each field shows its **lore default** as placeholder/help and is
   **optional**: an omitted field falls through to lore's compiled-in default, so

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -386,7 +386,7 @@ export interface HostTimeoutOptions {
   runtimeShutdownTimeoutSeconds?: number;
 }
 
-/// An opt-in internal endpoint (quic_internal / replication). mTLS required.
+/// An opt-in internal endpoint (quic_internal / grpc_internal). mTLS required.
 export interface HostInternalEndpointOptions {
   /** Enable the endpoint (default: false). */
   enabled?: boolean;
@@ -414,7 +414,7 @@ export interface HostAdvancedOptions {
   features?: HostFeatureOptions;
   timeouts?: HostTimeoutOptions;
   quicInternal?: HostInternalEndpointOptions;
-  replicationEndpoint?: HostInternalEndpointOptions;
+  grpcInternal?: HostInternalEndpointOptions;
   /** Lock-store mode (`[lock_store]`). Defaults to lore's "local". */
   lockStoreMode?: string;
 }

--- a/frontend/src/onboarding/server/AdvancedServerConfig.tsx
+++ b/frontend/src/onboarding/server/AdvancedServerConfig.tsx
@@ -328,7 +328,7 @@ export default function AdvancedServerConfig({
   const features = value.features ?? {};
   const timeouts = value.timeouts ?? {};
   const quicInternal = value.quicInternal ?? {};
-  const replication = value.replicationEndpoint ?? {};
+  const grpcInternal = value.grpcInternal ?? {};
   const topology = value.topology ?? {};
   const notification = value.notification ?? {};
 
@@ -776,17 +776,17 @@ export default function AdvancedServerConfig({
           </div>
         )}
 
-        <h3>Internal replication endpoints</h3>
+        <h3>Internal endpoints</h3>
         <p className="onboarding-field-hint">
           Opt-in, mTLS-only server-to-server endpoints (off by default).
         </p>
         {(
           [
             ["quicInternal", quicInternal, "QUIC internal"] as const,
-            ["replicationEndpoint", replication, "gRPC replication"] as const,
+            ["grpcInternal", grpcInternal, "gRPC internal"] as const,
           ] satisfies ReadonlyArray<
             readonly [
-              "quicInternal" | "replicationEndpoint",
+              "quicInternal" | "grpcInternal",
               {
                 enabled?: boolean;
                 port?: number;

--- a/frontend/src/onboarding/server/ServiceSetup.tsx
+++ b/frontend/src/onboarding/server/ServiceSetup.tsx
@@ -576,7 +576,7 @@ function validateAdvanced(adv: HostAdvancedOptions): Record<string, string> {
 
   for (const [key, ep] of [
     ["quicInternal", adv.quicInternal],
-    ["replicationEndpoint", adv.replicationEndpoint],
+    ["grpcInternal", adv.grpcInternal],
   ] as const) {
     if (ep?.enabled) {
       if (!ep.certFile?.trim()) {

--- a/src-tauri/src/server_host.rs
+++ b/src-tauri/src/server_host.rs
@@ -164,9 +164,12 @@ pub struct HostAdvancedOptions {
     /// `quic_internal` mTLS replication endpoint ([`server.quic_internal`]).
     #[serde(default)]
     pub quic_internal: Option<InternalEndpointOptions>,
-    /// `replication` gRPC endpoint ([`server.replication`]).
-    #[serde(default)]
-    pub replication_endpoint: Option<InternalEndpointOptions>,
+    /// `grpc_internal` mTLS gRPC endpoint ([`server.grpc_internal`]).
+    ///
+    /// Alias keeps older Expert-mode payloads that sent `replicationEndpoint`
+    /// (the wizard used to emit the unknown `[server.replication]` table).
+    #[serde(default, alias = "replicationEndpoint")]
+    pub grpc_internal: Option<InternalEndpointOptions>,
     /// Lock-store mode ([`lock_store`]). Defaults to lore's `local`.
     #[serde(default)]
     pub lock_store_mode: Option<String>,
@@ -400,7 +403,7 @@ pub struct TimeoutOptions {
     pub runtime_shutdown_timeout_seconds: Option<u16>,
 }
 
-/// Options for the internal `quic_internal` / `replication` endpoints. These
+/// Options for the internal `quic_internal` / `grpc_internal` endpoints. These
 /// are opt-in (`enabled = false` by lore default) and require mTLS certs.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -652,7 +655,7 @@ struct AdvancedConfig {
     features: Option<FeatureOptions>,
     timeouts: Option<TimeoutOptions>,
     quic_internal: Option<InternalEndpointOptions>,
-    replication_endpoint: Option<InternalEndpointOptions>,
+    grpc_internal: Option<InternalEndpointOptions>,
     lock_store_mode: Option<String>,
 }
 
@@ -820,14 +823,9 @@ fn render_config_toml(cfg: &ResolvedConfig) -> String {
     }
     out.push('\n');
 
-    // -- Internal endpoints (quic_internal / replication), opt-in + mTLS --
+    // -- Internal endpoints (quic_internal / grpc_internal), opt-in + mTLS --
     render_internal_endpoint(&mut out, "server.quic_internal", &adv.quic_internal, &escs);
-    render_internal_endpoint(
-        &mut out,
-        "server.replication",
-        &adv.replication_endpoint,
-        &escs,
-    );
+    render_internal_endpoint(&mut out, "server.grpc_internal", &adv.grpc_internal, &escs);
 
     // -- Graceful-shutdown timeouts --
     if let Some(t) = &adv.timeouts {
@@ -1060,7 +1058,7 @@ fn render_config_toml(cfg: &ResolvedConfig) -> String {
     out
 }
 
-/// Render an opt-in internal endpoint (`quic_internal` / `replication`). These
+/// Render an opt-in internal endpoint (`quic_internal` / `grpc_internal`). These
 /// default to `enabled = false`, so nothing is emitted unless the user supplied
 /// at least one explicit value. mTLS certs are nested under `<section>.certificate`.
 fn render_internal_endpoint(
@@ -1759,7 +1757,7 @@ fn resolve_advanced(opts: &HostServerOptions) -> Result<AdvancedConfig, LoreErro
         features: adv.features.clone(),
         timeouts: adv.timeouts.clone(),
         quic_internal: resolve_internal(&adv.quic_internal, "quic_internal")?,
-        replication_endpoint: resolve_internal(&adv.replication_endpoint, "replication")?,
+        grpc_internal: resolve_internal(&adv.grpc_internal, "grpc_internal")?,
         lock_store_mode: norm_str(&adv.lock_store_mode),
     })
 }
@@ -3085,7 +3083,7 @@ mod tests {
                     features: None,
                     timeouts: None,
                     quic_internal: None,
-                    replication_endpoint: None,
+                    grpc_internal: None,
                     lock_store_mode: None
                 }
             ),
@@ -3117,6 +3115,7 @@ mod tests {
         assert!(toml.contains("[topology]\nprovider = \"none\"\n"));
         // No advanced sections.
         assert!(!toml.contains("[server.quic_internal]"));
+        assert!(!toml.contains("[server.grpc_internal]"));
         assert!(!toml.contains("[server.replication]"));
         assert!(!toml.contains("[tokio]"));
         assert!(!toml.contains("[feature]"));
@@ -3518,7 +3517,7 @@ mod tests {
         let ok = adv_opts(
             "/srv/store",
             HostAdvancedOptions {
-                replication_endpoint: Some(InternalEndpointOptions {
+                grpc_internal: Some(InternalEndpointOptions {
                     enabled: Some(true),
                     port: Some(41340),
                     cert_file: Some("/c/cert.pem".into()),
@@ -3529,8 +3528,34 @@ mod tests {
             },
         );
         let toml = render_config(&ok, &CertContext::none()).expect("render");
-        assert!(toml.contains("[server.replication]\nenabled = true\nport = 41340"));
-        assert!(toml.contains("[server.replication.certificate]\ncert_file = \"/c/cert.pem\"\npkey_file = \"/c/key.pem\""));
+        // SBAI-7201: lore-server deserializes `[server.grpc_internal]`, not
+        // the unknown `[server.replication]` table the wizard used to emit.
+        assert!(toml.contains("[server.grpc_internal]\nenabled = true\nport = 41340"));
+        assert!(toml.contains("[server.grpc_internal.certificate]\ncert_file = \"/c/cert.pem\"\npkey_file = \"/c/key.pem\""));
+        assert!(!toml.contains("[server.replication]"));
+    }
+
+    #[test]
+    fn legacy_replication_endpoint_alias_emits_grpc_internal() {
+        // Pre-SBAI-7201 Expert payloads sent `replicationEndpoint`. The field
+        // renamed, but the alias must still deserialize and emit lore's real key.
+        let opts: HostServerOptions = serde_json::from_str(
+            r#"{
+                "storeDir": "/srv/store",
+                "advanced": {
+                    "replicationEndpoint": {
+                        "enabled": true,
+                        "port": 41340,
+                        "certFile": "/c/cert.pem",
+                        "pkeyFile": "/c/key.pem"
+                    }
+                }
+            }"#,
+        )
+        .expect("legacy Expert payload");
+        let toml = render_config(&opts, &CertContext::none()).expect("render");
+        assert!(toml.contains("[server.grpc_internal]\nenabled = true\nport = 41340"));
+        assert!(!toml.contains("[server.replication]"));
     }
 
     #[test]


### PR DESCRIPTION
Resolves SBAI-7201.

## What
Expert-mode host wizard wrote `[server.replication]`. Pinned lore-server (`ServerSettings`) reads `[server.grpc_internal]` (`enabled = false` by default). `deny_unknown_fields` is commented out, so the generated table was silently ignored and the internal gRPC replication endpoint never started. `[server.quic_internal]` was already named correctly.

## Change
- `render_internal_endpoint` now emits `[server.grpc_internal]` / `[server.grpc_internal.certificate]`
- `HostAdvancedOptions.replication_endpoint` → `grpc_internal` (serde alias `replicationEndpoint` for older Expert payloads)
- Frontend field `replicationEndpoint` → `grpcInternal`; label "gRPC replication" → "gRPC internal"
- Domain doc updated
- Render test asserts lore's real key and rejects the old table; extra test covers the serde alias

Does **not** enable internal endpoints for the SBAI-7200 cloud-sync checkbox.

## Verify
- `cargo fmt --all --check` clean
- `npm --prefix frontend run typecheck` clean
- `cargo test -p loregui --lib server_host` **blocked on a pre-existing main break**: `lore-vm` `clone.rs` assigns `direct_file_io` on `LoreRepositoryCloneArgs`, which pin `d09b1235` does not have. Same `error[E0560]` as main `core-check` on #466 (`31950861881`). Not introduced here. Open pin bump is #469.

## Files
- `src-tauri/src/server_host.rs`
- `frontend/src/api.ts`
- `frontend/src/onboarding/server/AdvancedServerConfig.tsx`
- `frontend/src/onboarding/server/ServiceSetup.tsx`
- `docs/domains/storage.md`