### PR TITLE
SBAI-7198: pin frontend nanoid >= 3.3.18

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,6 +42,9 @@
         "typescript": "^5",
         "vite": "^6.4.3",
         "vitest": "^3.2.7"
+      },
+      "overrides": {
+        "nanoid": "^3.3.18"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2928,9 +2931,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "npm run test:node && npm run test:vitest",
-    "test:node": "node --test --experimental-strip-types \"src/commercial/entitlement.test.ts\" \"src/commercial/license.test.ts\"",
+    "test:node": "node --test --experimental-strip-types \"src/commercial/entitlement.test.ts\" \"src/commercial/license.test.ts\" \"src/security/nanoid-resolution.test.ts\"",
     "test:vitest": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
@@ -49,5 +49,8 @@
     "typescript": "^5",
     "vite": "^6.4.3",
     "vitest": "^3.2.7"
+  },
+  "overrides": {
+    "nanoid": "^3.3.18"
   }
 }

--- a/frontend/src/security/nanoid-resolution.test.ts
+++ b/frontend/src/security/nanoid-resolution.test.ts
@@ -1,0 +1,52 @@
+/**
+ * SBAI-7198: lockfile must resolve nanoid >= 3.3.18 (GHSA-2v37-7h3g-55p8).
+ *
+ * nanoid is not a product import — it arrives via postcss (Vite). The advisory
+ * is a hang in custom generators when `size` is 0; this file pins the
+ * resolved version and exercises that path so a lockfile regression fails CI.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FRONTEND_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const MIN_PATCHED = [3, 3, 18] as const;
+
+function parseSemver(raw: string): [number, number, number] {
+  const m = raw.trim().match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!m) throw new Error(`not a x.y.z version: ${raw}`);
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function gte(a: [number, number, number], b: readonly [number, number, number]): boolean {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] > b[i]) return true;
+    if (a[i] < b[i]) return false;
+  }
+  return true;
+}
+
+test("package-lock resolves nanoid to a GHSA-2v37-7h3g-55p8 patched version", async () => {
+  const lock = JSON.parse(
+    await readFile(join(FRONTEND_ROOT, "package-lock.json"), "utf8"),
+  ) as {
+    packages?: Record<string, { version?: string }>;
+  };
+  const entry = lock.packages?.["node_modules/nanoid"];
+  assert.ok(entry?.version, "lockfile must contain node_modules/nanoid");
+  assert.ok(
+    gte(parseSemver(entry.version), MIN_PATCHED),
+    `resolved nanoid ${entry.version} is below 3.3.18 (GHSA-2v37-7h3g-55p8)`,
+  );
+});
+
+test("custom nanoid generator with size 0 returns without hanging", async () => {
+  const { customAlphabet } = await import("nanoid");
+  const gen = customAlphabet("abcdefghijklmnopqrstuvwxyz", 0);
+  const started = Date.now();
+  const out = gen();
+  assert.ok(Date.now() - started < 1000, "size-0 custom generator hung");
+  assert.equal(out, "");
+});


### PR DESCRIPTION
Resolves SBAI-7198.

## What
`npm audit` reported **GHSA-2v37-7h3g-55p8** (High): transitive `nanoid` `<3.3.18` can loop forever in a custom generator when `size` is 0.

## Parent
`npm ls nanoid` → `vite@6.4.3` → `postcss@8.5.25` → `nanoid`. Latest postcss still depends on `^3.3.16`/`^3.3.17` — no parent bump forces 3.3.18. Override is the justified fallback.

## Change
- `frontend/package.json` `overrides.nanoid = ^3.3.18`
- lockfile resolves `nanoid@3.3.18`
- `src/security/nanoid-resolution.test.ts` — lockfile version floor + size-0 custom generator does not hang

No product import of nanoid (build-time via Vite/postcss only).

## Verify
- `npm audit` → 0 vulnerabilities
- `npm run test:node` → 27/27
- `tsc --noEmit` clean

## Out of scope
`website/package-lock.json` still resolves `nanoid@3.3.12`. Same advisory, different package — follow-up, not this ticket.

Respect LoreGUI merge freeze: do not self-merge.