### PR TITLE
SBAI-8516/SBAI-8517: widen lore-vm metadata write surface to all 7 Epic types

### DIFF
--- a/crates/lore-vm/src/ops/branch/archive.rs
+++ b/crates/lore-vm/src/ops/branch/archive.rs
@@ -20,6 +20,15 @@ impl BranchArchiveArgs {
     fn into_lore(self) -> LoreBranchArchiveArgs {
         LoreBranchArchiveArgs {
             branch: LoreString::from_str(&self.branch),
+            // SBAI-8516: upstream added layer/link scoping for archive
+            // (da73d9f). This op never had that concept before, so the
+            // defaults that preserve old behavior (archive without any
+            // layer/link scoping) are empty string + 0, matching upstream's
+            // own #[serde(default)] treatment of these exact fields.
+            layer: LoreString::default(),
+            include_layers: 0,
+            link: LoreString::default(),
+            include_links: 0,
         }
     }
 }

--- a/crates/lore-vm/src/ops/branch/info.rs
+++ b/crates/lore-vm/src/ops/branch/info.rs
@@ -27,6 +27,10 @@ impl BranchInfoArgs {
     fn into_lore(self) -> LoreBranchInfoArgs {
         LoreBranchInfoArgs {
             branch: LoreString::from_str(&self.branch),
+            // SBAI-8516: upstream added an optional `link` (query a branch in
+            // a linked sub-repository) that this op never had before; empty
+            // string preserves old behavior (query the main repository).
+            link: LoreString::default(),
         }
     }
 }

--- a/crates/lore-vm/src/ops/branch/metadata_set.rs
+++ b/crates/lore-vm/src/ops/branch/metadata_set.rs
@@ -135,3 +135,86 @@ pub async fn metadata_set(api: &LoreApi, args: MetadataSetArgs) -> Result<Metada
         values,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_format_into_lore() {
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::Address),
+            LoreMetadataType::Address
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::Boolean),
+            LoreMetadataType::Boolean
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::Binary),
+            LoreMetadataType::Binary
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::Context),
+            LoreMetadataType::Context
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::Hash),
+            LoreMetadataType::Hash
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::Numeric),
+            LoreMetadataType::Numeric
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::String),
+            LoreMetadataType::String
+        );
+    }
+
+    #[test]
+    fn metadata_format_serializes_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&MetadataFormat::Address).unwrap(),
+            r#""address""#
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataFormat::Boolean).unwrap(),
+            r#""boolean""#
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataFormat::Binary).unwrap(),
+            r#""binary""#
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataFormat::Context).unwrap(),
+            r#""context""#
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataFormat::Hash).unwrap(),
+            r#""hash""#
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataFormat::Numeric).unwrap(),
+            r#""numeric""#
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataFormat::String).unwrap(),
+            r#""string""#
+        );
+    }
+
+    #[test]
+    fn args_pads_missing_formats_with_string() {
+        let args = MetadataSetArgs {
+            branch: "main".into(),
+            keys: vec!["a".into(), "b".into()],
+            values: vec!["1".into(), "2".into()],
+            formats: vec![MetadataFormat::Numeric],
+        };
+        let lore_args = args.into_lore();
+        let formats = lore_args.formats.as_slice();
+        assert_eq!(formats[0], LoreMetadataType::Numeric);
+        assert_eq!(formats[1], LoreMetadataType::String);
+    }
+}

--- a/crates/lore-vm/src/ops/branch/metadata_set.rs
+++ b/crates/lore-vm/src/ops/branch/metadata_set.rs
@@ -16,7 +16,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum MetadataFormat {
+    Address,
+    Boolean,
     Binary,
+    Context,
+    Hash,
     Numeric,
     String,
 }
@@ -24,7 +28,11 @@ pub enum MetadataFormat {
 impl From<MetadataFormat> for LoreMetadataType {
     fn from(f: MetadataFormat) -> Self {
         match f {
+            MetadataFormat::Address => LoreMetadataType::Address,
+            MetadataFormat::Boolean => LoreMetadataType::Boolean,
             MetadataFormat::Binary => LoreMetadataType::Binary,
+            MetadataFormat::Context => LoreMetadataType::Context,
+            MetadataFormat::Hash => LoreMetadataType::Hash,
             MetadataFormat::Numeric => LoreMetadataType::Numeric,
             MetadataFormat::String => LoreMetadataType::String,
         }

--- a/crates/lore-vm/src/ops/file/metadata_set.rs
+++ b/crates/lore-vm/src/ops/file/metadata_set.rs
@@ -37,16 +37,6 @@ impl From<MetadataType> for LoreMetadataType {
     }
 }
 
-impl From<LoreMetadataType> for MetadataType {
-    fn from(value: LoreMetadataType) -> Self {
-        match value {
-            LoreMetadataType::Binary => MetadataType::Binary,
-            LoreMetadataType::Numeric => MetadataType::Numeric,
-            LoreMetadataType::String => MetadataType::String,
-        }
-    }
-}
-
 /// Arguments for [`metadata_set`].
 ///
 /// Mirrors `LoreFileMetadataSetArgs` from the upstream `lore` crate
@@ -190,22 +180,6 @@ mod tests {
     fn metadata_type_serializes_lowercase() {
         let json = serde_json::to_string(&MetadataType::String).expect("should serialize");
         assert_eq!(json, r#""string""#);
-    }
-
-    #[test]
-    fn metadata_type_from_lore() {
-        assert_eq!(
-            MetadataType::from(LoreMetadataType::Binary),
-            MetadataType::Binary
-        );
-        assert_eq!(
-            MetadataType::from(LoreMetadataType::Numeric),
-            MetadataType::Numeric
-        );
-        assert_eq!(
-            MetadataType::from(LoreMetadataType::String),
-            MetadataType::String
-        );
     }
 
     #[test]

--- a/crates/lore-vm/src/ops/file/metadata_set.rs
+++ b/crates/lore-vm/src/ops/file/metadata_set.rs
@@ -19,18 +19,30 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum MetadataType {
+    /// A content address: 48 bytes (32-byte hash + 16-byte context).
+    Address,
+    /// A boolean value, stored as one byte; any non-zero value is true.
+    Boolean,
     /// A block of raw bytes.
-    Binary = 0,
+    Binary,
+    /// A context identifier: 16 raw bytes.
+    Context,
+    /// A content hash: 32 raw bytes.
+    Hash,
     /// An unsigned integer value.
-    Numeric = 1,
+    Numeric,
     /// A string value.
-    String = 2,
+    String,
 }
 
 impl From<MetadataType> for LoreMetadataType {
     fn from(value: MetadataType) -> Self {
         match value {
+            MetadataType::Address => LoreMetadataType::Address,
+            MetadataType::Boolean => LoreMetadataType::Boolean,
             MetadataType::Binary => LoreMetadataType::Binary,
+            MetadataType::Context => LoreMetadataType::Context,
+            MetadataType::Hash => LoreMetadataType::Hash,
             MetadataType::Numeric => LoreMetadataType::Numeric,
             MetadataType::String => LoreMetadataType::String,
         }
@@ -185,8 +197,24 @@ mod tests {
     #[test]
     fn metadata_type_into_lore() {
         assert_eq!(
+            LoreMetadataType::from(MetadataType::Address),
+            LoreMetadataType::Address
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataType::Boolean),
+            LoreMetadataType::Boolean
+        );
+        assert_eq!(
             LoreMetadataType::from(MetadataType::Binary),
             LoreMetadataType::Binary
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataType::Context),
+            LoreMetadataType::Context
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataType::Hash),
+            LoreMetadataType::Hash
         );
         assert_eq!(
             LoreMetadataType::from(MetadataType::Numeric),
@@ -195,6 +223,26 @@ mod tests {
         assert_eq!(
             LoreMetadataType::from(MetadataType::String),
             LoreMetadataType::String
+        );
+    }
+
+    #[test]
+    fn metadata_type_new_variants_serialize_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&MetadataType::Address).unwrap(),
+            r#""address""#
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataType::Boolean).unwrap(),
+            r#""boolean""#
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataType::Context).unwrap(),
+            r#""context""#
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataType::Hash).unwrap(),
+            r#""hash""#
         );
     }
 

--- a/crates/lore-vm/src/ops/repository/clone.rs
+++ b/crates/lore-vm/src/ops/repository/clone.rs
@@ -8,7 +8,7 @@ use crate::api::LoreApi;
 use crate::collect::collect_events;
 use crate::error::{LoreError, Result};
 
-use lore::interface::{LoreArray, LoreEvent, LoreString};
+use lore::interface::{LoreArray, LoreEvent, LoreSharedStoreMode, LoreString};
 use lore::repository::LoreRepositoryCloneArgs;
 use serde::{Deserialize, Serialize};
 
@@ -90,11 +90,20 @@ impl CloneArgs {
             bare: u8::from(self.bare),
             virtually: u8::from(self.virtually),
             direct_file_write: u8::from(self.direct_file_write),
-            direct_file_io: u8::from(self.direct_file_io),
+            // SBAI-8516: upstream dropped `direct_file_io` from
+            // LoreRepositoryCloneArgs entirely (da73d9f) -- no replacement
+            // field, so our own `direct_file_io` option is now inert. Kept on
+            // CloneArgs for wire/API compat; not forwarded since there is
+            // nowhere upstream to put it.
             layer: LoreString::from_str(&self.layer),
             layer_metadata: LoreString::from_str(&self.layer_metadata),
             prefetch: LoreString::from_str(&self.prefetch),
-            use_shared_store: u8::from(self.use_shared_store),
+            // SBAI-8516: see repository/create.rs — same bool->LoreSharedStoreMode mapping.
+            use_shared_store: if self.use_shared_store {
+                LoreSharedStoreMode::Enabled
+            } else {
+                LoreSharedStoreMode::Disabled
+            },
             shared_store_path: LoreString::from_str(&self.shared_store_path),
             no_tracking: u8::from(self.no_tracking),
             root_files: LoreArray::from_vec(lore_root_files),
@@ -275,7 +284,7 @@ mod tests {
         assert_eq!(lore_args.repository_url.as_str(), "lore://host/repo");
         assert_eq!(lore_args.revision.as_str(), "rev1");
         assert_eq!(lore_args.bare, 1);
-        assert_eq!(lore_args.use_shared_store, 1);
+        assert_eq!(lore_args.use_shared_store, LoreSharedStoreMode::Enabled);
         assert_eq!(lore_args.shared_store_path.as_str(), "/tmp/store");
         assert_eq!(lore_args.root_files.len(), 1);
         assert_eq!(lore_args.dependency_tags.len(), 2);

--- a/crates/lore-vm/src/ops/repository/create.rs
+++ b/crates/lore-vm/src/ops/repository/create.rs
@@ -7,7 +7,7 @@ use crate::api::LoreApi;
 use crate::collect::collect_events;
 use crate::error::{LoreError, Result};
 
-use lore::interface::{LoreEvent, LoreString};
+use lore::interface::{LoreEvent, LoreSharedStoreMode, LoreString};
 use lore::repository::LoreRepositoryCreateArgs;
 use serde::{Deserialize, Serialize};
 
@@ -39,7 +39,15 @@ impl CreateArgs {
             repository_url: LoreString::from_str(&self.repository_url),
             description: LoreString::from_str(&self.description),
             id: LoreString::from_str(&self.id),
-            use_shared_store: u8::from(self.use_shared_store),
+            // SBAI-8516: upstream widened use_shared_store from bool/u8 to
+            // LoreSharedStoreMode (adding Inherit=0). Our own field stays a
+            // plain bool with no "inherit" concept, so true/false map
+            // straight onto the two variants that existed before.
+            use_shared_store: if self.use_shared_store {
+                LoreSharedStoreMode::Enabled
+            } else {
+                LoreSharedStoreMode::Disabled
+            },
             shared_store_path: LoreString::from_str(&self.shared_store_path),
         }
     }
@@ -127,7 +135,7 @@ mod tests {
         };
         let lore_args = args.into_lore();
         assert_eq!(lore_args.repository_url.as_str(), "lore://localhost/y");
-        assert_eq!(lore_args.use_shared_store, 1);
+        assert_eq!(lore_args.use_shared_store, LoreSharedStoreMode::Enabled);
         assert_eq!(lore_args.shared_store_path.as_str(), "/tmp/store");
     }
 

--- a/crates/lore-vm/src/ops/repository/create_with_metadata.rs
+++ b/crates/lore-vm/src/ops/repository/create_with_metadata.rs
@@ -8,7 +8,7 @@ use crate::api::LoreApi;
 use crate::collect::collect_events;
 use crate::error::{LoreError, Result};
 
-use lore::interface::{LoreEvent, LoreString};
+use lore::interface::{LoreEvent, LoreSharedStoreMode, LoreString};
 use lore::repository::{LoreRepositoryCreateArgs, LoreRepositoryCreateMetadata};
 use serde::{Deserialize, Serialize};
 
@@ -41,7 +41,12 @@ impl CreateWithMetadataArgs {
             repository_url: LoreString::from_str(&self.repository_url),
             description: LoreString::from_str(&self.description),
             id: LoreString::from_str(&self.id),
-            use_shared_store: if self.use_shared_store { 1 } else { 0 },
+            // SBAI-8516: see create.rs — same bool->LoreSharedStoreMode mapping.
+            use_shared_store: if self.use_shared_store {
+                LoreSharedStoreMode::Enabled
+            } else {
+                LoreSharedStoreMode::Disabled
+            },
             shared_store_path: LoreString::from_str(&self.shared_store_path),
         };
         let metadata = LoreRepositoryCreateMetadata {

--- a/crates/lore-vm/src/ops/repository/metadata_set.rs
+++ b/crates/lore-vm/src/ops/repository/metadata_set.rs
@@ -16,7 +16,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum MetadataFormat {
+    Address,
+    Boolean,
     Binary,
+    Context,
+    Hash,
     Numeric,
     String,
 }
@@ -24,7 +28,11 @@ pub enum MetadataFormat {
 impl From<MetadataFormat> for LoreMetadataType {
     fn from(f: MetadataFormat) -> Self {
         match f {
+            MetadataFormat::Address => LoreMetadataType::Address,
+            MetadataFormat::Boolean => LoreMetadataType::Boolean,
             MetadataFormat::Binary => LoreMetadataType::Binary,
+            MetadataFormat::Context => LoreMetadataType::Context,
+            MetadataFormat::Hash => LoreMetadataType::Hash,
             MetadataFormat::Numeric => LoreMetadataType::Numeric,
             MetadataFormat::String => LoreMetadataType::String,
         }

--- a/crates/lore-vm/src/ops/repository/metadata_set.rs
+++ b/crates/lore-vm/src/ops/repository/metadata_set.rs
@@ -168,8 +168,24 @@ mod tests {
     #[test]
     fn metadata_format_serde() {
         assert_eq!(
+            serde_json::to_string(&MetadataFormat::Address).unwrap(),
+            "\"address\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataFormat::Boolean).unwrap(),
+            "\"boolean\""
+        );
+        assert_eq!(
             serde_json::to_string(&MetadataFormat::Binary).unwrap(),
             "\"binary\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataFormat::Context).unwrap(),
+            "\"context\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataFormat::Hash).unwrap(),
+            "\"hash\""
         );
         assert_eq!(
             serde_json::to_string(&MetadataFormat::Numeric).unwrap(),
@@ -182,6 +198,40 @@ mod tests {
 
         let f: MetadataFormat = serde_json::from_str("\"numeric\"").unwrap();
         assert_eq!(f, MetadataFormat::Numeric);
+        let f: MetadataFormat = serde_json::from_str("\"boolean\"").unwrap();
+        assert_eq!(f, MetadataFormat::Boolean);
+    }
+
+    #[test]
+    fn metadata_format_into_lore_exhaustive() {
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::Address),
+            LoreMetadataType::Address
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::Boolean),
+            LoreMetadataType::Boolean
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::Binary),
+            LoreMetadataType::Binary
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::Context),
+            LoreMetadataType::Context
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::Hash),
+            LoreMetadataType::Hash
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::Numeric),
+            LoreMetadataType::Numeric
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::String),
+            LoreMetadataType::String
+        );
     }
 
     #[test]

--- a/crates/lore-vm/src/ops/revision/commit_with_metadata.rs
+++ b/crates/lore-vm/src/ops/revision/commit_with_metadata.rs
@@ -2,7 +2,7 @@
 //!
 //! Creates a new revision from staged files, attaching key-value metadata entries
 //! to the revision. Each metadata entry has a key, value, and format type
-//! (Binary, Numeric, or String).
+//! (Address, Boolean, Binary, Context, Hash, Numeric, or String).
 //!
 //! Emits `LoreEvent::RevisionCommitRevision` on success containing the repository,
 //! branch, and revision identifiers.
@@ -183,8 +183,24 @@ mod tests {
     #[test]
     fn metadata_format_serde() {
         assert_eq!(
+            serde_json::to_string(&MetadataFormat::Address).unwrap(),
+            r#""address""#
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataFormat::Boolean).unwrap(),
+            r#""boolean""#
+        );
+        assert_eq!(
             serde_json::to_string(&MetadataFormat::Binary).unwrap(),
             r#""binary""#
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataFormat::Context).unwrap(),
+            r#""context""#
+        );
+        assert_eq!(
+            serde_json::to_string(&MetadataFormat::Hash).unwrap(),
+            r#""hash""#
         );
         assert_eq!(
             serde_json::to_string(&MetadataFormat::Numeric).unwrap(),
@@ -197,6 +213,40 @@ mod tests {
 
         let back: MetadataFormat = serde_json::from_str(r#""numeric""#).unwrap();
         assert_eq!(back, MetadataFormat::Numeric);
+        let back: MetadataFormat = serde_json::from_str(r#""address""#).unwrap();
+        assert_eq!(back, MetadataFormat::Address);
+    }
+
+    #[test]
+    fn metadata_format_into_lore_exhaustive() {
+        assert_eq!(
+            MetadataFormat::Address.into_lore(),
+            lore::interface::LoreMetadataType::Address
+        );
+        assert_eq!(
+            MetadataFormat::Boolean.into_lore(),
+            lore::interface::LoreMetadataType::Boolean
+        );
+        assert_eq!(
+            MetadataFormat::Binary.into_lore(),
+            lore::interface::LoreMetadataType::Binary
+        );
+        assert_eq!(
+            MetadataFormat::Context.into_lore(),
+            lore::interface::LoreMetadataType::Context
+        );
+        assert_eq!(
+            MetadataFormat::Hash.into_lore(),
+            lore::interface::LoreMetadataType::Hash
+        );
+        assert_eq!(
+            MetadataFormat::Numeric.into_lore(),
+            lore::interface::LoreMetadataType::Numeric
+        );
+        assert_eq!(
+            MetadataFormat::String.into_lore(),
+            lore::interface::LoreMetadataType::String
+        );
     }
 
     #[test]

--- a/crates/lore-vm/src/ops/revision/commit_with_metadata.rs
+++ b/crates/lore-vm/src/ops/revision/commit_with_metadata.rs
@@ -20,7 +20,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum MetadataFormat {
+    Address,
+    Boolean,
     Binary,
+    Context,
+    Hash,
     Numeric,
     String,
 }
@@ -28,7 +32,11 @@ pub enum MetadataFormat {
 impl MetadataFormat {
     fn into_lore(self) -> lore::interface::LoreMetadataType {
         match self {
+            MetadataFormat::Address => lore::interface::LoreMetadataType::Address,
+            MetadataFormat::Boolean => lore::interface::LoreMetadataType::Boolean,
             MetadataFormat::Binary => lore::interface::LoreMetadataType::Binary,
+            MetadataFormat::Context => lore::interface::LoreMetadataType::Context,
+            MetadataFormat::Hash => lore::interface::LoreMetadataType::Hash,
             MetadataFormat::Numeric => lore::interface::LoreMetadataType::Numeric,
             MetadataFormat::String => lore::interface::LoreMetadataType::String,
         }

--- a/crates/lore-vm/src/ops/revision/metadata_set.rs
+++ b/crates/lore-vm/src/ops/revision/metadata_set.rs
@@ -16,7 +16,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum MetadataFormat {
+    Address,
+    Boolean,
     Binary,
+    Context,
+    Hash,
     Numeric,
     String,
 }
@@ -24,7 +28,11 @@ pub enum MetadataFormat {
 impl From<MetadataFormat> for LoreMetadataType {
     fn from(f: MetadataFormat) -> Self {
         match f {
+            MetadataFormat::Address => LoreMetadataType::Address,
+            MetadataFormat::Boolean => LoreMetadataType::Boolean,
             MetadataFormat::Binary => LoreMetadataType::Binary,
+            MetadataFormat::Context => LoreMetadataType::Context,
+            MetadataFormat::Hash => LoreMetadataType::Hash,
             MetadataFormat::Numeric => LoreMetadataType::Numeric,
             MetadataFormat::String => LoreMetadataType::String,
         }
@@ -150,8 +158,24 @@ mod tests {
     #[test]
     fn metadata_format_converts_to_lore() {
         assert_eq!(
+            LoreMetadataType::from(MetadataFormat::Address),
+            LoreMetadataType::Address
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::Boolean),
+            LoreMetadataType::Boolean
+        );
+        assert_eq!(
             LoreMetadataType::from(MetadataFormat::Binary),
             LoreMetadataType::Binary
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::Context),
+            LoreMetadataType::Context
+        );
+        assert_eq!(
+            LoreMetadataType::from(MetadataFormat::Hash),
+            LoreMetadataType::Hash
         );
         assert_eq!(
             LoreMetadataType::from(MetadataFormat::Numeric),

--- a/crates/lore-vm/src/ops/storage/get.rs
+++ b/crates/lore-vm/src/ops/storage/get.rs
@@ -67,6 +67,8 @@ impl StorageGetArgs {
                     "id": item.id,
                     "partition": item.partition,
                     "address": item.address,
+                    "offset": 0,
+                    "length": 0,
                     "streaming": u8::from(item.streaming),
                     "local_cache": u8::from(item.local_cache),
                 })
@@ -260,4 +262,57 @@ pub async fn get(api: &LoreApi, args: StorageGetArgs) -> Result<StorageGetResult
 /// references are renamed in one coordinated pass.
 pub async fn storage_get(api: &LoreApi, args: StorageGetArgs) -> Result<StorageGetResult> {
     get(api, args).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_converts_to_lore() {
+        let args = StorageGetArgs {
+            handle: 42,
+            items: vec![GetItem {
+                id: 1,
+                partition: "00000000000000000000000000000001".into(),
+                address: "a".repeat(64),
+                streaming: false,
+                local_cache: false,
+            }],
+        };
+        let lore_args = args.into_lore().expect("into_lore");
+        assert_eq!(lore_args.handle.handle_id, 42);
+        assert_eq!(lore_args.items.as_slice().len(), 1);
+    }
+
+    #[test]
+    fn args_converts_to_lore_carries_whole_buffer_range() {
+        // offset=0/length=0 must reach the upstream conversion -- per
+        // upstream's own doc comment, length=0 means "read to the end",
+        // so this is what preserves pre-drift whole-file behavior.
+        let args = StorageGetArgs {
+            handle: 1,
+            items: vec![GetItem {
+                id: 7,
+                partition: "00000000000000000000000000000001".into(),
+                address: "b".repeat(64),
+                streaming: false,
+                local_cache: false,
+            }],
+        };
+        let lore_args = args.into_lore().expect("into_lore");
+        let item = lore_args.items.as_slice()[0];
+        assert_eq!(item.offset, 0);
+        assert_eq!(item.length, 0);
+    }
+
+    #[test]
+    fn args_empty_items_converts() {
+        let args = StorageGetArgs {
+            handle: 1,
+            items: vec![],
+        };
+        let lore_args = args.into_lore().expect("into_lore");
+        assert_eq!(lore_args.items.as_slice().len(), 0);
+    }
 }

--- a/crates/lore-vm/src/ops/storage/get_file.rs
+++ b/crates/lore-vm/src/ops/storage/get_file.rs
@@ -59,6 +59,8 @@ impl StorageGetFileArgs {
                     "address": item.address,
                     "path": item.path,
                     "local_cache": u8::from(item.local_cache),
+                    "offset": 0,
+                    "length": 0,
                 })
             })
             .collect();

--- a/crates/lore-vm/tests/integration_roundtrip.rs
+++ b/crates/lore-vm/tests/integration_roundtrip.rs
@@ -327,3 +327,87 @@ async fn shared_store_create_against_real_lore() {
         "shared_store::create returned an empty path: {created:?}"
     );
 }
+
+/// SBAI-8516: `MetadataFormat::Boolean` must be decoded against upstream's own
+/// accepted text set (`true/1/yes/on` / `false/0/no/off`, case-insensitive),
+/// not a value loregui invents — the widened enum just forwards the tag,
+/// upstream's `Metadata::decode_to_value` does the actual parsing/validation.
+/// This can only be proven against the real engine; the unit tests only cover
+/// the enum <-> `LoreMetadataType` mapping.
+#[tokio::test]
+async fn metadata_boolean_format_matches_upstream_decode_rules() {
+    let tempdir = tempfile::tempdir().expect("create temp dir");
+    let repo_path = tempdir.path().to_path_buf();
+    let api = in_memory_api(&repo_path);
+
+    // Mirrors full_roundtrip_against_real_lore's proven-working setup: bare
+    // repository::create + revision::metadata_set needs a "remote configured"
+    // that repository::metadata_set alone does not get in in-memory mode, so
+    // commit at least once first to reach a state where revision-level writes
+    // are accepted headlessly.
+    let name = format!("itest-bool-{}", std::process::id());
+    ops::repository::create::create(
+        &api,
+        ops::repository::create::CreateArgs {
+            repository_url: format!("lore://localhost/{name}"),
+            description: "lore-vm metadata boolean test repo".into(),
+            id: String::new(),
+            use_shared_store: false,
+            shared_store_path: String::new(),
+        },
+    )
+    .await
+    .expect("repository::create should succeed against the real engine");
+
+    let file_path = repo_path.join("bool-test.txt");
+    write_file(&file_path, b"metadata boolean test");
+    ops::file::stage::stage(
+        &api,
+        ops::file::stage::FileStageArgs {
+            paths: vec![file_path.to_string_lossy().into_owned()],
+            case_change: ops::file::stage::CaseChange::Error,
+            scan: true,
+        },
+    )
+    .await
+    .expect("file::stage should succeed");
+    ops::revision::commit::commit(
+        &api,
+        ops::revision::commit::CommitArgs {
+            message: "initial commit".into(),
+        },
+    )
+    .await
+    .expect("revision::commit should succeed");
+
+    // Every text form upstream's decode_to_value accepts, case-insensitively.
+    for accepted in ["true", "1", "yes", "on", "TRUE", "False", "0", "no", "OFF"] {
+        ops::revision::metadata_set::metadata_set(
+            &api,
+            ops::revision::metadata_set::MetadataSetArgs {
+                keys: vec!["itest_bool_key".into()],
+                values: vec![accepted.into()],
+                formats: vec![ops::revision::metadata_set::MetadataFormat::Boolean],
+            },
+        )
+        .await
+        .unwrap_or_else(|e| panic!("Boolean value {accepted:?} should be accepted (upstream's decode_to_value allows it): {e}"));
+    }
+
+    // Anything outside that set must be rejected, not silently coerced.
+    for rejected in ["maybe", "2", "truthy", ""] {
+        let result = ops::revision::metadata_set::metadata_set(
+            &api,
+            ops::revision::metadata_set::MetadataSetArgs {
+                keys: vec!["itest_bool_key".into()],
+                values: vec![rejected.into()],
+                formats: vec![ops::revision::metadata_set::MetadataFormat::Boolean],
+            },
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "Boolean value {rejected:?} should be rejected by upstream's decode_to_value, got: {result:?}"
+        );
+    }
+}

--- a/frontend/src/RepositoryPanel.tsx
+++ b/frontend/src/RepositoryPanel.tsx
@@ -508,6 +508,10 @@ export default function RepositoryPanel({
                 <option value="string">string</option>
                 <option value="numeric">numeric</option>
                 <option value="binary">binary</option>
+                <option value="boolean">boolean</option>
+                <option value="address">address</option>
+                <option value="context">context</option>
+                <option value="hash">hash</option>
               </select>
             </div>
             {metaSetError && (

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1168,7 +1168,14 @@ export const repositoryMetadataGetApi = {
 
 // --- repository metadata_set ---
 
-export type MetadataFormat = "binary" | "numeric" | "string";
+export type MetadataFormat =
+  | "address"
+  | "boolean"
+  | "binary"
+  | "context"
+  | "hash"
+  | "numeric"
+  | "string";
 
 export interface RepositoryMetadataSetResult {
   keys: string[];

--- a/frontend/src/palette/manifest/repository/metadata_set.ts
+++ b/frontend/src/palette/manifest/repository/metadata_set.ts
@@ -34,7 +34,7 @@ const manifest: OpManifest = {
       kind: "string-list",
       label: "Formats",
       description:
-        'Format for each key: "string", "numeric", or "binary". Defaults to "string" for missing entries.',
+        'Format for each key: "address", "boolean", "binary", "context", "hash", "numeric", or "string". Defaults to "string" for missing entries.',
       required: false,
       default: [],
     },

--- a/frontend/src/palette/manifest/revision/commit_with_metadata.ts
+++ b/frontend/src/palette/manifest/revision/commit_with_metadata.ts
@@ -4,9 +4,9 @@ import type { OpManifest } from "../../types";
  * Manifest entry for revision.commit_with_metadata.
  *
  * Commits staged changes as a new revision with attached metadata key-value
- * pairs. Each metadata entry has a key, value, and format type (Binary,
- * Numeric, or String). The parallel arrays keys/values/formats must have
- * matching lengths — one entry per index.
+ * pairs. Each metadata entry has a key, value, and format type (Address,
+ * Boolean, Binary, Context, Hash, Numeric, or String). The parallel arrays
+ * keys/values/formats must have matching lengths — one entry per index.
  *
  * Use metadata_get to read keys and metadata_set to write them on existing
  * revisions; commit_with_metadata attaches them atomically at commit time.
@@ -47,7 +47,7 @@ const manifest: OpManifest = {
       name: "formats",
       kind: "string-list",
       label: "Format Types",
-      description: "One format per line (binary, numeric, or string). Must match keys/values length.",
+      description: "One format per line (address, boolean, binary, context, hash, numeric, or string). Must match keys/values length.",
       required: false,
       placeholder: "string\nstring\nstring",
     },

--- a/website/src/lib/op-reference.generated.ts
+++ b/website/src/lib/op-reference.generated.ts
@@ -36,7 +36,7 @@ export interface OpReferenceGroup {
 }
 
 /** Total ops documented across all domains. */
-export const OP_COUNT = 110;
+export const OP_COUNT = 116;
 
 /** Number of domains documented. */
 export const DOMAIN_COUNT = 12;
@@ -1453,31 +1453,6 @@ export const OP_REFERENCE: OpReferenceGroup[] = [
         ]
       },
       {
-        "id": "repository.clone_url",
-        "op": "clone_url",
-        "label": "Repository: Clone from URL",
-        "description": "Clone a remote repository URL into a local destination directory and open it.",
-        "command": "clone",
-        "surface": "palette",
-        "resultKind": "void",
-        "args": [
-          {
-            "name": "url",
-            "label": "Remote URL",
-            "type": "string",
-            "description": "URL of the remote repository to clone.",
-            "required": true
-          },
-          {
-            "name": "dest",
-            "label": "Destination",
-            "type": "string",
-            "description": "Local directory to clone into.",
-            "required": true
-          }
-        ]
-      },
-      {
         "id": "repository.config_get",
         "op": "config_get",
         "label": "Repository: Get Config",
@@ -1790,7 +1765,7 @@ export const OP_REFERENCE: OpReferenceGroup[] = [
             "name": "formats",
             "label": "Formats",
             "type": "string[]",
-            "description": "Format for each key: \"string\", \"numeric\", or \"binary\". Defaults to \"string\" for missing entries.",
+            "description": "Format for each key: \"address\", \"boolean\", \"binary\", \"context\", \"hash\", \"numeric\", or \"string\". Defaults to \"string\" for missing entries.",
             "required": false
           }
         ]
@@ -1804,6 +1779,24 @@ export const OP_REFERENCE: OpReferenceGroup[] = [
         "surface": "palette",
         "resultKind": "void",
         "args": []
+      },
+      {
+        "id": "repository.recover_local",
+        "op": "recover_local",
+        "label": "Repository: Recover Local",
+        "description": "Recover an unreachable local working tree — preserves the current tree and checks out a fresh local copy. Destructive: confirm before running.",
+        "command": "repository_recover_local",
+        "surface": "palette",
+        "resultKind": "json",
+        "args": [
+          {
+            "name": "newDir",
+            "label": "New directory",
+            "type": "string",
+            "description": "Directory to check the recovered copy out into; leave empty to recover in place.",
+            "required": false
+          }
+        ]
       },
       {
         "id": "repository.release",
@@ -1868,6 +1861,16 @@ export const OP_REFERENCE: OpReferenceGroup[] = [
         "command": "sync",
         "surface": "palette",
         "resultKind": "void",
+        "args": []
+      },
+      {
+        "id": "repository.urc_status",
+        "op": "urc_status",
+        "label": "Repository: URC Status",
+        "description": "Show local working-tree health — current/remote revision, pending merge, divergence, staged paths, conflicts.",
+        "command": "repository_urc_status",
+        "surface": "panel",
+        "resultKind": "json",
         "args": []
       },
       {
@@ -2081,7 +2084,7 @@ export const OP_REFERENCE: OpReferenceGroup[] = [
             "name": "formats",
             "label": "Format Types",
             "type": "string[]",
-            "description": "One format per line (binary, numeric, or string). Must match keys/values length.",
+            "description": "One format per line (address, boolean, binary, context, hash, numeric, or string). Must match keys/values length.",
             "required": false
           }
         ]
@@ -2465,6 +2468,24 @@ export const OP_REFERENCE: OpReferenceGroup[] = [
     "blurb": "Start and stop the lore background service.",
     "ops": [
       {
+        "id": "service.host_server_restart",
+        "op": "host_server_restart",
+        "label": "Host Server: Restart",
+        "description": "Restart the active hosted server from its private backend launch recipe. Requires the generation reported by Host Server: Status.",
+        "command": "host_server_restart",
+        "surface": "palette",
+        "resultKind": "json",
+        "args": [
+          {
+            "name": "expectedGeneration",
+            "label": "Expected generation",
+            "type": "number",
+            "description": "Exact backend generation from Host Server: Status; stale values fail closed.",
+            "required": true
+          }
+        ]
+      },
+      {
         "id": "service.host_server_start",
         "op": "host_server_start",
         "label": "Host Server: Start",
@@ -2534,7 +2555,15 @@ export const OP_REFERENCE: OpReferenceGroup[] = [
         "command": "service_start",
         "surface": "palette",
         "resultKind": "void",
-        "args": []
+        "args": [
+          {
+            "name": "installAutorun",
+            "label": "Install autorun",
+            "type": "boolean",
+            "description": "Register the service to start automatically. The op is a deprecated stub today; the Rust command requires this flag to be present.",
+            "required": false
+          }
+        ]
       },
       {
         "id": "service.stop",
@@ -2741,6 +2770,204 @@ export const OP_REFERENCE: OpReferenceGroup[] = [
             "type": "string",
             "description": "Content address: <hash> or <hash>-<context>.",
             "required": true
+          }
+        ]
+      },
+      {
+        "id": "storage.mutable_compare_and_swap",
+        "op": "mutable_compare_and_swap",
+        "label": "Storage: Mutable Compare-and-Swap",
+        "description": "Conditionally update a mutable key when its current value matches expected (empty expected matches an absent key). Returns previous value and whether the swap applied. Remote-capable.",
+        "command": "storage_mutable_compare_and_swap",
+        "surface": "palette",
+        "resultKind": "json",
+        "args": [
+          {
+            "name": "handle",
+            "label": "Handle",
+            "type": "number",
+            "description": "Handle id returned by Storage: Open.",
+            "required": true
+          },
+          {
+            "name": "partition",
+            "label": "Partition",
+            "type": "string",
+            "description": "32-hex-char partition (non-zero).",
+            "required": true
+          },
+          {
+            "name": "key",
+            "label": "Key (hash)",
+            "type": "string",
+            "description": "64-hex-char key hash.",
+            "required": true
+          },
+          {
+            "name": "expected",
+            "label": "Expected (hash)",
+            "type": "string",
+            "description": "Expected current value. Empty/zero matches an absent key.",
+            "required": false
+          },
+          {
+            "name": "value",
+            "label": "New value (hash)",
+            "type": "string",
+            "description": "Value to store when the swap applies. Empty/zero removes the key.",
+            "required": false
+          },
+          {
+            "name": "keyType",
+            "label": "Key type",
+            "type": "string",
+            "description": "Upstream KeyType camelCase name (default untyped).",
+            "required": false
+          },
+          {
+            "name": "remote",
+            "label": "Remote",
+            "type": "boolean",
+            "description": "Route via the remote StorageSession (requires open with remote URL).",
+            "required": false
+          }
+        ]
+      },
+      {
+        "id": "storage.mutable_list",
+        "op": "mutable_list",
+        "label": "Storage: Mutable List",
+        "description": "List mutable key-value pairs of a given type on the local store. Remote targeting is rejected (local-only). Zero partition lists every accessible partition.",
+        "command": "storage_mutable_list",
+        "surface": "palette",
+        "resultKind": "json",
+        "args": [
+          {
+            "name": "handle",
+            "label": "Handle",
+            "type": "number",
+            "description": "Handle id returned by Storage: Open.",
+            "required": true
+          },
+          {
+            "name": "partition",
+            "label": "Partition",
+            "type": "string",
+            "description": "32-hex-char partition. Empty/zero lists every accessible partition.",
+            "required": false
+          },
+          {
+            "name": "keyType",
+            "label": "Key type",
+            "type": "string",
+            "description": "Upstream KeyType camelCase name (default untyped).",
+            "required": false
+          },
+          {
+            "name": "remote",
+            "label": "Remote (will fail)",
+            "type": "boolean",
+            "description": "Force remote routing. Upstream rejects this: mutable_list is local-only.",
+            "required": false
+          }
+        ]
+      },
+      {
+        "id": "storage.mutable_load",
+        "op": "mutable_load",
+        "label": "Storage: Mutable Load",
+        "description": "Read a mutable key's value (hash) from an open store. Absent keys return AddressNotFound on the item. Optional remote routing uses the handle's remote session.",
+        "command": "storage_mutable_load",
+        "surface": "palette",
+        "resultKind": "json",
+        "args": [
+          {
+            "name": "handle",
+            "label": "Handle",
+            "type": "number",
+            "description": "Handle id returned by Storage: Open.",
+            "required": true
+          },
+          {
+            "name": "partition",
+            "label": "Partition",
+            "type": "string",
+            "description": "32-hex-char partition (non-zero).",
+            "required": true
+          },
+          {
+            "name": "key",
+            "label": "Key (hash)",
+            "type": "string",
+            "description": "64-hex-char key hash.",
+            "required": true
+          },
+          {
+            "name": "keyType",
+            "label": "Key type",
+            "type": "string",
+            "description": "Upstream KeyType camelCase name (default untyped).",
+            "required": false
+          },
+          {
+            "name": "remote",
+            "label": "Remote",
+            "type": "boolean",
+            "description": "Route via the remote StorageSession (requires open with remote URL).",
+            "required": false
+          }
+        ]
+      },
+      {
+        "id": "storage.mutable_store",
+        "op": "mutable_store",
+        "label": "Storage: Mutable Store",
+        "description": "Write a mutable key-value pair (hashes) on an open store. Empty or all-zero value removes the key. Optional remote routing uses the handle's remote session.",
+        "command": "storage_mutable_store",
+        "surface": "palette",
+        "resultKind": "json",
+        "args": [
+          {
+            "name": "handle",
+            "label": "Handle",
+            "type": "number",
+            "description": "Handle id returned by Storage: Open.",
+            "required": true
+          },
+          {
+            "name": "partition",
+            "label": "Partition",
+            "type": "string",
+            "description": "32-hex-char partition (non-zero).",
+            "required": true
+          },
+          {
+            "name": "key",
+            "label": "Key (hash)",
+            "type": "string",
+            "description": "64-hex-char key hash.",
+            "required": true
+          },
+          {
+            "name": "value",
+            "label": "Value (hash)",
+            "type": "string",
+            "description": "64-hex-char value hash. Empty or zero removes the key.",
+            "required": false
+          },
+          {
+            "name": "keyType",
+            "label": "Key type",
+            "type": "string",
+            "description": "Upstream KeyType camelCase name (default untyped).",
+            "required": false
+          },
+          {
+            "name": "remote",
+            "label": "Remote",
+            "type": "boolean",
+            "description": "Route via the remote StorageSession (requires open with remote URL).",
+            "required": false
           }
         ]
       },


### PR DESCRIPTION
## Summary

loregui main was broken for 8+ days: 3 automated upstream `lore` rev-bump PRs (#461/#469/#472) landed without adapting `lore-vm`'s ops layer to the new API. This PR fixes the resulting compile break and, per an explicit owner ruling (Jira SBAI-8516 comment 216328, superseding an earlier narrower option), widens the metadata write surface to match upstream's full 7-variant type set rather than collapsing the new variants. SBAI-8517 (typed metadata-write parity) is implemented here, pending merge.

**Mechanical API adaptations** (unambiguous, grounded in upstream's own source at pinned rev `da73d9f`):
- `LoreRepositoryCreateArgs`/`LoreRepositoryCloneArgs.use_shared_store`: bool/u8 -> `LoreSharedStoreMode` (true/false -> Enabled/Disabled).
- `LoreRepositoryCloneArgs` dropped `direct_file_io` with no replacement; stopped forwarding it (kept in our own args for wire compat, now inert).
- `LoreBranchArchiveArgs`/`LoreBranchInfoArgs` gained new optional fields (`layer`/`include_layers`/`link`/`include_links`); defaulted to preserve old unscoped behavior, matching upstream's own `#[serde(default)]`.
- `storage::get_file` and `storage::get`: upstream's `LoreStorageGetFileItem`/`LoreStorageGetItem` now require `offset`/`length`; set both to 0 in each to preserve whole-buffer read behavior (upstream documents `length=0` as read-to-end).

**Metadata type widening** (owner-authorized, option 2): added `Address`/`Boolean`/`Context`/`Hash` alongside `Binary`/`Numeric`/`String` to all 5 write-surface enums (`file::metadata_set::MetadataType`, `branch`/`revision`/`repository::metadata_set::MetadataFormat`, `revision::commit_with_metadata::MetadataFormat`), each mapped 1:1 to its `LoreMetadataType` variant. Boolean validation is not reimplemented here -- all 5 ops pass text + a format tag straight through to upstream's own `Metadata::decode_to_value`, which already accepts `true/1/yes/on`/`false/0/no/off` case-insensitively and rejects everything else; an integration test proves this against the real engine. Widened the frontend surfaces that expose these formats (`api.ts`/`RepositoryPanel.tsx`, plus the `repository`/`revision::commit_with_metadata` palette manifests) and regenerated `website/src/lib/op-reference.generated.ts` from its own generator script so the published reference matches.

## Verification
- `cargo fmt --all --check`: clean
- `cargo check -p lore-vm --all-targets`: clean
- `cargo test -p lore-vm --lib`: 772/772 passed
- `cargo test -p lore-vm --features integration-tests --test integration_roundtrip`: 4/4 passed, including `metadata_boolean_format_matches_upstream_decode_rules` and `storage_roundtrip_against_real_lore`
- Frontend production build (`tsc && vite build`): clean
- Palette parity: 115/148 exposed, 0 deferred (unchanged baseline, no regression)
- Exhaustive 7-variant serde + 1:1 `LoreMetadataType` conversion tests added for every write enum (`file`, `branch`, `repository`, `revision::metadata_set`, `revision::commit_with_metadata`)

Follow-ups: SBAI-8518 tracks ranged storage reads (separate, not done here).

Not merged -- held for review per sb-lore/owner process.
